### PR TITLE
processor: Do not flush on resolved event

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -361,7 +361,6 @@ func (c *changeFeed) applyJob(job *pmodel.Job) error {
 
 		addID := uint64(job.BinlogInfo.TableInfo.ID)
 		c.addTable(schemaID, addID, job.BinlogInfo.FinishedTS, schema.TableName{Schema: schamaName, Table: tableName})
-	default:
 	}
 
 	return nil
@@ -816,7 +815,6 @@ func (o *ownerImpl) handleDDL(ctx context.Context) error {
 // if the status is in ChangeFeedWaitToExecDDL.
 // After executing the DDL successfully, the status will be changed to be ChangeFeedSyncDML.
 func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.CaptureInfo) error {
-
 	if c.ddlState != model.ChangeFeedWaitToExecDDL {
 		return nil
 	}

--- a/tests/util/db.go
+++ b/tests/util/db.go
@@ -134,7 +134,7 @@ func CheckSyncState(sourceDB, targetDB *sql.DB, schema string) bool {
 	}
 	for _, table := range targetTables {
 		if _, exist := sourceTableMap[table]; !exist {
-			log.Info("The table in target db is not exist in source db:", zap.String("table", table))
+			log.Info("The table in target db does not exist in source db", zap.String("table", table))
 			return false
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If we flush on each `resolved` event, the bulks being synced would be too small.


### What is changed and how it works?

Don't flush on `resolved` events, record the last resolved ts received and forward it only after flushing.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test