### PR TITLE
cmd: add ctrl command to encapsulate some etcd query

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -57,7 +57,7 @@ var cliCmd = &cobra.Command{
 			StartTs:    startTs,
 			TargetTs:   targetTs,
 		}
-		fmt.Printf("create changefeed detail %+v\n", detail)
+		fmt.Printf("create changefeed ID: %s detail %+v\n", id, detail)
 		return kv.SaveChangeFeedDetail(context.Background(), cli, detail, id)
 	},
 }

--- a/cmd/ctrl.go
+++ b/cmd/ctrl.go
@@ -1,0 +1,127 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+// command type
+const (
+	// query changefeed info, returns a json marshalled ChangeFeedDetail
+	CtrlQueryCfInfo = "query-cf-info"
+	// query changefeed replication status
+	CtrlQueryCfStatus = "query-cf-status"
+	// query changefeed list
+	CtrlQueryCfs = "query-cf-list"
+	// query capture list
+	CtrlQueryCaptures = "query-capture-list"
+	// query subchangefeed replication status
+	CtrlQuerySubCf = "query-sub-cf"
+)
+
+func init() {
+	rootCmd.AddCommand(ctrlCmd)
+
+	ctrlCmd.Flags().StringVar(&ctrlPdAddr, "pd-addr", "localhost:2379", "address of PD")
+	ctrlCmd.Flags().StringVar(&ctrlCfID, "changefeed-id", "", "changefeed ID")
+	ctrlCmd.Flags().StringVar(&ctrlCaptureID, "capture-id", "", "capture ID")
+	ctrlCmd.Flags().StringVar(&ctrlCommand, "cmd", CtrlQueryCaptures, "controller command type")
+}
+
+var (
+	ctrlPdAddr    string
+	ctrlCfID      string
+	ctrlCaptureID string
+	ctrlCommand   string
+)
+
+// cf holds changefeed id, which is used for output only
+type cf struct {
+	ID string `json:"id"`
+}
+
+func jsonPrint(v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", data)
+	return nil
+}
+
+var ctrlCmd = &cobra.Command{
+	Use:   "ctrl",
+	Short: "cdc controller",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := clientv3.New(clientv3.Config{
+			Endpoints:   []string{ctrlPdAddr},
+			DialTimeout: 5 * time.Second,
+			DialOptions: []grpc.DialOption{
+				grpc.WithBackoffMaxDelay(time.Second * 3),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		switch ctrlCommand {
+		case CtrlQueryCfInfo:
+			info, err := kv.GetChangeFeedDetail(context.Background(), cli, ctrlCfID)
+			if err != nil {
+				return err
+			}
+			return jsonPrint(info)
+		case CtrlQueryCfStatus:
+			info, err := kv.GetChangeFeedInfo(context.Background(), cli, ctrlCfID)
+			if err != nil {
+				return err
+			}
+			return jsonPrint(info)
+		case CtrlQueryCfs:
+			_, raw, err := kv.GetChangeFeeds(context.Background(), cli)
+			if err != nil {
+				return err
+			}
+			cfs := make([]*cf, 0, len(raw))
+			for id := range raw {
+				cfs = append(cfs, &cf{ID: id})
+			}
+			return jsonPrint(cfs)
+		case CtrlQueryCaptures:
+			_, captures, err := kv.GetCaptures(context.Background(), cli)
+			if err != nil {
+				return err
+			}
+			return jsonPrint(captures)
+		case CtrlQuerySubCf:
+			_, info, err := kv.GetSubChangeFeedInfo(context.Background(), cli, ctrlCfID, ctrlCaptureID)
+			if err != nil {
+				return err
+			}
+			return jsonPrint(info)
+		default:
+			fmt.Printf("unknown controller command: %s\n", ctrlCommand)
+		}
+		return nil
+	},
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In the current design, all CDC metadata is stored in etcd, we should provide some method for users to query the required information.
NOTE this pr doesn't expose any API using HTTP, gRPC or some other way. We will consider exposing these APIs when the `CDC SQL management design` in TiDB is ready.

### What is changed and how it works?

Add a `ctrl` subcommand, can be used as following:

```
# query changefeed list
➜  ./bin/cdc ctrl --cmd=query-cf-list
[{"id":"a2339fed-d360-4726-bd42-f2f0c08daa44"}]

# query capture server list
➜  ./bin/cdc ctrl --cmd=query-capture-list
[{"id":"3feb1b3b-9010-4043-a573-68e4c150d59c"}]

# query changefeed config info
➜  ./bin/cdc ctrl --cmd=query-cf-info --changefeed-id=a2339fed-d360-4726-bd42-f2f0c08daa44
{"sink-uri":"root@tcp(127.0.0.1:3306)/test","opts":{},"create-time":"2019-12-10T11:37:29.7099354+08:00","start-ts":413125585561190400,"target-ts":0}

# query changefeed replication status
➜  ./bin/cdc ctrl --cmd=query-cf-status --changefeed-id=a2339fed-d360-4726-bd42-f2f0c08daa44
{"sink-uri":"root@tcp(127.0.0.1:3306)/test","resolved-ts":413128531400720385,"checkpoint-ts":413128528739696641}

# query subchangefeed (changefeed on specific capture server) replication status
➜  ./bin/cdc ctrl --cmd=query-sub-cf --changefeed-id=a2339fed-d360-4726-bd42-f2f0c08daa44 --capture-id=3feb1b3b-9010-4043-a573-68e4c150d59c
{"checkpoint-ts":413128528739696641,"resolved-ts":413128531400720385,"table-infos":[{"id":43,"start-ts":413125585561190400},{"id":47,"start-ts":413125585561190400}],"table-p-lock":null,"table-c-lock":null}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test