### PR TITLE
retry when etcd watch meets mvcc.ErrCompacted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,8 @@ check: fmt lint check-static tidy
 
 coverage:
 	GO111MODULE=off go get github.com/zhouqiang-cl/gocovmerge
-	gocovmerge "$(TEST_DIR)"/cov.* | grep -v "$(CDC_PKG)/cdc/kv/testing.go" > "$(TEST_DIR)/all_cov.out"
-	grep -v "$(CDC_PKG)/cdc/kv/testing.go" "$(TEST_DIR)/cov.unit.out" > "$(TEST_DIR)/unit_cov.out"
+	gocovmerge "$(TEST_DIR)"/cov.* | grep -vE "$(CDC_PKG)/cdc/kv/testing.go|.*.__failpoint_binding__.go" > "$(TEST_DIR)/all_cov.out"
+	grep -vE "$(CDC_PKG)/cdc/kv/testing.go|.*.__failpoint_binding__.go" "$(TEST_DIR)/cov.unit.out" > "$(TEST_DIR)/unit_cov.out"
 ifeq ("$(JenkinsCI)", "1")
 	GO111MODULE=off go get github.com/mattn/goveralls
 	@goveralls -coverprofile=$(TEST_DIR)/all_cov.out -service=jenkins-ci -repotoken $(COVERALLS_TOKEN)

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -130,6 +130,7 @@ func (c *Capture) Start(ctx context.Context) (err error) {
 			err := watcher.Watch(cctx, c)
 			if errors.Cause(err) == mvcc.ErrCompacted {
 				log.Warn("changefeed watcher watch retryable error", zap.Error(err))
+				time.Sleep(time.Millisecond * 500)
 				continue
 			}
 			return errors.Trace(err)

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc"
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -125,7 +126,14 @@ func (c *Capture) Start(ctx context.Context) (err error) {
 
 	watcher := NewChangeFeedWatcher(c.info.ID, c.pdEndpoints, c.etcdClient)
 	errg.Go(func() error {
-		return watcher.Watch(cctx, c)
+		for {
+			err := watcher.Watch(cctx, c)
+			if errors.Cause(err) == mvcc.ErrCompacted {
+				log.Warn("changefeed watcher watch retryable error", zap.Error(err))
+				continue
+			}
+			return errors.Trace(err)
+		}
 	})
 
 	return errg.Wait()

--- a/cdc/capture_info.go
+++ b/cdc/capture_info.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
@@ -99,6 +101,10 @@ func newCaptureInfoWatch(
 		etcdWatchC := cli.Watch(ctx, captureEinfoKeyPrefix, clientv3.WithPrefix(), clientv3.WithRev(revision+1), clientv3.WithPrevKV())
 
 		for resp := range etcdWatchC {
+			failpoint.Inject("WatchCaptureInfoCompactionErr", func() {
+				watchResp <- &CaptureInfoWatchResp{Err: errors.Trace(mvcc.ErrCompacted)}
+				return
+			})
 			if resp.Err() != nil {
 				watchResp <- &CaptureInfoWatchResp{Err: errors.Trace(resp.Err())}
 				return

--- a/cdc/capture_info.go
+++ b/cdc/capture_info.go
@@ -103,7 +103,7 @@ func newCaptureInfoWatch(
 		for resp := range etcdWatchC {
 			failpoint.Inject("WatchCaptureInfoCompactionErr", func() {
 				watchResp <- &CaptureInfoWatchResp{Err: errors.Trace(mvcc.ErrCompacted)}
-				return
+				failpoint.Return()
 			})
 			if resp.Err() != nil {
 				watchResp <- &CaptureInfoWatchResp{Err: errors.Trace(resp.Err())}

--- a/cdc/capture_info_test.go
+++ b/cdc/capture_info_test.go
@@ -3,11 +3,15 @@ package cdc
 import (
 	"context"
 	"net/url"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/embed"
+	"github.com/coreos/etcd/mvcc"
 	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -80,9 +84,15 @@ func (ci *captureInfoSuite) TestPutDeleteGet(c *check.C) {
 }
 
 func (ci *captureInfoSuite) TestWatch(c *check.C) {
+	watcherRetry := int64(0)
 	info1 := &model.CaptureInfo{ID: "1"}
 	info2 := &model.CaptureInfo{ID: "2"}
 	info3 := &model.CaptureInfo{ID: "3"}
+
+	owner := &ownerImpl{
+		etcdClient: ci.client,
+		captures:   make(map[model.CaptureID]*model.CaptureInfo),
+	}
 
 	ctx := context.Background()
 	var err error
@@ -93,16 +103,29 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 	watchCtx, watchCancel := context.WithCancel(ctx)
 	infos, watchC, err := newCaptureInfoWatch(watchCtx, ci.client)
 	c.Assert(err, check.IsNil)
+	owner.captureWatchC = watchC
 	// infos contains info1
 	c.Assert(infos, check.HasLen, 1)
 	c.Assert(infos[0], check.DeepEquals, info1)
 
 	mustGetResp := func() *CaptureInfoWatchResp {
 		select {
-		case resp, ok := <-watchC:
-			c.Assert(ok, check.IsTrue)
+		case resp := <-owner.captureWatchC:
+			err := resp.Err
+			if err != nil && errors.Cause(err) == mvcc.ErrCompacted {
+				atomic.AddInt64(&watcherRetry, 1)
+				err2 := owner.resetCaptureInfoWatcher(watchCtx)
+				c.Assert(err2, check.IsNil)
+				return nil
+			}
+			c.Assert(err, check.IsNil)
+			if resp.IsDelete {
+				owner.removeCapture(resp.Info)
+			} else {
+				owner.addCapture(resp.Info)
+			}
 			return resp
-		case <-time.After(time.Second * 5):
+		case <-time.After(time.Second * 2):
 			c.Fatal("timeout to get resp from watchC")
 			return nil
 		}
@@ -110,29 +133,35 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 
 	mustClosed := func() {
 		select {
-		case _, ok := <-watchC:
+		case _, ok := <-owner.captureWatchC:
 			c.Assert(ok, check.IsFalse)
-		case <-time.After(time.Second * 5):
+		case <-time.After(time.Second * 2):
 			c.Fatal("timeout to get resp from watchC")
-
 		}
 	}
 
-	// put info2 and info3
+	checkCaptureLen := func(expected int) {
+		owner.l.RLock()
+		defer owner.l.RUnlock()
+		c.Assert(len(owner.captures), check.Equals, expected)
+	}
+
+	failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr", "1*return")
+
 	err = PutCaptureInfo(ctx, info2, ci.client)
 	c.Assert(err, check.IsNil)
+	resp := mustGetResp()
+	c.Assert(resp, check.IsNil)
+	c.Assert(atomic.LoadInt64(&watcherRetry), check.Equals, int64(1))
+	checkCaptureLen(2)
+	failpoint.Disable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr")
+
 	err = PutCaptureInfo(ctx, info3, ci.client)
 	c.Assert(err, check.IsNil)
-
-	resp := mustGetResp()
-	c.Assert(resp.Err, check.IsNil)
-	c.Assert(resp.IsDelete, check.IsFalse)
-	c.Assert(resp.Info, check.DeepEquals, info2)
-
 	resp = mustGetResp()
-	c.Assert(resp.Err, check.IsNil)
 	c.Assert(resp.IsDelete, check.IsFalse)
 	c.Assert(resp.Info, check.DeepEquals, info3)
+	checkCaptureLen(3)
 
 	// delete info2 and info3
 	err = DeleteCaptureInfo(ctx, info2.ID, ci.client)
@@ -141,14 +170,14 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	resp = mustGetResp()
-	c.Assert(resp.Err, check.IsNil)
 	c.Assert(resp.IsDelete, check.IsTrue)
 	c.Assert(resp.Info, check.DeepEquals, info2)
+	checkCaptureLen(2)
 
 	resp = mustGetResp()
-	c.Assert(resp.Err, check.IsNil)
 	c.Assert(resp.IsDelete, check.IsTrue)
 	c.Assert(resp.Info, check.DeepEquals, info3)
+	checkCaptureLen(1)
 
 	// cancel the watch
 	watchCancel()

--- a/cdc/capture_info_test.go
+++ b/cdc/capture_info_test.go
@@ -146,15 +146,14 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 		c.Assert(len(owner.captures), check.Equals, expected)
 	}
 
-	failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr", "1*return")
-
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr", "1*return"), check.IsNil)
 	err = PutCaptureInfo(ctx, info2, ci.client)
 	c.Assert(err, check.IsNil)
 	resp := mustGetResp()
 	c.Assert(resp, check.IsNil)
 	c.Assert(atomic.LoadInt64(&watcherRetry), check.Equals, int64(1))
 	checkCaptureLen(2)
-	failpoint.Disable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr")
+	c.Assert(failpoint.Disable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr"), check.IsNil)
 
 	err = PutCaptureInfo(ctx, info3, ci.client)
 	c.Assert(err, check.IsNil)

--- a/cdc/capture_info_test.go
+++ b/cdc/capture_info_test.go
@@ -143,7 +143,7 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 	checkCaptureLen := func(expected int) {
 		owner.l.RLock()
 		defer owner.l.RUnlock()
-		c.Assert(len(owner.captures), check.Equals, expected)
+		c.Assert(owner.captures, check.HasLen, expected)
 	}
 
 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr", "1*return"), check.IsNil)

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -883,6 +883,7 @@ func (o *ownerImpl) Run(ctx context.Context, tickTime time.Duration) error {
 				break
 			}
 			log.Warn("capture info watcher retryable error", zap.Error(err))
+			time.Sleep(time.Millisecond * 500)
 			err = o.resetCaptureInfoWatcher(ctx)
 			if err != nil {
 				break

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -876,8 +876,9 @@ func (o *ownerImpl) Run(ctx context.Context, tickTime time.Duration) error {
 	defer o.cancelWatchCapture()
 	handleWatchCaptureC := make(chan error, 1)
 	go func() {
+		var err error
 		for {
-			err := o.handleWatchCapture()
+			err = o.handleWatchCapture()
 			if errors.Cause(err) != mvcc.ErrCompacted {
 				break
 			}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/coreos/etcd/mvcc"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	pmodel "github.com/pingcap/parser/model"
@@ -432,6 +433,19 @@ func (o *ownerImpl) removeCapture(info *model.CaptureInfo) {
 			log.Warn("failed to delete key", zap.Error(err))
 		}
 	}
+}
+
+func (o *ownerImpl) resetCaptureInfoWatcher(ctx context.Context) error {
+	infos, watchC, err := newCaptureInfoWatch(ctx, o.etcdClient)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, info := range infos {
+		// use addCapture is ok, old info will be covered
+		o.addCapture(info)
+	}
+	o.captureWatchC = watchC
+	return nil
 }
 
 func (o *ownerImpl) handleWatchCapture() error {
@@ -862,7 +876,17 @@ func (o *ownerImpl) Run(ctx context.Context, tickTime time.Duration) error {
 	defer o.cancelWatchCapture()
 	handleWatchCaptureC := make(chan error, 1)
 	go func() {
-		err := o.handleWatchCapture()
+		for {
+			err := o.handleWatchCapture()
+			if errors.Cause(err) != mvcc.ErrCompacted {
+				break
+			}
+			log.Warn("capture info watcher retryable error", zap.Error(err))
+			err = o.resetCaptureInfoWatcher(ctx)
+			if err != nil {
+				break
+			}
+		}
 		if err != nil {
 			handleWatchCaptureC <- err
 		}

--- a/cdc/roles/manager.go
+++ b/cdc/roles/manager.go
@@ -289,6 +289,12 @@ func (m *ownerManager) watchOwner(ctx context.Context, etcdSession *concurrency.
 				return
 			}
 
+			err := resp.Err()
+			if err != nil {
+				m.logger.Error("watch owner key error", zap.Error(err))
+				return
+			}
+
 			for _, ev := range resp.Events {
 				if ev.Type == mvccpb.DELETE {
 					m.logger.Info("watch failed, owner is deleted")

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -211,10 +211,9 @@ func (w *ProcessorWatcher) Watch(ctx context.Context, errCh chan<- error, cb pro
 		errCh <- errors.Trace(err)
 		return
 	}
-	revision := getResp.Header.Revision
 	if getResp.Count == 0 {
 		// wait for key to appear
-		watchCh := w.etcdCli.Watch(ctx, key, clientv3.WithRev(revision))
+		watchCh := w.etcdCli.Watch(ctx, key)
 	waitKeyLoop:
 		for {
 			select {

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -20,8 +20,10 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
@@ -125,6 +127,9 @@ func (w *ChangeFeedWatcher) Watch(ctx context.Context, cb processorCallback) err
 				log.Info("watcher is closed")
 				return nil
 			}
+			failpoint.Inject("WatchChangeFeedInfoCompactionErr", func() {
+				failpoint.Return(errors.Trace(mvcc.ErrCompacted))
+			})
 			respErr := resp.Err()
 			if respErr != nil {
 				return errors.Trace(respErr)

--- a/cdc/scheduler_test.go
+++ b/cdc/scheduler_test.go
@@ -286,7 +286,7 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 		return len(w.infos) == 0
 	}), check.IsTrue)
 
-	failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchChangeFeedInfoCompactionErr", "1*return")
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchChangeFeedInfoCompactionErr", "1*return"), check.IsNil)
 
 	// create a changefeed
 	err = kv.SaveChangeFeedInfo(context.Background(), cli, detail, changefeedID)
@@ -299,7 +299,7 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 	w.lock.RUnlock()
 	c.Assert(atomic.LoadInt64(&watcherRetry), check.Equals, int64(1))
 
-	failpoint.Disable("github.com/pingcap/ticdc/cdc/WatchChangeFeedInfoCompactionErr")
+	c.Assert(failpoint.Disable("github.com/pingcap/ticdc/cdc/WatchChangeFeedInfoCompactionErr"), check.IsNil)
 
 	// dispatch a stop changefeed admin job
 	detail.AdminJobType = model.AdminStop

--- a/cdc/scheduler_test.go
+++ b/cdc/scheduler_test.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/embed"
+	"github.com/coreos/etcd/mvcc"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/etcd"
@@ -217,12 +219,13 @@ func (s *schedulerSuite) TestProcessorWatcherError(c *check.C) {
 
 func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 	var (
-		changefeedID = "test-changefeed-watcher"
-		captureID    = "test-capture"
-		pdEndpoints  = []string{}
-		sinkURI      = "root@tcp(127.0.0.1:3306)/test"
-		detail       = &model.ChangeFeedInfo{SinkURI: sinkURI}
-		key          = kv.GetEtcdKeyChangeFeedInfo(changefeedID)
+		changefeedID       = "test-changefeed-watcher"
+		captureID          = "test-capture"
+		pdEndpoints        = []string{}
+		sinkURI            = "root@tcp(127.0.0.1:3306)/test"
+		detail             = &model.ChangeFeedInfo{SinkURI: sinkURI}
+		key                = kv.GetEtcdKeyChangeFeedInfo(changefeedID)
+		watcherRetry int64 = 0
 	)
 
 	oriRunProcessorWatcher := runProcessorWatcher
@@ -246,9 +249,17 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err2 := w.Watch(ctx, nil)
-		if err2 != nil && errors.Cause(err2) != context.Canceled {
-			c.Fatal(err2)
+		for {
+			err2 := w.Watch(ctx, nil)
+			switch errors.Cause(err2) {
+			case nil, context.Canceled:
+				return
+			case mvcc.ErrCompacted:
+				atomic.AddInt64(&watcherRetry, 1)
+				continue
+			default:
+				c.Fatal(err2)
+			}
 		}
 	}()
 
@@ -275,6 +286,8 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 		return len(w.infos) == 0
 	}), check.IsTrue)
 
+	failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchChangeFeedInfoCompactionErr", "1*return")
+
 	// create a changefeed
 	err = kv.SaveChangeFeedInfo(context.Background(), cli, detail, changefeedID)
 	c.Assert(err, check.IsNil)
@@ -284,6 +297,9 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 	w.lock.RLock()
 	c.Assert(len(w.infos), check.Equals, 1)
 	w.lock.RUnlock()
+	c.Assert(atomic.LoadInt64(&watcherRetry), check.Equals, int64(1))
+
+	failpoint.Disable("github.com/pingcap/ticdc/cdc/WatchChangeFeedInfoCompactionErr")
 
 	// dispatch a stop changefeed admin job
 	detail.AdminJobType = model.AdminStop

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
 	github.com/pingcap/errors v0.11.4
+	github.com/pingcap/failpoint v0.0.0-20200115060041-f2180fbf0df8
 	github.com/pingcap/kvproto v0.0.0-20200108025604-a4dc183d2af5
 	github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9
 	github.com/pingcap/parser v0.0.0-20191012071233-32876040fefb

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c h1:hvQd3aOLKLF7xvRV6DzvPkKY4QXzfVbjU1BhW0d9yL8=
 github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
+github.com/pingcap/failpoint v0.0.0-20200115060041-f2180fbf0df8 h1:P1+sLSDI3Aw1UURnn8VOTY3kEv47a3MSnxUyBkwAcR8=
+github.com/pingcap/failpoint v0.0.0-20200115060041-f2180fbf0df8/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e h1:P73/4dPCL96rGrobssy1nVy2VaVpNCuLpCbr+FEaTA8=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20190822090350-11ea838aedf7/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
@@ -208,6 +210,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237 h1:HQagqIiBmr8YXawX/le3+O26N+vPPC1PtjaF3mwnook=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

etcd has an auto compaction mechanism, we have some etcd key watch with revision. If error happens and retries from a compacted key revision, the error "mvcc: required revision has been compacted" will be returned from etcd API.

### What is changed and how it works?
- add necessary retry on the `mvcc.ErrCompacted`
- remove revision if we can watch without rev
- add failpoint in unit  test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test