### PR TITLE
Refactor, extract functions to simplify loadChangeFeeds

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"encoding/json"
+	"math"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -33,7 +34,7 @@ type ChangeFeedDetail struct {
 	Info     *ChangeFeedInfo `json:"-"`
 }
 
-// GetStartTs return StartTs if it's  specified or using the CreateTime of changefeed.
+// GetStartTs returns StartTs if it's  specified or using the CreateTime of changefeed.
 func (detail *ChangeFeedDetail) GetStartTs() uint64 {
 	if detail.StartTs > 0 {
 		return detail.StartTs
@@ -42,7 +43,15 @@ func (detail *ChangeFeedDetail) GetStartTs() uint64 {
 	return oracle.EncodeTSO(detail.CreateTime.Unix() * 1000)
 }
 
-// GetCheckpointTs return the checkpoint ts of changefeed.
+// GetTargetTs returns TargetTs if it's specified, otherwise MaxUint64 is returned.
+func (detail *ChangeFeedDetail) GetTargetTs() uint64 {
+	if detail.TargetTs > 0 {
+		return detail.TargetTs
+	}
+	return uint64(math.MaxUint64)
+}
+
+// GetCheckpointTs returns the checkpoint ts of changefeed.
 func (detail *ChangeFeedDetail) GetCheckpointTs() uint64 {
 	if detail.Info != nil {
 		return detail.Info.CheckpointTs


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `loadChangeFeeds` method is too complex.


### What is changed and how it works?

Simplify the method by extracting functions.

The algorithm is actually quite simple:

1. For existing change feeds, try to set the last updated time and mark some as unavailable
1. Create new change feeds for non-exist change feeds and register them into owner
1. Distribute tables among available processors


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test