### PR TITLE
owner rebalance tables when marking processor down

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/roles"
 	"github.com/pingcap/ticdc/pkg/flags"
+	"github.com/pingcap/ticdc/pkg/util"
 	tidbkv "github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store"
 	"github.com/pingcap/tidb/store/tikv"
@@ -97,7 +98,7 @@ func (c *Capture) OnRunProcessor(p *processor) {
 // OnStopProcessor implements processorCallback.
 func (c *Capture) OnStopProcessor(p *processor, err error) {
 	// TODO: handle processor error
-	log.Info("stop to run processor", zap.String("changefeed id", p.changefeedID), zap.Error(err))
+	log.Info("stop to run processor", zap.String("changefeed id", p.changefeedID), util.ZapErrorFilter(err, context.Canceled))
 	c.procLock.Lock()
 	defer c.procLock.Unlock()
 	delete(c.processors, p.changefeedID)

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -252,24 +252,3 @@ func DeleteSubChangeFeedInfo(
 	_, err := cli.Delete(ctx, key)
 	return errors.Trace(err)
 }
-
-// DeleteCaptureFeeds removes all subchangefeedinfo belongs to a capture in etcd
-func DeleteCaptureFeeds(
-	ctx context.Context,
-	cli *clientv3.Client,
-	captureID string,
-	opts ...clientv3.OpOption,
-) error {
-	_, changefeeds, err := GetChangeFeeds(ctx, cli, opts...)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for cfID := range changefeeds {
-		key := GetEtcdKeySubChangeFeed(cfID, captureID)
-		_, err = cli.Delete(ctx, key)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -239,3 +239,24 @@ func PutChangeFeedStatus(
 	_, err = client.Put(ctx, key, value, opts...)
 	return errors.Trace(err)
 }
+
+// DeleteCaptureFeeds removes all subchangefeedinfo belongs to a capture in etcd
+func DeleteCaptureFeeds(
+	ctx context.Context,
+	cli *clientv3.Client,
+	captureID string,
+	opts ...clientv3.OpOption,
+) error {
+	_, changefeeds, err := GetChangeFeeds(ctx, cli, opts...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for cfID := range changefeeds {
+		key := GetEtcdKeySubChangeFeed(cfID, captureID)
+		_, err = cli.Delete(ctx, key)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -240,6 +240,7 @@ func PutChangeFeedStatus(
 	return errors.Trace(err)
 }
 
+// DeleteSubChangeFeedInfo deletes subchangefeedinfo from etcd
 func DeleteSubChangeFeedInfo(
 	ctx context.Context,
 	cli *clientv3.Client,

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -240,6 +240,18 @@ func PutChangeFeedStatus(
 	return errors.Trace(err)
 }
 
+func DeleteSubChangeFeedInfo(
+	ctx context.Context,
+	cli *clientv3.Client,
+	cfID string,
+	captureID string,
+	opts ...clientv3.OpOption,
+) error {
+	key := GetEtcdKeySubChangeFeed(cfID, captureID)
+	_, err := cli.Delete(ctx, key)
+	return errors.Trace(err)
+}
+
 // DeleteCaptureFeeds removes all subchangefeedinfo belongs to a capture in etcd
 func DeleteCaptureFeeds(
 	ctx context.Context,

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -143,26 +143,3 @@ func (s *etcdSuite) TestDeleteSubChangeFeedInfo(c *check.C) {
 	_, _, err = GetSubChangeFeedInfo(ctx, s.client, feedID, captureID)
 	c.Assert(errors.Cause(err), check.Equals, model.ErrSubChangeFeedInfoNotExists)
 }
-
-func (s *etcdSuite) TestDeleteCaptureFeeds(c *check.C) {
-	ctx := context.Background()
-	info := &model.SubChangeFeedInfo{
-		CheckPointTs: 100,
-		ResolvedTs:   200,
-		TableInfos: []*model.ProcessTableInfo{
-			{ID: 1, StartTs: 100},
-		},
-	}
-	feedID := "feedid"
-	captureID := "captureid"
-
-	_, err := s.client.Put(ctx, GetEtcdKeyChangeFeedConfig(feedID), "")
-	c.Assert(err, check.IsNil)
-	err = PutSubChangeFeedInfo(ctx, s.client, feedID, captureID, info)
-	c.Assert(err, check.IsNil)
-
-	err = DeleteCaptureFeeds(ctx, s.client, captureID)
-	c.Assert(err, check.IsNil)
-	_, _, err = GetSubChangeFeedInfo(ctx, s.client, feedID, captureID)
-	c.Assert(errors.Cause(err), check.Equals, model.ErrSubChangeFeedInfoNotExists)
-}

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -122,3 +122,26 @@ func (s *etcdSuite) TestGetPutSubchangeFeed(c *check.C) {
 	_, _, err = GetSubChangeFeedInfo(ctx, s.client, feedID, captureID)
 	c.Assert(errors.Cause(err), check.Equals, model.ErrSubChangeFeedInfoNotExists)
 }
+
+func (s *etcdSuite) TestDeleteCaptureFeeds(c *check.C) {
+	ctx := context.Background()
+	info := &model.SubChangeFeedInfo{
+		CheckPointTs: 100,
+		ResolvedTs:   200,
+		TableInfos: []*model.ProcessTableInfo{
+			{ID: 1, StartTs: 100},
+		},
+	}
+	feedID := "feedid"
+	captureID := "captureid"
+
+	_, err := s.client.Put(ctx, GetEtcdKeyChangeFeedConfig(feedID), "")
+	c.Assert(err, check.IsNil)
+	err = PutSubChangeFeedInfo(ctx, s.client, feedID, captureID, info)
+	c.Assert(err, check.IsNil)
+
+	err = DeleteCaptureFeeds(ctx, s.client, captureID)
+	c.Assert(err, check.IsNil)
+	_, _, err = GetSubChangeFeedInfo(ctx, s.client, feedID, captureID)
+	c.Assert(errors.Cause(err), check.Equals, model.ErrSubChangeFeedInfoNotExists)
+}

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -123,6 +123,27 @@ func (s *etcdSuite) TestGetPutSubchangeFeed(c *check.C) {
 	c.Assert(errors.Cause(err), check.Equals, model.ErrSubChangeFeedInfoNotExists)
 }
 
+func (s *etcdSuite) TestDeleteSubChangeFeedInfo(c *check.C) {
+	ctx := context.Background()
+	info := &model.SubChangeFeedInfo{
+		CheckPointTs: 100,
+		ResolvedTs:   200,
+		TableInfos: []*model.ProcessTableInfo{
+			{ID: 1, StartTs: 100},
+		},
+	}
+	feedID := "feedid"
+	captureID := "captureid"
+
+	err := PutSubChangeFeedInfo(ctx, s.client, feedID, captureID, info)
+	c.Assert(err, check.IsNil)
+
+	err = DeleteSubChangeFeedInfo(ctx, s.client, feedID, captureID)
+	c.Assert(err, check.IsNil)
+	_, _, err = GetSubChangeFeedInfo(ctx, s.client, feedID, captureID)
+	c.Assert(errors.Cause(err), check.Equals, model.ErrSubChangeFeedInfoNotExists)
+}
+
 func (s *etcdSuite) TestDeleteCaptureFeeds(c *check.C) {
 	ctx := context.Background()
 	info := &model.SubChangeFeedInfo{

--- a/cdc/model/owner_test.go
+++ b/cdc/model/owner_test.go
@@ -64,16 +64,16 @@ func (s *cloneSubChangeFeedInfoSuite) TestProcSnapshot(c *check.C) {
 		CheckPointTs: 0,
 		ResolvedTs:   20,
 		TableInfos: []*ProcessTableInfo{
-			{ID: 10},
+			{ID: 10, StartTs: 100},
 		},
 	}
 	cfID := "changefeed-1"
 	captureID := "capture-1"
 	snap := info.Snapshot(cfID, captureID)
 	c.Assert(snap.CfID, check.Equals, cfID)
-	c.Assert(snap.CaptureID, check.Equals, cfID)
+	c.Assert(snap.CaptureID, check.Equals, captureID)
 	c.Assert(snap.Tables, check.HasLen, 1)
-	c.Assert(snap.Tables[0].StartTs, check.Equals, 10)
+	c.Assert(snap.Tables[0].StartTs, check.Equals, uint64(100))
 }
 
 type removeTableSuite struct{}

--- a/cdc/model/owner_test.go
+++ b/cdc/model/owner_test.go
@@ -59,6 +59,23 @@ func (s *cloneSubChangeFeedInfoSuite) TestShouldBeDeepCopy(c *check.C) {
 	assertIsSnapshot()
 }
 
+func (s *cloneSubChangeFeedInfoSuite) TestProcSnapshot(c *check.C) {
+	info := SubChangeFeedInfo{
+		CheckPointTs: 0,
+		ResolvedTs:   20,
+		TableInfos: []*ProcessTableInfo{
+			{ID: 10},
+		},
+	}
+	cfID := "changefeed-1"
+	captureID := "capture-1"
+	snap := info.Snapshot(cfID, captureID)
+	c.Assert(snap.CfID, check.Equals, cfID)
+	c.Assert(snap.CaptureID, check.Equals, cfID)
+	c.Assert(snap.Tables, check.HasLen, 1)
+	c.Assert(snap.Tables[0].StartTs, check.Equals, 10)
+}
+
 type removeTableSuite struct{}
 
 var _ = check.Suite(&removeTableSuite{})

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -366,6 +366,11 @@ func (o *ownerImpl) handleMarkdownProcessor(ctx context.Context) {
 			log.Warn("failed to delete key", zap.Error(err))
 			continue
 		}
+		err = kv.DeleteCaptureFeeds(ctx, o.etcdClient, id)
+		if err != nil {
+			log.Warn("failed to delete all subchangefeed infos", zap.Error(err))
+			continue
+		}
 
 		log.Info("delete capture info", zap.String("id", id))
 		delete(o.markDownProcessor, id)

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -108,22 +108,6 @@ func (c *changeFeed) updateProcessorInfos(processInfos model.ProcessorsInfos) {
 	c.ProcessorInfos = processInfos
 }
 
-// filter return true if we should not sync the table to downstream.
-// we can add configuration support at the detail.
-func filter(_ *model.ChangeFeedDetail, table schema.TableName) bool {
-	ignoreSchema := []string{"INFORMATION_SCHEMA", "PERFORMANCE_SCHEMA", "mysql"}
-
-	log.Debug("filter table", zap.Stringer("table", table))
-
-	for _, schema := range ignoreSchema {
-		if schema == table.Schema {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (c *changeFeed) reAddTable(id, startTs uint64) {
 	c.orphanTables[id] = model.ProcessTableInfo{
 		ID:      id,

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,17 +69,16 @@ func runEServer(cmd *cobra.Command, args []string) error {
 	go func() {
 		sig := <-sc
 		log.Info("got signal to exit", zap.Stringer("signal", sig))
-		server.Close(ctx, cancel)
+		cancel()
 	}()
 
 	err = server.Run(ctx)
-	if err != nil {
-		if errors.Cause(err) == context.Canceled {
-			return nil
-		}
+	if err != nil && errors.Cause(err) != context.Canceled {
 		log.Error("run server", zap.String("error", errors.ErrorStack(err)))
 		return errors.Annotate(err, "run server")
 	}
+	server.Close()
+	log.Info("cdc server exits successfully")
 
 	return nil
 }

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
 )
@@ -83,4 +84,15 @@ func InitLogger(cfg *Config) error {
 	log.ReplaceGlobals(lg, _globalP)
 
 	return nil
+}
+
+// ZapErrorFilter wraps zap.Error, if err is in given filterErrors, it will be set to nil
+func ZapErrorFilter(err error, filterErrors ...error) zap.Field {
+	cause := errors.Cause(err)
+	for _, ferr := range filterErrors {
+		if cause == ferr {
+			return zap.Error(nil)
+		}
+	}
+	return zap.Error(err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add clean strategy for `SubChangefeedInfo` when a processor is down and table rebalance at the same time.

### What is changed and how it works?

When the owner marks a processor down, clean both `CaptureInfo` and all `SubChangeFeedInfo` belongs to the capture, and rebalance tables when marking processor down.
One exception, if the owner cleans the processor `SubChangeFeedInfo` and it crashes before table rebalance, some tables replication information is missing. In this scenario, the global `CheckpointTs` will not be forwarded until another owner is elected. In order to keep state management simple, we tend to add some recover mechanism in the owner's logic for this scenario, which will be solved in another PR.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test