### PR TITLE
*: Merge similar structs

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -401,7 +401,7 @@ func (c *CDCClient) singleEventFeed(
 
 		// emit a checkpoint
 		revent := &model.RegionFeedEvent{
-			Checkpoint: &model.RegionFeedCheckpoint{
+			Checkpoint: &model.ResolvedSpan{
 				Span:       span,
 				ResolvedTs: item.commit,
 			},
@@ -414,7 +414,7 @@ func (c *CDCClient) singleEventFeed(
 	}
 
 	// TODO: drop this if we totally depends on the ResolvedTs event from
-	// tikv to emit the RegionFeedCheckpoint.
+	// tikv to emit the ResolvedSpan.
 	sorter := newSorter(maxItemFn)
 	defer sorter.close()
 
@@ -451,7 +451,7 @@ func (c *CDCClient) singleEventFeed(
 						}
 
 						revent := &model.RegionFeedEvent{
-							Val: &model.RegionFeedValue{
+							Val: &model.RawKVEntry{
 								OpType: opType,
 								Key:    row.Key,
 								Value:  row.GetValue(),
@@ -488,7 +488,7 @@ func (c *CDCClient) singleEventFeed(
 						}
 
 						revent := &model.RegionFeedEvent{
-							Val: &model.RegionFeedValue{
+							Val: &model.RawKVEntry{
 								OpType: opType,
 								Key:    row.Key,
 								Value:  value,
@@ -523,7 +523,7 @@ func (c *CDCClient) singleEventFeed(
 				if atomic.LoadUint32(&initialized) == 1 {
 					// emit a checkpoint
 					revent := &model.RegionFeedEvent{
-						Checkpoint: &model.RegionFeedCheckpoint{
+						Checkpoint: &model.ResolvedSpan{
 							Span:       span,
 							ResolvedTs: x.ResolvedTs,
 						},

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -356,7 +356,7 @@ func (c *CDCClient) divideAndSendEventFeedToRegions(
 // singleEventFeed makes a EventFeed RPC call.
 // Results will be send to eventCh
 // EventFeed RPC will not return checkpoint event directly
-// Checkpoint event is generate while there's not non-match pre-write
+// Resolved event is generate while there's not non-match pre-write
 // Return the maximum checkpoint
 func (c *CDCClient) singleEventFeed(
 	ctx context.Context,
@@ -401,7 +401,7 @@ func (c *CDCClient) singleEventFeed(
 
 		// emit a checkpoint
 		revent := &model.RegionFeedEvent{
-			Checkpoint: &model.ResolvedSpan{
+			Resolved: &model.ResolvedSpan{
 				Span:       span,
 				ResolvedTs: item.commit,
 			},
@@ -523,7 +523,7 @@ func (c *CDCClient) singleEventFeed(
 				if atomic.LoadUint32(&initialized) == 1 {
 					// emit a checkpoint
 					revent := &model.RegionFeedEvent{
-						Checkpoint: &model.ResolvedSpan{
+						Resolved: &model.ResolvedSpan{
 							Span:       span,
 							ResolvedTs: x.ResolvedTs,
 						},

--- a/cdc/kv/testing.go
+++ b/cdc/kv/testing.go
@@ -32,11 +32,11 @@ type eventChecker struct {
 	eventCh chan *model.RegionFeedEvent
 	closeCh chan struct{}
 
-	vals        []*model.RegionFeedValue
-	checkpoints []*model.RegionFeedCheckpoint
+	vals        []*model.RawKVEntry
+	checkpoints []*model.ResolvedSpan
 }
 
-func valInSlice(val *model.RegionFeedValue, vals []*model.RegionFeedValue) bool {
+func valInSlice(val *model.RawKVEntry, vals []*model.RawKVEntry) bool {
 	for _, v := range vals {
 		if val.Ts == v.Ts && bytes.Equal(val.Key, v.Key) {
 			return true
@@ -253,7 +253,7 @@ func TestGetKVSimple(t require.TestingT, pdCli pd.Client, storage kv.Storage) {
 		checker.stop()
 
 		// filter the unrelated keys event.
-		var vals []*model.RegionFeedValue
+		var vals []*model.RawKVEntry
 		for _, v := range checker.vals {
 			if bytes.Equal(v.Key, key) {
 				vals = append(vals, v)

--- a/cdc/kv/testing.go
+++ b/cdc/kv/testing.go
@@ -72,7 +72,7 @@ func newEventChecker(t require.TestingT) *eventChecker {
 
 					ec.vals = append(ec.vals, e.Val)
 				} else {
-					ec.checkpoints = append(ec.checkpoints, e.Checkpoint)
+					ec.checkpoints = append(ec.checkpoints, e.Resolved)
 				}
 			case <-ec.closeCh:
 				return

--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -19,16 +19,16 @@ const (
 // RegionFeedEvent from the kv layer.
 // Only one of the event will be setted.
 type RegionFeedEvent struct {
-	Val        *RawKVEntry
-	Checkpoint *ResolvedSpan
+	Val      *RawKVEntry
+	Resolved *ResolvedSpan
 }
 
 // GetValue returns the underlying value
 func (e *RegionFeedEvent) GetValue() interface{} {
 	if e.Val != nil {
 		return e.Val
-	} else if e.Checkpoint != nil {
-		return e.Checkpoint
+	} else if e.Resolved != nil {
+		return e.Resolved
 	} else {
 		return nil
 	}

--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -16,48 +16,33 @@ const (
 	OpTypeDelete OpType = 2
 )
 
-// RawKVEntry is entries received from TiKV
-type RawKVEntry = RegionFeedValue
-
-// KvOrResolved can be used as a union type of RawKVEntry and ResolvedSpan
-type KvOrResolved struct {
-	KV       *RawKVEntry
-	Resolved *ResolvedSpan
-}
-
-// ResolvedSpan represents that a span is resolved at a certain timestamp
-type ResolvedSpan struct {
-	Span      util.Span
-	Timestamp uint64
+// RegionFeedEvent from the kv layer.
+// Only one of the event will be setted.
+type RegionFeedEvent struct {
+	Val        *RawKVEntry
+	Checkpoint *ResolvedSpan
 }
 
 // GetValue returns the underlying value
-func (e *KvOrResolved) GetValue() interface{} {
-	if e.KV != nil {
-		return e.KV
-	} else if e.Resolved != nil {
-		return e.Resolved
+func (e *RegionFeedEvent) GetValue() interface{} {
+	if e.Val != nil {
+		return e.Val
+	} else if e.Checkpoint != nil {
+		return e.Checkpoint
 	} else {
 		return nil
 	}
 }
 
-// RegionFeedEvent from the kv layer.
-// Only one of the event will be setted.
-type RegionFeedEvent struct {
-	Val        *RegionFeedValue
-	Checkpoint *RegionFeedCheckpoint
-}
-
-// RegionFeedCheckpoint guarantees all the KV value event
+// ResolvedSpan guarantees all the KV value event
 // with commit ts less than ResolvedTs has been emitted.
-type RegionFeedCheckpoint struct {
+type ResolvedSpan struct {
 	Span       util.Span
 	ResolvedTs uint64
 }
 
-// RegionFeedValue notify the KV operator
-type RegionFeedValue struct {
+// RawKVEntry notify the KV operator
+type RawKVEntry struct {
 	OpType OpType
 	Key    []byte
 	// Nil fro delete type
@@ -65,6 +50,6 @@ type RegionFeedValue struct {
 	Ts    uint64
 }
 
-func (v *RegionFeedValue) String() string {
+func (v *RawKVEntry) String() string {
 	return fmt.Sprintf("OpType: %v, Key: %s, Value: %s, ts: %d", v.OpType, string(v.Key), string(v.Value), v.Ts)
 }

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -363,7 +363,7 @@ func (p *processor) localResolvedWorker(ctx context.Context) error {
 			resolvedTsGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(oracle.ExtractPhysical(minResolvedTs)))
 		case e, ok := <-p.executedTxns:
 			if !ok {
-				log.Info("Checkpoint worker exited")
+				log.Info("Resolved worker exited")
 				return nil
 			}
 			if e.IsResolved {

--- a/cdc/puller/buffer.go
+++ b/cdc/puller/buffer.go
@@ -4,21 +4,17 @@ import (
 	"context"
 
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
 )
 
-// BufferEntry is the type for buffer entry from kv layer
-type BufferEntry = model.KvOrResolved
-
 // Buffer buffers kv entries
-type Buffer chan BufferEntry
+type Buffer chan model.RegionFeedEvent
 
 func makeBuffer() Buffer {
 	return make(Buffer, 8)
 }
 
 // AddEntry adds an entry to the buffer
-func (b Buffer) AddEntry(ctx context.Context, entry BufferEntry) error {
+func (b Buffer) AddEntry(ctx context.Context, entry model.RegionFeedEvent) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -27,21 +23,11 @@ func (b Buffer) AddEntry(ctx context.Context, entry BufferEntry) error {
 	}
 }
 
-// AddKVEntry adds a kv entry to the buffer
-func (b Buffer) AddKVEntry(ctx context.Context, kv *model.RawKVEntry) error {
-	return b.AddEntry(ctx, BufferEntry{KV: kv})
-}
-
-// AddResolved adds a resolved entry to the buffer
-func (b Buffer) AddResolved(ctx context.Context, span util.Span, ts uint64) error {
-	return b.AddEntry(ctx, BufferEntry{Resolved: &model.ResolvedSpan{Span: span, Timestamp: ts}})
-}
-
 // Get waits for an entry from the input channel but will stop with respect to the context
-func (b Buffer) Get(ctx context.Context) (BufferEntry, error) {
+func (b Buffer) Get(ctx context.Context) (model.RegionFeedEvent, error) {
 	select {
 	case <-ctx.Done():
-		return BufferEntry{}, ctx.Err()
+		return model.RegionFeedEvent{}, ctx.Err()
 	case e := <-b:
 		return e, nil
 	}

--- a/cdc/puller/buffer_test.go
+++ b/cdc/puller/buffer_test.go
@@ -40,7 +40,7 @@ func (bs *bufferSuite) TestCanAddAndReadEntriesInOrder(c *check.C) {
 		c.Assert(first.Val.Ts, check.Equals, uint64(110))
 		second, err := b.Get(ctx)
 		c.Assert(err, check.IsNil)
-		c.Assert(second.Checkpoint.ResolvedTs, check.Equals, uint64(111))
+		c.Assert(second.Resolved.ResolvedTs, check.Equals, uint64(111))
 	}()
 
 	err := b.AddEntry(ctx, model.RegionFeedEvent{
@@ -48,7 +48,7 @@ func (bs *bufferSuite) TestCanAddAndReadEntriesInOrder(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	err = b.AddEntry(ctx, model.RegionFeedEvent{
-		Checkpoint: &model.ResolvedSpan{
+		Resolved: &model.ResolvedSpan{
 			Span:       util.Span{},
 			ResolvedTs: 111,
 		},
@@ -68,7 +68,7 @@ func (bs *bufferSuite) TestWaitsCanBeCanceled(c *check.C) {
 	go func() {
 		for {
 			err := b.AddEntry(timeout, model.RegionFeedEvent{
-				Checkpoint: &model.ResolvedSpan{
+				Resolved: &model.ResolvedSpan{
 					Span:       util.Span{},
 					ResolvedTs: 111,
 				},

--- a/cdc/puller/buffer_test.go
+++ b/cdc/puller/buffer_test.go
@@ -37,20 +37,22 @@ func (bs *bufferSuite) TestCanAddAndReadEntriesInOrder(c *check.C) {
 		defer wg.Done()
 		first, err := b.Get(ctx)
 		c.Assert(err, check.IsNil)
-		c.Assert(first.KV.Ts, check.Equals, uint64(111))
+		c.Assert(first.Val.Ts, check.Equals, uint64(110))
 		second, err := b.Get(ctx)
 		c.Assert(err, check.IsNil)
-		c.Assert(second.Resolved.Timestamp, check.Equals, uint64(110))
-		third, err := b.Get(ctx)
-		c.Assert(err, check.IsNil)
-		c.Assert(third.KV.Ts, check.Equals, uint64(112))
+		c.Assert(second.Checkpoint.ResolvedTs, check.Equals, uint64(111))
 	}()
 
-	err := b.AddKVEntry(ctx, &model.RawKVEntry{Ts: 111})
+	err := b.AddEntry(ctx, model.RegionFeedEvent{
+		Val: &model.RawKVEntry{Ts: 110},
+	})
 	c.Assert(err, check.IsNil)
-	err = b.AddResolved(ctx, util.Span{}, 110)
-	c.Assert(err, check.IsNil)
-	err = b.AddKVEntry(ctx, &model.RawKVEntry{Ts: 112})
+	err = b.AddEntry(ctx, model.RegionFeedEvent{
+		Checkpoint: &model.ResolvedSpan{
+			Span:       util.Span{},
+			ResolvedTs: 111,
+		},
+	})
 	c.Assert(err, check.IsNil)
 
 	wg.Wait()
@@ -65,7 +67,12 @@ func (bs *bufferSuite) TestWaitsCanBeCanceled(c *check.C) {
 	stopped := make(chan struct{})
 	go func() {
 		for {
-			err := b.AddEntry(timeout, BufferEntry{KV: &model.RawKVEntry{Ts: 111}})
+			err := b.AddEntry(timeout, model.RegionFeedEvent{
+				Checkpoint: &model.ResolvedSpan{
+					Span:       util.Span{},
+					ResolvedTs: 111,
+				},
+			})
 			if err == context.DeadlineExceeded {
 				close(stopped)
 				return

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -123,20 +123,12 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 						continue
 					}
 
-					kv := &model.RawKVEntry{
-						OpType: val.OpType,
-						Key:    val.Key,
-						Value:  val.Value,
-						Ts:     val.Ts,
-					}
-
-					if err := p.buf.AddKVEntry(ctx, kv); err != nil {
+					if err := p.buf.AddEntry(ctx, *e); err != nil {
 						return errors.Trace(err)
 					}
 					eventCounter.WithLabelValues(captureID, "kv").Inc()
 				} else if e.Checkpoint != nil {
-					cp := e.Checkpoint
-					if err := p.buf.AddResolved(ctx, cp.Span, cp.ResolvedTs); err != nil {
+					if err := p.buf.AddEntry(ctx, *e); err != nil {
 						return errors.Trace(err)
 					}
 					eventCounter.WithLabelValues(captureID, "resolved").Inc()
@@ -162,7 +154,7 @@ func (p *pullerImpl) CollectRawTxns(ctx context.Context, outputFn func(context.C
 // groups them by transactions and sends them to the outputFn.
 func collectRawTxns(
 	ctx context.Context,
-	inputFn func(context.Context) (model.KvOrResolved, error),
+	inputFn func(context.Context) (model.RegionFeedEvent, error),
 	outputFn func(context.Context, model.RawTxn) error,
 	tracker resolveTsTracker,
 ) error {
@@ -172,15 +164,15 @@ func collectRawTxns(
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if be.KV != nil {
-			entryGroups[be.KV.Ts] = append(entryGroups[be.KV.Ts], be.KV)
-		} else if be.Resolved != nil {
-			resolvedTs := be.Resolved.Timestamp
+		if be.Val != nil {
+			entryGroups[be.Val.Ts] = append(entryGroups[be.Val.Ts], be.Val)
+		} else if be.Checkpoint != nil {
+			resolvedTs := be.Checkpoint.ResolvedTs
 			// 1. Forward is called in a single thread
 			// 2. The only way the global minimum resolved Ts can be forwarded is that
 			// 	  the resolveTs we pass in replaces the original one
 			// Thus, we can just use resolvedTs here as the new global minimum resolved Ts.
-			forwarded := tracker.Forward(be.Resolved.Span, resolvedTs)
+			forwarded := tracker.Forward(be.Checkpoint.Span, resolvedTs)
 			if !forwarded {
 				continue
 			}

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -127,7 +127,7 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 						return errors.Trace(err)
 					}
 					eventCounter.WithLabelValues(captureID, "kv").Inc()
-				} else if e.Checkpoint != nil {
+				} else if e.Resolved != nil {
 					if err := p.buf.AddEntry(ctx, *e); err != nil {
 						return errors.Trace(err)
 					}
@@ -166,13 +166,13 @@ func collectRawTxns(
 		}
 		if be.Val != nil {
 			entryGroups[be.Val.Ts] = append(entryGroups[be.Val.Ts], be.Val)
-		} else if be.Checkpoint != nil {
-			resolvedTs := be.Checkpoint.ResolvedTs
+		} else if be.Resolved != nil {
+			resolvedTs := be.Resolved.ResolvedTs
 			// 1. Forward is called in a single thread
 			// 2. The only way the global minimum resolved Ts can be forwarded is that
 			// 	  the resolveTs we pass in replaces the original one
 			// Thus, we can just use resolvedTs here as the new global minimum resolved Ts.
-			forwarded := tracker.Forward(be.Checkpoint.Span, resolvedTs)
+			forwarded := tracker.Forward(be.Resolved.Span, resolvedTs)
 			if !forwarded {
 				continue
 			}

--- a/cdc/puller/txn_test.go
+++ b/cdc/puller/txn_test.go
@@ -64,7 +64,7 @@ func (cs *CollectRawTxnsSuite) TestShouldOutputTxnsInOrder(c *check.C) {
 	// Only add resolved entry for the first 2 transaction
 	for i = 0; i < 2; i++ {
 		e := model.RegionFeedEvent{
-			Checkpoint: &model.ResolvedSpan{ResolvedTs: startTs + i},
+			Resolved: &model.ResolvedSpan{ResolvedTs: startTs + i},
 		}
 		entries = append(entries, e)
 	}
@@ -121,7 +121,7 @@ func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
 		var e model.RegionFeedEvent
 		if v.isResolvedTs {
 			e = model.RegionFeedEvent{
-				Checkpoint: &model.ResolvedSpan{ResolvedTs: v.ts},
+				Resolved: &model.ResolvedSpan{ResolvedTs: v.ts},
 			}
 		} else {
 			e = model.RegionFeedEvent{
@@ -168,8 +168,8 @@ func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
 
 func (cs *CollectRawTxnsSuite) TestShouldOutputBinlogEvenWhenThereIsNoRealEvent(c *check.C) {
 	entries := []model.RegionFeedEvent{
-		{Checkpoint: &model.ResolvedSpan{ResolvedTs: 1024}},
-		{Checkpoint: &model.ResolvedSpan{ResolvedTs: 2000}},
+		{Resolved: &model.ResolvedSpan{ResolvedTs: 1024}},
+		{Resolved: &model.ResolvedSpan{ResolvedTs: 2000}},
 	}
 
 	cursor := 0
@@ -196,6 +196,6 @@ func (cs *CollectRawTxnsSuite) TestShouldOutputBinlogEvenWhenThereIsNoRealEvent(
 	c.Assert(rawTxns, check.HasLen, len(entries))
 	for i, t := range rawTxns {
 		c.Assert(t.Entries, check.HasLen, 0)
-		c.Assert(t.Ts, check.Equals, entries[i].Checkpoint.ResolvedTs)
+		c.Assert(t.Ts, check.Equals, entries[i].Resolved.ResolvedTs)
 	}
 }

--- a/cdc/puller/txn_test.go
+++ b/cdc/puller/txn_test.go
@@ -46,13 +46,13 @@ func (t *mockTracker) Frontier() uint64 {
 var _ = check.Suite(&CollectRawTxnsSuite{})
 
 func (cs *CollectRawTxnsSuite) TestShouldOutputTxnsInOrder(c *check.C) {
-	var entries []model.KvOrResolved
+	var entries []model.RegionFeedEvent
 	var startTs uint64 = 1024
 	var i uint64
 	for i = 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
-			e := model.KvOrResolved{
-				KV: &model.RawKVEntry{
+			e := model.RegionFeedEvent{
+				Val: &model.RawKVEntry{
 					OpType: model.OpTypePut,
 					Key:    []byte(fmt.Sprintf("key-%d-%d", i, j)),
 					Ts:     startTs + i,
@@ -63,16 +63,16 @@ func (cs *CollectRawTxnsSuite) TestShouldOutputTxnsInOrder(c *check.C) {
 	}
 	// Only add resolved entry for the first 2 transaction
 	for i = 0; i < 2; i++ {
-		e := model.KvOrResolved{
-			Resolved: &model.ResolvedSpan{Timestamp: startTs + i},
+		e := model.RegionFeedEvent{
+			Checkpoint: &model.ResolvedSpan{ResolvedTs: startTs + i},
 		}
 		entries = append(entries, e)
 	}
 
 	nRead := 0
-	input := func(ctx context.Context) (model.KvOrResolved, error) {
+	input := func(ctx context.Context) (model.RegionFeedEvent, error) {
 		if nRead >= len(entries) {
-			return model.KvOrResolved{}, errors.New("End")
+			return model.RegionFeedEvent{}, errors.New("End")
 		}
 		e := entries[nRead]
 		nRead++
@@ -103,7 +103,7 @@ func (cs *CollectRawTxnsSuite) TestShouldOutputTxnsInOrder(c *check.C) {
 }
 
 func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
-	var entries []model.KvOrResolved
+	var entries []model.RegionFeedEvent
 	for _, v := range []struct {
 		key          []byte
 		ts           uint64
@@ -118,14 +118,14 @@ func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
 		{key: []byte("key2-1"), ts: 2},
 		{ts: 1, isResolvedTs: true},
 	} {
-		var e model.KvOrResolved
+		var e model.RegionFeedEvent
 		if v.isResolvedTs {
-			e = model.KvOrResolved{
-				Resolved: &model.ResolvedSpan{Timestamp: v.ts},
+			e = model.RegionFeedEvent{
+				Checkpoint: &model.ResolvedSpan{ResolvedTs: v.ts},
 			}
 		} else {
-			e = model.KvOrResolved{
-				KV: &model.RawKVEntry{
+			e = model.RegionFeedEvent{
+				Val: &model.RawKVEntry{
 					OpType: model.OpTypePut,
 					Key:    v.key,
 					Ts:     v.ts,
@@ -136,9 +136,9 @@ func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
 	}
 
 	cursor := 0
-	input := func(ctx context.Context) (model.KvOrResolved, error) {
+	input := func(ctx context.Context) (model.RegionFeedEvent, error) {
 		if cursor >= len(entries) {
-			return model.KvOrResolved{}, errors.New("End")
+			return model.RegionFeedEvent{}, errors.New("End")
 		}
 		e := entries[cursor]
 		cursor++
@@ -167,15 +167,15 @@ func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
 }
 
 func (cs *CollectRawTxnsSuite) TestShouldOutputBinlogEvenWhenThereIsNoRealEvent(c *check.C) {
-	entries := []model.KvOrResolved{
-		{Resolved: &model.ResolvedSpan{Timestamp: 1024}},
-		{Resolved: &model.ResolvedSpan{Timestamp: 2000}},
+	entries := []model.RegionFeedEvent{
+		{Checkpoint: &model.ResolvedSpan{ResolvedTs: 1024}},
+		{Checkpoint: &model.ResolvedSpan{ResolvedTs: 2000}},
 	}
 
 	cursor := 0
-	input := func(ctx context.Context) (model.KvOrResolved, error) {
+	input := func(ctx context.Context) (model.RegionFeedEvent, error) {
 		if cursor >= len(entries) {
-			return model.KvOrResolved{}, errors.New("End")
+			return model.RegionFeedEvent{}, errors.New("End")
 		}
 		e := entries[cursor]
 		cursor++
@@ -196,6 +196,6 @@ func (cs *CollectRawTxnsSuite) TestShouldOutputBinlogEvenWhenThereIsNoRealEvent(
 	c.Assert(rawTxns, check.HasLen, len(entries))
 	for i, t := range rawTxns {
 		c.Assert(t.Entries, check.HasLen, 0)
-		c.Assert(t.Ts, check.Equals, entries[i].Resolved.Timestamp)
+		c.Assert(t.Ts, check.Equals, entries[i].Checkpoint.ResolvedTs)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. `RawKVEntry` is an alias of `RegionFeedValue`
1. `ResolvedSpan` contains exactly the same information as `RegionFeedCheckpoint`
1. `KvOrResolved` is just a disguised `RegionFeedEvent`

This PR aims to simplify the code by merging these structs.

### What is changed and how it works?

Only one of the dupcalited structs is kept for each twin structs.
We no longer need to create a new struct and copy each field from the old one.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test