### PR TITLE
owner: fix startTs in processor table info dispatched from owner

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -454,8 +454,9 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 		}
 
 		detail := changefeeds[changeFeedID]
+		checkpointTs := detail.GetCheckpointTs()
 		log.Info("find new changefeed", zap.Reflect("detail", detail),
-			zap.Uint64("checkpoint ts", detail.GetCheckpointTs()))
+			zap.Uint64("checkpoint ts", checkpointTs))
 
 		// we find a new changefeed, init changefeed info here.
 		var targetTs uint64
@@ -475,12 +476,12 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 			return errors.Annotate(err, "create schema store failed")
 		}
 
-		err = schemaStorage.HandlePreviousDDLJobIfNeed(detail.GetCheckpointTs())
+		err = schemaStorage.HandlePreviousDDLJobIfNeed(checkpointTs)
 		if err != nil {
 			return errors.Annotate(err, "handle ddl job failed")
 		}
 
-		ddlHandler := newDDLHandler(o.pdClient, detail.GetCheckpointTs())
+		ddlHandler := newDDLHandler(o.pdClient, checkpointTs)
 
 		tables := make(map[uint64]schema.TableName)
 		orphanTables := make(map[uint64]model.ProcessTableInfo)
@@ -489,10 +490,14 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 				continue
 			}
 
+			startTs := changefeed.StartTs
+			if checkpointTs > startTs {
+				startTs = checkpointTs
+			}
 			tables[id] = table
 			orphanTables[id] = model.ProcessTableInfo{
 				ID:      id,
-				StartTs: changefeed.StartTs,
+				StartTs: startTs,
 			}
 		}
 
@@ -509,7 +514,7 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 			ChangeFeedInfo: &model.ChangeFeedInfo{
 				SinkURI:      changefeed.SinkURI,
 				ResolvedTs:   0,
-				CheckpointTs: detail.GetCheckpointTs(),
+				CheckpointTs: checkpointTs,
 			},
 			Status:          model.ChangeFeedSyncDML,
 			TargetTs:        targetTs,

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -490,14 +490,10 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 				continue
 			}
 
-			startTs := changefeed.StartTs
-			if checkpointTs > startTs {
-				startTs = checkpointTs
-			}
 			tables[id] = table
 			orphanTables[id] = model.ProcessTableInfo{
 				ID:      id,
-				StartTs: startTs,
+				StartTs: checkpointTs,
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

A processor starts a table replication from `StartTs`, which is first set by the owner.
The `StartTs` should consider both the `StartTs` of the changefeed and the `CheckpointTs` of the changefeed.

### What is changed and how it works?

~Use max(`StartTs`, `CheckpointTs`) as `StartTs` in the `ProcessTableInfo`~
Use `detail.GetCheckpointTs()` as `StartTs` in the `ProcessTableInfo`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test