### PR TITLE
Only emit log when the changefeed is indeed updated

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -620,15 +620,23 @@ func (o *ownerImpl) calcResolvedTs() error {
 			cfInfo.Status = model.ChangeFeedWaitToExecDDL
 		}
 
-		cfInfo.ResolvedTs = minResolvedTs
+		var tsUpdated bool
+
+		if minResolvedTs > cfInfo.ResolvedTs {
+			cfInfo.ResolvedTs = minResolvedTs
+			tsUpdated = true
+		}
 
 		if minCheckpointTs > cfInfo.CheckpointTs {
 			cfInfo.CheckpointTs = minCheckpointTs
+			tsUpdated = true
 		}
 
-		log.Debug("update changefeed", zap.String("id", cfInfo.ID),
-			zap.Uint64("checkpoint ts", minCheckpointTs),
-			zap.Uint64("resolved ts", minResolvedTs))
+		if tsUpdated {
+			log.Debug("update changefeed", zap.String("id", cfInfo.ID),
+				zap.Uint64("checkpoint ts", minCheckpointTs),
+				zap.Uint64("resolved ts", minResolvedTs))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

There are too many "update changefeed" messages in the log when debugging.

### What is changed and how it works?

Only emit the log when the changefeed is indeed updated.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
    
    I ran `test.sh --debug` and check that the message is only printed when the fake txns forward the global resolved ts.