### PR TITLE
wait all processors exit in capture

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -107,14 +107,7 @@ func (c *Capture) OnStopProcessor(p *processor, err error) {
 	if atomic.LoadInt32(&c.procState.closed) == 1 {
 		return
 	}
-	err2 := p.wg.Wait()
-	if err2 != nil && errors.Cause(err2) != context.Canceled {
-		log.Error("processor wait error",
-			zap.String("captureID", p.captureID),
-			zap.String("changefeedID", p.changefeedID),
-			zap.Error(err2),
-		)
-	}
+	p.wait()
 	delete(c.processors, p.changefeedID)
 }
 
@@ -152,14 +145,7 @@ func (c *Capture) Cleanup() {
 	atomic.StoreInt32(&c.procState.closed, 1)
 
 	for _, processor := range c.processors {
-		err := processor.wg.Wait()
-		if err != nil && errors.Cause(err) != context.Canceled {
-			log.Error("processor wait error",
-				zap.String("captureID", processor.captureID),
-				zap.String("changefeedID", processor.changefeedID),
-				zap.Error(err),
-			)
-		}
+		processor.wait()
 	}
 }
 

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -100,7 +100,6 @@ func (c *Capture) OnStopProcessor(p *processor, err error) {
 	log.Info("stop to run processor", zap.String("changefeed id", p.changefeedID), zap.Error(err))
 	c.procLock.Lock()
 	defer c.procLock.Unlock()
-	p.wait()
 	delete(c.processors, p.changefeedID)
 }
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -264,6 +264,18 @@ func (p *processor) Run(ctx context.Context, errCh chan<- error) {
 	}()
 }
 
+// wait blocks until all routines in processor are returned
+func (p *processor) wait() {
+	err := p.wg.Wait()
+	if err != nil && errors.Cause(err) != context.Canceled {
+		log.Error("processor wait error",
+			zap.String("captureID", p.captureID),
+			zap.String("changefeedID", p.changefeedID),
+			zap.Error(err),
+		)
+	}
+}
+
 func (p *processor) writeDebugInfo(w io.Writer) {
 	fmt.Fprintf(w, "changefeedID: %s, detail: %+v, subInfo: %+v\n", p.changefeedID, p.changefeed, p.subInfo)
 

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -113,4 +113,5 @@ func (s *Server) Close(ctx context.Context, cancel context.CancelFunc) {
 		s.statusServer = nil
 	}
 	cancel()
+	s.capture.Cleanup()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR makes capture acts like a resource manager by the following two changes:

- capture doesn't exit when meeting a processor error
- capture waits for all processors exit during system shutdown

more resources management will be added later, such as the changefeed pause/resume

### What is changed and how it works?

Still use the callback way for the interactions between capture and processors, we may refactor it later.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test