### PR TITLE
set puller with precise tableIDs in debug cmd

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -52,7 +52,7 @@ func (detail *ChangeFeedDetail) getFilter() *filter.Filter {
 // ShouldIgnoreTable returns true if the specified table should be ignored by this change feed.
 // Set `tbl` to an empty string to test against the whole database.
 func (detail *ChangeFeedDetail) ShouldIgnoreTable(db, tbl string) bool {
-	if isSysSchema(db) {
+	if IsSysSchema(db) {
 		return true
 	}
 	f := detail.getFilter()
@@ -117,7 +117,8 @@ func (detail *ChangeFeedDetail) Unmarshal(data []byte) error {
 	return errors.Annotatef(err, "Unmarshal data: %v", data)
 }
 
-func isSysSchema(db string) bool {
+// IsSysSchema returns true if the given schema is a system schema
+func IsSysSchema(db string) bool {
 	db = strings.ToUpper(db)
 	for _, schema := range []string{"INFORMATION_SCHEMA", "PERFORMANCE_SCHEMA", "MYSQL", "METRIC_SCHEMA"} {
 		if schema == db {

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -2,17 +2,18 @@ package cmd
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
 
 	pd "github.com/pingcap/pd/client"
+	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller"
+	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/pingcap/ticdc/pkg/util"
 )
 
 func init() {
@@ -22,6 +23,65 @@ func init() {
 }
 
 var pdAddr string
+
+func getTableIDs() (tableIDs []int64, err error) {
+	var (
+		host     = "127.0.0.1"
+		password = ""
+		user     = "root"
+		port     = 4000
+		tableID  sql.NullInt64
+		schemas  = make([]string, 0)
+		schema   string
+	)
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4&interpolateParams=true", user, password, host, port)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return
+	}
+
+	sqlQuerySchemas := "SHOW DATABASES"
+	result, err := db.Query(sqlQuerySchemas)
+	if err != nil {
+		return
+	}
+	for result.Next() {
+		err = result.Scan(&schema)
+		if err != nil {
+			return
+		}
+		if model.IsSysSchema(schema) {
+			continue
+		}
+		schemas = append(schemas, schema)
+	}
+	err = result.Close()
+	if err != nil {
+		return
+	}
+
+	ifconv := func(input []string) (ret []interface{}) {
+		ret = make([]interface{}, len(input))
+		for i, s := range input {
+			ret[i] = s
+		}
+		return
+	}
+	sqlQuerySchema := "SELECT TIDB_TABLE_ID FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN (?" + strings.Repeat(",?", len(schemas)-1) + ")"
+	result, err = db.Query(sqlQuerySchema, ifconv(schemas)...)
+	if err != nil {
+		return
+	}
+	for result.Next() {
+		err = result.Scan(&tableID)
+		if err != nil {
+			return
+		}
+		tableIDs = append(tableIDs, tableID.Int64)
+	}
+	err = result.Close()
+	return
+}
 
 var pullCmd = &cobra.Command{
 	Use:   "pull",
@@ -34,20 +94,17 @@ var pullCmd = &cobra.Command{
 			return
 		}
 
-		ts := oracle.ComposeTS(time.Now().Unix()*1000, 0)
-		// set `needEncode` to true, only DML kv pair will be retained
-		p := puller.NewPuller(cli, ts, []util.Span{{Start: nil, End: nil}}, true)
-		buf := p.Output()
-
 		g, ctx := errgroup.WithContext(context.Background())
+		ts := oracle.ComposeTS(time.Now().Unix()*1000, 0)
 
+		ddlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetDDLSpan()}, false)
+		ddlBuf := ddlPuller.Output()
 		g.Go(func() error {
-			return p.Run(ctx)
+			return ddlPuller.Run(ctx)
 		})
-
 		g.Go(func() error {
 			for {
-				entry, err := buf.Get(ctx)
+				entry, err := ddlBuf.Get(ctx)
 				if err != nil {
 					return err
 				}
@@ -55,6 +112,29 @@ var pullCmd = &cobra.Command{
 				fmt.Printf("%+v\n", entry.GetValue())
 			}
 		})
+
+		tableIDs, err := getTableIDs()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		for _, tid := range tableIDs {
+			dmlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetTableSpan(tid, true)}, true)
+			dmlBuf := dmlPuller.Output()
+			g.Go(func() error {
+				return dmlPuller.Run(ctx)
+			})
+			g.Go(func() error {
+				for {
+					entry, err := dmlBuf.Get(ctx)
+					if err != nil {
+						return err
+					}
+
+					fmt.Printf("%+v\n", entry.GetValue())
+				}
+			})
+		}
 
 		err = g.Wait()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We have region fully coverage check in the TiKV client, so we should use precise tableID in table puller. Just make the debug cmd works.

### What is changed and how it works?
fetch tableID from upstream

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test