### PR TITLE
Return value for model.Txn

### DIFF
--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -67,7 +67,7 @@ func (cs *mountTxnsSuite) TestInsertPkNotHandle(c *check.C) {
 	rawTxn := getFirstRealTxn(ctx, c, plr)
 	t, err := mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -94,7 +94,7 @@ func (cs *mountTxnsSuite) TestInsertPkNotHandle(c *check.C) {
 	rawTxn = getFirstRealTxn(ctx, c, plr)
 	t, err = mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -129,7 +129,7 @@ func (cs *mountTxnsSuite) TestInsertPkNotHandle(c *check.C) {
 	rawTxn = getFirstRealTxn(ctx, c, plr)
 	t, err = mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -160,7 +160,7 @@ func (cs *mountTxnsSuite) TestInsertPkIsHandle(c *check.C) {
 	rawTxn := getFirstRealTxn(ctx, c, plr)
 	t, err := mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -187,7 +187,7 @@ func (cs *mountTxnsSuite) TestInsertPkIsHandle(c *check.C) {
 	rawTxn = getFirstRealTxn(ctx, c, plr)
 	t, err = mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -222,7 +222,7 @@ func (cs *mountTxnsSuite) TestInsertPkIsHandle(c *check.C) {
 	rawTxn = getFirstRealTxn(ctx, c, plr)
 	t, err = mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -261,7 +261,7 @@ func (cs *mountTxnsSuite) TestLargeInteger(c *check.C) {
 	rawTxn := getFirstRealTxn(ctx, c, plr)
 	t, err := mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -291,7 +291,7 @@ func (cs *mountTxnsSuite) TestLargeInteger(c *check.C) {
 	rawTxn = getFirstRealTxn(ctx, c, plr)
 	t, err = mounter.Mount(rawTxn)
 	c.Assert(err, check.IsNil)
-	cs.assertTableTxnEquals(c, t, &model.Txn{
+	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
 			{
@@ -309,7 +309,7 @@ func (cs *mountTxnsSuite) TestLargeInteger(c *check.C) {
 }
 
 func (cs *mountTxnsSuite) assertTableTxnEquals(c *check.C,
-	obtained, expected *model.Txn) {
+	obtained, expected model.Txn) {
 	obtainedDMLs := obtained.DMLs
 	expectedDMLs := expected.DMLs
 	obtained.DMLs = nil

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -51,7 +51,7 @@ var (
 )
 
 type mounter interface {
-	Mount(rawTxn model.RawTxn) (*model.Txn, error)
+	Mount(rawTxn model.RawTxn) (model.Txn, error)
 }
 
 type txnChannel struct {
@@ -562,7 +562,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				if err := p.sink.Emit(ctx, *txn); err != nil {
+				if err := p.sink.Emit(ctx, txn); err != nil {
 					return errors.Trace(err)
 				}
 				txnCounter.WithLabelValues("executed", p.changefeedID, p.captureID).Inc()

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -79,8 +79,8 @@ func (s *mockTsRWriter) SetGlobalResolvedTs(ts uint64) {
 // mockMounter pretend to decode a RawTxn by returning a Txn of the same Ts
 type mockMounter struct{}
 
-func (m mockMounter) Mount(rawTxn model.RawTxn) (*model.Txn, error) {
-	return &model.Txn{Ts: rawTxn.Ts}, nil
+func (m mockMounter) Mount(rawTxn model.RawTxn) (model.Txn, error) {
+	return model.Txn{Ts: rawTxn.Ts}, nil
 }
 
 // mockSinker append all received Txns for validation


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`model.Txn` is so small that we don't need to avoid copying the return value.


### What is changed and how it works?

Return value for model.Txn.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test