### PR TITLE
etcd: split TaskStatus into two structs

### DIFF
--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -100,8 +100,6 @@ func (s *etcdSuite) TestGetChangeFeeds(c *check.C) {
 func (s *etcdSuite) TestGetPutTaskStatus(c *check.C) {
 	ctx := context.Background()
 	info := &model.TaskStatus{
-		CheckPointTs: 100,
-		ResolvedTs:   200,
 		TableInfos: []*model.ProcessTableInfo{
 			{ID: 1, StartTs: 100},
 		},
@@ -126,8 +124,6 @@ func (s *etcdSuite) TestGetPutTaskStatus(c *check.C) {
 func (s *etcdSuite) TestDeleteTaskStatus(c *check.C) {
 	ctx := context.Background()
 	info := &model.TaskStatus{
-		CheckPointTs: 100,
-		ResolvedTs:   200,
 		TableInfos: []*model.ProcessTableInfo{
 			{ID: 1, StartTs: 100},
 		},
@@ -142,6 +138,47 @@ func (s *etcdSuite) TestDeleteTaskStatus(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, _, err = GetTaskStatus(ctx, s.client, feedID, captureID)
 	c.Assert(errors.Cause(err), check.Equals, model.ErrTaskStatusNotExists)
+}
+
+func (s *etcdSuite) TestGetPutTaskPosition(c *check.C) {
+	ctx := context.Background()
+	info := &model.TaskPosition{
+		ResolvedTs:   66,
+		CheckPointTs: 77,
+	}
+
+	feedID := "feedid"
+	captureID := "captureid"
+
+	err := PutTaskPosition(ctx, s.client, feedID, captureID, info)
+	c.Assert(err, check.IsNil)
+
+	_, getInfo, err := GetTaskPosition(ctx, s.client, feedID, captureID)
+	c.Assert(err, check.IsNil)
+	c.Assert(getInfo, check.DeepEquals, info)
+
+	err = ClearAllCDCInfo(context.Background(), s.client)
+	c.Assert(err, check.IsNil)
+	_, _, err = GetTaskStatus(ctx, s.client, feedID, captureID)
+	c.Assert(errors.Cause(err), check.Equals, model.ErrTaskStatusNotExists)
+}
+
+func (s *etcdSuite) TestDeleteTaskPosition(c *check.C) {
+	ctx := context.Background()
+	info := &model.TaskPosition{
+		ResolvedTs:   77,
+		CheckPointTs: 88,
+	}
+	feedID := "feedid"
+	captureID := "captureid"
+
+	err := PutTaskPosition(ctx, s.client, feedID, captureID, info)
+	c.Assert(err, check.IsNil)
+
+	err = DeleteTaskPosition(ctx, s.client, feedID, captureID)
+	c.Assert(err, check.IsNil)
+	_, _, err = GetTaskPosition(ctx, s.client, feedID, captureID)
+	c.Assert(errors.Cause(err), check.Equals, model.ErrTaskPositionNotExists)
 }
 
 func (s *etcdSuite) TestOpChangeFeedDetail(c *check.C) {

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -22,7 +22,8 @@ import (
 var (
 	ErrWriteTsConflict        = errors.New("write ts conflict")
 	ErrChangeFeedNotExists    = errors.New("changefeed not exists")
-	ErrTaskStatusNotExists    = errors.New("task not exists")
+	ErrTaskStatusNotExists    = errors.New("task status not exists")
+	ErrTaskPositionNotExists  = errors.New("task position not exists")
 	ErrWriteTaskStatusConlict = errors.New("write task status conflict")
 	ErrFindPLockNotCommit     = errors.New("task status has p-lock not committed")
 	ErrAdminStopProcessor     = errors.New("stop processor by admin command")

--- a/cdc/model/owner_test.go
+++ b/cdc/model/owner_test.go
@@ -21,14 +21,12 @@ import (
 
 func TestSuite(t *testing.T) { check.TestingT(t) }
 
-type cloneTaskStatusSuite struct{}
+type taskStatusSuite struct{}
 
-var _ = check.Suite(&cloneTaskStatusSuite{})
+var _ = check.Suite(&taskStatusSuite{})
 
-func (s *cloneTaskStatusSuite) TestShouldBeDeepCopy(c *check.C) {
+func (s *taskStatusSuite) TestShouldBeDeepCopy(c *check.C) {
 	info := TaskStatus{
-		CheckPointTs: 12,
-		ResolvedTs:   20,
 		TableInfos: []*ProcessTableInfo{
 			{ID: 1},
 			{ID: 2},
@@ -39,8 +37,6 @@ func (s *cloneTaskStatusSuite) TestShouldBeDeepCopy(c *check.C) {
 
 	clone := info.Clone()
 	assertIsSnapshot := func() {
-		c.Assert(clone.CheckPointTs, check.Equals, uint64(12))
-		c.Assert(clone.ResolvedTs, check.Equals, uint64(20))
 		c.Assert(clone.TableInfos, check.HasLen, 3)
 		for i, info := range clone.TableInfos {
 			c.Assert(info.ID, check.Equals, uint64(i+1))
@@ -51,7 +47,6 @@ func (s *cloneTaskStatusSuite) TestShouldBeDeepCopy(c *check.C) {
 
 	assertIsSnapshot()
 
-	info.CheckPointTs = 1111
 	info.TableInfos[2] = &ProcessTableInfo{ID: 1212}
 	info.TablePLock.Ts = 100
 	info.TableCLock = &TableLock{Ts: 100}
@@ -59,21 +54,19 @@ func (s *cloneTaskStatusSuite) TestShouldBeDeepCopy(c *check.C) {
 	assertIsSnapshot()
 }
 
-func (s *cloneTaskStatusSuite) TestProcSnapshot(c *check.C) {
+func (s *taskStatusSuite) TestProcSnapshot(c *check.C) {
 	info := TaskStatus{
-		CheckPointTs: 0,
-		ResolvedTs:   20,
 		TableInfos: []*ProcessTableInfo{
 			{ID: 10, StartTs: 100},
 		},
 	}
 	cfID := "changefeed-1"
 	captureID := "capture-1"
-	snap := info.Snapshot(cfID, captureID)
+	snap := info.Snapshot(cfID, captureID, 200)
 	c.Assert(snap.CfID, check.Equals, cfID)
 	c.Assert(snap.CaptureID, check.Equals, captureID)
 	c.Assert(snap.Tables, check.HasLen, 1)
-	c.Assert(snap.Tables[0].StartTs, check.Equals, uint64(100))
+	c.Assert(snap.Tables[0].StartTs, check.Equals, uint64(200))
 }
 
 type removeTableSuite struct{}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -543,9 +543,15 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 
 	existingTables := make(map[uint64]uint64)
 	for captureID, taskStatus := range processorsInfos {
-		pos := taskPositions[captureID]
+		var checkpointTs uint64
+		if pos, exist := taskPositions[captureID]; exist {
+			checkpointTs = pos.CheckPointTs
+		}
 		for _, tbl := range taskStatus.TableInfos {
-			existingTables[tbl.ID] = pos.CheckPointTs
+			if tbl.StartTs > checkpointTs {
+				checkpointTs = tbl.StartTs
+			}
+			existingTables[tbl.ID] = checkpointTs
 		}
 	}
 

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -61,7 +61,7 @@ type OwnerDDLHandler interface {
 // ChangeFeedRWriter defines the Reader and Writer for changeFeed
 type ChangeFeedRWriter interface {
 	// Read the changefeed info from storage such as etcd.
-	Read(ctx context.Context) (map[model.ChangeFeedID]*model.ChangeFeedInfo, map[model.ChangeFeedID]*model.ChangeFeedStatus, map[model.ChangeFeedID]model.ProcessorsInfos, error)
+	Read(ctx context.Context) (map[model.ChangeFeedID]*model.ChangeFeedInfo, map[model.ChangeFeedID]*model.ChangeFeedStatus, map[model.ChangeFeedID]model.ProcessorsInfos, map[model.ChangeFeedID]map[model.CaptureID]*model.TaskPosition, error)
 	// Write the changefeed info to storage such as etcd.
 	Write(ctx context.Context, infos map[model.ChangeFeedID]*model.ChangeFeedStatus) error
 }
@@ -74,7 +74,8 @@ type changeFeed struct {
 	schema                  *schema.Storage
 	ddlState                model.ChangeFeedDDLState
 	targetTs                uint64
-	processorInfos          model.ProcessorsInfos
+	taskStatus              model.ProcessorsInfos
+	taskPositions           map[string]*model.TaskPosition
 	processorLastUpdateTime map[string]time.Time
 	filter                  *txnFilter
 
@@ -94,7 +95,7 @@ type changeFeed struct {
 func (c *changeFeed) String() string {
 	format := "{\n ID: %s\n info: %+v\n status: %+v\n State: %v\n ProcessorInfos: %+v\n tables: %+v\n orphanTables: %+v\n toCleanTables: %v\n ddlResolvedTs: %d\n ddlJobHistory: %+v\n}\n\n"
 	s := fmt.Sprintf(format,
-		c.id, c.info, c.status, c.ddlState, c.processorInfos, c.tables,
+		c.id, c.info, c.status, c.ddlState, c.taskStatus, c.tables,
 		c.orphanTables, c.toCleanTables, c.ddlResolvedTs, c.ddlJobHistory)
 
 	if len(c.ddlJobHistory) > 0 {
@@ -105,20 +106,21 @@ func (c *changeFeed) String() string {
 	return s
 }
 
-func (c *changeFeed) updateProcessorInfos(processInfos model.ProcessorsInfos) {
-	for cid, pinfo := range processInfos {
+func (c *changeFeed) updateProcessorInfos(processInfos model.ProcessorsInfos, position map[string]*model.TaskPosition) {
+	for cid, pinfo := range position {
 		if _, ok := c.processorLastUpdateTime[cid]; !ok {
 			c.processorLastUpdateTime[cid] = time.Now()
 			continue
 		}
 
-		oldPinfo, ok := c.processorInfos[cid]
+		oldPinfo, ok := c.taskPositions[cid]
 		if !ok || oldPinfo.ResolvedTs != pinfo.ResolvedTs || oldPinfo.CheckPointTs != pinfo.CheckPointTs {
 			c.processorLastUpdateTime[cid] = time.Now()
 		}
 	}
 
-	c.processorInfos = processInfos
+	c.taskStatus = processInfos
+	c.taskPositions = position
 }
 
 func (c *changeFeed) addSchema(schemaID uint64) {
@@ -190,7 +192,7 @@ func (c *changeFeed) minimumTablesCapture(captures map[string]*model.CaptureInfo
 
 	for id := range captures {
 		// We have not dispatch any table to this capture yet.
-		if _, ok := c.processorInfos[id]; !ok {
+		if _, ok := c.taskStatus[id]; !ok {
 			return id
 		}
 	}
@@ -198,7 +200,7 @@ func (c *changeFeed) minimumTablesCapture(captures map[string]*model.CaptureInfo
 	var minCount int = math.MaxInt64
 	var minID string
 
-	for id, pinfo := range c.processorInfos {
+	for id, pinfo := range c.taskStatus {
 		if len(pinfo.TableInfos) < minCount {
 			minID = id
 			minCount = len(pinfo.TableInfos)
@@ -214,7 +216,7 @@ func (c *changeFeed) tryBalance(ctx context.Context, captures map[string]*model.
 }
 
 func (c *changeFeed) restoreTableInfos(infoSnapshot *model.TaskStatus, captureID string) {
-	c.processorInfos[captureID].TableInfos = infoSnapshot.TableInfos
+	c.taskStatus[captureID].TableInfos = infoSnapshot.TableInfos
 }
 
 func (c *changeFeed) cleanTables(ctx context.Context) {
@@ -222,7 +224,7 @@ func (c *changeFeed) cleanTables(ctx context.Context) {
 
 cleanLoop:
 	for id := range c.toCleanTables {
-		captureID, taskStatus, ok := findTaskStatusWithTable(c.processorInfos, id)
+		captureID, taskStatus, ok := findTaskStatusWithTable(c.taskStatus, id)
 		if !ok {
 			log.Warn("ignore clean table id", zap.Uint64("id", id))
 			cleanIDs = append(cleanIDs, id)
@@ -234,7 +236,7 @@ cleanLoop:
 
 		newInfo, err := c.infoWriter.Write(ctx, c.id, captureID, taskStatus, true)
 		if err == nil {
-			c.processorInfos[captureID] = newInfo
+			c.taskStatus[captureID] = newInfo
 		}
 		switch errors.Cause(err) {
 		case model.ErrFindPLockNotCommit:
@@ -283,7 +285,7 @@ func (c *changeFeed) banlanceOrphanTables(ctx context.Context, captures map[stri
 			return
 		}
 
-		info := c.processorInfos[captureID]
+		info := c.taskStatus[captureID]
 		if info == nil {
 			info = new(model.TaskStatus)
 		}
@@ -295,7 +297,7 @@ func (c *changeFeed) banlanceOrphanTables(ctx context.Context, captures map[stri
 
 		newInfo, err := c.infoWriter.Write(ctx, c.id, captureID, info, false)
 		if err == nil {
-			c.processorInfos[captureID] = newInfo
+			c.taskStatus[captureID] = newInfo
 		}
 		switch errors.Cause(err) {
 		case model.ErrFindPLockNotCommit:
@@ -457,7 +459,11 @@ func (o *ownerImpl) removeCapture(info *model.CaptureInfo) {
 	delete(o.captures, info.ID)
 
 	for _, feed := range o.changeFeeds {
-		pinfo, ok := feed.processorInfos[info.ID]
+		pinfo, ok := feed.taskStatus[info.ID]
+		if !ok {
+			continue
+		}
+		pos, ok := feed.taskPositions[info.ID]
 		if !ok {
 			continue
 		}
@@ -465,14 +471,18 @@ func (o *ownerImpl) removeCapture(info *model.CaptureInfo) {
 		for _, table := range pinfo.TableInfos {
 			feed.orphanTables[table.ID] = model.ProcessTableInfo{
 				ID:      table.ID,
-				StartTs: pinfo.CheckPointTs,
+				StartTs: pos.CheckPointTs,
 			}
 		}
 
-		key := kv.GetEtcdKeyTask(feed.id, info.ID)
-		if _, err := o.etcdClient.Delete(context.Background(), key); err != nil {
-			log.Warn("failed to delete key", zap.Error(err))
+		ctx := context.Background()
+		if err := kv.DeleteTaskStatus(ctx, o.etcdClient, feed.id, info.ID); err != nil {
+			log.Warn("failed to delete task status", zap.Error(err))
 		}
+		if err := kv.DeleteTaskPosition(ctx, o.etcdClient, feed.id, info.ID); err != nil {
+			log.Warn("failed to delete task position", zap.Error(err))
+		}
+
 	}
 }
 
@@ -506,7 +516,7 @@ func (o *ownerImpl) handleWatchCapture() error {
 	return nil
 }
 
-func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.ProcessorsInfos, info *model.ChangeFeedInfo, checkpointTs uint64) (*changeFeed, error) {
+func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.ProcessorsInfos, taskPositions map[string]*model.TaskPosition, info *model.ChangeFeedInfo, checkpointTs uint64) (*changeFeed, error) {
 	log.Info("Find new changefeed", zap.Reflect("info", info),
 		zap.String("id", id), zap.Uint64("checkpoint ts", checkpointTs))
 
@@ -523,9 +533,10 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 	ddlHandler := newDDLHandler(o.pdClient, checkpointTs)
 
 	existingTables := make(map[uint64]uint64)
-	for _, taskStatus := range processorsInfos {
+	for captureID, taskStatus := range processorsInfos {
+		pos := taskPositions[captureID]
 		for _, tbl := range taskStatus.TableInfos {
-			existingTables[tbl.ID] = taskStatus.CheckPointTs
+			existingTables[tbl.ID] = pos.CheckPointTs
 		}
 	}
 
@@ -578,28 +589,31 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 			ResolvedTs:   0,
 			CheckpointTs: checkpointTs,
 		},
-		ddlState:       model.ChangeFeedSyncDML,
-		targetTs:       info.GetTargetTs(),
-		processorInfos: processorsInfos,
-		infoWriter:     storage.NewOwnerTaskStatusEtcdWriter(o.etcdClient),
-		filter:         filter,
+		ddlState:      model.ChangeFeedSyncDML,
+		targetTs:      info.GetTargetTs(),
+		taskStatus:    processorsInfos,
+		taskPositions: taskPositions,
+		infoWriter:    storage.NewOwnerTaskStatusEtcdWriter(o.etcdClient),
+		filter:        filter,
 	}
 	return cf, nil
 }
 
 func (o *ownerImpl) loadChangeFeeds(ctx context.Context) error {
-	cfInfo, cfStatus, pinfos, err := o.cfRWriter.Read(ctx)
+	cfInfo, cfStatus, pinfos, positions, err := o.cfRWriter.Read(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	for changeFeedID, procInfos := range pinfos {
 		if cf, exist := o.changeFeeds[changeFeedID]; exist {
-			cf.updateProcessorInfos(procInfos)
-			for id, info := range cf.processorInfos {
+			taskPos := positions[changeFeedID]
+			cf.updateProcessorInfos(procInfos, taskPos)
+			for id, info := range cf.taskStatus {
 				lastUpdateTime := cf.processorLastUpdateTime[id]
+				pos := taskPos[id]
 				if time.Since(lastUpdateTime) > markProcessorDownTime {
-					snap := info.Snapshot(changeFeedID, id)
+					snap := info.Snapshot(changeFeedID, id, pos.CheckPointTs)
 					o.markDownProcessor = append(o.markDownProcessor, snap)
 					log.Info("markdown processor", zap.String("id", id),
 						zap.Reflect("info", info), zap.Time("update time", lastUpdateTime))
@@ -620,7 +634,8 @@ func (o *ownerImpl) loadChangeFeeds(ctx context.Context) error {
 		}
 		checkpointTs := info.GetCheckpointTs(status)
 
-		newCf, err := o.newChangeFeed(changeFeedID, procInfos, info, checkpointTs)
+		taskPos := positions[changeFeedID]
+		newCf, err := o.newChangeFeed(changeFeedID, procInfos, taskPos, info, checkpointTs)
 		if err != nil {
 			return errors.Annotatef(err, "create change feed %s", changeFeedID)
 		}
@@ -670,13 +685,13 @@ func (c *changeFeed) calcResolvedTs() error {
 		minCheckpointTs = c.status.CheckpointTs
 	} else {
 		// calc the min of all resolvedTs in captures
-		for _, pStatus := range c.processorInfos {
-			if minResolvedTs > pStatus.ResolvedTs {
-				minResolvedTs = pStatus.ResolvedTs
+		for _, position := range c.taskPositions {
+			if minResolvedTs > position.ResolvedTs {
+				minResolvedTs = position.ResolvedTs
 			}
 
-			if minCheckpointTs > pStatus.CheckPointTs {
-				minCheckpointTs = pStatus.CheckPointTs
+			if minCheckpointTs > position.CheckPointTs {
+				minCheckpointTs = position.CheckPointTs
 			}
 		}
 	}
@@ -768,7 +783,7 @@ func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.C
 	todoDDLJob := c.ddlJobHistory[0]
 
 	// Check if all the checkpointTs of capture are achieving global resolvedTs(which is equal to todoDDLJob.FinishedTS)
-	for cid, pInfo := range c.processorInfos {
+	for cid, pInfo := range c.taskPositions {
 		if pInfo.CheckPointTs != todoDDLJob.Job.BinlogInfo.FinishedTS {
 			log.Debug("wait checkpoint ts", zap.String("cid", cid),
 				zap.Uint64("checkpoint ts", pInfo.CheckPointTs),
@@ -839,7 +854,7 @@ func (o *ownerImpl) dispatchJob(ctx context.Context, job model.AdminJob) error {
 	if !ok {
 		return errors.Errorf("changefeed %s not found in owner cache", job.CfID)
 	}
-	for captureID, pinfo := range cf.processorInfos {
+	for captureID, pinfo := range cf.taskStatus {
 		pinfo.TablePLock = nil
 		pinfo.TableCLock = nil
 		pinfo.AdminJobType = job.Type

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -501,9 +501,6 @@ func (p *processor) handleTables(ctx context.Context, oldInfo, newInfo *model.Ta
 			Ts:           newInfo.TablePLock.Ts,
 			CheckpointTs: checkpointTs,
 		}
-		log.Info("show write clock",
-			zap.Reflect("plock", newInfo.TablePLock),
-			zap.Reflect("clock", newInfo.TableCLock))
 	}
 
 	// add tables

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -159,7 +159,8 @@ type processor struct {
 	resolvedTxns chan model.RawTxn
 	executedTxns chan model.RawTxn
 
-	status *model.TaskStatus
+	status   *model.TaskStatus
+	position *model.TaskPosition
 
 	tablesMu sync.Mutex
 	tables   map[int64]*tableInfo
@@ -250,6 +251,7 @@ func NewProcessor(pdEndpoints []string, changefeed model.ChangeFeedInfo, changef
 
 		tsRWriter:    tsRWriter,
 		status:       tsRWriter.GetTaskStatus(),
+		position:     &model.TaskPosition{},
 		resolvedTxns: make(chan model.RawTxn, 1),
 		executedTxns: make(chan model.RawTxn, 1),
 		ddlJobsCh:    make(chan model.RawTxn, 16),
@@ -359,7 +361,7 @@ func (p *processor) localResolvedWorker(ctx context.Context) error {
 				}
 			}
 			p.tablesMu.Unlock()
-			p.status.ResolvedTs = minResolvedTs
+			p.position.ResolvedTs = minResolvedTs
 			resolvedTsGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(oracle.ExtractPhysical(minResolvedTs)))
 		case e, ok := <-p.executedTxns:
 			if !ok {
@@ -367,7 +369,7 @@ func (p *processor) localResolvedWorker(ctx context.Context) error {
 				return nil
 			}
 			if e.IsResolved {
-				p.status.CheckPointTs = e.Ts
+				p.position.CheckPointTs = e.Ts
 				checkpointTsGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(oracle.ExtractPhysical(e.Ts)))
 			}
 		case <-updateInfoTick.C:
@@ -388,42 +390,43 @@ func (p *processor) localResolvedWorker(ctx context.Context) error {
 }
 
 func (p *processor) updateInfo(ctx context.Context) error {
-	err := p.tsRWriter.WriteInfoIntoStorage(ctx)
+	err := p.tsRWriter.WritePosition(ctx, p.position)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	switch errors.Cause(err) {
-	case model.ErrWriteTsConflict:
-		oldInfo, _, err := p.tsRWriter.UpdateInfo(ctx)
+	return retry.Run(func() error {
+		statusChanged, err := p.tsRWriter.UpdateInfo(ctx)
 		if err != nil {
-			return errors.Trace(err)
+			return backoff.Permanent(errors.Trace(err))
 		}
-
+		if !statusChanged {
+			return nil
+		}
+		oldStatus := p.status
 		p.status = p.tsRWriter.GetTaskStatus()
-
 		if p.status.AdminJobType == model.AdminStop || p.status.AdminJobType == model.AdminRemove {
 			err = p.stop(ctx)
 			if err != nil {
-				return errors.Trace(err)
+				return backoff.Permanent(errors.Trace(err))
 			}
-			return errors.Trace(model.ErrAdminStopProcessor)
+			return backoff.Permanent(errors.Trace(model.ErrAdminStopProcessor))
 		}
 
-		p.handleTables(ctx, oldInfo, p.status, oldInfo.CheckPointTs)
+		p.handleTables(ctx, oldStatus, p.status, p.position.CheckPointTs)
 		syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(len(p.status.TableInfos)))
 
-		if len(oldInfo.TableInfos) > len(p.status.TableInfos) {
-			// some table is removed, we will not both remove and add table in one operation.
-			// keep CheckpointTs and ResolvedTs as the old in memory cache one.
-			p.status.CheckPointTs = oldInfo.CheckPointTs
-			p.status.ResolvedTs = oldInfo.ResolvedTs
+		err = p.tsRWriter.WriteInfoIntoStorage(ctx)
+		switch errors.Cause(err) {
+		case model.ErrWriteTsConflict:
+			return errors.Trace(err)
+		case nil:
+			log.Info("update task status", zap.Stringer("status", p.status))
+			return nil
+		default:
+			return backoff.Permanent(errors.Trace(err))
 		}
-
-		log.Info("update task status", zap.Stringer("status", p.status))
-		return nil
-	case nil:
-		return nil
-	default:
-		return errors.Trace(err)
-	}
+	}, 5)
 }
 
 func diffProcessTableInfos(oldInfo, newInfo []*model.ProcessTableInfo) (removed, added []*model.ProcessTableInfo) {
@@ -498,6 +501,9 @@ func (p *processor) handleTables(ctx context.Context, oldInfo, newInfo *model.Ta
 			Ts:           newInfo.TablePLock.Ts,
 			CheckpointTs: checkpointTs,
 		}
+		log.Info("show write clock",
+			zap.Reflect("plock", newInfo.TablePLock),
+			zap.Reflect("clock", newInfo.TableCLock))
 	}
 
 	// add tables

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -48,6 +48,10 @@ func (s *mockTsRWriter) ReadGlobalResolvedTs(ctx context.Context) (uint64, error
 	return s.globalResolvedTs, nil
 }
 
+func (s *mockTsRWriter) WritePosition(ctx context.Context, taskPosition *model.TaskPosition) error {
+	return nil
+}
+
 // GetTaskStatus implement ProcessorTsRWriter interface.
 func (s *mockTsRWriter) GetTaskStatus() *model.TaskStatus {
 	return s.memInfo
@@ -60,14 +64,11 @@ func (s *mockTsRWriter) WriteInfoIntoStorage(ctx context.Context) error {
 }
 
 // UpdateInfo implement ProcessorTsRWriter interface.
-func (s *mockTsRWriter) UpdateInfo(ctx context.Context) (oldInfo *model.TaskStatus, newInfo *model.TaskStatus, err error) {
-	oldInfo = s.memInfo
-	newInfo = s.storageInfo
-
+func (s *mockTsRWriter) UpdateInfo(ctx context.Context) (bool, error) {
 	s.memInfo = s.storageInfo
 	s.storageInfo = s.memInfo.Clone()
 
-	return
+	return true, nil
 }
 
 func (s *mockTsRWriter) SetGlobalResolvedTs(ts uint64) {

--- a/cdc/roles/storage/etcd.go
+++ b/cdc/roles/storage/etcd.go
@@ -45,36 +45,43 @@ func NewChangeFeedEtcdRWriter(cli *clientv3.Client) *ChangeFeedRWriter {
 // Read reads from etcd, and returns
 // - map mapping from changefeedID to `*model.ChangeFeedInfo`
 // - map mapping from changefeedID to `model.ProcessorsInfos`
-func (rw *ChangeFeedRWriter) Read(ctx context.Context) (map[model.ChangeFeedID]*model.ChangeFeedInfo, map[model.ChangeFeedID]*model.ChangeFeedStatus, map[model.ChangeFeedID]model.ProcessorsInfos, error) {
+// FIXME: the return value of this function is too many, split this function
+func (rw *ChangeFeedRWriter) Read(ctx context.Context) (map[model.ChangeFeedID]*model.ChangeFeedInfo, map[model.ChangeFeedID]*model.ChangeFeedStatus, map[model.ChangeFeedID]model.ProcessorsInfos, map[model.ChangeFeedID]map[model.CaptureID]*model.TaskPosition, error) {
 	_, details, err := kv.GetChangeFeeds(ctx, rw.etcdClient)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	changefeedInfos := make(map[string]*model.ChangeFeedInfo, len(details))
 	changefeedStatus := make(map[string]*model.ChangeFeedStatus, len(details))
 	pinfos := make(map[string]model.ProcessorsInfos, len(details))
+	postitions := make(map[model.ChangeFeedID]map[model.CaptureID]*model.TaskPosition, len(details))
 	for changefeedID, rawKv := range details {
 		changefeed := &model.ChangeFeedInfo{}
 		err := changefeed.Unmarshal(rawKv.Value)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
 		pinfo, err := kv.GetAllTaskStatus(ctx, rw.etcdClient, changefeedID)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
+		}
+		postition, err := kv.GetAllTaskPositions(ctx, rw.etcdClient, changefeedID)
+		if err != nil {
+			return nil, nil, nil, nil, err
 		}
 
 		status, err := kv.GetChangeFeedStatus(ctx, rw.etcdClient, changefeedID)
 		if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
 		changefeedStatus[changefeedID] = status
 		changefeedInfos[changefeedID] = changefeed
 		pinfos[changefeedID] = pinfo
+		postitions[changefeedID] = postition
 	}
-	return changefeedInfos, changefeedStatus, pinfos, nil
+	return changefeedInfos, changefeedStatus, pinfos, postitions, nil
 }
 
 // Write writes ChangeFeedStatus of each changefeed into etcd
@@ -113,12 +120,15 @@ type ProcessorTsRWriter interface {
 	// ReadGlobalResolvedTs read the bloable resolved ts.
 	ReadGlobalResolvedTs(ctx context.Context) (uint64, error)
 
+	// WritePosition update taskPosition into storage, return model.ErrWriteTsConflict if in last learn taskPosition is out dated and must call UpdateInfo.
+	WritePosition(ctx context.Context, taskPosition *model.TaskPosition) error
+
 	// The flowing methods *IS NOT* thread safe.
 	// GetTaskStatus returns the in memory cache *model.TaskStatus
 	GetTaskStatus() *model.TaskStatus
 	// UpdateInfo update the in memory cache as taskStatus in storage.
 	// oldInfo and newInfo is the old and new in memory cache taskStatus.
-	UpdateInfo(ctx context.Context) (oldInfo *model.TaskStatus, newInfo *model.TaskStatus, err error)
+	UpdateInfo(ctx context.Context) (bool, error)
 	// WriteInfoIntoStorage update taskStatus into storage, return model.ErrWriteTsConflict if in last learn taskStatus is out dated and must call UpdateInfo.
 	WriteInfoIntoStorage(ctx context.Context) error
 }
@@ -157,19 +167,24 @@ func NewProcessorTsEtcdRWriter(cli *clientv3.Client, changefeedID, captureID str
 	return rw, nil
 }
 
+// WritePosition implements ProcessorTsRWriter interface.
+func (rw *ProcessorTsEtcdRWriter) WritePosition(ctx context.Context, taskPosition *model.TaskPosition) error {
+	return errors.Trace(kv.PutTaskPosition(ctx, rw.etcdClient, rw.changefeedID, rw.captureID, taskPosition))
+}
+
 // UpdateInfo implements ProcessorTsRWriter interface.
 func (rw *ProcessorTsEtcdRWriter) UpdateInfo(
 	ctx context.Context,
-) (oldInfo *model.TaskStatus, newInfo *model.TaskStatus, err error) {
+) (changed bool, err error) {
 	modRevision, info, err := kv.GetTaskStatus(ctx, rw.etcdClient, rw.changefeedID, rw.captureID)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return false, errors.Trace(err)
 	}
-
-	oldInfo = rw.taskStatus
-	newInfo = info
-	rw.taskStatus = newInfo
-	rw.modRevision = modRevision
+	changed = rw.modRevision != modRevision
+	if changed {
+		rw.taskStatus = info
+		rw.modRevision = modRevision
+	}
 	return
 }
 
@@ -177,7 +192,8 @@ func (rw *ProcessorTsEtcdRWriter) UpdateInfo(
 func (rw *ProcessorTsEtcdRWriter) WriteInfoIntoStorage(
 	ctx context.Context,
 ) error {
-	key := kv.GetEtcdKeyTask(rw.changefeedID, rw.captureID)
+
+	key := kv.GetEtcdKeyTaskStatus(rw.changefeedID, rw.captureID)
 	value, err := rw.taskStatus.Marshal()
 	if err != nil {
 		return errors.Trace(err)
@@ -271,6 +287,7 @@ func (ow *OwnerTaskStatusEtcdWriter) checkLock(
 		}
 		return
 	}
+	log.Info("show check lock", zap.Reflect("status", info))
 
 	// in most cases there is no p-lock
 	if info.TablePLock == nil {
@@ -319,13 +336,12 @@ func (ow *OwnerTaskStatusEtcdWriter) Write(
 		}
 	}
 
-	key := kv.GetEtcdKeyTask(changefeedID, captureID)
+	key := kv.GetEtcdKeyTaskStatus(changefeedID, captureID)
 	err = retry.Run(func() error {
 		value, err := newInfo.Marshal()
 		if err != nil {
 			return errors.Trace(err)
 		}
-
 		resp, err := ow.etcdClient.KV.Txn(ctx).If(
 			clientv3.Compare(clientv3.ModRevision(key), "=", newInfo.ModRevision),
 		).Then(

--- a/cdc/roles/storage/etcd_test.go
+++ b/cdc/roles/storage/etcd_test.go
@@ -71,20 +71,26 @@ func (s *etcdSuite) TestInfoReader(c *check.C) {
 	var (
 		status1 = map[model.CaptureID]*model.TaskStatus{
 			"capture1": {
-				CheckPointTs: 1000,
-				ResolvedTs:   1024,
 				TableInfos: []*model.ProcessTableInfo{
 					{ID: 1000, StartTs: 0},
 					{ID: 1001, StartTs: 100},
 				},
 			},
 			"capture2": {
-				CheckPointTs: 1000,
-				ResolvedTs:   1500,
 				TableInfos: []*model.ProcessTableInfo{
 					{ID: 1002, StartTs: 150},
 					{ID: 1003, StartTs: 200},
 				},
+			},
+		}
+		pos1 = map[model.CaptureID]*model.TaskPosition{
+			"capture1": {
+				ResolvedTs:   100,
+				CheckPointTs: 99,
+			},
+			"capture2": {
+				ResolvedTs:   200,
+				CheckPointTs: 188,
 			},
 		}
 		err error
@@ -92,10 +98,15 @@ func (s *etcdSuite) TestInfoReader(c *check.C) {
 	testCases := []struct {
 		ids    []string
 		pinfos map[string]model.ProcessorsInfos
+		ppos   map[string]map[string]*model.TaskPosition
 	}{
-		{ids: nil, pinfos: nil},
-		{ids: []string{"changefeed1"}, pinfos: map[string]model.ProcessorsInfos{"changefeed1": status1}},
-		{ids: []string{"changefeed1", "changefeed2"}, pinfos: map[string]model.ProcessorsInfos{"changefeed1": status1, "changefeed2": status1}},
+		{ids: nil, pinfos: nil, ppos: nil},
+		{ids: []string{"changefeed1"},
+			pinfos: map[string]model.ProcessorsInfos{"changefeed1": status1},
+			ppos:   map[string]map[string]*model.TaskPosition{"changefeed1": pos1}},
+		{ids: []string{"changefeed1", "changefeed2"},
+			pinfos: map[string]model.ProcessorsInfos{"changefeed1": status1, "changefeed2": status1},
+			ppos:   map[string]map[string]*model.TaskPosition{"changefeed1": pos1, "changefeed2": pos1}},
 	}
 
 	rw := NewChangeFeedEtcdRWriter(s.client)
@@ -103,7 +114,7 @@ func (s *etcdSuite) TestInfoReader(c *check.C) {
 		_, err = s.client.Delete(context.Background(), kv.GetEtcdKeyChangeFeedList(), clientv3.WithPrefix())
 		c.Assert(err, check.IsNil)
 		for _, changefeedID := range tc.ids {
-			_, err = s.client.Delete(context.Background(), kv.GetEtcdKeyTaskList(changefeedID), clientv3.WithPrefix())
+			_, err = s.client.Delete(context.Background(), kv.GetEtcdKeyTaskStatusList(changefeedID), clientv3.WithPrefix())
 			c.Assert(err, check.IsNil)
 		}
 		for i := 0; i < len(tc.ids); i++ {
@@ -113,21 +124,29 @@ func (s *etcdSuite) TestInfoReader(c *check.C) {
 			for captureID, cinfo := range tc.pinfos[changefeedID] {
 				sinfo, err := cinfo.Marshal()
 				c.Assert(err, check.IsNil)
-				_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTask(changefeedID, captureID), sinfo)
+				_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTaskStatus(changefeedID, captureID), sinfo)
+				c.Assert(err, check.IsNil)
+
+				pos := tc.ppos[changefeedID][captureID]
+				spos, err := pos.Marshal()
+				c.Assert(err, check.IsNil)
+				_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTaskPosition(changefeedID, captureID), spos)
 				c.Assert(err, check.IsNil)
 			}
 		}
-		cfInfo, cfStatus, pinfos, err := rw.Read(context.Background())
+		cfInfo, cfStatus, pinfos, ppos, err := rw.Read(context.Background())
 		c.Assert(err, check.IsNil)
 		c.Assert(len(cfInfo), check.Equals, len(tc.ids))
 		c.Assert(len(cfStatus), check.Equals, len(tc.ids))
 		c.Assert(len(pinfos), check.Equals, len(tc.ids))
+		c.Assert(len(ppos), check.Equals, len(tc.ids))
 		for _, changefeedID := range tc.ids {
 			// don't check ModRevision
 			for _, si := range pinfos[changefeedID] {
 				si.ModRevision = 0
 			}
 			c.Assert(pinfos[changefeedID], check.DeepEquals, tc.pinfos[changefeedID])
+			c.Assert(ppos[changefeedID], check.DeepEquals, tc.ppos[changefeedID])
 		}
 	}
 }
@@ -189,7 +208,7 @@ func (s *etcdSuite) TestNewProcessorTsEtcdRWriter(c *check.C) {
 	info := new(model.TaskStatus)
 	sinfo, err := info.Marshal()
 	c.Assert(err, check.IsNil)
-	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTask(changefeedID, captureID), sinfo)
+	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTaskStatus(changefeedID, captureID), sinfo)
 	c.Assert(err, check.IsNil)
 
 	_, err = NewProcessorTsEtcdRWriter(s.client, changefeedID, captureID)
@@ -213,7 +232,7 @@ func (s *etcdSuite) TestProcessorTsWriter(c *check.C) {
 	// create a task record in etcd
 	sinfo, err := info.Marshal()
 	c.Assert(err, check.IsNil)
-	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTask(changefeedID, captureID), sinfo)
+	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTaskStatus(changefeedID, captureID), sinfo)
 	c.Assert(err, check.IsNil)
 
 	// test WriteResolvedTs
@@ -221,52 +240,56 @@ func (s *etcdSuite) TestProcessorTsWriter(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rw.GetTaskStatus(), check.DeepEquals, info)
 
-	info = rw.GetTaskStatus()
-	info.ResolvedTs = 128
+	pos := &model.TaskPosition{
+		CheckPointTs: 96,
+		ResolvedTs:   128,
+	}
+	err = rw.WritePosition(context.Background(), pos)
+	c.Assert(err, check.IsNil)
+
+	_, getPos, err := kv.GetTaskPosition(context.Background(), s.client, changefeedID, captureID)
+	c.Assert(err, check.IsNil)
+	c.Assert(getPos.ResolvedTs, check.Equals, pos.ResolvedTs)
+	c.Assert(getPos.CheckPointTs, check.Equals, pos.CheckPointTs)
+
+	rw.GetTaskStatus().AdminJobType = model.AdminStop
 	err = rw.WriteInfoIntoStorage(context.Background())
 	c.Assert(err, check.IsNil)
-
-	revision, getInfo, err = kv.GetTaskStatus(context.Background(), s.client, changefeedID, captureID)
+	revision, getStatus, err := kv.GetTaskStatus(context.Background(), s.client, changefeedID, captureID)
 	c.Assert(err, check.IsNil)
+	c.Assert(getStatus, check.DeepEquals, rw.GetTaskStatus())
 	c.Assert(revision, check.Equals, rw.modRevision)
-	c.Assert(getInfo.ResolvedTs, check.Equals, uint64(128))
-
-	// test WriteCheckpointTs
-	info.CheckPointTs = 96
-	err = rw.WriteInfoIntoStorage(context.Background())
-	c.Assert(err, check.IsNil)
-
-	revision, getInfo, err = kv.GetTaskStatus(context.Background(), s.client, changefeedID, captureID)
-	c.Assert(err, check.IsNil)
-	c.Assert(revision, check.Equals, rw.modRevision)
-	c.Assert(getInfo.CheckPointTs, check.Equals, uint64(96))
 
 	// test table taskStatus changed, should return ErrWriteTsConflict.
 	getInfo = info.Clone()
 	getInfo.TableInfos = []*model.ProcessTableInfo{{ID: 11}, {ID: 12}, {ID: 13}}
 	sinfo, err = getInfo.Marshal()
 	c.Assert(err, check.IsNil)
-	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTask(changefeedID, captureID), sinfo)
+	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTaskStatus(changefeedID, captureID), sinfo)
 	c.Assert(err, check.IsNil)
 
-	info.ResolvedTs = 196
+	info.TableCLock = &model.TableLock{Ts: 6}
 	err = rw.WriteInfoIntoStorage(context.Background())
 	c.Assert(errors.Cause(err), check.Equals, model.ErrWriteTsConflict)
 
-	oldInfo, newInfo, err := rw.UpdateInfo(context.Background())
+	changed, err := rw.UpdateInfo(context.Background())
 	c.Assert(err, check.IsNil)
-	c.Assert(oldInfo, check.DeepEquals, info)
-	c.Assert(newInfo, check.DeepEquals, getInfo)
+	c.Assert(changed, check.IsTrue)
+	c.Assert(rw.GetTaskStatus(), check.DeepEquals, getInfo)
 	info = rw.GetTaskStatus()
 
 	// update success again.
-	info.ResolvedTs = 196
+	info.TableCLock = &model.TableLock{Ts: 6}
 	err = rw.WriteInfoIntoStorage(context.Background())
 	c.Assert(err, check.IsNil)
 	revision, getInfo, err = kv.GetTaskStatus(context.Background(), s.client, changefeedID, captureID)
 	c.Assert(err, check.IsNil)
 	c.Assert(revision, check.Equals, rw.modRevision)
-	c.Assert(getInfo.ResolvedTs, check.Equals, uint64(196))
+	c.Assert(getInfo.TableCLock.Ts, check.Equals, uint64(6))
+}
+
+func (s *etcdSuite) TestProcessorTsWritePos(c *check.C) {
+
 }
 
 func (s *etcdSuite) TestProcessorTsReader(c *check.C) {
@@ -291,7 +314,7 @@ func (s *etcdSuite) TestProcessorTsReader(c *check.C) {
 	subInfo := new(model.TaskStatus)
 	subInfoData, err := subInfo.Marshal()
 	c.Assert(err, check.IsNil)
-	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTask(changefeedID, captureID), subInfoData)
+	_, err = s.client.Put(context.Background(), kv.GetEtcdKeyTaskStatus(changefeedID, captureID), subInfoData)
 	c.Assert(err, check.IsNil)
 
 	rw, err := NewProcessorTsEtcdRWriter(s.client, changefeedID, captureID)
@@ -317,13 +340,6 @@ func (s *etcdSuite) TestOwnerTableInfoWriter(c *check.C) {
 	info, err = ow.Write(context.Background(), changefeedID, captureID, info, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.TableInfos, check.HasLen, 1)
-
-	// simulate processor updates the task status
-	infoClone := info.Clone()
-	infoClone.ResolvedTs = 200
-	infoClone.CheckPointTs = 100
-	err = kv.PutTaskStatus(context.Background(), s.client, changefeedID, captureID, infoClone)
-	c.Assert(err, check.IsNil)
 
 	// owner adds table to processor when remote data is updated
 	info.TableInfos = append(info.TableInfos, &model.ProcessTableInfo{ID: 52, StartTs: 100})

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -214,7 +214,7 @@ func (w *ProcessorWatcher) reopen() error {
 // Watch wait for the key `/changefeed/task/<fid>/cid>` appear and run the processor.
 func (w *ProcessorWatcher) Watch(ctx context.Context, errCh chan<- error, cb processorCallback) {
 	defer w.wg.Done()
-	key := kv.GetEtcdKeyTask(w.changefeedID, w.captureID)
+	key := kv.GetEtcdKeyTaskStatus(w.changefeedID, w.captureID)
 
 	getResp, err := w.etcdCli.Get(ctx, key)
 	if err != nil {

--- a/cdc/scheduler_test.go
+++ b/cdc/scheduler_test.go
@@ -113,7 +113,7 @@ func (s *schedulerSuite) TestProcessorWatcher(c *check.C) {
 		captureID    = "test-capture"
 		pdEndpoints  = []string{}
 		detail       = model.ChangeFeedInfo{}
-		key          = kv.GetEtcdKeyTask(changefeedID, captureID)
+		key          = kv.GetEtcdKeyTaskStatus(changefeedID, captureID)
 	)
 
 	oriRunProcessor := runProcessor
@@ -177,7 +177,7 @@ func (s *schedulerSuite) TestProcessorWatcherError(c *check.C) {
 		captureID    = "test-capture-err"
 		pdEndpoints  = []string{}
 		detail       = model.ChangeFeedInfo{}
-		key          = kv.GetEtcdKeyTask(changefeedID, captureID)
+		key          = kv.GetEtcdKeyTaskStatus(changefeedID, captureID)
 	)
 
 	oriRunProcessor := runProcessor


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
reduce the probability of write conflicts about `TaskStatus`

### What is changed and how it works?
split `TaskStatus` into `TaskStatus` and `TaskPosition`
The processor write ResolvedTS and CheckpointTs into `TaskPosition`, and rarely write `TaskStatus`,
so we can reduce the probability of write conflicts about `TaskStatus`
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test