### PR TITLE
Split DMLs into independent groups, execute them concurrently

### DIFF
--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -116,7 +116,7 @@ func (h *ddlHandler) ExecDDL(ctx context.Context, sinkURI string, txn model.Txn)
 	defer db.Close()
 	s := sink.NewMySQLSinkDDLOnly(db)
 
-	err = s.Emit(ctx, txn)
+	err = s.EmitDDL(ctx, txn)
 	return errors.Trace(err)
 }
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -573,7 +573,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 		if len(pendingTxns) == 0 {
 			return nil
 		}
-		if err := p.sink.Emit(ctx2, pendingTxns...); err != nil {
+		if err := p.sink.EmitDMLs(ctx2, pendingTxns...); err != nil {
 			return errors.Trace(err)
 		}
 		txnCounter.WithLabelValues("executed", p.changefeedID, p.captureID).Add(float64(len(pendingTxns)))

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -65,7 +65,7 @@ func (s EmitSuite) TestShouldExecDDL(c *check.C) {
 	mock.ExpectCommit()
 
 	// Execute
-	err = sink.Emit(context.Background(), t)
+	err = sink.EmitDDL(context.Background(), t)
 
 	// Validate
 	c.Assert(err, check.IsNil)
@@ -101,7 +101,7 @@ func (s EmitSuite) TestShouldIgnoreCertainDDLError(c *check.C) {
 	mock.ExpectExec(t.DDL.Job.Query).WillReturnError(&ignorable)
 
 	// Execute
-	err = sink.Emit(context.Background(), t)
+	err = sink.EmitDDL(context.Background(), t)
 
 	// Validate
 	c.Assert(err, check.IsNil)
@@ -185,7 +185,7 @@ func (s EmitSuite) TestShouldExecReplaceInto(c *check.C) {
 	mock.ExpectCommit()
 
 	// Execute
-	err = sink.Emit(context.Background(), t)
+	err = sink.EmitDMLs(context.Background(), t)
 
 	// Validate
 	c.Assert(err, check.IsNil)
@@ -226,7 +226,7 @@ func (s EmitSuite) TestShouldExecDelete(c *check.C) {
 	mock.ExpectCommit()
 
 	// Execute
-	err = sink.Emit(context.Background(), t)
+	err = sink.EmitDMLs(context.Background(), t)
 
 	// Validate
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -232,3 +232,41 @@ func (s EmitSuite) TestShouldExecDelete(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mock.ExpectationsWereMet(), check.IsNil)
 }
+
+type splitSuite struct{}
+
+var _ = check.Suite(&splitSuite{})
+
+func (s *splitSuite) TestCanHandleEmptyInput(c *check.C) {
+	c.Assert(splitIndependentGroups(nil), check.HasLen, 0)
+}
+
+func (s *splitSuite) TestShouldSplitByTable(c *check.C) {
+	var dmls []*model.DML
+	addDMLs := func(n int, db, tbl string) {
+		for i := 0; i < n; i++ {
+			dml := model.DML{
+				Database: db,
+				Table:    tbl,
+			}
+			dmls = append(dmls, &dml)
+		}
+	}
+	addDMLs(3, "db", "tbl1")
+	addDMLs(2, "db", "tbl2")
+	addDMLs(2, "db", "tbl1")
+	addDMLs(2, "db2", "tbl2")
+
+	groups := splitIndependentGroups(dmls)
+
+	assertAllAreFromTbl := func(dmls []*model.DML, db, tbl string) {
+		for _, dml := range dmls {
+			c.Assert(dml.Database, check.Equals, db)
+			c.Assert(dml.Table, check.Equals, tbl)
+		}
+	}
+	c.Assert(groups, check.HasLen, 3)
+	assertAllAreFromTbl(groups[0], "db", "tbl1")
+	assertAllAreFromTbl(groups[1], "db", "tbl2")
+	assertAllAreFromTbl(groups[2], "db2", "tbl2")
+}

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -22,8 +22,10 @@ import (
 
 // Sink is an abstraction for anything that a changefeed may emit into.
 type Sink interface {
-	// Emit saves the specified transactions to the sink backend
-	Emit(ctx context.Context, txns ...model.Txn) error
+	// EmitDMLs saves the specified DMLs to the sink backend
+	EmitDMLs(ctx context.Context, txn ...model.Txn) error
+	// EmitDDL saves the specified DDL to the sink backend
+	EmitDDL(ctx context.Context, txn model.Txn) error
 	// Close does not guarantee delivery of outstanding messages.
 	Close() error
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`model.Txn`s are executed one by one in `mysqlSink`.


### What is changed and how it works?

Try to execute DML SQLs concurrently.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test