### PR TITLE
Move txn filtering out of mysqlSink

### DIFF
--- a/cdc/filter.go
+++ b/cdc/filter.go
@@ -1,0 +1,37 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"regexp"
+
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+func filterBySchemaAndTable(t *model.Txn) {
+	toIgnore := regexp.MustCompile("(?i)^(INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|MYSQL)$")
+	if t.IsDDL() {
+		if toIgnore.MatchString(t.DDL.Database) {
+			t.DDL = nil
+		}
+	} else {
+		filteredDMLs := make([]*model.DML, 0, len(t.DMLs))
+		for _, dml := range t.DMLs {
+			if !toIgnore.MatchString(dml.Database) {
+				filteredDMLs = append(filteredDMLs, dml)
+			}
+		}
+		t.DMLs = filteredDMLs
+	}
+}

--- a/cdc/filter_test.go
+++ b/cdc/filter_test.go
@@ -1,0 +1,52 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+type FilterSuite struct{}
+
+var _ = check.Suite(&FilterSuite{})
+
+func (s *FilterSuite) TestFilterDMLs(c *check.C) {
+	t := model.Txn{
+		DMLs: []*model.DML{
+			{Database: "INFORMATIOn_SCHEmA"},
+			{Database: "test"},
+			{Database: "test_mysql"},
+			{Database: "mysql"},
+		},
+		Ts: 213,
+	}
+	filterBySchemaAndTable(&t)
+	c.Assert(t.Ts, check.Equals, uint64(213))
+	c.Assert(t.DDL, check.IsNil)
+	c.Assert(t.DMLs, check.HasLen, 2)
+	c.Assert(t.DMLs[0].Database, check.Equals, "test")
+	c.Assert(t.DMLs[1].Database, check.Equals, "test_mysql")
+}
+
+func (s *FilterSuite) TestFilterDDL(c *check.C) {
+	t := model.Txn{
+		DDL: &model.DDL{Database: "performance_schema"},
+		Ts:  10234,
+	}
+	filterBySchemaAndTable(&t)
+	c.Assert(t.Ts, check.Equals, uint64((10234)))
+	c.Assert(t.DMLs, check.HasLen, 0)
+	c.Assert(t.DDL, check.IsNil)
+}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -43,7 +43,7 @@ type OwnerDDLHandler interface {
 	PullDDL() (resolvedTs uint64, jobs []*model.DDL, err error)
 
 	// ExecDDL executes the ddl job
-	ExecDDL(ctx context.Context, sinkURI string, ddl *model.DDL) error
+	ExecDDL(ctx context.Context, sinkURI string, txn model.Txn) error
 }
 
 // ChangeFeedInfoRWriter defines the Reader and Writer for changeFeed
@@ -637,22 +637,30 @@ waitCheckpointTsLoop:
 		}
 
 		cfInfo.banlanceOrphanTables(context.Background(), o.captures)
