### PR TITLE
Fix deadlock while successive drop tables

### DIFF
--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -16,12 +16,19 @@ package kv
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	regionSplitCounter = prometheus.NewCounter(
+	eventFeedErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "ticdc",
 			Subsystem: "kvclient",
-			Name:      "region_split_count",
-			Help:      "The number of region split events since start.",
+			Name:      "event_feed_error_count",
+			Help:      "The number of error return by tikv",
+		}, []string{"type"})
+	eventFeedGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "event_feed_count",
+			Help:      "The number of event feed running",
 		})
 	scanRegionsDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -43,7 +50,8 @@ var (
 
 // InitMetrics registers all metrics in the kv package
 func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(regionSplitCounter)
+	registry.MustRegister(eventFeedErrorCounter)
 	registry.MustRegister(scanRegionsDuration)
 	registry.MustRegister(eventSize)
+	registry.MustRegister(eventFeedGauge)
 }

--- a/cdc/metrics_processor.go
+++ b/cdc/metrics_processor.go
@@ -25,6 +25,13 @@ var (
 			Name:      "resolved_ts",
 			Help:      "local resolved ts of processor",
 		}, []string{"changefeed", "capture"})
+	tableResolvedTsGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "processor",
+			Name:      "table_resolved_ts",
+			Help:      "local resolved ts of processor",
+		}, []string{"changefeed", "capture", "table"})
 	checkpointTsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "ticdc",
@@ -59,6 +66,7 @@ var (
 // initProcessorMetrics registers all metrics used in processor
 func initProcessorMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(resolvedTsGauge)
+	registry.MustRegister(tableResolvedTsGauge)
 	registry.MustRegister(checkpointTsGauge)
 	registry.MustRegister(syncTableNumGauge)
 	registry.MustRegister(txnCounter)

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -223,7 +223,7 @@ func (p *processorSuite) TestDiffProcessTableInfos(c *check.C) {
 			{emptyInfo, []*model.ProcessTableInfo{infos[0]}, nil, []*model.ProcessTableInfo{infos[0]}},
 			{[]*model.ProcessTableInfo{infos[0]}, emptyInfo, []*model.ProcessTableInfo{infos[0]}, nil},
 			{[]*model.ProcessTableInfo{infos[0]}, []*model.ProcessTableInfo{infos[1]}, []*model.ProcessTableInfo{infos[0]}, []*model.ProcessTableInfo{infos[1]}},
-			{[]*model.ProcessTableInfo{infos[0], infos[1]}, []*model.ProcessTableInfo{infos[1], infos[2]}, []*model.ProcessTableInfo{infos[0]}, []*model.ProcessTableInfo{infos[2]}},
+			{[]*model.ProcessTableInfo{infos[1], infos[0]}, []*model.ProcessTableInfo{infos[2], infos[1]}, []*model.ProcessTableInfo{infos[0]}, []*model.ProcessTableInfo{infos[2]}},
 			{[]*model.ProcessTableInfo{infos[1]}, []*model.ProcessTableInfo{infos[0]}, []*model.ProcessTableInfo{infos[1]}, []*model.ProcessTableInfo{infos[0]}},
 		}
 	)


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1, Adjust and add some metrics.

2, Fix goroutine leak by not close sorter

3, Fix diffProcessTableInfos assume tables is sorted by id.

4, Fix deadlock while successive drop tables.

drop two table at upstream: drop table t1; drop table t2;
ts1 = the timestamp of "drop table t1"
ts2 = the timestamp of "drop table t2"
the flowing step may happen:

a. gloableResolveTS = t1, checkpointTS of processor = ts (after execute
	drop table t1)
b. processor update resolveTS = t2;
c. owner update gloableResolveTS = t2;
d. processor update checkpointTS = t2(in memory).
e. owner remove table t1 in etcd.
f. processor learn t1 removed and update the in memory checkpointTS as
the one in etch which is t1.
g. processor will never forward checkpointTS and owner wait checkpointTS
of processor to be t2 for execute DDL `drop table t2`

### What is changed and how it works?
2, close the sorter
3, sort it first
4, don't let ts fallback when some tables is removed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
will add in https://github.com/pingcap/ticdc/pull/180

Code changes



Side effects



Related changes


