### PR TITLE
Fix TestShouldSplitByTable

### DIFF
--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -15,6 +15,7 @@ package sink
 
 import (
 	"context"
+	"sort"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	dmysql "github.com/go-sql-driver/mysql"
@@ -266,6 +267,14 @@ func (s *splitSuite) TestShouldSplitByTable(c *check.C) {
 		}
 	}
 	c.Assert(groups, check.HasLen, 3)
+	sort.Slice(groups, func(i, j int) bool {
+		tblI := groups[i][0]
+		tblJ := groups[j][0]
+		if tblI.Database != tblJ.Database {
+			return tblI.Database < tblJ.Database
+		}
+		return tblI.Table < tblJ.Table
+	})
 	assertAllAreFromTbl(groups[0], "db", "tbl1")
 	assertAllAreFromTbl(groups[1], "db", "tbl2")
 	assertAllAreFromTbl(groups[2], "db2", "tbl2")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The test assumed that the splitted groups are in order, which is not true because it's generated from a `map`.

### What is changed and how it works?

Select the expected database and table by inspecting the first table in each group.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test