### PR TITLE
Refactor, get table name directly

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -146,17 +146,17 @@ func (m *Mounter) mountIndexKVEntry(idx *indexKVEntry) (*model.DML, error) {
 	}, nil
 }
 
-func (m *Mounter) fetchTableInfo(tableID int64) (tableInfo *schema.TableInfo, tableName *schema.TableName, err error) {
+func (m *Mounter) fetchTableInfo(tableID int64) (tableInfo *schema.TableInfo, tableName schema.TableName, err error) {
 	tableInfo, exist := m.schemaStorage.TableByID(tableID)
 	if !exist {
-		return nil, nil, errors.Errorf("can not find table, id: %d", tableID)
+		err = errors.Errorf("can not find table, id: %d", tableID)
+		return
 	}
 
-	database, table, exist := m.schemaStorage.SchemaAndTableName(tableID)
+	tableName, exist = m.schemaStorage.GetTableNameByID(tableID)
 	if !exist {
-		return nil, nil, errors.Errorf("can not find table, id: %d", tableID)
+		err = errors.Errorf("can not find table, id: %d", tableID)
 	}
-	tableName = &schema.TableName{Schema: database, Table: table}
 	return
 }
 

--- a/cdc/schema/storage.go
+++ b/cdc/schema/storage.go
@@ -179,14 +179,10 @@ func (s *Storage) SchemaMetaVersion() int64 {
 	return s.schemaMetaVersion
 }
 
-// SchemaAndTableName returns the tableName by table id
-func (s *Storage) SchemaAndTableName(id int64) (string, string, bool) {
-	tn, ok := s.tableIDToName[id]
-	if !ok {
-		return "", "", false
-	}
-
-	return tn.Schema, tn.Table, true
+// GetTableNameByID looks up a TableName with the given table id
+func (s *Storage) GetTableNameByID(id int64) (TableName, bool) {
+	name, ok := s.tableIDToName[id]
+	return name, ok
 }
 
 // GetTableIDByName returns the tableID by table schemaName and tableName

--- a/cdc/schema/storage_test.go
+++ b/cdc/schema/storage_test.go
@@ -269,8 +269,8 @@ func (*schemaSuite) TestTable(c *C) {
 
 	_, ok = schema2.TableByID(tblInfo.ID)
 	c.Assert(ok, IsFalse)
-	// test schemaAndTableName
-	_, _, ok = schema1.SchemaAndTableName(9)
+	// test GetTableNameByID
+	_, ok = schema1.GetTableNameByID(9)
 	c.Assert(ok, IsTrue)
 	// drop schema
 	_, err = schema1.DropSchema(3)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

A `TableName` is looked up and unpacked, and then recreated outside.

### What is changed and how it works?

Return the `TableName` direclty.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test