### PR TITLE
mounter: don't build delete dml when set index key

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -119,6 +119,10 @@ func (m *Mounter) mountRowKVEntry(row *rowKVEntry) (*model.DML, error) {
 }
 
 func (m *Mounter) mountIndexKVEntry(idx *indexKVEntry) (*model.DML, error) {
+	// skip set index KV
+	if !idx.Delete {
+		return nil, nil
+	}
 	tableInfo, tableName, err := m.fetchTableInfo(idx.TableID)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -27,7 +27,7 @@ func setUpPullerAndSchema(ctx context.Context, c *check.C, sqls ...string) (*pul
 	}
 
 	jobs := pm.GetDDLJobs()
-	schemaStorage, err := schema.NewStorage(jobs, false)
+	schemaStorage, err := schema.NewStorage(jobs)
 	c.Assert(err, check.IsNil)
 	err = schemaStorage.HandlePreviousDDLJobIfNeed(jobs[len(jobs)-1].BinlogInfo.FinishedTS)
 	c.Assert(err, check.IsNil)

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -27,7 +27,7 @@ func setUpPullerAndSchema(ctx context.Context, c *check.C, sqls ...string) (*pul
 	}
 
 	jobs := pm.GetDDLJobs()
-	schemaStorage, err := schema.NewStorage(jobs)
+	schemaStorage, err := schema.NewStorage(jobs, false)
 	c.Assert(err, check.IsNil)
 	err = schemaStorage.HandlePreviousDDLJobIfNeed(jobs[len(jobs)-1].BinlogInfo.FinishedTS)
 	c.Assert(err, check.IsNil)
@@ -73,14 +73,6 @@ func (cs *mountTxnsSuite) TestInsertPkNotHandle(c *check.C) {
 			{
 				Database: "testDB",
 				Table:    "test1",
-				Tp:       model.DeleteDMLType,
-				Values: map[string]types.Datum{
-					"id": types.NewBytesDatum([]byte("ttt")),
-				},
-			},
-			{
-				Database: "testDB",
-				Table:    "test1",
 				Tp:       model.InsertDMLType,
 				Values: map[string]types.Datum{
 					"id": types.NewBytesDatum([]byte("ttt")),
@@ -97,14 +89,6 @@ func (cs *mountTxnsSuite) TestInsertPkNotHandle(c *check.C) {
 	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
-			{
-				Database: "testDB",
-				Table:    "test1",
-				Tp:       model.DeleteDMLType,
-				Values: map[string]types.Datum{
-					"id": types.NewBytesDatum([]byte("vvv")),
-				},
-			},
 			{
 				Database: "testDB",
 				Table:    "test1",
@@ -166,14 +150,6 @@ func (cs *mountTxnsSuite) TestInsertPkIsHandle(c *check.C) {
 			{
 				Database: "testDB",
 				Table:    "test1",
-				Tp:       model.DeleteDMLType,
-				Values: map[string]types.Datum{
-					"a": types.NewIntDatum(888),
-				},
-			},
-			{
-				Database: "testDB",
-				Table:    "test1",
 				Tp:       model.InsertDMLType,
 				Values: map[string]types.Datum{
 					"id": types.NewIntDatum(777),
@@ -190,14 +166,6 @@ func (cs *mountTxnsSuite) TestInsertPkIsHandle(c *check.C) {
 	cs.assertTableTxnEquals(c, t, model.Txn{
 		Ts: rawTxn.Entries[0].Ts,
 		DMLs: []*model.DML{
-			{
-				Database: "testDB",
-				Table:    "test1",
-				Tp:       model.DeleteDMLType,
-				Values: map[string]types.Datum{
-					"a": types.NewIntDatum(888),
-				},
-			},
 			{
 				Database: "testDB",
 				Table:    "test1",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
don't build delete dml when set index key

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test