### PR TITLE
owner: release ddl puller when a changefeed is stopped

### DIFF
--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -356,6 +356,7 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 			"capture_2": {},
 		},
 		infoWriter: storage.NewOwnerTaskStatusEtcdWriter(s.client),
+		ddlHandler: &handlerForDDLTest{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	manager := roles.NewMockManager(uuid.New().String(), cancel)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When a changefeed is stopped or removed, the `OwnerDDLHandler` of this changefeed is not released.

### What is changed and how it works?

Close the `OwnerDDLHandler` before the `changeFeed` is removed from owner memory.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