-
-		err = cfInfo.ddlHandler.ExecDDL(ctx, cfInfo.SinkURI, todoDDLJob)
-		// o.l.Lock()
-		// defer o.l.Unlock()
-		// If DDL executing failed, pause the changefeed and print log
-		if err != nil {
-			cfInfo.Status = model.ChangeFeedDDLExecuteFailed
-			log.Error("Execute DDL failed",
+		ddlTxn := model.Txn{Ts: todoDDLJob.Job.BinlogInfo.FinishedTS, DDL: todoDDLJob}
+		filterBySchemaAndTable(&ddlTxn)
+		if ddlTxn.DDL == nil {
+			log.Warn(
+				"DDL ignored",
+				zap.Int64("ID", todoDDLJob.Job.ID),
+				zap.String("db", todoDDLJob.Database),
+				zap.String("tbl", todoDDLJob.Table),
+			)
+		} else {
+			err = cfInfo.ddlHandler.ExecDDL(ctx, cfInfo.SinkURI, ddlTxn)
+			// If DDL executing failed, pause the changefeed and print log
+			if err != nil {
+				cfInfo.Status = model.ChangeFeedDDLExecuteFailed
+				log.Error("Execute DDL failed",
+					zap.String("ChangeFeedID", changeFeedID),
+					zap.Error(err),
+					zap.Reflect("ddlJob", todoDDLJob))
+				return errors.Trace(err)
+			}
+			log.Info("Execute DDL succeeded",
 				zap.String("ChangeFeedID", changeFeedID),
-				zap.Error(err),
 				zap.Reflect("ddlJob", todoDDLJob))
-			return errors.Trace(err)
 		}
-		log.Info("Execute DDL succeeded",
-			zap.String("ChangeFeedID", changeFeedID),
-			zap.Reflect("ddlJob", todoDDLJob))
 		if cfInfo.Status != model.ChangeFeedExecDDL {
 			log.Fatal("changeFeedState must be ChangeFeedExecDDL when DDL is executed",
 				zap.String("ChangeFeedID", changeFeedID),

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -104,7 +104,7 @@ func (h *ddlHandler) PullDDL() (uint64, []*model.DDL, error) {
 }
 
 // ExecDDL implements roles.OwnerDDLHandler interface.
-func (h *ddlHandler) ExecDDL(ctx context.Context, sinkURI string, ddl *model.DDL) error {
+func (h *ddlHandler) ExecDDL(ctx context.Context, sinkURI string, txn model.Txn) error {
 	// TODO cache the sink
 	// TODO handle other target database, kile kafka, file
 	db, err := sql.Open("mysql", sinkURI)
@@ -114,7 +114,7 @@ func (h *ddlHandler) ExecDDL(ctx context.Context, sinkURI string, ddl *model.DDL
 	defer db.Close()
 	s := sink.NewMySQLSinkDDLOnly(db)
 
-	err = s.Emit(ctx, model.Txn{Ts: ddl.Job.BinlogInfo.FinishedTS, DDL: ddl})
+	err = s.Emit(ctx, txn)
 	return errors.Trace(err)
 }
 

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -71,7 +71,7 @@ func (h *handlerForPrueDMLTest) PullDDL() (resolvedTs uint64, ddl []*model.DDL, 
 	return uint64(math.MaxUint64), nil, nil
 }
 
-func (h *handlerForPrueDMLTest) ExecDDL(context.Context, string, *model.DDL) error {
+func (h *handlerForPrueDMLTest) ExecDDL(context.Context, string, model.Txn) error {
 	panic("unreachable")
 }
 
@@ -190,12 +190,12 @@ func (h *handlerForDDLTest) PullDDL() (resolvedTs uint64, jobs []*model.DDL, err
 	return h.ddlResolvedTs[h.ddlIndex], []*model.DDL{h.ddls[h.ddlIndex]}, nil
 }
 
-func (h *handlerForDDLTest) ExecDDL(ctx context.Context, sinkURI string, ddl *model.DDL) error {
+func (h *handlerForDDLTest) ExecDDL(ctx context.Context, sinkURI string, txn model.Txn) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.ddlExpectIndex++
-	h.c.Assert(ddl, check.DeepEquals, h.ddls[h.ddlExpectIndex])
-	h.c.Assert(ddl.Job.BinlogInfo.FinishedTS, check.Equals, h.currentGlobalResolvedTs)
+	h.c.Assert(txn.DDL, check.DeepEquals, h.ddls[h.ddlExpectIndex])
+	h.c.Assert(txn.DDL.Job.BinlogInfo.FinishedTS, check.Equals, h.currentGlobalResolvedTs)
 	return nil
 }
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -586,6 +586,10 @@ func (p *processor) syncResolved(ctx context.Context) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
+			filterBySchemaAndTable(&txn)
+			if len(txn.DMLs) == 0 {
+				continue
+			}
 			pendingTxns = append(pendingTxns, txn)
 			if len(pendingTxns) >= bulkLimit {
 				if err := flush(ctx); err != nil {

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -232,36 +232,3 @@ func (s EmitSuite) TestShouldExecDelete(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mock.ExpectationsWereMet(), check.IsNil)
 }
-
-type FilterSuite struct{}
-
-var _ = check.Suite(&FilterSuite{})
-
-func (s *FilterSuite) TestFilterDMLs(c *check.C) {
-	t := model.Txn{
-		DMLs: []*model.DML{
-			{Database: "INFORMATIOn_SCHEmA"},
-			{Database: "test"},
-			{Database: "test_mysql"},
-			{Database: "mysql"},
-		},
-		Ts: 213,
-	}
-	filterBySchemaAndTable(&t)
-	c.Assert(t.Ts, check.Equals, uint64(213))
-	c.Assert(t.DDL, check.IsNil)
-	c.Assert(t.DMLs, check.HasLen, 2)
-	c.Assert(t.DMLs[0].Database, check.Equals, "test")
-	c.Assert(t.DMLs[1].Database, check.Equals, "test_mysql")
-}
-
-func (s *FilterSuite) TestFilterDDL(c *check.C) {
-	t := model.Txn{
-		DDL: &model.DDL{Database: "performance_schema"},
-		Ts:  10234,
-	}
-	filterBySchemaAndTable(&t)
-	c.Assert(t.Ts, check.Equals, uint64((10234)))
-	c.Assert(t.DMLs, check.HasLen, 0)
-	c.Assert(t.DDL, check.IsNil)
-}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Ignored or not, a "success" message was logged for each DDL passed to `sink.Emit`.
We need to separate the ignored and those that were actually executed.

### What is changed and how it works?

Move txn filtering out of `mysqlSink`, the callers should filter the txns and decide what to do if the whole txn is ignored.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test