### PR TITLE
tests: wait cdc server exits in integration test

### DIFF
--- a/tests/_utils/cleanup_process
+++ b/tests/_utils/cleanup_process
@@ -2,7 +2,7 @@
 # parameter 1: process name
 
 process=$1
-retry_count=40
+retry_count=20
 
 killall $process || true
 

--- a/tests/_utils/cleanup_process
+++ b/tests/_utils/cleanup_process
@@ -1,0 +1,23 @@
+#!/bin/bash
+# parameter 1: process name
+
+process=$1
+retry_count=40
+
+killall $process || true
+
+counter=0
+while [ $counter -lt $retry_count ]; do
+    pgrep $process > /dev/null 2>&1
+    ret=$?
+    if [ "$ret" != "0" ]; then
+        echo "process $process already exit"
+        exit 0
+    fi
+    ((counter+=1))
+    sleep 0.5
+    echo "wait process $process exit for $counter-th time..."
+done
+
+echo "wait process $process exit timeout"
+exit 1

--- a/tests/multi_capture/run.sh
+++ b/tests/multi_capture/run.sh
@@ -46,7 +46,7 @@ function run() {
     done
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
-    killall $CDC_BINARY || true
+    cleanup_process $CDC_BINARY
 }
 
 trap stop_tidb_cluster EXIT

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -86,7 +86,7 @@ function sql_test() {
         exit 1
     fi
 
-    killall $CDC_BINARY || true
+    cleanup_process $CDC_BINARY
 }
 
 trap stop_tidb_cluster EXIT

--- a/tests/split_region/run.sh
+++ b/tests/split_region/run.sh
@@ -33,7 +33,7 @@ function run() {
     run_sql_file $CUR/data/increment.sql ${US_TIDB_HOST} ${US_TIDB_PORT}
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
-    killall $CDC_BINARY || true
+    cleanup_process $CDC_BINARY
 }
 
 trap stop_tidb_cluster EXIT


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In each integration test case, we should wait for the cdc gotest server daemon exits (which will ensure all coverage data is flushed into the disk),  before we stash the coverage file.

### What is changed and how it works?

Add a process aliveness checker in the integration test script.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test