### PR TITLE
Use a new async interface for Sink

### DIFF
--- a/cdc/model/txn.go
+++ b/cdc/model/txn.go
@@ -58,6 +58,10 @@ type Txn struct {
 	DDL  *DDL
 
 	Ts uint64
+	// IsResolved is true if this is a fake Txn used as a mark that
+	// all Txns with a ts smaller or equal to Txn.Ts have already been
+	// sent
+	IsResolved bool
 }
 
 // IsDDL returns true if it's a DDL transaction

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -61,7 +61,6 @@ func NewMySQLSink(
 	infoGetter TableInfoGetter,
 	opts map[string]string,
 ) (Sink, error) {
-	// TODO
 	sinkURI, err := configureSinkURI(sinkURI)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -71,12 +70,8 @@ func NewMySQLSink(
 		return nil, errors.Trace(err)
 	}
 	cachedInspector := newCachedInspector(db)
-	sink := mysqlSink{
-		db:           db,
-		infoGetter:   infoGetter,
-		tblInspector: cachedInspector,
-	}
-	return &sink, nil
+	sink := newMySQLSink(db, infoGetter, cachedInspector, false)
+	return sink, nil
 }
 
 func configureSinkURI(sinkURI string) (string, error) {
@@ -102,18 +97,20 @@ func NewMySQLSinkUsingSchema(db *sql.DB, schemaStorage *schema.Storage) Sink {
 			return info, err
 		},
 	}
-	return &mysqlSink{
-		db:           db,
-		infoGetter:   schemaStorage,
-		tblInspector: inspector,
-	}
+	return newMySQLSink(db, schemaStorage, inspector, false)
 }
 
 // NewMySQLSinkDDLOnly returns a sink that only processes DDL
 func NewMySQLSinkDDLOnly(db *sql.DB) Sink {
+	return newMySQLSink(db, nil, nil, true)
+}
+
+func newMySQLSink(db *sql.DB, infoGetter TableInfoGetter, tblInspector tableInspector, ddlOnly bool) Sink {
 	return &mysqlSink{
-		db:      db,
-		ddlOnly: true,
+		db:           db,
+		infoGetter:   infoGetter,
+		tblInspector: tblInspector,
+		ddlOnly:      ddlOnly,
 	}
 }
 

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -22,17 +22,12 @@ import (
 
 // Sink is an abstraction for anything that a changefeed may emit into.
 type Sink interface {
+	// Emit writes to the backend asynchronously
 	Emit(ctx context.Context, t model.Txn) error
-	EmitResolvedTimestamp(
-		ctx context.Context,
-		resolved uint64,
-	) error
-	// TODO: Add GetLastSuccessTs() uint64
-	// Flush blocks until every message enqueued by EmitRow and
-	// EmitResolvedTimestamp has been acknowledged by the sink.
-	Flush(ctx context.Context) error
-	// Close does not guarantee delivery of outstanding messages.
-	Close() error
+	// Start starts accepting Txns from Emit and saving them in order
+	Start(ctx context.Context) error
+	// Success returns a channel for receiving Txns that have been successfully saved
+	Success() <-chan model.Txn
 }
 
 // TableInfoGetter is used to get table info by table id of TiDB

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -15,8 +15,6 @@ package sink
 
 import (
 	"context"
-	"fmt"
-	"io"
 
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/ticdc/cdc/model"
@@ -41,28 +39,4 @@ type Sink interface {
 type TableInfoGetter interface {
 	TableByID(id int64) (info *timodel.TableInfo, ok bool)
 	GetTableIDByName(schema, table string) (int64, bool)
-}
-
-type writerSink struct {
-	io.Writer
-}
-
-var _ Sink = &writerSink{}
-
-func (s *writerSink) Emit(ctx context.Context, t model.Txn) error {
-	fmt.Fprintf(s, "commit ts: %d", t.Ts)
-	return nil
-}
-
-func (s *writerSink) EmitResolvedTimestamp(ctx context.Context, resolved uint64) error {
-	fmt.Fprintf(s, "resolved: %d", resolved)
-	return nil
-}
-
-func (s *writerSink) Flush(ctx context.Context) error {
-	return nil
-}
-
-func (s *writerSink) Close() error {
-	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The original Sink implementation accepts and saves transactions one by one.
If we want to utilize bulk writing or introduce some concurrency to improve performance, we need an async interface.


### What is changed and how it works?

Change the Sink interface to an async one.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test