### PR TITLE
Add a metric to track the number of txns resolved in one go

### DIFF
--- a/cdc/puller/metrics.go
+++ b/cdc/puller/metrics.go
@@ -23,9 +23,18 @@ var (
 			Name:      "event_count",
 			Help:      "The number of events received.",
 		}, []string{"captureID", "type"})
+	resolvedTxnsBatchSize = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "ticdc",
+			Subsystem: "puller",
+			Name:      "resolved_txns_batch_size",
+			Help:      "The number of txns resolved in one go.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 16),
+		})
 )
 
 // InitMetrics registers all metrics in this file
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(eventCounter)
+	registry.MustRegister(resolvedTxnsBatchSize)
 }

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -200,6 +200,7 @@ func collectRawTxns(
 					return errors.Trace(err)
 				}
 			}
+			resolvedTxnsBatchSize.Observe(float64(len(readyTxns)))
 			if len(readyTxns) == 0 {
 				log.Info("Forwarding fake txn", zap.Uint64("ts", resolvedTs))
 				fakeTxn := model.RawTxn{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When fine tuning performance, it would be helpful to know the statistics of the txns resolved in one go.

### What is changed and how it works?

Add a metric.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test