### PR TITLE
bug fix: kvclient may be output a row which value is null

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -98,7 +98,7 @@ func (c *Capture) OnRunProcessor(p *processor) {
 // OnStopProcessor implements processorCallback.
 func (c *Capture) OnStopProcessor(p *processor, err error) {
 	// TODO: handle processor error
-	log.Info("stop to run processor", zap.String("changefeed id", p.changefeedID), util.ZapErrorFilter(err, context.Canceled))
+	log.Info("stop to run processor", zap.String("changefeed id", p.changefeedID), util.ZapErrorFilter(err, context.Canceled), zap.Error(err))
 	c.procLock.Lock()
 	defer c.procLock.Unlock()
 	delete(c.processors, p.changefeedID)
@@ -120,7 +120,7 @@ func (c *Capture) Start(ctx context.Context) (err error) {
 	errg, cctx := errgroup.WithContext(ctx)
 
 	errg.Go(func() error {
-		return c.ownerWorker.Run(cctx, time.Millisecond*100)
+		return c.ownerWorker.Run(cctx, time.Millisecond*500)
 	})
 
 	watcher := NewChangeFeedWatcher(c.info.ID, c.pdEndpoints, c.etcdClient)

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -98,7 +98,7 @@ func (c *Capture) OnRunProcessor(p *processor) {
 // OnStopProcessor implements processorCallback.
 func (c *Capture) OnStopProcessor(p *processor, err error) {
 	// TODO: handle processor error
-	log.Info("stop to run processor", zap.String("changefeed id", p.changefeedID), util.ZapErrorFilter(err, context.Canceled), zap.Error(err))
+	log.Info("stop to run processor", zap.String("changefeed id", p.changefeedID), util.ZapErrorFilter(err, context.Canceled))
 	c.procLock.Lock()
 	defer c.procLock.Unlock()
 	delete(c.processors, p.changefeedID)

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -462,7 +462,7 @@ func (c *CDCClient) singleEventFeed(
 						})
 					case cdcpb.Event_COMMIT:
 						// emit a value
-						err := matcher.matchRow(row)
+						row, err := matcher.matchRow(row)
 						if err != nil {
 							return atomic.LoadUint64(&req.CheckpointTs), errors.Trace(err)
 						}

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -462,11 +462,10 @@ func (c *CDCClient) singleEventFeed(
 						})
 					case cdcpb.Event_COMMIT:
 						// emit a value
-						row, err := matcher.matchRow(row)
+						value, err := matcher.matchRow(row)
 						if err != nil {
 							return atomic.LoadUint64(&req.CheckpointTs), errors.Trace(err)
 						}
-						value := row.GetValue()
 
 						var opType model.OpType
 						switch row.GetOpType() {

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -375,8 +375,7 @@ func (c *CDCClient) singleEventFeed(
 	}
 
 	client := cdcpb.NewChangeDataClient(conn)
-
-	notMatch := make(map[string][]byte)
+	matcher := newMatcher()
 
 	log.Debug("start new request", zap.Reflect("request", req))
 	stream, err := client.EventFeed(ctx, req)
@@ -456,21 +455,18 @@ func (c *CDCClient) singleEventFeed(
 							return atomic.LoadUint64(&req.CheckpointTs), errors.Trace(ctx.Err())
 						}
 					case cdcpb.Event_PREWRITE:
-						notMatch[string(row.Key)] = row.GetValue()
+						matcher.putPrewriteRow(row)
 						sorter.pushTsItem(sortItem{
 							start: row.GetStartTs(),
 							tp:    cdcpb.Event_PREWRITE,
 						})
 					case cdcpb.Event_COMMIT:
 						// emit a value
-						value := row.GetValue()
-						if pvalue, ok := notMatch[string(row.Key)]; ok {
-							if len(pvalue) > 0 {
-								value = pvalue
-							}
+						err := matcher.matchRow(row)
+						if err != nil {
+							return atomic.LoadUint64(&req.CheckpointTs), errors.Trace(err)
 						}
-
-						delete(notMatch, string(row.Key))
+						value := row.GetValue()
 
 						var opType model.OpType
 						switch row.GetOpType() {
@@ -502,7 +498,7 @@ func (c *CDCClient) singleEventFeed(
 							tp:     cdcpb.Event_COMMIT,
 						})
 					case cdcpb.Event_ROLLBACK:
-						delete(notMatch, string(row.Key))
+						matcher.rollbackRow(row)
 						sorter.pushTsItem(sortItem{
 							start:  row.GetStartTs(),
 							commit: row.GetCommitTs(),

--- a/cdc/kv/matcher.go
+++ b/cdc/kv/matcher.go
@@ -29,17 +29,10 @@ func (m *matcher) putPrewriteRow(row *cdcpb.Event_Row) {
 	m.unmatchedValue[newMatchKey(row)] = row.GetValue()
 }
 
-func (m *matcher) matchRow(row *cdcpb.Event_Row) (*cdcpb.Event_Row, error) {
+func (m *matcher) matchRow(row *cdcpb.Event_Row) ([]byte, error) {
 	if value, exist := m.unmatchedValue[newMatchKey(row)]; exist {
 		delete(m.unmatchedValue, newMatchKey(row))
-		return &cdcpb.Event_Row{
-			StartTs:  row.GetStartTs(),
-			CommitTs: row.GetCommitTs(),
-			Type:     row.GetType(),
-			OpType:   row.GetOpType(),
-			Key:      row.GetKey(),
-			Value:    value,
-		}, nil
+		return value, nil
 	}
 	return nil, errors.NotFoundf("prewrite row, startTs:%d", row.GetStartTs())
 

--- a/cdc/kv/matcher.go
+++ b/cdc/kv/matcher.go
@@ -29,13 +29,19 @@ func (m *matcher) putPrewriteRow(row *cdcpb.Event_Row) {
 	m.unmatchedValue[newMatchKey(row)] = row.GetValue()
 }
 
-func (m *matcher) matchRow(row *cdcpb.Event_Row) error {
+func (m *matcher) matchRow(row *cdcpb.Event_Row) (*cdcpb.Event_Row, error) {
 	if value, exist := m.unmatchedValue[newMatchKey(row)]; exist {
-		row.Value = value
 		delete(m.unmatchedValue, newMatchKey(row))
-		return nil
+		return &cdcpb.Event_Row{
+			StartTs:  row.GetStartTs(),
+			CommitTs: row.GetCommitTs(),
+			Type:     row.GetType(),
+			OpType:   row.GetOpType(),
+			Key:      row.GetKey(),
+			Value:    value,
+		}, nil
 	}
-	return errors.NotFoundf("prewrite row, startTs:%d", row.GetStartTs())
+	return nil, errors.NotFoundf("prewrite row, startTs:%d", row.GetStartTs())
 
 }
 

--- a/cdc/kv/matcher.go
+++ b/cdc/kv/matcher.go
@@ -1,0 +1,44 @@
+package kv
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/cdcpb"
+)
+
+type matcher struct {
+	// TODO : clear the single prewrite
+	unmatchedValue map[matchKey][]byte
+}
+
+type matchKey struct {
+	startTs uint64
+	key     string
+}
+
+func newMatchKey(row *cdcpb.Event_Row) matchKey {
+	return matchKey{startTs: row.GetStartTs(), key: string(row.GetKey())}
+}
+
+func newMatcher() *matcher {
+	return &matcher{
+		unmatchedValue: make(map[matchKey][]byte),
+	}
+}
+
+func (m *matcher) putPrewriteRow(row *cdcpb.Event_Row) {
+	m.unmatchedValue[newMatchKey(row)] = row.GetValue()
+}
+
+func (m *matcher) matchRow(row *cdcpb.Event_Row) error {
+	if value, exist := m.unmatchedValue[newMatchKey(row)]; exist {
+		row.Value = value
+		delete(m.unmatchedValue, newMatchKey(row))
+		return nil
+	}
+	return errors.NotFoundf("prewrite row, startTs:%d", row.GetStartTs())
+
+}
+
+func (m *matcher) rollbackRow(row *cdcpb.Event_Row) {
+	delete(m.unmatchedValue, newMatchKey(row))
+}

--- a/cdc/kv/matcher_test.go
+++ b/cdc/kv/matcher_test.go
@@ -29,13 +29,13 @@ func (s *MatcherSuite) TestMatcher(c *check.C) {
 		StartTs: 1,
 		Key:     []byte("k1"),
 	}
-	commitRow1, err := matcher.matchRow(commitRow1)
+	_, err := matcher.matchRow(commitRow1)
 	c.Assert(err, check.ErrorMatches, "*not found*")
 	commitRow2 := &cdcpb.Event_Row{
 		StartTs: 2,
 		Key:     []byte("k1"),
 	}
-	commitRow2, err = matcher.matchRow(commitRow2)
+	value2, err := matcher.matchRow(commitRow2)
 	c.Assert(err, check.IsNil)
-	c.Assert(commitRow2.Value, check.BytesEquals, []byte("v2"))
+	c.Assert(value2, check.BytesEquals, []byte("v2"))
 }

--- a/cdc/kv/matcher_test.go
+++ b/cdc/kv/matcher_test.go
@@ -29,13 +29,13 @@ func (s *MatcherSuite) TestMatcher(c *check.C) {
 		StartTs: 1,
 		Key:     []byte("k1"),
 	}
-	err := matcher.matchRow(commitRow1)
+	commitRow1, err := matcher.matchRow(commitRow1)
 	c.Assert(err, check.ErrorMatches, "*not found*")
 	commitRow2 := &cdcpb.Event_Row{
 		StartTs: 2,
 		Key:     []byte("k1"),
 	}
-	err = matcher.matchRow(commitRow2)
+	commitRow2, err = matcher.matchRow(commitRow2)
 	c.Assert(err, check.IsNil)
 	c.Assert(commitRow2.Value, check.BytesEquals, []byte("v2"))
 }

--- a/cdc/kv/matcher_test.go
+++ b/cdc/kv/matcher_test.go
@@ -1,0 +1,41 @@
+package kv
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/cdcpb"
+)
+
+type MatcherSuite struct{}
+
+var _ = check.Suite(&MatcherSuite{})
+
+func (s *MatcherSuite) TestMatcher(c *check.C) {
+	matcher := newMatcher()
+	matcher.putPrewriteRow(&cdcpb.Event_Row{
+		StartTs: 1,
+		Key:     []byte("k1"),
+		Value:   []byte("v1"),
+	})
+	matcher.putPrewriteRow(&cdcpb.Event_Row{
+		StartTs: 2,
+		Key:     []byte("k1"),
+		Value:   []byte("v2"),
+	})
+	matcher.rollbackRow(&cdcpb.Event_Row{
+		StartTs: 1,
+		Key:     []byte("k1"),
+	})
+	commitRow1 := &cdcpb.Event_Row{
+		StartTs: 1,
+		Key:     []byte("k1"),
+	}
+	err := matcher.matchRow(commitRow1)
+	c.Assert(err, check.ErrorMatches, "*not found*")
+	commitRow2 := &cdcpb.Event_Row{
+		StartTs: 2,
+		Key:     []byte("k1"),
+	}
+	err = matcher.matchRow(commitRow2)
+	c.Assert(err, check.IsNil)
+	c.Assert(commitRow2.Value, check.BytesEquals, []byte("v2"))
+}

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -247,35 +247,19 @@ func (p *processor) Run(ctx context.Context, errCh chan<- error) {
 	p.errCh = errCh
 
 	wg.Go(func() error {
-		err := p.localResolvedWorker(cctx)
-		if err != nil {
-			log.Error("", zap.Error(err))
-		}
-		return err
+		return p.localResolvedWorker(cctx)
 	})
 
 	wg.Go(func() error {
-		err := p.globalResolvedWorker(cctx)
-		if err != nil {
-			log.Error("", zap.Error(err))
-		}
-		return err
+		return p.globalResolvedWorker(cctx)
 	})
 
 	wg.Go(func() error {
-		err := p.syncResolved(cctx)
-		if err != nil {
-			log.Error("", zap.Error(err))
-		}
-		return err
+		return p.syncResolved(cctx)
 	})
 
 	wg.Go(func() error {
-		err := p.pullDDLJob(cctx)
-		if err != nil {
-			log.Error("", zap.Error(err))
-		}
-		return err
+		return p.pullDDLJob(cctx)
 	})
 
 	go func() {
@@ -659,7 +643,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 			}
 			txn, err := p.mounter.Mount(rawTxn)
 			if err != nil {
-				return errors.Annotatef(err, "ts: %d", rawTxn.Ts)
+				return errors.Trace(err)
 			}
 			if p.changefeed.ShouldIgnoreTxn(&txn) {
 				log.Info("DML txn ignored", zap.Uint64("ts", txn.Ts))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
kvclient may be output a row which value is null

When two changes of the same key get received, the previous one may be overridden after the second prewrite.

### What is changed and how it works?

Use "startTs + key" instead of "key" alone as the key of the state map.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test