### PR TITLE
support changefeed stop/pause/remove operation

### DIFF
--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -15,9 +15,16 @@ package cdc
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+const (
+	opVarAdminJob     = "job"
+	opVarChangefeedID = "cf-id"
 )
 
 type commonResp struct {
@@ -25,12 +32,7 @@ type commonResp struct {
 	Message string `json:"message"`
 }
 
-func (s *Server) handleResignOwner(w http.ResponseWriter, req *http.Request) {
-	if req.Method != http.MethodPost {
-		writeError(w, http.StatusBadRequest, errors.New("this api only supports POST method"))
-		return
-	}
-	err := s.capture.ownerManager.ResignOwner(req.Context())
+func handleOwnerResp(w http.ResponseWriter, err error) {
 	if err != nil {
 		if errors.Cause(err) == concurrency.ErrElectionNotLeader {
 			writeError(w, http.StatusBadRequest, err)
@@ -40,4 +42,37 @@ func (s *Server) handleResignOwner(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	writeData(w, commonResp{Status: true})
+}
+
+func (s *Server) handleResignOwner(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		writeError(w, http.StatusBadRequest, errors.New("this api only supports POST method"))
+		return
+	}
+	err := s.capture.ownerManager.ResignOwner(req.Context())
+	handleOwnerResp(w, err)
+}
+
+func (s *Server) handleChangefeedAdmin(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		writeError(w, http.StatusBadRequest, errors.New("this api only supports POST method"))
+		return
+	}
+	err := req.ParseForm()
+	if err != nil {
+		writeInternalServerError(w, err)
+		return
+	}
+	typeStr := req.Form.Get(opVarAdminJob)
+	typ, err := strconv.ParseInt(typeStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, errors.Errorf("invalid admin job type: %s", typeStr))
+		return
+	}
+	job := &model.AdminJob{
+		CfID: req.Form.Get(opVarChangefeedID),
+		Type: model.AdminJobType(typ),
+	}
+	err = s.capture.ownerWorker.EnqueueJob(job)
+	handleOwnerResp(w, err)
 }

--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	opVarAdminJob     = "job"
+	opVarAdminJob     = "admin-job"
 	opVarChangefeedID = "cf-id"
 )
 
@@ -69,7 +69,7 @@ func (s *Server) handleChangefeedAdmin(w http.ResponseWriter, req *http.Request)
 		writeError(w, http.StatusBadRequest, errors.Errorf("invalid admin job type: %s", typeStr))
 		return
 	}
