### PR TITLE
fix table management when owner starts up

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -418,7 +418,7 @@ func (o *ownerImpl) handleWatchCapture() error {
 func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.ProcessorsInfos, detail *model.ChangeFeedDetail) (*changeFeed, error) {
 	checkpointTs := detail.GetCheckpointTs()
 	log.Info("Find new changefeed", zap.Reflect("detail", detail),
-		zap.Uint64("checkpoint ts", checkpointTs))
+		zap.String("id", id), zap.Uint64("checkpoint ts", checkpointTs))
 
 	schemaStorage, err := createSchemaStore(o.pdEndpoints)
 	if err != nil {
@@ -448,9 +448,7 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 
 		tables[tid] = table
 		if ts, ok := existingTables[tid]; ok {
-			log.Info("ignore existing replication table",
-				zap.Uint64("tableID", tid), zap.Stringer("table", table),
-				zap.String("changefeedID", id), zap.Uint64("checkpointTs", ts))
+			log.Debug("ignore known table", zap.Uint64("tid", tid), zap.Stringer("table", table), zap.Uint64("ts", ts))
 			continue
 		}
 		orphanTables[tid] = model.ProcessTableInfo{

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -432,10 +432,10 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 
 	ddlHandler := newDDLHandler(o.pdClient, checkpointTs)
 
-	existingTables := make(map[uint64]struct{})
+	existingTables := make(map[uint64]uint64)
 	for _, subCfInfo := range processorsInfos {
 		for _, tbl := range subCfInfo.TableInfos {
-			existingTables[tbl.ID] = struct{}{}
+			existingTables[tbl.ID] = subCfInfo.CheckPointTs
 		}
 	}
 
@@ -447,10 +447,10 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 		}
 
 		tables[tid] = table
-		if _, ok := existingTables[tid]; ok {
+		if ts, ok := existingTables[tid]; ok {
 			log.Info("ignore existing replication table",
 				zap.Uint64("tableID", tid), zap.Stringer("table", table),
-				zap.String("changefeedID", id))
+				zap.String("changefeedID", id), zap.Uint64("checkpointTs", ts))
 			continue
 		}
 		orphanTables[tid] = model.ProcessTableInfo{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently when a capture becomes owner, it always scans all changefeeds, and re-assign each table to be replicated.

### What is changed and how it works?

Filter tables already in replication state in all processors, don't re-assign them.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test