### PR TITLE
Delete from map directly

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -376,7 +376,6 @@ func (o *ownerImpl) addCapture(info *model.CaptureInfo) {
 }
 
 func (o *ownerImpl) handleMarkdownProcessor(ctx context.Context) {
-	var deleted []string
 	for id := range o.markDownProcessor {
 		err := DeleteCaptureInfo(ctx, id, o.etcdClient)
 		if err != nil {
@@ -384,10 +383,6 @@ func (o *ownerImpl) handleMarkdownProcessor(ctx context.Context) {
 			continue
 		}
 
-		deleted = append(deleted, id)
-	}
-
-	for _, id := range deleted {
 		log.Info("delete capture info", zap.String("id", id))
 		delete(o.markDownProcessor, id)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

All capture IDs are collected into a slice before they are deleted from the map.

In Go, it's OK to delete from a map while iterating over it. ([ref](https://github.com/golang/go/issues/9926#issuecomment-74988212))


### What is changed and how it works?

Delete while iterating.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test