-	job := &model.AdminJob{
+	job := model.AdminJob{
 		CfID: req.Form.Get(opVarChangefeedID),
 		Type: model.AdminJobType(typ),
 	}

--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -44,6 +44,7 @@ func (s *Server) startStatusHTTP() {
 	serverMux.HandleFunc("/status", s.handleStatus)
 	serverMux.HandleFunc("/debug/info", s.handleDebugInfo)
 	serverMux.HandleFunc("/capture/owner/resign", s.handleResignOwner)
+	serverMux.HandleFunc("/capture/owner/admin", s.handleChangefeedAdmin)
 
 	prometheus.DefaultGatherer = registry
 	serverMux.Handle("/metrics", promhttp.Handler())

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -102,6 +102,13 @@ func GetChangeFeedDetail(ctx context.Context, cli *clientv3.Client, id string, o
 	return detail, errors.Trace(err)
 }
 
+// DeleteChangeFeedDetail deletes a changefeed config from etcd
+func DeleteChangeFeedDetail(ctx context.Context, cli *clientv3.Client, id string, opts ...clientv3.OpOption) error {
+	key := GetEtcdKeyChangeFeedConfig(id)
+	_, err := cli.Delete(ctx, key, opts...)
+	return errors.Trace(err)
+}
+
 // GetChangeFeedInfo queries the checkpointTs and resovledTs of a given changefeed
 func GetChangeFeedInfo(ctx context.Context, cli *clientv3.Client, id string, opts ...clientv3.OpOption) (*model.ChangeFeedInfo, error) {
 	key := GetEtcdKeyChangeFeedStatus(id)

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -143,3 +143,24 @@ func (s *etcdSuite) TestDeleteSubChangeFeedInfo(c *check.C) {
 	_, _, err = GetSubChangeFeedInfo(ctx, s.client, feedID, captureID)
 	c.Assert(errors.Cause(err), check.Equals, model.ErrSubChangeFeedInfoNotExists)
 }
+
+func (s *etcdSuite) TestOpChangeFeedDetail(c *check.C) {
+	ctx := context.Background()
+	detail := &model.ChangeFeedDetail{
+		SinkURI: "root@tcp(127.0.0.1:3306)/mysql",
+	}
+	cfID := "test-op-cf"
+
+	err := SaveChangeFeedDetail(ctx, s.client, detail, cfID)
+	c.Assert(err, check.IsNil)
+
+	d, err := GetChangeFeedDetail(ctx, s.client, cfID)
+	c.Assert(err, check.IsNil)
+	c.Assert(d.SinkURI, check.Equals, detail.SinkURI)
+
+	err = DeleteChangeFeedDetail(ctx, s.client, cfID)
+	c.Assert(err, check.IsNil)
+
+	_, err = GetChangeFeedDetail(ctx, s.client, cfID)
+	c.Assert(errors.Cause(err), check.Equals, model.ErrChangeFeedNotExists)
+}

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -33,9 +33,7 @@ type ChangeFeedDetail struct {
 	StartTs uint64 `json:"start-ts"`
 	// The ChangeFeed will exits until sync to timestamp TargetTs
 	TargetTs uint64 `json:"target-ts"`
-	// ChangeFeed can be resumed from stop state, this field is used to trigger a watch event in each capture
-	ResumeTs uint64 `json:"resume-ts"`
-	// used for admin job notification
+	// used for admin job notification, trigger watch event in capture
 	AdminJobType AdminJobType    `json:"admin-job-type"`
 	Info         *ChangeFeedInfo `json:"-"`
 
@@ -89,10 +87,6 @@ func (detail *ChangeFeedDetail) FilterTxn(t *Txn) {
 
 // GetStartTs returns StartTs if it's  specified or using the CreateTime of changefeed.
 func (detail *ChangeFeedDetail) GetStartTs() uint64 {
-	if detail.ResumeTs > 0 {
-		return detail.ResumeTs
-	}
-
 	if detail.StartTs > 0 {
 		return detail.StartTs
 	}

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -36,8 +36,8 @@ type ChangeFeedDetail struct {
 	// ChangeFeed can be resumed from stop state, this field is used to trigger a watch event in each capture
 	ResumeTs uint64 `json:"resume-ts"`
 	// used for admin job notification
-	Admin AdminJobType    `json:"admin"`
-	Info  *ChangeFeedInfo `json:"-"`
+	AdminJobType AdminJobType    `json:"admin-job-type"`
+	Info         *ChangeFeedInfo `json:"-"`
 
 	filter              *filter.Filter
 	FilterCaseSensitive bool          `json:"filter-case-sensitive"`

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -25,4 +25,5 @@ var (
 	ErrSubChangeFeedInfoNotExists    = errors.New("subchangefeedinfo not exists")
 	ErrWriteSubChangeFeedInfoConlict = errors.New("write subchangefeedinfo conflict")
 	ErrFindPLockNotCommit            = errors.New("subchangefeedinfo has p-lock not commited")
+	ErrAdminStopProcessor            = errors.New("stop processor by admin command")
 )

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -90,11 +90,11 @@ type SubChangeFeedInfo struct {
 	ResolvedTs uint64 `json:"resolved-ts"`
 	// Table information list, containing tables that processor should process, updated by ownrer, processor is read only.
 	// TODO change to be a map for easy update.
-	TableInfos  []*ProcessTableInfo `json:"table-infos"`
-	TablePLock  *TableLock          `json:"table-p-lock"`
-	TableCLock  *TableLock          `json:"table-c-lock"`
-	Admin       AdminJobType        `json:"admin"`
-	ModRevision int64               `json:"-"`
+	TableInfos   []*ProcessTableInfo `json:"table-infos"`
+	TablePLock   *TableLock          `json:"table-p-lock"`
+	TableCLock   *TableLock          `json:"table-c-lock"`
+	AdminJobType AdminJobType        `json:"admin-job-type"`
+	ModRevision  int64               `json:"-"`
 }
 
 // String implements fmt.Stringer interface.

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -229,7 +229,7 @@ type ChangeFeedInfo struct {
 	SinkURI      string       `json:"sink-uri"`
 	ResolvedTs   uint64       `json:"resolved-ts"`
 	CheckpointTs uint64       `json:"checkpoint-ts"`
-	Admin        AdminJobType `json:"admin"`
+	AdminJobType AdminJobType `json:"admin-job-type"`
 }
 
 // Marshal returns json encoded string of ChangeFeedInfo, only contains necessary fields stored in storage

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -50,7 +50,7 @@ const (
 	TablePLockCommited
 )
 
-// AdminJob represents for admin job type, both used in owner and processor
+// AdminJobType represents for admin job type, both used in owner and processor
 type AdminJobType int
 
 // AdminJob holds an admin job
@@ -226,11 +226,10 @@ func (s ChangeFeedStatus) String() string {
 
 // ChangeFeedInfo stores information about a ChangeFeed
 type ChangeFeedInfo struct {
-	SinkURI      string           `json:"sink-uri"`
-	ResolvedTs   uint64           `json:"resolved-ts"`
-	CheckpointTs uint64           `json:"checkpoint-ts"`
-	Status       ChangeFeedStatus `json:"status"`
-	Admin        AdminJobType     `json:"admin"`
+	SinkURI      string       `json:"sink-uri"`
+	ResolvedTs   uint64       `json:"resolved-ts"`
+	CheckpointTs uint64       `json:"checkpoint-ts"`
+	Admin        AdminJobType `json:"admin"`
 }
 
 // Marshal returns json encoded string of ChangeFeedInfo, only contains necessary fields stored in storage

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -50,6 +50,38 @@ const (
 	TablePLockCommited
 )
 
+// AdminJob represents for admin job type, both used in owner and processor
+type AdminJobType int
+
+// AdminJob holds an admin job
+type AdminJob struct {
+	CfID string
+	Type AdminJobType
+}
+
+// All AdminJob types
+const (
+	AdminNone AdminJobType = iota
+	AdminStop
+	AdminResume
+	AdminRemove
+)
+
+// String implements fmt.Stringer interface.
+func (t AdminJobType) String() string {
+	switch t {
+	case AdminNone:
+		return "noop"
+	case AdminStop:
+		return "stop changefeed"
+	case AdminResume:
+		return "resume changefeed"
+	case AdminRemove:
+		return "remove changefeed"
+	}
+	return "unknown"
+}
+
 // SubChangeFeedInfo records the process information of a capture
 type SubChangeFeedInfo struct {
 	// The maximum event CommitTs that has been synchronized. This is updated by corresponding processor.
@@ -61,6 +93,7 @@ type SubChangeFeedInfo struct {
 	TableInfos  []*ProcessTableInfo `json:"table-infos"`
 	TablePLock  *TableLock          `json:"table-p-lock"`
 	TableCLock  *TableLock          `json:"table-c-lock"`
+	Admin       AdminJobType        `json:"admin"`
 	ModRevision int64               `json:"-"`
 }
 
@@ -193,9 +226,11 @@ func (s ChangeFeedStatus) String() string {
 
 // ChangeFeedInfo stores information about a ChangeFeed
 type ChangeFeedInfo struct {
-	SinkURI      string `json:"sink-uri"`
-	ResolvedTs   uint64 `json:"resolved-ts"`
-	CheckpointTs uint64 `json:"checkpoint-ts"`
+	SinkURI      string           `json:"sink-uri"`
+	ResolvedTs   uint64           `json:"resolved-ts"`
+	CheckpointTs uint64           `json:"checkpoint-ts"`
+	Status       ChangeFeedStatus `json:"status"`
+	Admin        AdminJobType     `json:"admin"`
 }
 
 // Marshal returns json encoded string of ChangeFeedInfo, only contains necessary fields stored in storage

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -808,7 +808,6 @@ func (o *ownerImpl) handleAdminJob(ctx context.Context) error {
 
 			// set admin job in changefeed detail to trigger each capture's changefeed list watch event
 			detail.AdminJobType = model.AdminResume
-			detail.ResumeTs = cfInfo.CheckpointTs
 			err = kv.SaveChangeFeedDetail(ctx, o.etcdClient, detail, job.CfID)
 			if err != nil {
 				return errors.Trace(err)

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -61,6 +61,7 @@ type changeFeed struct {
 	*model.ChangeFeedInfo
 
 	schema                  *schema.Storage
+	Status                  model.ChangeFeedStatus
 	TargetTs                uint64
 	ProcessorInfos          model.ProcessorsInfos
 	processorLastUpdateTime map[string]time.Time
@@ -502,8 +503,8 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 			SinkURI:      detail.SinkURI,
 			ResolvedTs:   0,
 			CheckpointTs: checkpointTs,
-			Status:       model.ChangeFeedSyncDML,
 		},
+		Status:          model.ChangeFeedSyncDML,
 		TargetTs:        detail.GetTargetTs(),
 		ProcessorInfos:  processorsInfos,
 		DDLCurrentIndex: 0,

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -324,7 +324,7 @@ type ownerImpl struct {
 	cancelWatchCapture func()
 	captures           map[model.CaptureID]*model.CaptureInfo
 
-	adminJobs     []*model.AdminJob
+	adminJobs     []model.AdminJob
 	adminJobsLock sync.Mutex
 }
 
@@ -700,7 +700,7 @@ handleEachChangefeed:
 					zap.String("ChangeFeedID", changeFeedID),
 					zap.Error(err),
 					zap.Reflect("ddlJob", todoDDLJob))
-				err = o.EnqueueJob(&model.AdminJob{
+				err = o.EnqueueJob(model.AdminJob{
 					CfID: changeFeedID,
 					Type: model.AdminStop,
 				})
@@ -727,7 +727,7 @@ handleEachChangefeed:
 }
 
 // dispatchJob dispatches job to processors
-func (o *ownerImpl) dispatchJob(ctx context.Context, job *model.AdminJob) error {
+func (o *ownerImpl) dispatchJob(ctx context.Context, job model.AdminJob) error {
 	cf, ok := o.changeFeeds[job.CfID]
 	if !ok {
 		return errors.Errorf("changefeed %s not found in owner cache", job.CfID)
@@ -896,7 +896,7 @@ func (o *ownerImpl) IsOwner(_ context.Context) bool {
 	return o.manager.IsOwner()
 }
 
-func (o *ownerImpl) EnqueueJob(job *model.AdminJob) error {
+func (o *ownerImpl) EnqueueJob(job model.AdminJob) error {
 	if !o.manager.IsOwner() {
 		return errors.Trace(concurrency.ErrElectionNotLeader)
 	}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -324,8 +324,8 @@ type ownerImpl struct {
 	cancelWatchCapture func()
 	captures           map[model.CaptureID]*model.CaptureInfo
 
-	jobs     []*model.AdminJob
-	jobsLock sync.Mutex
+	adminJobs     []*model.AdminJob
+	adminJobsLock sync.Mutex
 }
 
 // NewOwner creates a new ownerImpl instance
@@ -754,12 +754,12 @@ func (o *ownerImpl) dispatchJob(ctx context.Context, job *model.AdminJob) error 
 
 func (o *ownerImpl) handleAdminJob(ctx context.Context) error {
 	removeIdx := 0
-	o.jobsLock.Lock()
+	o.adminJobsLock.Lock()
 	defer func() {
-		o.jobs = o.jobs[removeIdx:]
-		o.jobsLock.Unlock()
+		o.adminJobs = o.adminJobs[removeIdx:]
+		o.adminJobsLock.Unlock()
 	}()
-	for i, job := range o.jobs {
+	for i, job := range o.adminJobs {
 		log.Info("handle admin job", zap.String("changefeed", job.CfID), zap.Stringer("type", job.Type))
 		switch job.Type {
 		case model.AdminStop:
@@ -910,9 +910,9 @@ func (o *ownerImpl) EnqueueJob(job *model.AdminJob) error {
 	default:
 		return errors.Errorf("invalid admin job type: %d", job.Type)
 	}
-	o.jobsLock.Lock()
-	o.jobs = append(o.jobs, job)
-	o.jobsLock.Unlock()
+	o.adminJobsLock.Lock()
+	o.adminJobs = append(o.adminJobs, job)
+	o.adminJobsLock.Unlock()
 	return nil
 }
 

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -735,7 +735,7 @@ func (o *ownerImpl) dispatchJob(ctx context.Context, job model.AdminJob) error {
 	for captureID, pinfo := range cf.ProcessorInfos {
 		pinfo.TablePLock = nil
 		pinfo.TableCLock = nil
-		pinfo.Admin = job.Type
+		pinfo.AdminJobType = job.Type
 		_, err := cf.infoWriter.Write(ctx, cf.ID, captureID, pinfo, false)
 		if err != nil {
 			return errors.Trace(err)
@@ -768,7 +768,7 @@ func (o *ownerImpl) handleAdminJob(ctx context.Context) error {
 			if !ok {
 				return errors.Errorf("changefeed %s not found in owner cache", job.CfID)
 			}
-			cf.detail.Admin = model.AdminStop
+			cf.detail.AdminJobType = model.AdminStop
 			err := kv.SaveChangeFeedDetail(ctx, o.etcdClient, cf.detail, job.CfID)
 			if err != nil {
 				return errors.Trace(err)
@@ -807,7 +807,7 @@ func (o *ownerImpl) handleAdminJob(ctx context.Context) error {
 			}
 
 			// set admin job in changefeed detail to trigger each capture's changefeed list watch event
-			detail.Admin = model.AdminResume
+			detail.AdminJobType = model.AdminResume
 			detail.ResumeTs = cfInfo.CheckpointTs
 			err = kv.SaveChangeFeedDetail(ctx, o.etcdClient, detail, job.CfID)
 			if err != nil {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	pmodel "github.com/pingcap/parser/model"
@@ -60,7 +61,6 @@ type changeFeed struct {
 	*model.ChangeFeedInfo
 
 	schema                  *schema.Storage
-	Status                  model.ChangeFeedStatus
 	TargetTs                uint64
 	ProcessorInfos          model.ProcessorsInfos
 	processorLastUpdateTime map[string]time.Time
@@ -322,6 +322,9 @@ type ownerImpl struct {
 	captureWatchC      <-chan *CaptureInfoWatchResp
 	cancelWatchCapture func()
 	captures           map[model.CaptureID]*model.CaptureInfo
+
+	jobs     []*model.AdminJob
+	jobsLock sync.Mutex
 }
 
 // NewOwner creates a new ownerImpl instance
@@ -499,8 +502,8 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 			SinkURI:      detail.SinkURI,
 			ResolvedTs:   0,
 			CheckpointTs: checkpointTs,
+			Status:       model.ChangeFeedSyncDML,
 		},
-		Status:          model.ChangeFeedSyncDML,
 		TargetTs:        detail.GetTargetTs(),
 		ProcessorInfos:  processorsInfos,
 		DDLCurrentIndex: 0,
@@ -534,6 +537,9 @@ func (o *ownerImpl) loadChangeFeeds(ctx context.Context) error {
 		detail, ok := cfDetails[changeFeedID]
 		if !ok {
 			return errors.Annotatef(model.ErrChangeFeedNotExists, "id:%s", changeFeedID)
+		}
+		if detail.Info != nil && (detail.Info.Admin == model.AdminStop || detail.Info.Admin == model.AdminRemove) {
+			continue
 		}
 
 		newCf, err := o.newChangeFeed(changeFeedID, procInfos, detail)
@@ -645,7 +651,7 @@ func (o *ownerImpl) calcResolvedTs() error {
 // if the status is in ChangeFeedWaitToExecDDL.
 // After executing the DDL successfully, the status will be changed to be ChangeFeedSyncDML.
 func (o *ownerImpl) handleDDL(ctx context.Context) error {
-waitCheckpointTsLoop:
+handleEachChangefeed:
 	for changeFeedID, cfInfo := range o.changeFeeds {
 		if cfInfo.Status != model.ChangeFeedWaitToExecDDL {
 			continue
@@ -658,7 +664,7 @@ waitCheckpointTsLoop:
 				log.Debug("wait checkpoint ts", zap.String("cid", cid),
 					zap.Uint64("checkpoint ts", pInfo.CheckPointTs),
 					zap.Uint64("finish ts", todoDDLJob.Job.BinlogInfo.FinishedTS))
-				continue waitCheckpointTsLoop
+				continue handleEachChangefeed
 			}
 		}
 
@@ -685,14 +691,22 @@ waitCheckpointTsLoop:
 			)
 		} else {
 			err = cfInfo.ddlHandler.ExecDDL(ctx, cfInfo.SinkURI, ddlTxn)
-			// If DDL executing failed, pause the changefeed and print log
+			// If DDL executing failed, pause the changefeed and print log, rather
+			// than return an error and break the running of this owner.
 			if err != nil {
 				cfInfo.Status = model.ChangeFeedDDLExecuteFailed
 				log.Error("Execute DDL failed",
 					zap.String("ChangeFeedID", changeFeedID),
 					zap.Error(err),
 					zap.Reflect("ddlJob", todoDDLJob))
-				return errors.Trace(err)
+				err = o.EnqueueJob(&model.AdminJob{
+					CfID: changeFeedID,
+					Type: model.AdminStop,
+				})
+				if err != nil {
+					return errors.Trace(err)
+				}
+				continue handleEachChangefeed
 			}
 			log.Info("Execute DDL succeeded",
 				zap.String("ChangeFeedID", changeFeedID),
@@ -708,6 +722,99 @@ waitCheckpointTsLoop:
 		return nil
 	}
 
+	return nil
+}
+
+// dispatchJob dispatches job to processors
+func (o *ownerImpl) dispatchJob(ctx context.Context, job *model.AdminJob) error {
+	cf, ok := o.changeFeeds[job.CfID]
+	if !ok {
+		return errors.Errorf("changefeed %s not found in owner cache", job.CfID)
+	}
+	for captureID, pinfo := range cf.ProcessorInfos {
+		pinfo.TablePLock = nil
+		pinfo.TableCLock = nil
+		pinfo.Admin = job.Type
+		_, err := cf.infoWriter.Write(ctx, cf.ID, captureID, pinfo, false)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	// record admin job in changefeed status
+	cf.ChangeFeedInfo.Admin = job.Type
+	infos := map[model.ChangeFeedID]*model.ChangeFeedInfo{job.CfID: cf.ChangeFeedInfo}
+	err := o.cfRWriter.Write(ctx, infos)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	delete(o.changeFeeds, job.CfID)
+	return nil
+}
+
+func (o *ownerImpl) handleAdminJob(ctx context.Context) error {
+	removeIdx := 0
+	o.jobsLock.Lock()
+	defer func() {
+		o.jobs = o.jobs[removeIdx:]
+		o.jobsLock.Unlock()
+	}()
+	for i, job := range o.jobs {
+		log.Info("handle admin job", zap.String("changefeed", job.CfID), zap.Stringer("type", job.Type))
+		switch job.Type {
+		case model.AdminStop:
+			// update ChangeFeedDetail to tell capture ChangeFeedDetail watcher to cleanup
+			cf, ok := o.changeFeeds[job.CfID]
+			if !ok {
+				return errors.Errorf("changefeed %s not found in owner cache", job.CfID)
+			}
+			cf.detail.Admin = model.AdminStop
+			err := kv.SaveChangeFeedDetail(ctx, o.etcdClient, cf.detail, job.CfID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			err = o.dispatchJob(ctx, job)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		case model.AdminRemove:
+			err := o.dispatchJob(ctx, job)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			// remove changefeed detail
+			err = kv.DeleteChangeFeedDetail(ctx, o.etcdClient, job.CfID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		case model.AdminResume:
+			cfInfo, err := kv.GetChangeFeedInfo(ctx, o.etcdClient, job.CfID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			detail, err := kv.GetChangeFeedDetail(ctx, o.etcdClient, job.CfID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			// set admin job in changefeed status to tell owner resume changefeed
+			cfInfo.Admin = model.AdminResume
+			err = kv.PutChangeFeedStatus(ctx, o.etcdClient, job.CfID, cfInfo)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			// set admin job in changefeed detail to trigger each capture's changefeed list watch event
+			detail.Admin = model.AdminResume
+			detail.ResumeTs = cfInfo.CheckpointTs
+			err = kv.SaveChangeFeedDetail(ctx, o.etcdClient, detail, job.CfID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+		removeIdx = i + 1
+	}
 	return nil
 }
 
@@ -772,6 +879,11 @@ func (o *ownerImpl) run(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 
+	err = o.handleAdminJob(cctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	err = o.flushChangeFeedInfos(cctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -781,6 +893,26 @@ func (o *ownerImpl) run(ctx context.Context) error {
 
 func (o *ownerImpl) IsOwner(_ context.Context) bool {
 	return o.manager.IsOwner()
+}
+
+func (o *ownerImpl) EnqueueJob(job *model.AdminJob) error {
+	if !o.manager.IsOwner() {
+		return errors.Trace(concurrency.ErrElectionNotLeader)
+	}
+	switch job.Type {
+	case model.AdminResume:
+	case model.AdminStop, model.AdminRemove:
+		_, ok := o.changeFeeds[job.CfID]
+		if !ok {
+			return errors.Errorf("changefeed [%s] not found", job.CfID)
+		}
+	default:
+		return errors.Errorf("invalid admin job type: %d", job.Type)
+	}
+	o.jobsLock.Lock()
+	o.jobs = append(o.jobs, job)
+	o.jobsLock.Unlock()
+	return nil
 }
 
 func (o *ownerImpl) writeDebugInfo(w io.Writer) {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -539,7 +539,7 @@ func (o *ownerImpl) loadChangeFeeds(ctx context.Context) error {
 		if !ok {
 			return errors.Annotatef(model.ErrChangeFeedNotExists, "id:%s", changeFeedID)
 		}
-		if detail.Info != nil && (detail.Info.Admin == model.AdminStop || detail.Info.Admin == model.AdminRemove) {
+		if detail.Info != nil && (detail.Info.AdminJobType == model.AdminStop || detail.Info.AdminJobType == model.AdminRemove) {
 			continue
 		}
 
@@ -742,7 +742,7 @@ func (o *ownerImpl) dispatchJob(ctx context.Context, job model.AdminJob) error {
 		}
 	}
 	// record admin job in changefeed status
-	cf.ChangeFeedInfo.Admin = job.Type
+	cf.ChangeFeedInfo.AdminJobType = job.Type
 	infos := map[model.ChangeFeedID]*model.ChangeFeedInfo{job.CfID: cf.ChangeFeedInfo}
 	err := o.cfRWriter.Write(ctx, infos)
 	if err != nil {
@@ -800,7 +800,7 @@ func (o *ownerImpl) handleAdminJob(ctx context.Context) error {
 			}
 
 			// set admin job in changefeed status to tell owner resume changefeed
-			cfInfo.Admin = model.AdminResume
+			cfInfo.AdminJobType = model.AdminResume
 			err = kv.PutChangeFeedStatus(ctx, o.etcdClient, job.CfID, cfInfo)
 			if err != nil {
 				return errors.Trace(err)

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -391,17 +391,17 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	// check changefeed detail is set admin job
 	d, err := kv.GetChangeFeedDetail(ctx, owner.etcdClient, cfID)
 	c.Assert(err, check.IsNil)
-	c.Assert(d.Admin, check.Equals, model.AdminStop)
+	c.Assert(d.AdminJobType, check.Equals, model.AdminStop)
 	// check processor is set admin job
 	for cid := range sampleCF.ProcessorInfos {
 		_, subInfo, err := kv.GetSubChangeFeedInfo(ctx, owner.etcdClient, cfID, cid)
 		c.Assert(err, check.IsNil)
-		c.Assert(subInfo.Admin, check.Equals, model.AdminStop)
+		c.Assert(subInfo.AdminJobType, check.Equals, model.AdminStop)
 	}
 	// check changefeed status is set admin job
 	st, err := kv.GetChangeFeedInfo(ctx, owner.etcdClient, cfID)
 	c.Assert(err, check.IsNil)
-	c.Assert(st.Admin, check.Equals, model.AdminStop)
+	c.Assert(st.AdminJobType, check.Equals, model.AdminStop)
 
 	c.Assert(owner.EnqueueJob(model.AdminJob{CfID: cfID, Type: model.AdminResume}), check.IsNil)
 	c.Assert(owner.handleAdminJob(ctx), check.IsNil)
@@ -409,11 +409,11 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	// check changefeed detail is set admin job
 	d, err = kv.GetChangeFeedDetail(ctx, owner.etcdClient, cfID)
 	c.Assert(err, check.IsNil)
-	c.Assert(d.Admin, check.Equals, model.AdminResume)
+	c.Assert(d.AdminJobType, check.Equals, model.AdminResume)
 	// check changefeed status is set admin job
 	st, err = kv.GetChangeFeedInfo(ctx, owner.etcdClient, cfID)
 	c.Assert(err, check.IsNil)
-	c.Assert(st.Admin, check.Equals, model.AdminResume)
+	c.Assert(st.AdminJobType, check.Equals, model.AdminResume)
 
 	owner.changeFeeds[cfID] = sampleCF
 	c.Assert(owner.EnqueueJob(model.AdminJob{CfID: cfID, Type: model.AdminRemove}), check.IsNil)
@@ -427,12 +427,12 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	for cid := range sampleCF.ProcessorInfos {
 		_, subInfo, err := kv.GetSubChangeFeedInfo(ctx, owner.etcdClient, cfID, cid)
 		c.Assert(err, check.IsNil)
-		c.Assert(subInfo.Admin, check.Equals, model.AdminRemove)
+		c.Assert(subInfo.AdminJobType, check.Equals, model.AdminRemove)
 	}
 	// check changefeed status is set admin job
 	st, err = kv.GetChangeFeedInfo(ctx, owner.etcdClient, cfID)
 	c.Assert(err, check.IsNil)
-	c.Assert(st.Admin, check.Equals, model.AdminRemove)
+	c.Assert(st.AdminJobType, check.Equals, model.AdminRemove)
 }
 
 type changefeedInfoSuite struct {

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -379,11 +379,11 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 		owner.adminJobsLock.Unlock()
 	}
 
-	err := owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminStop})
+	err := owner.EnqueueJob(model.AdminJob{CfID: cfID, Type: model.AdminStop})
 	c.Assert(errors.Cause(err), check.Equals, concurrency.ErrElectionNotLeader)
 	c.Assert(manager.CampaignOwner(ctx), check.IsNil)
 
-	c.Assert(owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminStop}), check.IsNil)
+	c.Assert(owner.EnqueueJob(model.AdminJob{CfID: cfID, Type: model.AdminStop}), check.IsNil)
 	checkAdminJobLen(1)
 	c.Assert(owner.handleAdminJob(ctx), check.IsNil)
 	checkAdminJobLen(0)
@@ -403,7 +403,7 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(st.Admin, check.Equals, model.AdminStop)
 
-	c.Assert(owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminResume}), check.IsNil)
+	c.Assert(owner.EnqueueJob(model.AdminJob{CfID: cfID, Type: model.AdminResume}), check.IsNil)
 	c.Assert(owner.handleAdminJob(ctx), check.IsNil)
 	checkAdminJobLen(0)
 	// check changefeed detail is set admin job
@@ -416,7 +416,7 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	c.Assert(st.Admin, check.Equals, model.AdminResume)
 
 	owner.changeFeeds[cfID] = sampleCF
-	c.Assert(owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminRemove}), check.IsNil)
+	c.Assert(owner.EnqueueJob(model.AdminJob{CfID: cfID, Type: model.AdminRemove}), check.IsNil)
 	c.Assert(owner.handleAdminJob(ctx), check.IsNil)
 	checkAdminJobLen(0)
 	c.Assert(len(owner.changeFeeds), check.Equals, 0)

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -8,14 +8,17 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/coreos/etcd/embed"
 	"github.com/google/uuid"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	timodel "github.com/pingcap/parser/model"
+	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/roles"
+	"github.com/pingcap/ticdc/cdc/roles/storage"
 	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -339,6 +342,97 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 	s.owner = owner
 	err = owner.Run(ctx, 50*time.Millisecond)
 	c.Assert(errors.Cause(err), check.DeepEquals, context.Canceled)
+}
+
+func (s *ownerSuite) TestHandleAdmin(c *check.C) {
+	cfID := "test_handle_admin"
+	sampleCF := &changeFeed{
+		ID:             cfID,
+		detail:         &model.ChangeFeedDetail{},
+		ChangeFeedInfo: &model.ChangeFeedInfo{},
+		Status:         model.ChangeFeedSyncDML,
+		ProcessorInfos: model.ProcessorsInfos{
+			"capture_1": {ResolvedTs: 10001},
+			"capture_2": {},
+		},
+		infoWriter: storage.NewOwnerSubCFInfoEtcdWriter(s.client),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	manager := roles.NewMockManager(uuid.New().String(), cancel)
+	owner := &ownerImpl{
+		cancelWatchCapture: cancel,
+		manager:            manager,
+		etcdClient:         s.client,
+		cfRWriter:          storage.NewChangeFeedInfoEtcdRWriter(s.client),
+	}
+	owner.changeFeeds = map[model.ChangeFeedID]*changeFeed{cfID: sampleCF}
+	for cid, pinfo := range sampleCF.ProcessorInfos {
+		key := kv.GetEtcdKeySubChangeFeed(cfID, cid)
+		pinfoStr, err := pinfo.Marshal()
+		c.Assert(err, check.IsNil)
+		_, err = s.client.Put(ctx, key, pinfoStr)
+		c.Assert(err, check.IsNil)
+	}
+	checkAdminJobLen := func(length int) {
+		owner.jobsLock.Lock()
+		c.Assert(owner.jobs, check.HasLen, length)
+		owner.jobsLock.Unlock()
+	}
+
+	err := owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminStop})
+	c.Assert(errors.Cause(err), check.Equals, concurrency.ErrElectionNotLeader)
+	c.Assert(manager.CampaignOwner(ctx), check.IsNil)
+
+	c.Assert(owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminStop}), check.IsNil)
+	checkAdminJobLen(1)
+	c.Assert(owner.handleAdminJob(ctx), check.IsNil)
+	checkAdminJobLen(0)
+	c.Assert(len(owner.changeFeeds), check.Equals, 0)
+	// check changefeed detail is set admin job
+	d, err := kv.GetChangeFeedDetail(ctx, owner.etcdClient, cfID)
+	c.Assert(err, check.IsNil)
+	c.Assert(d.Admin, check.Equals, model.AdminStop)
+	// check processor is set admin job
+	for cid := range sampleCF.ProcessorInfos {
+		_, subInfo, err := kv.GetSubChangeFeedInfo(ctx, owner.etcdClient, cfID, cid)
+		c.Assert(err, check.IsNil)
+		c.Assert(subInfo.Admin, check.Equals, model.AdminStop)
+	}
+	// check changefeed status is set admin job
+	st, err := kv.GetChangeFeedInfo(ctx, owner.etcdClient, cfID)
+	c.Assert(err, check.IsNil)
+	c.Assert(st.Admin, check.Equals, model.AdminStop)
+
+	c.Assert(owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminResume}), check.IsNil)
+	c.Assert(owner.handleAdminJob(ctx), check.IsNil)
+	checkAdminJobLen(0)
+	// check changefeed detail is set admin job
+	d, err = kv.GetChangeFeedDetail(ctx, owner.etcdClient, cfID)
+	c.Assert(err, check.IsNil)
+	c.Assert(d.Admin, check.Equals, model.AdminResume)
+	// check changefeed status is set admin job
+	st, err = kv.GetChangeFeedInfo(ctx, owner.etcdClient, cfID)
+	c.Assert(err, check.IsNil)
+	c.Assert(st.Admin, check.Equals, model.AdminResume)
+
+	owner.changeFeeds[cfID] = sampleCF
+	c.Assert(owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminRemove}), check.IsNil)
+	c.Assert(owner.handleAdminJob(ctx), check.IsNil)
+	checkAdminJobLen(0)
+	c.Assert(len(owner.changeFeeds), check.Equals, 0)
+	// check changefeed detail is deleted
+	_, err = kv.GetChangeFeedDetail(ctx, owner.etcdClient, cfID)
+	c.Assert(errors.Cause(err), check.Equals, model.ErrChangeFeedNotExists)
+	// check processor is set admin job
+	for cid := range sampleCF.ProcessorInfos {
+		_, subInfo, err := kv.GetSubChangeFeedInfo(ctx, owner.etcdClient, cfID, cid)
+		c.Assert(err, check.IsNil)
+		c.Assert(subInfo.Admin, check.Equals, model.AdminRemove)
+	}
+	// check changefeed status is set admin job
+	st, err = kv.GetChangeFeedInfo(ctx, owner.etcdClient, cfID)
+	c.Assert(err, check.IsNil)
+	c.Assert(st.Admin, check.Equals, model.AdminRemove)
 }
 
 type changefeedInfoSuite struct {

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -374,9 +374,9 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 		c.Assert(err, check.IsNil)
 	}
 	checkAdminJobLen := func(length int) {
-		owner.jobsLock.Lock()
-		c.Assert(owner.jobs, check.HasLen, length)
-		owner.jobsLock.Unlock()
+		owner.adminJobsLock.Lock()
+		c.Assert(owner.adminJobs, check.HasLen, length)
+		owner.adminJobsLock.Unlock()
 	}
 
 	err := owner.EnqueueJob(&model.AdminJob{CfID: cfID, Type: model.AdminStop})

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -372,7 +372,7 @@ func (p *processor) updateInfo(ctx context.Context) error {
 
 		p.subInfo = p.tsRWriter.GetSubChangeFeedInfo()
 
-		if p.subInfo.Admin == model.AdminStop || p.subInfo.Admin == model.AdminRemove {
+		if p.subInfo.AdminJobType == model.AdminStop || p.subInfo.AdminJobType == model.AdminRemove {
 			err = p.stop(ctx)
 			if err != nil {
 				return errors.Trace(err)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -293,6 +293,7 @@ func (p *processor) writeDebugInfo(w io.Writer) {
 // 1, update resolve ts by scaning all table's resolve ts.
 // 2, update checkpoint ts by consuming entry from p.executedTxns.
 // 3, sync SubChangeFeedInfo between in memory and storage.
+// 4, check admin command in SubChangeFeedInfo and apply corresponding command
 func (p *processor) localResolvedWorker(ctx context.Context) error {
 	updateInfoTick := time.NewTicker(time.Second)
 	defer updateInfoTick.Stop()
@@ -345,7 +346,11 @@ func (p *processor) localResolvedWorker(ctx context.Context) error {
 		case <-updateInfoTick.C:
 			t0Update := time.Now()
 			err := retry.Run(func() error {
-				return p.updateInfo(ctx)
+				inErr := p.updateInfo(ctx)
+				if errors.Cause(inErr) == model.ErrAdminStopProcessor {
+					return backoff.Permanent(inErr)
+				}
+				return inErr
 			}, 3)
 			updateInfoDuration.WithLabelValues(p.captureID).Observe(time.Since(t0Update).Seconds())
 			if err != nil {
@@ -366,6 +371,14 @@ func (p *processor) updateInfo(ctx context.Context) error {
 		}
 
 		p.subInfo = p.tsRWriter.GetSubChangeFeedInfo()
+
+		if p.subInfo.Admin == model.AdminStop || p.subInfo.Admin == model.AdminRemove {
+			err = p.stop(ctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			return errors.Trace(model.ErrAdminStopProcessor)
+		}
 
 		p.handleTables(ctx, oldInfo, p.subInfo, oldInfo.CheckPointTs)
 		syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(len(p.subInfo.TableInfos)))
@@ -746,6 +759,15 @@ func (p *processor) startPuller(ctx context.Context, span util.Span, checkpointT
 	}()
 
 	return puller
+}
+
+func (p *processor) stop(ctx context.Context) error {
+	p.tablesMu.Lock()
+	for _, tbl := range p.tables {
+		tbl.puller.Cancel()
+	}
+	p.tablesMu.Unlock()
+	return errors.Trace(kv.DeleteSubChangeFeedInfo(ctx, p.etcdCli, p.changefeedID, p.captureID))
 }
 
 func newMounter(schema *schema.Storage) mounter {

--- a/cdc/roles/storage/etcd.go
+++ b/cdc/roles/storage/etcd.go
@@ -248,7 +248,7 @@ func (ow *OwnerSubCFInfoEtcdWriter) updateInfo(
 	// TableInfos and TablePLock is updated by owner only
 	newInfo = info
 	newInfo.TableInfos = oldInfo.TableInfos
-	newInfo.Admin = oldInfo.Admin
+	newInfo.AdminJobType = oldInfo.AdminJobType
 	newInfo.TablePLock = oldInfo.TablePLock
 	newInfo.ModRevision = modRevision
 

--- a/cdc/roles/storage/etcd.go
+++ b/cdc/roles/storage/etcd.go
@@ -236,7 +236,7 @@ func NewOwnerSubCFInfoEtcdWriter(cli *clientv3.Client) *OwnerSubCFInfoEtcdWriter
 	}
 }
 
-// updateInfo updates the local SubChangeFeedInfo with etcd value, except for TableInfos and TablePLock
+// updateInfo updates the local SubChangeFeedInfo with etcd value, except for TableInfos, Admin and TablePLock
 func (ow *OwnerSubCFInfoEtcdWriter) updateInfo(
 	ctx context.Context, changefeedID, captureID string, oldInfo *model.SubChangeFeedInfo,
 ) (newInfo *model.SubChangeFeedInfo, err error) {
@@ -246,11 +246,10 @@ func (ow *OwnerSubCFInfoEtcdWriter) updateInfo(
 	}
 
 	// TableInfos and TablePLock is updated by owner only
-	tableInfos := oldInfo.TableInfos
-	pLock := oldInfo.TablePLock
 	newInfo = info
-	newInfo.TableInfos = tableInfos
-	newInfo.TablePLock = pLock
+	newInfo.TableInfos = oldInfo.TableInfos
+	newInfo.Admin = oldInfo.Admin
+	newInfo.TablePLock = oldInfo.TablePLock
 	newInfo.ModRevision = modRevision
 
 	if newInfo.TablePLock != nil {

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -71,6 +71,7 @@ func (w *ChangeFeedWatcher) processPutKv(kv *mvccpb.KeyValue) (bool, string, mod
 		needRunWatcher = true
 	}
 	if detail.Admin == model.AdminStop {
+		// only handle model.AdminStop, the model.AdminRemove case will be handled in `processDeleteKv`
 		delete(w.details, changefeedID)
 	} else {
 		w.details[changefeedID] = detail

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -70,7 +70,11 @@ func (w *ChangeFeedWatcher) processPutKv(kv *mvccpb.KeyValue) (bool, string, mod
 	if !ok {
 		needRunWatcher = true
 	}
-	w.details[changefeedID] = detail
+	if detail.Admin == model.AdminStop {
+		delete(w.details, changefeedID)
+	} else {
+		w.details[changefeedID] = detail
+	}
 	w.lock.Unlock()
 	// TODO: this detail is not copied, should be readonly
 	return needRunWatcher, changefeedID, detail, nil

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -70,7 +70,7 @@ func (w *ChangeFeedWatcher) processPutKv(kv *mvccpb.KeyValue) (bool, string, mod
 	if !ok {
 		needRunWatcher = true
 	}
-	if detail.Admin == model.AdminStop {
+	if detail.AdminJobType == model.AdminStop {
 		// only handle model.AdminStop, the model.AdminRemove case will be handled in `processDeleteKv`
 		delete(w.details, changefeedID)
 	} else {

--- a/cdc/scheduler_test.go
+++ b/cdc/scheduler_test.go
@@ -270,6 +270,26 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 		return len(w.details) == 0
 	}), check.IsTrue)
 
+	// create a changefeed
+	err = kv.SaveChangeFeedDetail(context.Background(), cli, detail, changefeedID)
+	c.Assert(err, check.IsNil)
+	c.Assert(util.WaitSomething(10, time.Millisecond*50, func() bool {
+		return atomic.LoadInt32(&runChangeFeedWatcherCount) == 2
+	}), check.IsTrue)
+	w.lock.RLock()
+	c.Assert(len(w.details), check.Equals, 1)
+	w.lock.RUnlock()
+
+	// dispatch a stop changefeed admin job
+	detail.Admin = model.AdminStop
+	err = kv.SaveChangeFeedDetail(context.Background(), cli, detail, changefeedID)
+	c.Assert(err, check.IsNil)
+	c.Assert(util.WaitSomething(10, time.Millisecond*50, func() bool {
+		w.lock.RLock()
+		defer w.lock.RUnlock()
+		return len(w.details) == 0
+	}), check.IsTrue)
+
 	cancel()
 	wg.Wait()
 }

--- a/cdc/scheduler_test.go
+++ b/cdc/scheduler_test.go
@@ -281,7 +281,7 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 	w.lock.RUnlock()
 
 	// dispatch a stop changefeed admin job
-	detail.Admin = model.AdminStop
+	detail.AdminJobType = model.AdminStop
 	err = kv.SaveChangeFeedDetail(context.Background(), cli, detail, changefeedID)
 	c.Assert(err, check.IsNil)
 	c.Assert(util.WaitSomething(10, time.Millisecond*50, func() bool {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We have no management to a running changefeed, such as pause replication, resume replication or remove this changefeed from a CDC cluster.

### What is changed and how it works?

- Treat changefeed as resource both in owner and processor, so if a DDL executed to downstream with failure, we don't exit the whole owner, but only pause the changefeed replication.
- Introduce the `AdminJob` concept, which can be processed by the owner only. We can use this feature by HTTP API now.
- In both `Stop` and `Remove` job, we release all the TiKV gRPC connections and stop the replication. The difference between these two jobs is the `Stop` job will preserve the `Changefeed` information, so we can resume the replication of this changefeed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test