### PR TITLE
capture: add the hostname to capture info

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -16,6 +16,7 @@ package cdc
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -63,8 +64,14 @@ func NewCapture(pdEndpoints []string) (c *Capture, err error) {
 	}
 
 	id := uuid.New().String()
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "Unknown"
+		log.Warn("can not get hostname", zap.Error(err))
+	}
 	info := &model.CaptureInfo{
-		ID: id,
+		ID:       id,
+		HostName: hostname,
 	}
 
 	log.Info("creating capture", zap.String("capture-id", id))

--- a/cdc/model/capture.go
+++ b/cdc/model/capture.go
@@ -21,7 +21,8 @@ import (
 
 // CaptureInfo store in etcd.
 type CaptureInfo struct {
-	ID string `json:"id"`
+	ID       string `json:"id"`
+	HostName string `json:"hostname"`
 }
 
 // Marshal using json.Marshal.

--- a/cmd/ctrl.go
+++ b/cmd/ctrl.go
@@ -70,8 +70,9 @@ type cf struct {
 
 // capture holds capture information
 type capture struct {
-	ID      string `json:"id"`
-	IsOwner bool   `json:"is-owner"`
+	ID       string `json:"id"`
+	HostName string `json:"hostname"`
+	IsOwner  bool   `json:"is-owner"`
 }
 
 func jsonPrint(v interface{}) error {
@@ -133,7 +134,7 @@ var ctrlCmd = &cobra.Command{
 			captures := make([]*capture, 0, len(raw))
 			for _, c := range raw {
 				isOwner := c.ID == ownerID
-				captures = append(captures, &capture{ID: c.ID, IsOwner: isOwner})
+				captures = append(captures, &capture{ID: c.ID, HostName: c.HostName, IsOwner: isOwner})
 			}
 			return jsonPrint(captures)
 		case CtrlQuerySubCf:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
It's difficult to determine which server the capture is running on 

### What is changed and how it works?
add the hostname to capture info

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
run ticdc cluster and run query  capture list:
```
./cdc ctrl --cmd=query-capture-list
[{"id":"21a54198-1644-4c8b-9c59-58ac3af547dc","hostname":"834031ee1ee9","is-owner":true}]
```