### PR TITLE
bug fix: ignore the column which is in `write only` status

### DIFF
--- a/cdc/entry/kv_entry.go
+++ b/cdc/entry/kv_entry.go
@@ -112,7 +112,7 @@ func (row *rowKVEntry) unflatten(tableInfo *schema.TableInfo) error {
 	for colID, v := range row.Row {
 		colInfo, exist := tableInfo.GetColumnInfo(colID)
 		if !exist {
-			log.Info("can not find column info, ignore this column", zap.Int64("colID", colID))
+			log.Info("can not find column info, ignore this column because the column should be in WRITE ONLY state", zap.Int64("colID", colID), zap.Uint64("ts", row.Ts))
 			delete(row.Row, colID)
 			continue
 		}

--- a/cdc/entry/kv_entry.go
+++ b/cdc/entry/kv_entry.go
@@ -21,10 +21,12 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/tidb/types"
+	"go.uber.org/zap"
 )
 
 type kvEntry interface {
@@ -110,7 +112,9 @@ func (row *rowKVEntry) unflatten(tableInfo *schema.TableInfo) error {
 	for colID, v := range row.Row {
 		colInfo, exist := tableInfo.GetColumnInfo(colID)
 		if !exist {
-			return errors.NotFoundf("column info, colID: %d", colID)
+			log.Info("can not find column info, ignore this column", zap.Int64("colID", colID))
+			delete(row.Row, colID)
+			continue
 		}
 		fieldType := &colInfo.FieldType
 		datum, err := unflatten(v, fieldType)

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -202,7 +202,7 @@ func collectRawTxns(
 			}
 			resolvedTxnsBatchSize.Observe(float64(len(readyTxns)))
 			if len(readyTxns) == 0 {
-				log.Info("Forwarding fake txn", zap.Uint64("ts", resolvedTs))
+				log.Debug("Forwarding fake txn", zap.Uint64("ts", resolvedTs))
 				fakeTxn := model.RawTxn{
 					Ts:      resolvedTs,
 					Entries: nil,

--- a/tests/util/db.go
+++ b/tests/util/db.go
@@ -155,14 +155,13 @@ func CreateSourceDBs() (dbs []*sql.DB, err error) {
 		return nil, errors.Trace(err)
 	}
 
-	//cfg.Port = 4001
-	//src2, err := CreateDB(cfg)
-	//if err != nil {
-	//	return nil, errors.Trace(err)
-	//}
+	cfg.Port = 4001
+	src2, err := CreateDB(cfg)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
-	//dbs = append(dbs, src1, src2)
-	dbs = append(dbs, src1)
+	dbs = append(dbs, src1, src2)
 	return
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when upstream execute an adding column DDL, the DDL job state will follow `none` -> `delete-only` -> `write only` -> `done`.
When the column is `write only`, `TiDB` may write some value into this column. But CDC will receive ddl job after the job is `done`. So when CDC can't find the column info.

When the column is `write only`, it's not public yet, so the value inserted in this column must be default value.

### What is changed and how it works?
Just ignore the `write only` column

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test