### PR TITLE
Add a channel-based interface for sink to allow batch processing

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -38,6 +38,12 @@ import (
 	"github.com/pingcap/tidb/types"
 )
 
+// TableInfoGetter is used to get table info by table id of TiDB
+type TableInfoGetter interface {
+	TableByID(id int64) (info *model.TableInfo, ok bool)
+	GetTableIDByName(schema, table string) (int64, bool)
+}
+
 type tableInspector interface {
 	// Get returns information about the specified table
 	Get(schema, table string) (*tableInfo, error)

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -132,18 +132,6 @@ func filterBySchemaAndTable(t *txn.Txn) {
 	}
 }
 
-func (s *mysqlSink) EmitResolvedTimestamp(ctx context.Context, resolved uint64) error {
-	return nil
-}
-
-func (s *mysqlSink) Flush(ctx context.Context) error {
-	return nil
-}
-
-func (s *mysqlSink) Close() error {
-	return nil
-}
-
 func (s *mysqlSink) execDDLWithMaxRetries(ctx context.Context, ddl *txn.DDL, maxRetries uint64) error {
 	retryCfg := backoff.WithMaxRetries(
 		backoff.WithContext(

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -120,7 +120,6 @@ func (s *mysqlSink) Run(ctx context.Context, input <-chan txn.Txn) error {
 			return ctx.Err()
 		}
 	}
-	return nil
 }
 
 func (s *mysqlSink) Success() <-chan txn.Txn {

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -100,10 +100,14 @@ func NewMySQLSinkUsingSchema(db *sql.DB, picker *schema.Schema) Sink {
 	}
 }
 
-func (s *mysqlSink) Run(ctx context.Context, txns <-chan txn.Txn) error {
+func (s *mysqlSink) Run(ctx context.Context, input <-chan txn.Txn) error {
 	for {
 		select {
-		case t := <-txns:
+		case t, ok := <-input:
+			if !ok {
+				log.Info("Input channel closed")
+				return nil
+			}
 			if err := s.Emit(ctx, t); err != nil {
 				return err
 			}

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -16,17 +16,10 @@ package sink
 import (
 	"context"
 
-	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb-cdc/cdc/txn"
 )
 
 // Sink is an abstraction for anything that a changefeed may emit into.
 type Sink interface {
 	Emit(ctx context.Context, t txn.Txn) error
-}
-
-// TableInfoGetter is used to get table info by table id of TiDB
-type TableInfoGetter interface {
-	TableByID(id int64) (info *model.TableInfo, ok bool)
-	GetTableIDByName(schema, table string) (int64, bool)
 }

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -23,16 +23,6 @@ import (
 // Sink is an abstraction for anything that a changefeed may emit into.
 type Sink interface {
 	Emit(ctx context.Context, t txn.Txn) error
-	EmitResolvedTimestamp(
-		ctx context.Context,
-		resolved uint64,
-	) error
-	// TODO: Add GetLastSuccessTs() uint64
-	// Flush blocks until every message enqueued by EmitRow and
-	// EmitResolvedTimestamp has been acknowledged by the sink.
-	Flush(ctx context.Context) error
-	// Close does not guarantee delivery of outstanding messages.
-	Close() error
 }
 
 // TableInfoGetter is used to get table info by table id of TiDB

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -15,8 +15,6 @@ package sink
 
 import (
 	"context"
-	"fmt"
-	"io"
 
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb-cdc/cdc/txn"
@@ -41,28 +39,4 @@ type Sink interface {
 type TableInfoGetter interface {
 	TableByID(id int64) (info *model.TableInfo, ok bool)
 	GetTableIDByName(schema, table string) (int64, bool)
-}
-
-type writerSink struct {
-	io.Writer
-}
-
-var _ Sink = &writerSink{}
-
-func (s *writerSink) Emit(ctx context.Context, t txn.Txn) error {
-	fmt.Fprintf(s, "commit ts: %d", t.Ts)
-	return nil
-}
-
-func (s *writerSink) EmitResolvedTimestamp(ctx context.Context, resolved uint64) error {
-	fmt.Fprintf(s, "resolved: %d", resolved)
-	return nil
-}
-
-func (s *writerSink) Flush(ctx context.Context) error {
-	return nil
-}
-
-func (s *writerSink) Close() error {
-	return nil
 }

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -21,5 +21,10 @@ import (
 
 // Sink is an abstraction for anything that a changefeed may emit into.
 type Sink interface {
-	Emit(ctx context.Context, t txn.Txn) error
+	Run(ctx context.Context, txns <-chan txn.Txn) error
+	Success() <-chan txn.Txn
+	Error() <-chan error
+	Close() error
+	// TODO: Replace Emit completely with Run
+	Emit(ctx context.Context, txn txn.Txn) error
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

With `Emit` we can only process `txn.Txn`s one by one.

### What is changed and how it works?

1. Add channel based methods into the interface
1. Remove unused methods

The original `Emit` method is still kept so that I don't have to rewrite large part of the old code.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes