### PR TITLE
Add support for `cdc cli` to read filter configs from file

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -70,7 +70,7 @@ func (detail *ChangeFeedDetail) ShouldIgnoreTable(db, tbl string) bool {
 // CDC only supports filtering by database/table now.
 func (detail *ChangeFeedDetail) FilterTxn(t *Txn) {
 	if t.IsDDL() {
-		if detail.ShouldIgnoreTable(t.DDL.Database, "") {
+		if detail.ShouldIgnoreTable(t.DDL.Database, t.DDL.Table) {
 			t.DDL = nil
 		}
 	} else {

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -64,4 +64,11 @@ func (s *filterSuite) TestShouldUseCustomRules(c *check.C) {
 	}}
 	detail.FilterTxn(&txn)
 	c.Assert(txn.DMLs, check.HasLen, 2)
+
+	txn = Txn{DDL: &DDL{
+		Database: "sns",
+		Table:    "log",
+	}}
+	detail.FilterTxn(&txn)
+	c.Assert(txn.DDL, check.IsNil)
 }

--- a/cmd/cdc.toml
+++ b/cmd/cdc.toml
@@ -1,0 +1,12 @@
+filter-case-sensitive = false
+
+[filter-rules]
+ignore-dbs = ["test", "sys"]
+
+[[filter-rules.do-tables]]
+db-name = "sns"
+tbl-name = "user"
+
+[[filter-rules.do-tables]]
+db-name = "sns"
+tbl-name = "following"

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -3,7 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
+
+	"github.com/pingcap/tidb-tools/pkg/filter"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pingcap/errors"
 
 	"github.com/coreos/etcd/clientv3"
 	_ "github.com/go-sql-driver/mysql" // mysql driver
@@ -23,14 +29,21 @@ func init() {
 	cliCmd.Flags().Uint64Var(&startTs, "start-ts", 0, "start ts of changefeed")
 	cliCmd.Flags().Uint64Var(&startTs, "target-ts", 0, "target ts of changefeed")
 	cliCmd.Flags().StringVar(&sinkURI, "sink-uri", "root@tcp(127.0.0.1:3306)/test", "sink uri")
+	cliCmd.Flags().StringVar(&configFile, "config", "", "path of the configuration file")
 }
 
 var (
-	pdAddress string
-	startTs   uint64
-	targetTs  uint64
-	sinkURI   string
+	pdAddress  string
+	startTs    uint64
+	targetTs   uint64
+	sinkURI    string
+	configFile string
 )
+
+type config struct {
+	FilterCaseSensitive bool          `toml:"filter-case-sensitive"`
+	FilterRules         *filter.Rules `toml:"filter-rules"`
+}
 
 var cliCmd = &cobra.Command{
 	Use:   "cli",
@@ -59,14 +72,51 @@ var cliCmd = &cobra.Command{
 			}
 			startTs = oracle.ComposeTS(ts, logical)
 		}
-		detail := &model.ChangeFeedDetail{
-			SinkURI:    sinkURI,
-			Opts:       make(map[string]string),
-			CreateTime: time.Now(),
-			StartTs:    startTs,
-			TargetTs:   targetTs,
+
+		cfg := new(config)
+		if len(configFile) > 0 {
+			if err := strictDecodeFile(configFile, "cdc", cfg); err != nil {
+				return err
+			}
 		}
-		fmt.Printf("create changefeed ID: %s detail %+v\n", id, detail)
+
+		detail := &model.ChangeFeedDetail{
+			SinkURI:             sinkURI,
+			Opts:                make(map[string]string),
+			CreateTime:          time.Now(),
+			StartTs:             startTs,
+			TargetTs:            targetTs,
+			FilterRules:         cfg.FilterRules,
+			FilterCaseSensitive: cfg.FilterCaseSensitive,
+		}
+		d, err := detail.Marshal()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("create changefeed ID: %s detail %s\n", id, d)
 		return kv.SaveChangeFeedDetail(context.Background(), cli, detail, id)
 	},
+}
+
+// strictDecodeFile decodes the toml file strictly. If any item in confFile file is not mapped
+// into the Config struct, issue an error and stop the server from starting.
+func strictDecodeFile(path, component string, cfg interface{}) error {
+	metaData, err := toml.DecodeFile(path, cfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if undecoded := metaData.Undecoded(); len(undecoded) > 0 {
+		var b strings.Builder
+		for i, item := range undecoded {
+			if i != 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(item.String())
+		}
+		err = errors.Errorf("component %s's config file %s contained unknown configuration options: %s",
+			component, path, b.String())
+	}
+
+	return errors.Trace(err)
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,75 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/pingcap/tidb-tools/pkg/filter"
+
+	"github.com/pingcap/check"
+)
+
+func TestSuite(t *testing.T) { check.TestingT(t) }
+
+type decodeFileSuite struct{}
+
+var _ = check.Suite(&decodeFileSuite{})
+
+func (s *decodeFileSuite) TestCanDecodeTOML(c *check.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+filter-case-sensitive = false
+
+[filter-rules]
+ignore-dbs = ["test", "sys"]
+
+[[filter-rules.do-tables]]
+db-name = "sns"
+tbl-name = "user"
+
+[[filter-rules.do-tables]]
+db-name = "sns"
+tbl-name = "following"
+`
+	err := ioutil.WriteFile(path, []byte(content), 0644)
+	c.Assert(err, check.IsNil)
+
+	cfg := new(config)
+	err = strictDecodeFile(path, "cdc", &cfg)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(cfg.FilterCaseSensitive, check.IsFalse)
+	c.Assert(cfg.FilterRules.IgnoreDBs, check.DeepEquals, []string{"test", "sys"})
+	c.Assert(cfg.FilterRules.DoTables, check.DeepEquals, []*filter.Table{
+		{Schema: "sns", Name: "user"},
+		{Schema: "sns", Name: "following"},
+	})
+}
+
+func (s *decodeFileSuite) TestShouldReturnErrForUnknownCfgs(c *check.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `filter-case-insensitive = true`
+	err := ioutil.WriteFile(path, []byte(content), 0644)
+	c.Assert(err, check.IsNil)
+
+	cfg := new(config)
+	err = strictDecodeFile(path, "cdc", &cfg)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, ".*unknown config.*")
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

A command line interface is needed to test filter rules.

### What is changed and how it works?

1. Add a `config` option for `cdc cli` to read configurations like `filter-rules` from a file
1. Fix a bug

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test
   Change `run.sh` to specify a config file and observe that tables are filtered according to the configuration.