### PR TITLE
uniform terminology about changefeed

### DIFF
--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -73,7 +73,7 @@ func (s *etcdSuite) TestGetChangeFeeds(c *check.C) {
 	}
 	for _, tc := range testCases {
 		for i := 0; i < len(tc.ids); i++ {
-			_, err := s.client.Put(context.Background(), GetEtcdKeyChangeFeedConfig(tc.ids[i]), tc.details[i])
+			_, err := s.client.Put(context.Background(), GetEtcdKeyChangeFeedInfo(tc.ids[i]), tc.details[i])
 			c.Assert(err, check.IsNil)
 		}
 		_, result, err := GetChangeFeeds(context.Background(), s.client)
@@ -146,21 +146,21 @@ func (s *etcdSuite) TestDeleteTaskStatus(c *check.C) {
 
 func (s *etcdSuite) TestOpChangeFeedDetail(c *check.C) {
 	ctx := context.Background()
-	detail := &model.ChangeFeedDetail{
+	detail := &model.ChangeFeedInfo{
 		SinkURI: "root@tcp(127.0.0.1:3306)/mysql",
 	}
 	cfID := "test-op-cf"
 
-	err := SaveChangeFeedDetail(ctx, s.client, detail, cfID)
+	err := SaveChangeFeedInfo(ctx, s.client, detail, cfID)
 	c.Assert(err, check.IsNil)
 
-	d, err := GetChangeFeedDetail(ctx, s.client, cfID)
+	d, err := GetChangeFeedInfo(ctx, s.client, cfID)
 	c.Assert(err, check.IsNil)
 	c.Assert(d.SinkURI, check.Equals, detail.SinkURI)
 
-	err = DeleteChangeFeedDetail(ctx, s.client, cfID)
+	err = DeleteChangeFeedInfo(ctx, s.client, cfID)
 	c.Assert(err, check.IsNil)
 
-	_, err = GetChangeFeedDetail(ctx, s.client, cfID)
+	_, err = GetChangeFeedInfo(ctx, s.client, cfID)
 	c.Assert(errors.Cause(err), check.Equals, model.ErrChangeFeedNotExists)
 }

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -24,8 +24,8 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 )
 
-// ChangeFeedDetail describes the detail of a ChangeFeed
-type ChangeFeedDetail struct {
+// ChangeFeedInfo describes the detail of a ChangeFeed
+type ChangeFeedInfo struct {
 	SinkURI    string            `json:"sink-uri"`
 	Opts       map[string]string `json:"opts"`
 	CreateTime time.Time         `json:"create-time"`
@@ -34,31 +34,31 @@ type ChangeFeedDetail struct {
 	// The ChangeFeed will exits until sync to timestamp TargetTs
 	TargetTs uint64 `json:"target-ts"`
 	// used for admin job notification, trigger watch event in capture
-	AdminJobType AdminJobType    `json:"admin-job-type"`
-	Info         *ChangeFeedInfo `json:"-"`
+	AdminJobType AdminJobType      `json:"admin-job-type"`
+	Status       *ChangeFeedStatus `json:"-"`
 
 	filter *filter.Filter
 	Config *ReplicaConfig `json:"config"`
 }
 
-func (detail *ChangeFeedDetail) getConfig() *ReplicaConfig {
-	if detail.Config == nil {
-		detail.Config = &ReplicaConfig{}
+func (info *ChangeFeedInfo) getConfig() *ReplicaConfig {
+	if info.Config == nil {
+		info.Config = &ReplicaConfig{}
 	}
-	return detail.Config
+	return info.Config
 }
 
-func (detail *ChangeFeedDetail) getFilter() *filter.Filter {
-	if detail.filter == nil {
-		rules := detail.getConfig().FilterRules
-		detail.filter = filter.New(detail.getConfig().FilterCaseSensitive, rules)
+func (info *ChangeFeedInfo) getFilter() *filter.Filter {
+	if info.filter == nil {
+		rules := info.getConfig().FilterRules
+		info.filter = filter.New(info.getConfig().FilterCaseSensitive, rules)
 	}
-	return detail.filter
+	return info.filter
 }
 
 // ShouldIgnoreTxn returns true is the given txn should be ignored
-func (detail *ChangeFeedDetail) ShouldIgnoreTxn(t *Txn) bool {
-	for _, ignoreTs := range detail.getConfig().IgnoreTxnCommitTs {
+func (info *ChangeFeedInfo) ShouldIgnoreTxn(t *Txn) bool {
+	for _, ignoreTs := range info.getConfig().IgnoreTxnCommitTs {
 		if ignoreTs == t.Ts {
 			return true
 		}
@@ -68,11 +68,11 @@ func (detail *ChangeFeedDetail) ShouldIgnoreTxn(t *Txn) bool {
 
 // ShouldIgnoreTable returns true if the specified table should be ignored by this change feed.
 // Set `tbl` to an empty string to test against the whole database.
-func (detail *ChangeFeedDetail) ShouldIgnoreTable(db, tbl string) bool {
+func (info *ChangeFeedInfo) ShouldIgnoreTable(db, tbl string) bool {
 	if IsSysSchema(db) {
 		return true
 	}
-	f := detail.getFilter()
+	f := info.getFilter()
 	// TODO: Change filter to support simple check directly
 	left := f.ApplyOn([]*filter.Table{{Schema: db, Name: tbl}})
 	return len(left) == 0
@@ -80,15 +80,15 @@ func (detail *ChangeFeedDetail) ShouldIgnoreTable(db, tbl string) bool {
 
 // FilterTxn removes DDL/DMLs that's not wanted by this change feed.
 // CDC only supports filtering by database/table now.
-func (detail *ChangeFeedDetail) FilterTxn(t *Txn) {
+func (info *ChangeFeedInfo) FilterTxn(t *Txn) {
 	if t.IsDDL() {
-		if detail.ShouldIgnoreTable(t.DDL.Database, t.DDL.Table) {
+		if info.ShouldIgnoreTable(t.DDL.Database, t.DDL.Table) {
 			t.DDL = nil
 		}
 	} else {
 		var filteredDMLs []*DML
 		for _, dml := range t.DMLs {
-			if !detail.ShouldIgnoreTable(dml.Database, dml.Table) {
+			if !info.ShouldIgnoreTable(dml.Database, dml.Table) {
 				filteredDMLs = append(filteredDMLs, dml)
 			}
 		}
@@ -97,40 +97,40 @@ func (detail *ChangeFeedDetail) FilterTxn(t *Txn) {
 }
 
 // GetStartTs returns StartTs if it's  specified or using the CreateTime of changefeed.
-func (detail *ChangeFeedDetail) GetStartTs() uint64 {
-	if detail.StartTs > 0 {
-		return detail.StartTs
+func (info *ChangeFeedInfo) GetStartTs() uint64 {
+	if info.StartTs > 0 {
+		return info.StartTs
 	}
 
-	return oracle.EncodeTSO(detail.CreateTime.Unix() * 1000)
+	return oracle.EncodeTSO(info.CreateTime.Unix() * 1000)
 }
 
 // GetTargetTs returns TargetTs if it's specified, otherwise MaxUint64 is returned.
-func (detail *ChangeFeedDetail) GetTargetTs() uint64 {
-	if detail.TargetTs > 0 {
-		return detail.TargetTs
+func (info *ChangeFeedInfo) GetTargetTs() uint64 {
+	if info.TargetTs > 0 {
+		return info.TargetTs
 	}
 	return uint64(math.MaxUint64)
 }
 
 // GetCheckpointTs returns the checkpoint ts of changefeed.
-func (detail *ChangeFeedDetail) GetCheckpointTs() uint64 {
-	if detail.Info != nil {
-		return detail.Info.CheckpointTs
+func (info *ChangeFeedInfo) GetCheckpointTs() uint64 {
+	if info.Status != nil {
+		return info.Status.CheckpointTs
 	}
 
-	return detail.GetStartTs()
+	return info.GetStartTs()
 }
 
-// Marshal returns the json marshal format of a ChangeFeedDetail
-func (detail *ChangeFeedDetail) Marshal() (string, error) {
-	data, err := json.Marshal(detail)
+// Marshal returns the json marshal format of a ChangeFeedInfo
+func (info *ChangeFeedInfo) Marshal() (string, error) {
+	data, err := json.Marshal(info)
 	return string(data), errors.Trace(err)
 }
 
-// Unmarshal unmarshals into *ChangeFeedDetail from json marshal byte slice
-func (detail *ChangeFeedDetail) Unmarshal(data []byte) error {
-	err := json.Unmarshal(data, &detail)
+// Unmarshal unmarshals into *ChangeFeedInfo from json marshal byte slice
+func (info *ChangeFeedInfo) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, &info)
 	return errors.Annotatef(err, "Unmarshal data: %v", data)
 }
 

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -181,12 +181,12 @@ type ChangeFeedID = string
 // ProcessorsInfos maps from capture IDs to TaskStatus
 type ProcessorsInfos map[CaptureID]*TaskStatus
 
-// ChangeFeedStatus is the type for change feed status
-type ChangeFeedStatus int
+// ChangeFeedState is the type for change feed status
+type ChangeFeedState int
 
 const (
 	// ChangeFeedUnknown stands for all unknown status
-	ChangeFeedUnknown ChangeFeedStatus = iota
+	ChangeFeedUnknown ChangeFeedState = iota
 	// ChangeFeedSyncDML means DMLs are being processed
 	ChangeFeedSyncDML
 	// ChangeFeedWaitToExecDDL means we are waiting to execute a DDL
@@ -210,7 +210,7 @@ func (p ProcessorsInfos) String() string {
 }
 
 // String implements fmt.Stringer interface.
-func (s ChangeFeedStatus) String() string {
+func (s ChangeFeedState) String() string {
 	switch s {
 	case ChangeFeedSyncDML:
 		return "SyncDML"
@@ -224,23 +224,23 @@ func (s ChangeFeedStatus) String() string {
 	return "Unknown"
 }
 
-// ChangeFeedInfo stores information about a ChangeFeed
-type ChangeFeedInfo struct {
+// ChangeFeedStatus stores information about a ChangeFeed
+type ChangeFeedStatus struct {
 	SinkURI      string       `json:"sink-uri"`
 	ResolvedTs   uint64       `json:"resolved-ts"`
 	CheckpointTs uint64       `json:"checkpoint-ts"`
 	AdminJobType AdminJobType `json:"admin-job-type"`
 }
 
-// Marshal returns json encoded string of ChangeFeedInfo, only contains necessary fields stored in storage
-func (info *ChangeFeedInfo) Marshal() (string, error) {
-	data, err := json.Marshal(info)
+// Marshal returns json encoded string of ChangeFeedStatus, only contains necessary fields stored in storage
+func (status *ChangeFeedStatus) Marshal() (string, error) {
+	data, err := json.Marshal(status)
 	return string(data), errors.Trace(err)
 }
 
-// Unmarshal unmarshals into *ChangeFeedInfo from json marshal byte slice
-func (info *ChangeFeedInfo) Unmarshal(data []byte) error {
-	err := json.Unmarshal(data, info)
+// Unmarshal unmarshals into *ChangeFeedStatus from json marshal byte slice
+func (status *ChangeFeedStatus) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, status)
 	return errors.Annotatef(err, "Unmarshal data: %v", data)
 }
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -133,7 +133,7 @@ func newTxnChannel(inputTxn <-chan model.RawTxn, chanSize int, handleResolvedTs 
 type processor struct {
 	captureID    string
 	changefeedID string
-	changefeed   model.ChangeFeedDetail
+	changefeed   model.ChangeFeedInfo
 
 	pdCli   pd.Client
 	etcdCli *clientv3.Client
@@ -176,7 +176,7 @@ func (t *tableInfo) storeResolvedTS(ts uint64) {
 }
 
 // NewProcessor creates and returns a processor for the specified change feed
-func NewProcessor(pdEndpoints []string, changefeed model.ChangeFeedDetail, changefeedID, captureID string) (*processor, error) {
+func NewProcessor(pdEndpoints []string, changefeed model.ChangeFeedInfo, changefeedID, captureID string) (*processor, error) {
 	pdCli, err := fNewPDCli(pdEndpoints, pd.SecurityOption{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "create pd client failed, addr: %v", pdEndpoints)
@@ -282,7 +282,7 @@ func (p *processor) wait() {
 }
 
 func (p *processor) writeDebugInfo(w io.Writer) {
-	fmt.Fprintf(w, "changefeedID: %s, detail: %+v, status: %+v\n", p.changefeedID, p.changefeed, p.status)
+	fmt.Fprintf(w, "changefeedID: %s, info: %+v, status: %+v\n", p.changefeedID, p.changefeed, p.status)
 
 	p.tablesMu.Lock()
 	for _, table := range p.tables {

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -157,7 +157,7 @@ func runCase(c *check.C, cases *processorTestCase) {
 	c.Assert(err, check.IsNil)
 	defer etcd.Close()
 
-	p, err := NewProcessor([]string{etcdURL.String()}, model.ChangeFeedDetail{}, "", "")
+	p, err := NewProcessor([]string{etcdURL.String()}, model.ChangeFeedInfo{}, "", "")
 	c.Assert(err, check.IsNil)
 	errCh := make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -72,7 +72,7 @@ var cliCmd = &cobra.Command{
 			}
 		}
 
-		detail := &model.ChangeFeedDetail{
+		detail := &model.ChangeFeedInfo{
 			SinkURI:    sinkURI,
 			Opts:       make(map[string]string),
 			CreateTime: time.Now(),
@@ -85,7 +85,7 @@ var cliCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("create changefeed ID: %s detail %s\n", id, d)
-		return kv.SaveChangeFeedDetail(context.Background(), cli, detail, id)
+		return kv.SaveChangeFeedInfo(context.Background(), cli, detail, id)
 	},
 }
 

--- a/cmd/ctrl.go
+++ b/cmd/ctrl.go
@@ -100,13 +100,13 @@ var ctrlCmd = &cobra.Command{
 		}
 		switch ctrlCommand {
 		case CtrlQueryCfInfo:
-			info, err := kv.GetChangeFeedDetail(context.Background(), cli, ctrlCfID)
+			info, err := kv.GetChangeFeedInfo(context.Background(), cli, ctrlCfID)
 			if err != nil {
 				return err
 			}
 			return jsonPrint(info)
 		case CtrlQueryCfStatus:
-			info, err := kv.GetChangeFeedInfo(context.Background(), cli, ctrlCfID)
+			info, err := kv.GetChangeFeedStatus(context.Background(), cli, ctrlCfID)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
uniform terminology:
we name XXXStatus to the struct which includes the variable changed continually.
we name XXXInfo to the struct which includes config or environment info changed occasionally.