### PR TITLE
move some time interval constant variables

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -37,7 +37,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var markProcessorDownTime = 1 * time.Minute
+const (
+	markProcessorDownTime      = time.Minute
+	captureInfoWatchRetryDelay = time.Millisecond * 500
+)
 
 // OwnerDDLHandler defines the ddl handler for Owner
 // which can pull ddl jobs and execute ddl jobs
@@ -883,7 +886,7 @@ func (o *ownerImpl) Run(ctx context.Context, tickTime time.Duration) error {
 				break
 			}
 			log.Warn("capture info watcher retryable error", zap.Error(err))
-			time.Sleep(time.Millisecond * 500)
+			time.Sleep(captureInfoWatchRetryDelay)
 			err = o.resetCaptureInfoWatcher(ctx)
 			if err != nil {
 				break

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -31,6 +31,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	checkTaskKeyInterval = time.Second * 1
+)
+
 var (
 	runProcessorWatcher = realRunProcessorWatcher
 	runProcessor        = realRunProcessor
@@ -260,7 +264,7 @@ func (w *ProcessorWatcher) Watch(ctx context.Context, errCh chan<- error, cb pro
 				errCh <- err
 			}
 			return
-		case <-time.After(time.Second):
+		case <-time.After(checkTaskKeyInterval):
 			resp, err := w.etcdCli.Get(ctx, key)
 			if err != nil {
 				errCh <- errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Some time interval variables have significant effect to replication performance. We should have more clear way to manage them.

### What is changed and how it works?
move these variables to a constant group in the file where they belong. (Easy for benchmark, of course some of the polling mechanism will be refined in the future)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test