### PR TITLE
close channel p.executedTxns where we use it as sender

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -477,7 +477,6 @@ func (p *processor) globalResolvedWorker(ctx context.Context) error {
 
 	defer func() {
 		close(p.resolvedTxns)
-		close(p.executedTxns)
 	}()
 
 	retryCfg := backoff.WithMaxRetries(
@@ -580,6 +579,11 @@ func (p *processor) syncResolved(ctx context.Context) error {
 		pendingTxns = pendingTxns[:0]
 		return nil
 	}
+
+	defer func() {
+		close(p.executedTxns)
+	}()
+
 	for {
 		select {
 		case rawTxn, ok := <-p.ddlJobsCh:

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -475,9 +475,7 @@ func (p *processor) globalResolvedWorker(ctx context.Context) error {
 		lastGlobalResolvedTs uint64
 	)
 
-	defer func() {
-		close(p.resolvedTxns)
-	}()
+	defer close(p.resolvedTxns)
 
 	retryCfg := backoff.WithMaxRetries(
 		backoff.WithContext(
@@ -580,9 +578,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 		return nil
 	}
 
-	defer func() {
-		close(p.executedTxns)
-	}()
+	defer close(p.executedTxns)
 
 	for {
 		select {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a potential panic of `send on closed channel`, which is caused by the branch of a select that is chosen could be non-deterministic (except for the `default` branch).

### What is changed and how it works?

Close the channel p.executedTxns where we use it as sender

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test