### PR TITLE
Refactor, changeFeedInfo -> changeFeed

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -46,7 +46,7 @@ type OwnerDDLHandler interface {
 	ExecDDL(ctx context.Context, sinkURI string, ddl *model.DDL) error
 }
 
-// ChangeFeedInfoRWriter defines the Reader and Writer for changeFeedInfo
+// ChangeFeedInfoRWriter defines the Reader and Writer for changeFeed
 type ChangeFeedInfoRWriter interface {
 	// Read the changefeed info from storage such as etcd.
 	Read(ctx context.Context) (map[model.ChangeFeedID]*model.ChangeFeedDetail, map[model.ChangeFeedID]model.ProcessorsInfos, error)
@@ -54,7 +54,7 @@ type ChangeFeedInfoRWriter interface {
 	Write(ctx context.Context, infos map[model.ChangeFeedID]*model.ChangeFeedInfo) error
 }
 
-type changeFeedInfo struct {
+type changeFeed struct {
 	ID     string
 	detail *model.ChangeFeedDetail
 	*model.ChangeFeedInfo
@@ -78,7 +78,7 @@ type changeFeedInfo struct {
 }
 
 // String implements fmt.Stringer interface.
-func (c *changeFeedInfo) String() string {
+func (c *changeFeed) String() string {
 	format := "{\n ID: %s\n detail: %+v\n info: %+v\n Status: %v\n ProcessorInfos: %+v\n tables: %+v\n orphanTables: %+v\n toCleanTables: %v\n DDLCurrentIndex: %d\n ddlResolvedTs: %d\n ddlJobHistory: %+v\n}\n\n"
 	s := fmt.Sprintf(format,
 		c.ID, c.detail, c.ChangeFeedInfo, c.Status, c.ProcessorInfos, c.tables,
@@ -108,7 +108,7 @@ func filter(_ *model.ChangeFeedDetail, table schema.TableName) bool {
 	return false
 }
 
-func (c *changeFeedInfo) addTable(id, startTs uint64, table schema.TableName) {
+func (c *changeFeed) addTable(id, startTs uint64, table schema.TableName) {
 	if filter(c.detail, table) {
 		return
 	}
@@ -120,7 +120,7 @@ func (c *changeFeedInfo) addTable(id, startTs uint64, table schema.TableName) {
 	}
 }
 
-func (c *changeFeedInfo) removeTable(id uint64) {
+func (c *changeFeed) removeTable(id uint64) {
 	delete(c.tables, id)
 
 	if _, ok := c.orphanTables[id]; ok {
@@ -130,11 +130,11 @@ func (c *changeFeedInfo) removeTable(id uint64) {
 	}
 }
 
-func (c *changeFeedInfo) selectCapture(captures map[string]*model.CaptureInfo) string {
+func (c *changeFeed) selectCapture(captures map[string]*model.CaptureInfo) string {
 	return c.minimumTablesCapture(captures)
 }
 
-func (c *changeFeedInfo) minimumTablesCapture(captures map[string]*model.CaptureInfo) string {
+func (c *changeFeed) minimumTablesCapture(captures map[string]*model.CaptureInfo) string {
 	if len(captures) == 0 {
 		return ""
 	}
@@ -159,16 +159,16 @@ func (c *changeFeedInfo) minimumTablesCapture(captures map[string]*model.Capture
 	return minID
 }
 
-func (c *changeFeedInfo) tryBalance(ctx context.Context, captures map[string]*model.CaptureInfo) {
+func (c *changeFeed) tryBalance(ctx context.Context, captures map[string]*model.CaptureInfo) {
 	c.cleanTables(ctx)
 	c.banlanceOrphanTables(ctx, captures)
 }
 
-func (c *changeFeedInfo) restoreTableInfos(infoSnapshot *model.SubChangeFeedInfo, captureID string) {
+func (c *changeFeed) restoreTableInfos(infoSnapshot *model.SubChangeFeedInfo, captureID string) {
 	c.ProcessorInfos[captureID].TableInfos = infoSnapshot.TableInfos
 }
 
-func (c *changeFeedInfo) cleanTables(ctx context.Context) {
+func (c *changeFeed) cleanTables(ctx context.Context) {
 	var cleanIDs []uint64
 
 cleanLoop:
@@ -223,7 +223,7 @@ func findSubChangefeedWithTable(infos model.ProcessorsInfos, tableID uint64) (ca
 	return "", nil, false
 }
 
-func (c *changeFeedInfo) banlanceOrphanTables(ctx context.Context, captures map[string]*model.CaptureInfo) {
+func (c *changeFeed) banlanceOrphanTables(ctx context.Context, captures map[string]*model.CaptureInfo) {
 	if len(captures) == 0 {
 		return
 	}
@@ -268,7 +268,7 @@ func (c *changeFeedInfo) banlanceOrphanTables(ctx context.Context, captures map[
 	}
 }
 
-func (c *changeFeedInfo) applyJob(job *pmodel.Job) error {
+func (c *changeFeed) applyJob(job *pmodel.Job) error {
 	log.Info("apply job", zap.String("sql", job.Query), zap.Int64("job id", job.ID))
 
 	schamaName, tableName, _, err := c.schema.HandleDDL(job)
@@ -300,7 +300,7 @@ func (c *changeFeedInfo) applyJob(job *pmodel.Job) error {
 }
 
 type ownerImpl struct {
-	changeFeedInfos   map[model.ChangeFeedID]*changeFeedInfo
+	changeFeeds       map[model.ChangeFeedID]*changeFeed
 	markDownProcessor map[string]struct{}
 
 	cfRWriter ChangeFeedInfoRWriter
@@ -341,7 +341,7 @@ func NewOwner(pdEndpoints []string, cli *clientv3.Client, manager roles.Manager)
 		pdEndpoints:        pdEndpoints,
 		pdClient:           pdClient,
 		markDownProcessor:  make(map[string]struct{}),
-		changeFeedInfos:    make(map[model.ChangeFeedID]*changeFeedInfo),
+		changeFeeds:        make(map[model.ChangeFeedID]*changeFeed),
 		cfRWriter:          storage.NewChangeFeedInfoEtcdRWriter(cli),
 		etcdClient:         cli,
 		manager:            manager,
@@ -382,7 +382,7 @@ func (o *ownerImpl) removeCapture(info *model.CaptureInfo) {
 
 	delete(o.captures, info.ID)
 
-	for _, feed := range o.changeFeedInfos {
+	for _, feed := range o.changeFeeds {
 		pinfo, ok := feed.ProcessorInfos[info.ID]
 		if !ok {
 			continue
@@ -426,10 +426,10 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 	}
 
 	for changeFeedID, etcdChangeFeedInfo := range pinfos {
-		var cfInfo *changeFeedInfo
+		var cfInfo *changeFeed
 		var exist bool
 
-		if cfInfo, exist = o.changeFeedInfos[changeFeedID]; exist {
+		if cfInfo, exist = o.changeFeeds[changeFeedID]; exist {
 			for cid, pinfo := range etcdChangeFeedInfo {
 				if _, ok := cfInfo.processorLastUpdateTime[cid]; !ok {
 					cfInfo.processorLastUpdateTime[cid] = time.Now()
@@ -497,7 +497,7 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 			}
 		}
 
-		o.changeFeedInfos[changeFeedID] = &changeFeedInfo{
+		o.changeFeeds[changeFeedID] = &changeFeed{
 			detail:                  detail,
 			ID:                      changeFeedID,
 			client:                  o.etcdClient,
@@ -520,7 +520,7 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 		}
 	}
 
-	for _, info := range o.changeFeedInfos {
+	for _, info := range o.changeFeeds {
 		info.tryBalance(ctx, o.captures)
 	}
 
@@ -529,13 +529,13 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 
 func (o *ownerImpl) flushChangeFeedInfos(ctx context.Context) error {
 	infos := make(map[model.CaptureID]*model.ChangeFeedInfo)
-	for id, info := range o.changeFeedInfos {
+	for id, info := range o.changeFeeds {
 		infos[id] = info.ChangeFeedInfo
 	}
 	return errors.Trace(o.cfRWriter.Write(ctx, infos))
 }
 
-func (c *changeFeedInfo) pullDDLJob() error {
+func (c *changeFeed) pullDDLJob() error {
 	ddlResolvedTs, ddlJobs, err := c.ddlHandler.PullDDL()
 	if err != nil {
 		return errors.Trace(err)
@@ -547,7 +547,7 @@ func (c *changeFeedInfo) pullDDLJob() error {
 
 // calcResolvedTs update every changefeed's resolve ts and checkpoint ts.
 func (o *ownerImpl) calcResolvedTs() error {
-	for _, cfInfo := range o.changeFeedInfos {
+	for _, cfInfo := range o.changeFeeds {
 		if cfInfo.Status != model.ChangeFeedSyncDML {
 			continue
 		}
@@ -615,7 +615,7 @@ func (o *ownerImpl) calcResolvedTs() error {
 // After executing the DDL successfully, the status will be changed to be ChangeFeedSyncDML.
 func (o *ownerImpl) handleDDL(ctx context.Context) error {
 waitCheckpointTsLoop:
-	for changeFeedID, cfInfo := range o.changeFeedInfos {
+	for changeFeedID, cfInfo := range o.changeFeeds {
 		if cfInfo.Status != model.ChangeFeedWaitToExecDDL {
 			continue
 		}
@@ -742,7 +742,7 @@ func (o *ownerImpl) IsOwner(_ context.Context) bool {
 }
 
 func (o *ownerImpl) writeDebugInfo(w io.Writer) {
-	for _, info := range o.changeFeedInfos {
+	for _, info := range o.changeFeeds {
 		// fmt.Fprintf(w, "%+v\n", *info)
 		fmt.Fprintf(w, "%s\n", info)
 	}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -426,10 +426,7 @@ func (o *ownerImpl) loadChangeFeeds(ctx context.Context) error {
 	}
 
 	for changeFeedID, changeFeedInfo := range pinfos {
-		var cfInfo *changeFeed
-		var exist bool
-
-		if cfInfo, exist = o.changeFeeds[changeFeedID]; exist {
+		if cfInfo, exist := o.changeFeeds[changeFeedID]; exist {
 			for cid, pinfo := range changeFeedInfo {
 				if _, ok := cfInfo.processorLastUpdateTime[cid]; !ok {
 					cfInfo.processorLastUpdateTime[cid] = time.Now()

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -528,7 +528,7 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 }
 
 func (o *ownerImpl) flushChangeFeedInfos(ctx context.Context) error {
-	infos := make(map[model.CaptureID]*model.ChangeFeedInfo)
+	infos := make(map[model.ChangeFeedID]*model.ChangeFeedInfo, len(o.changeFeeds))
 	for id, info := range o.changeFeeds {
 		infos[id] = info.ChangeFeedInfo
 	}

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -130,7 +130,7 @@ func (s *ownerSuite) TestPureDML(c *check.C) {
 
 	tables := map[uint64]schema.TableName{1: {Schema: "any"}}
 
-	changeFeedInfos := map[model.ChangeFeedID]*changeFeed{
+	changeFeeds := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed": {
 			tables:                  tables,
 			ChangeFeedInfo:          &model.ChangeFeedInfo{},
@@ -150,7 +150,7 @@ func (s *ownerSuite) TestPureDML(c *check.C) {
 	c.Assert(err, check.IsNil)
 	owner := &ownerImpl{
 		cancelWatchCapture: cancel,
-		changeFeeds:        changeFeedInfos,
+		changeFeeds:        changeFeeds,
 		cfRWriter:          handler,
 		manager:            manager,
 	}
@@ -309,7 +309,7 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 
 	tables := map[uint64]schema.TableName{1: {Schema: "any"}}
 
-	changeFeedInfos := map[model.ChangeFeedID]*changeFeed{
+	changeFeeds := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed": {
 			tables:                  tables,
 			ChangeFeedInfo:          &model.ChangeFeedInfo{},
@@ -329,7 +329,7 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 	c.Assert(err, check.IsNil)
 	owner := &ownerImpl{
 		cancelWatchCapture: cancel,
-		changeFeeds:        changeFeedInfos,
+		changeFeeds:        changeFeeds,
 
 		// ddlHandler: handler,
 		cfRWriter: handler,

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -130,7 +130,7 @@ func (s *ownerSuite) TestPureDML(c *check.C) {
 
 	tables := map[uint64]schema.TableName{1: {Schema: "any"}}
 
-	changeFeedInfos := map[model.ChangeFeedID]*changeFeedInfo{
+	changeFeedInfos := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed": {
 			tables:                  tables,
 			ChangeFeedInfo:          &model.ChangeFeedInfo{},
@@ -150,7 +150,7 @@ func (s *ownerSuite) TestPureDML(c *check.C) {
 	c.Assert(err, check.IsNil)
 	owner := &ownerImpl{
 		cancelWatchCapture: cancel,
-		changeFeedInfos:    changeFeedInfos,
+		changeFeeds:        changeFeedInfos,
 		cfRWriter:          handler,
 		manager:            manager,
 	}
@@ -309,7 +309,7 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 
 	tables := map[uint64]schema.TableName{1: {Schema: "any"}}
 
-	changeFeedInfos := map[model.ChangeFeedID]*changeFeedInfo{
+	changeFeedInfos := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed": {
 			tables:                  tables,
 			ChangeFeedInfo:          &model.ChangeFeedInfo{},
@@ -329,7 +329,7 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 	c.Assert(err, check.IsNil)
 	owner := &ownerImpl{
 		cancelWatchCapture: cancel,
-		changeFeedInfos:    changeFeedInfos,
+		changeFeeds:        changeFeedInfos,
 
 		// ddlHandler: handler,
 		cfRWriter: handler,
@@ -346,7 +346,7 @@ type changefeedInfoSuite struct {
 var _ = check.Suite(&changefeedInfoSuite{})
 
 func (s *changefeedInfoSuite) TestMinimumTables(c *check.C) {
-	cf := &changeFeedInfo{
+	cf := &changeFeed{
 		ProcessorInfos: map[model.CaptureID]*model.SubChangeFeedInfo{
 			"c1": {
 				TableInfos: make([]*model.ProcessTableInfo, 2),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We have already used the name `ChangeFeedInfo` for the parts of infomation about a change feed that's going to be saved in `etcd`.
It's confusing if we have both `ChangeFeedInfo` and `changeFeedInfo`.


### What is changed and how it works?

Simply use `changeFeed`.

Some other minor changes: fix a typo in `flushChangeFeedInfos` and preallocate the map.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test