### PR TITLE
Add capture ID and process pid in status API

### DIFF
--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/pprof"
+	"os"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pingcap/log"
@@ -62,6 +63,8 @@ func (s *Server) startStatusHTTP() {
 type status struct {
 	Version string `json:"version"`
 	GitHash string `json:"git_hash"`
+	ID      string `json:"id"`
+	Pid     int    `json:"pid"`
 }
 
 func (s *Server) writeEtcdInfo(ctx context.Context, cli *clientv3.Client, w io.Writer) {
@@ -94,6 +97,10 @@ func (s *Server) handleStatus(w http.ResponseWriter, req *http.Request) {
 	st := status{
 		Version: "0.0.1",
 		GitHash: "",
+		Pid:     os.Getpid(),
+	}
+	if s.capture != nil {
+		st.ID = s.capture.info.ID
 	}
 	writeData(w, st)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We only store `CaptureID` in etcd, it is hard to match CDC server with a capture

### What is changed and how it works?

Add `id` and `pid` in the status HTTP API

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test