### PR TITLE
Remove unused code copied from binlog

### DIFF
--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -27,7 +27,7 @@ func setUpPullerAndSchema(ctx context.Context, c *check.C, sqls ...string) (*pul
 	}
 
 	jobs := pm.GetDDLJobs()
-	schemaStorage, err := schema.NewStorage(jobs, false)
+	schemaStorage, err := schema.NewStorage(jobs)
 	c.Assert(err, check.IsNil)
 	err = schemaStorage.HandlePreviousDDLJobIfNeed(jobs[len(jobs)-1].BinlogInfo.FinishedTS)
 	c.Assert(err, check.IsNil)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -667,7 +667,7 @@ func createSchemaStore(pdEndpoints []string) (*schema.Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	schemaStorage, err := schema.NewStorage(jobs, false)
+	schemaStorage, err := schema.NewStorage(jobs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/schema/storage_test.go
+++ b/cdc/schema/storage_test.go
@@ -65,7 +65,7 @@ func (t *schemaSuite) TestSchema(c *C) {
 		BinlogInfo: &model.HistoryInfo{SchemaVersion: 2, DBInfo: dbInfo, FinishedTS: 125}})
 
 	// reconstruct the local schema
-	schema, err := NewStorage(jobs, false)
+	schema, err := NewStorage(jobs)
 	c.Assert(err, IsNil)
 	err = schema.HandlePreviousDDLJobIfNeed(123)
 	c.Assert(err, IsNil)
@@ -82,7 +82,7 @@ func (t *schemaSuite) TestSchema(c *C) {
 			Query:      "drop database test",
 		},
 	)
-	schema, err = NewStorage(jobs, false)
+	schema, err = NewStorage(jobs)
 	c.Assert(err, IsNil)
 	err = schema.HandlePreviousDDLJobIfNeed(124)
 	c.Assert(err, IsNil)
@@ -91,7 +91,7 @@ func (t *schemaSuite) TestSchema(c *C) {
 	jobs = jobs[:0]
 	jobs = append(jobs, job)
 	jobs = append(jobs, jobDup)
-	schema, err = NewStorage(jobs, false)
+	schema, err = NewStorage(jobs)
 	c.Assert(err, IsNil)
 	err = schema.HandlePreviousDDLJobIfNeed(125)
 	c.Log(err)
@@ -110,7 +110,7 @@ func (t *schemaSuite) TestSchema(c *C) {
 			Query:      "drop database test",
 		},
 	)
-	schema, err = NewStorage(jobs, false)
+	schema, err = NewStorage(jobs)
 	c.Assert(err, IsNil)
 	err = schema.HandlePreviousDDLJobIfNeed(123)
 	c.Assert(errors.IsNotFound(err), IsTrue)
@@ -208,7 +208,7 @@ func (*schemaSuite) TestTable(c *C) {
 	jobs = append(jobs, job)
 
 	// reconstruct the local schema
-	schema, err := NewStorage(jobs, false)
+	schema, err := NewStorage(jobs)
 	c.Assert(err, IsNil)
 	err = schema.HandlePreviousDDLJobIfNeed(126)
 	c.Assert(err, IsNil)
@@ -239,7 +239,7 @@ func (*schemaSuite) TestTable(c *C) {
 			Query:      "truncate table " + tbName.O,
 		},
 	)
-	schema1, err := NewStorage(jobs, false)
+	schema1, err := NewStorage(jobs)
 	c.Assert(err, IsNil)
 	err = schema1.HandlePreviousDDLJobIfNeed(127)
 	c.Assert(err, IsNil)
@@ -261,7 +261,7 @@ func (*schemaSuite) TestTable(c *C) {
 			Query:      "drop table " + tbName.O,
 		},
 	)
-	schema2, err := NewStorage(jobs, false)
+	schema2, err := NewStorage(jobs)
 	c.Assert(err, IsNil)
 	err = schema2.HandlePreviousDDLJobIfNeed(128)
 	c.Assert(err, IsNil)
@@ -279,7 +279,7 @@ func (*schemaSuite) TestTable(c *C) {
 }
 
 func (t *schemaSuite) TestHandleDDL(c *C) {
-	schema, err := NewStorage(nil, false)
+	schema, err := NewStorage(nil)
 	c.Assert(err, IsNil)
 	dbName := model.NewCIStr("Test")
 	colName := model.NewCIStr("A")
@@ -389,17 +389,6 @@ func (t *schemaSuite) TestHandleDDL(c *C) {
 			c.Assert(ok, IsFalse)
 		}
 	}
-}
-
-func (t *schemaSuite) TestAddImplicitColumn(c *C) {
-	tbl := model.TableInfo{}
-
-	addImplicitColumn(&tbl)
-
-	c.Assert(tbl.Columns, HasLen, 1)
-	c.Assert(tbl.Columns[0].ID, Equals, int64(implicitColID))
-	c.Assert(tbl.Indices, HasLen, 1)
-	c.Assert(tbl.Indices[0].Primary, IsTrue)
 }
 
 func testDoDDLAndCheck(c *C, schema *Storage, job *model.Job, isErr bool, sql string, expectedSchema string, expectedTable string) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The implicit column part of schema is never used. In fact it's not even used in binlog now.

### What is changed and how it works?

Remove unused code.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test