### PR TITLE
processor: make the buffer larger in processor and puller to improve performance

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -599,7 +599,6 @@ func (p *processor) syncResolved(ctx context.Context) error {
 				log.Warn("Receive non-DDL txn from ddlJobsCh", zap.Uint64("ts", t.Ts))
 				continue
 			}
-			log.Info("add ddl job", zap.Any("job", t.DDL.Job))
 			p.schemaStorage.AddJob(t.DDL.Job)
 			if err := flush(ctx); err != nil {
 				return errors.Trace(err)
@@ -621,7 +620,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 					return errors.Trace(ctx.Err())
 				}
 			}
-			log.Info("handle ddl", zap.Uint64("ts", rawTxn.Ts))
+
 			if err := p.schemaStorage.HandlePreviousDDLJobIfNeed(rawTxn.Ts); err != nil {
 				return errors.Trace(err)
 			}

--- a/cdc/puller/buffer.go
+++ b/cdc/puller/buffer.go
@@ -14,7 +14,7 @@ type BufferEntry = model.KvOrResolved
 type Buffer chan BufferEntry
 
 func makeBuffer() Buffer {
-	return make(Buffer)
+	return make(Buffer, 8)
 }
 
 // AddEntry adds an entry to the buffer

--- a/cdc/puller/buffer_test.go
+++ b/cdc/puller/buffer_test.go
@@ -64,9 +64,14 @@ func (bs *bufferSuite) TestWaitsCanBeCanceled(c *check.C) {
 	defer cancel()
 	stopped := make(chan struct{})
 	go func() {
-		err := b.AddEntry(timeout, BufferEntry{KV: &model.RawKVEntry{Ts: 111}})
-		c.Assert(err, check.Equals, context.DeadlineExceeded)
-		close(stopped)
+		for {
+			err := b.AddEntry(timeout, BufferEntry{KV: &model.RawKVEntry{Ts: 111}})
+			if err == context.DeadlineExceeded {
+				close(stopped)
+				return
+			}
+			c.Assert(err, check.Equals, nil)
+		}
 	}()
 	select {
 	case <-stopped:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TiCDC sync is too slow.

### What is changed and how it works?
make the buffer larger in processor and puller, lead to push revolved ts faster.

At least 10x better performance.



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test