### PR TITLE
Add a IsResolved field for RawTxn so that we can reuse it for a fake resolved txn

### DIFF
--- a/cdc/model/txn.go
+++ b/cdc/model/txn.go
@@ -8,8 +8,9 @@ import (
 
 // RawTxn represents a complete collection of Entries that belong to the same transaction
 type RawTxn struct {
-	Ts      uint64
-	Entries []*RawKVEntry
+	Ts         uint64
+	IsResolved bool
+	Entries    []*RawKVEntry
 }
 
 // IsFake returns true if this RawTxn is fake txn.

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -255,7 +255,7 @@ func (s *txnChannelSuite) TestShouldForwardTxnsByTs(c *check.C) {
 	}
 	close(input)
 
-	output := make(chan ProcessorEntry, 5)
+	output := make(chan model.RawTxn, 5)
 
 	assertCorrectOutput := func(expected []uint64) {
 		for _, ts := range expected {
@@ -290,7 +290,7 @@ func (s *txnChannelSuite) TestShouldBeCancellable(c *check.C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	stopped := make(chan struct{})
 	go func() {
-		tc.Forward(ctx, 1, make(chan ProcessorEntry))
+		tc.Forward(ctx, 1, make(chan model.RawTxn))
 		close(stopped)
 	}()
 	cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We've introduced a new struct because we can't tell a normal txn and a resolved one using only `model.RawTxn`.


### What is changed and how it works?

Add a `IsResolved` field to `model.RawTxn` so that we don't have to introduce a new struct.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test