### PR TITLE
Flush pending txns when the buffers are empty

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -602,6 +602,11 @@ func (p *processor) syncResolved(ctx context.Context) error {
 				cancel()
 			}
 			return ctx.Err()
+		default:
+			if err := flush(ctx); err != nil {
+				return errors.Trace(err)
+			}
+			time.Sleep(10 * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When there's no more incoming txns and the number of pending txns doesn't reach the limit, the txns are not flushed.

### What is changed and how it works?

Flush pending txns when the buffers are empty


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test