### PR TITLE
owner: fix checkpoint ts calculate in owner

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/ticdc/cdc/roles"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
 	"github.com/pingcap/ticdc/cdc/schema"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"go.uber.org/zap"
 )
 
@@ -494,18 +493,7 @@ func (o *ownerImpl) calcResolvedTs() error {
 		minCheckpointTs := cfInfo.TargetTs
 
 		if len(cfInfo.tables) == 0 {
-			var ts uint64
-
-			physical, logical, err := o.pdClient.GetTS(context.Background())
-			if err != nil {
-				log.Warn("get ts from pd failed", zap.Error(err))
-				continue
-			}
-
-			ts = oracle.ComposeTS(physical, logical)
-
-			minResolvedTs = ts
-			minCheckpointTs = ts
+			minCheckpointTs = cfInfo.CheckpointTs
 		} else {
 			// calc the min of all resolvedTs in captures
 			for _, pStatus := range cfInfo.ProcessorInfos {

--- a/cdc/schema/storage.go
+++ b/cdc/schema/storage.go
@@ -270,7 +270,7 @@ func (s *Storage) HandlePreviousDDLJobIfNeed(commitTs uint64) error {
 	var job *model.Job
 	for i, job = range s.jobs {
 		if skipJob(job) {
-			log.Debug("skip ddl job", zap.Stringer("job", job))
+			log.Info("skip ddl job", zap.Stringer("job", job))
 			continue
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When the `StartTs` of a changefeed is smaller than any none-system table DDL, we should have a right way to calculate `global resolved ts` and `global checkpoint ts`

### What is changed and how it works?

- The `global resolved ts` can use the `ddl resolved ts` value
- Set the `global checkpoint ts` to the local checkpoint cache stored in `ChangeFeedInfo`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test