### PR TITLE
support resign owner, add is-owner field in capture list result

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -34,11 +34,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	// CaptureOwnerKey is the capture owner path that is saved to etcd
-	CaptureOwnerKey = kv.EtcdKeyBase + "/capture/owner"
-)
-
 // Capture represents a Capture server, it monitors the changefeed information in etcd and schedules SubChangeFeed on it.
 type Capture struct {
 	pdEndpoints  []string
@@ -71,7 +66,7 @@ func NewCapture(pdEndpoints []string) (c *Capture, err error) {
 
 	log.Info("creating capture", zap.String("capture-id", id))
 
-	manager := roles.NewOwnerManager(cli, id, CaptureOwnerKey)
+	manager := roles.NewOwnerManager(cli, id, kv.CaptureOwnerKey)
 
 	worker, err := NewOwner(pdEndpoints, cli, manager)
 	if err != nil {

--- a/cdc/capture_info.go
+++ b/cdc/capture_info.go
@@ -103,7 +103,6 @@ func newCaptureInfoWatch(
 				watchResp <- &CaptureInfoWatchResp{Err: errors.Trace(resp.Err())}
 				return
 			}
-
 			for _, ev := range resp.Events {
 				infoResp := new(CaptureInfoWatchResp)
 
@@ -125,7 +124,7 @@ func newCaptureInfoWatch(
 				watchResp <- infoResp
 			}
 		}
-		log.Debug("watchC from etcd close normally")
+		log.Info("capture info watcher from etcd close normally")
 
 	}()
 

--- a/cdc/cdc_test.go
+++ b/cdc/cdc_test.go
@@ -1,0 +1,22 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"testing"
+
+	"github.com/pingcap/check"
+)
+
+func TestSuite(t *testing.T) { check.TestingT(t) }

--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -1,0 +1,43 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"net/http"
+
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/pingcap/errors"
+)
+
+type commonResp struct {
+	Status  bool   `json:"status"`
+	Message string `json:"message"`
+}
+
+func (s *Server) handleResignOwner(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		writeError(w, http.StatusBadRequest, errors.New("This api only supports POST method."))
+		return
+	}
+	err := s.capture.ownerManager.ResignOwner(req.Context())
+	if err != nil {
+		if errors.Cause(err) == concurrency.ErrElectionNotLeader {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeInternalServerError(w, err)
+		return
+	}
+	writeData(w, commonResp{Status: true})
+}

--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -27,7 +27,7 @@ type commonResp struct {
 
 func (s *Server) handleResignOwner(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
-		writeError(w, http.StatusBadRequest, errors.New("This api only supports POST method."))
+		writeError(w, http.StatusBadRequest, errors.New("this api only supports POST method"))
 		return
 	}
 	err := s.capture.ownerManager.ResignOwner(req.Context())

--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -42,6 +42,7 @@ func (s *Server) startStatusHTTP() {
 
 	serverMux.HandleFunc("/status", s.handleStatus)
 	serverMux.HandleFunc("/debug/info", s.handleDebugInfo)
+	serverMux.HandleFunc("/capture/owner/resign", s.handleResignOwner)
 
 	prometheus.DefaultGatherer = registry
 	serverMux.Handle("/metrics", promhttp.Handler())

--- a/cdc/http_status_test.go
+++ b/cdc/http_status_test.go
@@ -52,10 +52,23 @@ func (s *httpStatusSuite) TestHTTPStatus(c *check.C) {
 
 	s.waitUntilServerOnline(c)
 
+	testPprof(c)
+	testReisgnOwner(c)
+}
+
+func testPprof(c *check.C) {
 	resp, err := http.Get(fmt.Sprintf("http://%s:%d/debug/pprof/cmdline", defaultServerOptions.statusHost, defaultServerOptions.statusPort))
 	c.Assert(err, check.IsNil)
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, check.Equals, 200)
 	_, err = ioutil.ReadAll(resp.Body)
 	c.Assert(err, check.IsNil)
+}
+
+func testReisgnOwner(c *check.C) {
+	uri := fmt.Sprintf("http://%s:%d/capture/owner/resign", defaultServerOptions.statusHost, defaultServerOptions.statusPort)
+	resp, err := http.Get(uri)
+	c.Assert(err, check.IsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, check.Equals, http.StatusBadRequest)
 }

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -27,6 +27,8 @@ import (
 const (
 	// EtcdKeyBase is the common prefix of the keys in CDC
 	EtcdKeyBase = "/tidb/cdc"
+	// CaptureOwnerKey is the capture owner path that is saved to etcd
+	CaptureOwnerKey = EtcdKeyBase + "/capture/owner"
 )
 
 // GetEtcdKeyChangeFeedList returns the prefix key of all changefeed config

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -690,7 +690,8 @@ func (o *ownerImpl) Run(ctx context.Context, tickTime time.Duration) error {
 				continue
 			}
 			err := o.run(ctx)
-			if err != nil {
+			// owner may be evicted during running, ignore the context canceled error directly
+			if err != nil && errors.Cause(err) != context.Canceled {
 				return err
 			}
 		}
@@ -711,7 +712,7 @@ func (o *ownerImpl) run(ctx context.Context) error {
 	o.l.Lock()
 	defer o.l.Unlock()
 
-	o.handleMarkdownProcessor(ctx)
+	o.handleMarkdownProcessor(cctx)
 
 	err := o.loadChangeFeedInfos(cctx)
 	if err != nil {

--- a/cdc/roles/manager.go
+++ b/cdc/roles/manager.go
@@ -221,6 +221,7 @@ func (m *ownerManager) campaignLoop(ctx context.Context, etcdSession *concurrenc
 		if err != nil {
 			continue
 		}
+		m.logger.Info("campaign to be owner")
 
 		m.toBeOwner(elec)
 		m.watchOwner(ctx, etcdSession, ownerKey)

--- a/cdc/roles/mock_manager.go
+++ b/cdc/roles/mock_manager.go
@@ -60,6 +60,12 @@ func (m *mockManager) RetireOwner() {
 	atomic.StoreInt32(&m.owner, 0)
 }
 
+// ResignOwner implements Manager.ResignOwner interface.
+func (m *mockManager) ResignOwner(ctx context.Context) error {
+	atomic.StoreInt32(&m.owner, 0)
+	return nil
+}
+
 // Cancel implements Manager.Cancel interface.
 func (m *mockManager) Cancel() {
 	m.cancel()

--- a/cdc/roles/mock_manager.go
+++ b/cdc/roles/mock_manager.go
@@ -16,8 +16,6 @@ package roles
 import (
 	"context"
 	"sync/atomic"
-
-	"github.com/pingcap/errors"
 )
 
 var _ Manager = &mockManager{}
@@ -69,14 +67,6 @@ func (m *mockManager) ResignOwner(ctx context.Context) error {
 // Cancel implements Manager.Cancel interface.
 func (m *mockManager) Cancel() {
 	m.cancel()
-}
-
-// GetOwnerID implements Manager.GetOwnerID interface.
-func (m *mockManager) GetOwnerID(ctx context.Context) (string, error) {
-	if m.IsOwner() {
-		return m.ID(), nil
-	}
-	return "", errors.New("no owner")
 }
 
 // CampaignOwner implements Manager.CampaignOwner interface.

--- a/cmd/ctrl.go
+++ b/cmd/ctrl.go
@@ -20,8 +20,10 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/cdc/roles"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -64,6 +66,12 @@ var (
 // cf holds changefeed id, which is used for output only
 type cf struct {
 	ID string `json:"id"`
+}
+
+// capture holds capture information
+type capture struct {
+	ID      string `json:"id"`
+	IsOwner bool   `json:"is-owner"`
 }
 
 func jsonPrint(v interface{}) error {
@@ -114,14 +122,24 @@ var ctrlCmd = &cobra.Command{
 			}
 			return jsonPrint(cfs)
 		case CtrlQueryCaptures:
-			_, captures, err := kv.GetCaptures(context.Background(), cli)
+			_, raw, err := kv.GetCaptures(context.Background(), cli)
 			if err != nil {
 				return err
+			}
+			mockOwnerMgr := roles.NewOwnerManager(cli, "mock-id", kv.CaptureOwnerKey)
+			ownerID, err := mockOwnerMgr.GetOwnerID(context.Background())
+			if err != nil {
+				return err
+			}
+			captures := make([]*capture, 0, len(raw))
+			for _, c := range raw {
+				isOwner := c.ID == ownerID
+				captures = append(captures, &capture{ID: c.ID, IsOwner: isOwner})
 			}
 			return jsonPrint(captures)
 		case CtrlQuerySubCf:
 			_, info, err := kv.GetSubChangeFeedInfo(context.Background(), cli, ctrlCfID, ctrlCaptureID)
-			if err != nil {
+			if err != nil && err != concurrency.ErrElectionNoLeader {
 				return err
 			}
 			return jsonPrint(info)

--- a/cmd/ctrl.go
+++ b/cmd/ctrl.go
@@ -126,8 +126,7 @@ var ctrlCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			mockOwnerMgr := roles.NewOwnerManager(cli, "mock-id", kv.CaptureOwnerKey)
-			ownerID, err := mockOwnerMgr.GetOwnerID(context.Background())
+			ownerID, err := roles.GetOwnerID(context.Background(), cli, kv.CaptureOwnerKey)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add owner resign support and add a way for users to query which capture is the owner.

### What is changed and how it works?

- add `ResignOwner` function in the `Manager` interface
- add a `is-owner` field in the result of `./cdc ctrl --cmd=query-capture-list`, just for test at present
- add an HTTP api to resign owner from a capture
- unit test entrance is removed by accident, put it back

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test