### PR TITLE
add more metrics for tracing data replication link

### DIFF
--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -46,6 +46,20 @@ var (
 			Help:      "Size of KV events.",
 			Buckets:   prometheus.ExponentialBuckets(16, 2, 25),
 		}, []string{"captureID"})
+	pullEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "pull_event_count",
+			Help:      "event count received by this puller",
+		}, []string{"type", "capture", "changefeed"})
+	sendEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "send_event_count",
+			Help:      "event count sent to event channel by this puller",
+		}, []string{"type", "capture", "changefeed"})
 )
 
 // InitMetrics registers all metrics in the kv package
@@ -54,4 +68,6 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(scanRegionsDuration)
 	registry.MustRegister(eventSize)
 	registry.MustRegister(eventFeedGauge)
+	registry.MustRegister(pullEventCounter)
+	registry.MustRegister(sendEventCounter)
 }

--- a/cdc/metrics.go
+++ b/cdc/metrics.go
@@ -16,6 +16,7 @@ package cdc
 import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/puller"
+	"github.com/pingcap/ticdc/cdc/sink"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -27,5 +28,6 @@ func init() {
 
 	kv.InitMetrics(registry)
 	puller.InitMetrics(registry)
+	sink.InitMetrics(registry)
 	initProcessorMetrics(registry)
 }

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -158,10 +158,10 @@ func runCase(c *check.C, cases *processorTestCase) {
 	c.Assert(err, check.IsNil)
 	defer etcd.Close()
 
-	p, err := NewProcessor([]string{etcdURL.String()}, model.ChangeFeedInfo{}, "", "", 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	p, err := NewProcessor(ctx, []string{etcdURL.String()}, model.ChangeFeedInfo{}, "", "", 0)
 	c.Assert(err, check.IsNil)
 	errCh := make(chan error, 1)
-	ctx, cancel := context.WithCancel(context.Background())
 	p.Run(ctx, errCh)
 
 	for i, rawTxnTs := range cases.rawTxnTs {

--- a/cdc/puller/buffer.go
+++ b/cdc/puller/buffer.go
@@ -6,11 +6,15 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 )
 
+const (
+	defaultBufferSize = 8
+)
+
 // Buffer buffers kv entries
 type Buffer chan model.RegionFeedEvent
 
 func makeBuffer() Buffer {
-	return make(Buffer, 8)
+	return make(Buffer, defaultBufferSize)
 }
 
 // AddEntry adds an entry to the buffer

--- a/cdc/puller/metrics.go
+++ b/cdc/puller/metrics.go
@@ -16,13 +16,20 @@ package puller
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	eventCounter = prometheus.NewCounterVec(
+	kvEventCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "ticdc",
 			Subsystem: "puller",
-			Name:      "event_count",
-			Help:      "The number of events received.",
-		}, []string{"captureID", "type"})
+			Name:      "kv_event_count",
+			Help:      "The number of events received from kv client event channel",
+		}, []string{"capture", "changefeed", "type"})
+	txnCollectCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "puller",
+			Name:      "txn_collect_event_count",
+			Help:      "The number of events received from txn collector",
+		}, []string{"capture", "changefeed", "type"})
 	resolvedTxnsBatchSize = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "ticdc",
@@ -35,6 +42,7 @@ var (
 
 // InitMetrics registers all metrics in this file
 func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(eventCounter)
+	registry.MustRegister(kvEventCounter)
+	registry.MustRegister(txnCollectCounter)
 	registry.MustRegister(resolvedTxnsBatchSize)
 }

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -312,6 +312,7 @@ func realRunProcessorWatcher(
 	}
 	checkpointTs := info.GetCheckpointTs(status)
 	sw := NewProcessorWatcher(changefeedID, captureID, pdEndpoints, etcdCli, info, checkpointTs)
+	ctx = util.PutChangefeedIDInCtx(ctx, changefeedID)
 	sw.wg.Add(1)
 	go sw.Watch(ctx, errCh, cb)
 	return sw, nil
@@ -327,7 +328,7 @@ func realRunProcessor(
 	checkpointTs uint64,
 	cb processorCallback,
 ) error {
-	processor, err := NewProcessor(pdEndpoints, info, changefeedID, captureID, checkpointTs)
+	processor, err := NewProcessor(ctx, pdEndpoints, info, changefeedID, captureID, checkpointTs)
 	if err != nil {
 		return err
 	}

--- a/cdc/sink/metrics.go
+++ b/cdc/sink/metrics.go
@@ -1,0 +1,51 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	execDMLCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "exec_dml_count",
+			Help:      "The count of DML that is executed",
+		}, []string{"capture", "changefeed"})
+	execBatchHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "txn_batch_size",
+			Help:      "Bucketed histogram of batch size of a txn.",
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 18),
+		}, []string{"capture", "changefeed"})
+	execTxnHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "txn_exec_duration",
+			Help:      "Bucketed histogram of processing time (s) of a txn.",
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 18),
+		}, []string{"capture", "changefeed"})
+)
+
+// InitMetrics registers all metrics in this file
+func InitMetrics(registry *prometheus.Registry) {
+	registry.MustRegister(execDMLCounter)
+	registry.MustRegister(execBatchHistogram)
+	registry.MustRegister(execTxnHistogram)
+}

--- a/cdc/sink/metrics.go
+++ b/cdc/sink/metrics.go
@@ -18,13 +18,6 @@ import (
 )
 
 var (
-	execDMLCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "ticdc",
-			Subsystem: "sink",
-			Name:      "exec_dml_count",
-			Help:      "The count of DML that is executed",
-		}, []string{"capture", "changefeed"})
 	execBatchHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "ticdc",
@@ -45,7 +38,6 @@ var (
 
 // InitMetrics registers all metrics in this file
 func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(execDMLCounter)
 	registry.MustRegister(execBatchHistogram)
 	registry.MustRegister(execTxnHistogram)
 }

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -186,6 +186,7 @@ func (s *mysqlSink) execDDL(ctx context.Context, ddl *model.DDL) error {
 }
 
 func (s *mysqlSink) execDMLs(ctx context.Context, dmls []*model.DML) error {
+	startTime := time.Now()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.Trace(err)
@@ -220,7 +221,11 @@ func (s *mysqlSink) execDMLs(ctx context.Context, dmls []*model.DML) error {
 	if err = tx.Commit(); err != nil {
 		return errors.Trace(err)
 	}
-
+	captureID := util.CaptureIDFromCtx(ctx)
+	changefeedID := util.ChangefeedIDFromCtx(ctx)
+	execTxnHistogram.WithLabelValues(captureID, changefeedID).Observe(time.Since(startTime).Seconds())
+	execBatchHistogram.WithLabelValues(captureID, changefeedID).Observe(float64(len(dmls)))
+	execDMLCounter.WithLabelValues(captureID, changefeedID).Add(float64(len(dmls)))
 	log.Info("Exec DML succeeded", zap.Int("num of DMLs", len(dmls)))
 	return nil
 }

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -225,7 +225,6 @@ func (s *mysqlSink) execDMLs(ctx context.Context, dmls []*model.DML) error {
 	changefeedID := util.ChangefeedIDFromCtx(ctx)
 	execTxnHistogram.WithLabelValues(captureID, changefeedID).Observe(time.Since(startTime).Seconds())
 	execBatchHistogram.WithLabelValues(captureID, changefeedID).Observe(float64(len(dmls)))
-	execDMLCounter.WithLabelValues(captureID, changefeedID).Add(float64(len(dmls)))
 	log.Info("Exec DML succeeded", zap.Int("num of DMLs", len(dmls)))
 	return nil
 }

--- a/pkg/util/ctx.go
+++ b/pkg/util/ctx.go
@@ -18,7 +18,8 @@ import "context"
 type ctxKey string
 
 const (
-	ctxKeyCaptureID = ctxKey("captureID")
+	ctxKeyCaptureID    = ctxKey("captureID")
+	ctxKeyChangefeedID = ctxKey("changefeedID")
 )
 
 // CaptureIDFromCtx returns a capture ID stored in the specified context.
@@ -34,4 +35,19 @@ func CaptureIDFromCtx(ctx context.Context) string {
 // PutCaptureIDInCtx returns a new child context with the specified capture ID stored.
 func PutCaptureIDInCtx(ctx context.Context, captureID string) context.Context {
 	return context.WithValue(ctx, ctxKeyCaptureID, captureID)
+}
+
+// ChangefeedIDFromCtx returns a changefeedID stored in the specified context.
+// It returns an empty string if there's no valid changefeed ID found.
+func ChangefeedIDFromCtx(ctx context.Context) string {
+	changefeedID, ok := ctx.Value(ctxKeyChangefeedID).(string)
+	if !ok {
+		return ""
+	}
+	return changefeedID
+}
+
+// PutChangefeedIDInCtx returns a new child context with the specified changefeed ID stored.
+func PutChangefeedIDInCtx(ctx context.Context, changefeedID string) context.Context {
+	return context.WithValue(ctx, ctxKeyChangefeedID, changefeedID)
 }

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -19,17 +19,28 @@ import (
 	"github.com/pingcap/check"
 )
 
-type captureIDSuite struct{}
+type ctxValueSuite struct{}
 
-var _ = check.Suite(&captureIDSuite{})
+var _ = check.Suite(&ctxValueSuite{})
 
-func (s *captureIDSuite) TestShouldReturnCaptureID(c *check.C) {
+func (s *ctxValueSuite) TestShouldReturnCaptureID(c *check.C) {
 	ctx := PutCaptureIDInCtx(context.Background(), "ello")
 	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "ello")
 }
 
-func (s *captureIDSuite) TestShouldReturnEmptyStr(c *check.C) {
+func (s *ctxValueSuite) TestShouldReturnEmptyStr(c *check.C) {
 	c.Assert(CaptureIDFromCtx(context.Background()), check.Equals, "")
 	ctx := context.WithValue(context.Background(), ctxKeyCaptureID, 1321)
 	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "")
+}
+
+func (s *ctxValueSuite) TestShouldReturnChangefeedID(c *check.C) {
+	ctx := PutChangefeedIDInCtx(context.Background(), "ello")
+	c.Assert(ChangefeedIDFromCtx(ctx), check.Equals, "ello")
+}
+
+func (s *ctxValueSuite) TestShouldReturnEmptyStr(c *check.C) {
+	c.Assert(ChangefeedIDFromCtx(context.Background()), check.Equals, "")
+	ctx := context.WithValue(context.Background(), ctxKeyChangefeedID, 1321)
+	c.Assert(ChangefeedIDFromCtx(ctx), check.Equals, "")
 }

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -28,7 +28,7 @@ func (s *ctxValueSuite) TestShouldReturnCaptureID(c *check.C) {
 	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "ello")
 }
 
-func (s *ctxValueSuite) TestShouldReturnEmptyStr(c *check.C) {
+func (s *ctxValueSuite) TestCaptureIDNotSet(c *check.C) {
 	c.Assert(CaptureIDFromCtx(context.Background()), check.Equals, "")
 	ctx := context.WithValue(context.Background(), ctxKeyCaptureID, 1321)
 	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "")
@@ -39,7 +39,7 @@ func (s *ctxValueSuite) TestShouldReturnChangefeedID(c *check.C) {
 	c.Assert(ChangefeedIDFromCtx(ctx), check.Equals, "ello")
 }
 
-func (s *ctxValueSuite) TestShouldReturnEmptyStr(c *check.C) {
+func (s *ctxValueSuite) TestChangefeedIDNotSet(c *check.C) {
 	c.Assert(ChangefeedIDFromCtx(context.Background()), check.Equals, "")
 	ctx := context.WithValue(context.Background(), ctxKeyChangefeedID, 1321)
 	c.Assert(ChangefeedIDFromCtx(ctx), check.Equals, "")

--- a/ticdc.json
+++ b/ticdc.json
@@ -18,7 +18,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 18,
-  "iteration": 1578963537432,
+  "iteration": 1581473815404,
   "links": [],
   "panels": [
     {
@@ -731,6 +731,8 @@
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum(rate(ticdc_kvclient_event_size_bytes_bucket[1m])) by (le, instance))",
+          "format": "time_series",
+          "intervalFactor": 1,
           "legendFormat": "{{instance}} 95",
           "refId": "A"
         }
@@ -807,6 +809,7 @@
       },
       "lines": true,
       "linewidth": 1,
+      "links": [],
       "nullPointMode": "null",
       "options": {
         "dataLinks": []
@@ -821,8 +824,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(ticdc_kvclient_event_size_bytes_count[5m])) by (instance)",
-          "legendFormat": "{{instance}}",
+          "expr": "sum(rate(ticdc_kvclient_pull_event_count{changefeed=\"$changefeed\"}[5m])) by (instance, type)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}-{{type}}",
           "refId": "A"
         }
       ],
@@ -830,7 +835,101 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Event Count By Instance",
+      "title": "EventFeed Receive Event Count By Instance",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "cdc-server",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 0,
+        "y": 40
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(ticdc_kvclient_send_event_count{changefeed=\"$changefeed\"}[5m])) by (instance, type)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}-{{type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Dispatch Event Count By Instance",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -873,7 +972,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 47
       },
       "id": 11,
       "panels": [],
@@ -891,7 +990,7 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 41
+        "y": 48
       },
       "hiddenSeries": false,
       "id": 2,
@@ -981,9 +1080,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
-        "w": 11,
+        "w": 12,
         "x": 11,
-        "y": 41
+        "y": 48
       },
       "hiddenSeries": false,
       "id": 30,
@@ -1075,7 +1174,7 @@
         "h": 7,
         "w": 11,
         "x": 0,
-        "y": 49
+        "y": 56
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1165,7 +1264,7 @@
         "h": 7,
         "w": 12,
         "x": 11,
-        "y": 49
+        "y": 56
       },
       "hiddenSeries": false,
       "id": 3,
@@ -1249,16 +1348,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "description": "The number of events received from kv client event channel",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 11,
-        "y": 56
+        "w": 11,
+        "x": 0,
+        "y": 63
       },
       "hiddenSeries": false,
-      "id": 5,
+      "id": 32,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -1272,6 +1372,7 @@
       },
       "lines": true,
       "linewidth": 1,
+      "links": [],
       "nullPointMode": "null",
       "options": {
         "dataLinks": []
@@ -1286,7 +1387,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(ticdc_processor_txn_count{changefeed = \"$changefeed\"}[5m])) by (instance, type)",
+          "expr": "sum (rate(ticdc_puller_kv_event_count{changefeed=\"$changefeed\"}[5m])) by (instance, type)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{instance}} - {{type}}",
@@ -1297,7 +1398,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "ticdc_processor_txn_count",
+      "title": "puller receive kv event from chan",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1333,6 +1434,494 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "The number of events received from txn collector",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 11,
+        "y": 63
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum (rate(ticdc_puller_txn_collect_event_count{changefeed=\"$changefeed\"}[5m])) by (instance, type)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}} - {{type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Event Count Received in Txn Collector ",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "The number of events received from kv client event channel",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 0,
+        "y": 70
+      },
+      "hiddenSeries": false,
+      "id": 33,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum (rate(ticdc_processor_txn_count{changefeed=\"$changefeed\"}[5m])) by (instance, type)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}} - {{type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "processor txn count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "The number of events received from kv client event channel",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 11,
+        "y": 70
+      },
+      "hiddenSeries": false,
+      "id": 34,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum (rate(ticdc_sink_exec_dml_count{changefeed=\"$changefeed\"}[5m])) by (instance)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "sink exec DML count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "The number of events received from kv client event channel",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 0,
+        "y": 77
+      },
+      "hiddenSeries": false,
+      "id": 35,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(ticdc_sink_txn_exec_duration_bucket{changefeed=\"$changefeed\"}[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "90",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(ticdc_sink_txn_exec_duration_bucket{changefeed=\"$changefeed\"}[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "99",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(ticdc_sink_txn_exec_duration_sum{changefeed=\"$changefeed\"}[1m]) / rate(ticdc_sink_txn_exec_duration_count{changefeed=\"$changefeed\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "avg",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "exec txn duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "The number of events received from kv client event channel",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 11,
+        "y": 77
+      },
+      "hiddenSeries": false,
+      "id": 36,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(ticdc_sink_txn_batch_size_bucket{changefeed=\"$changefeed\"}[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(ticdc_sink_txn_batch_size_bucket{changefeed=\"$changefeed\"}[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "90",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(ticdc_sink_txn_batch_size_sum{changefeed=\"$changefeed\"}[1m]) / rate(ticdc_sink_txn_batch_size_count{changefeed=\"$changefeed\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "avg",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "exec txn batch",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "10s",
@@ -1346,8 +1935,8 @@
         "current": {
           "selected": false,
           "tags": [],
-          "text": "99e1f54e-4fb7-4275-aa5f-0efb8fb8920a",
-          "value": "99e1f54e-4fb7-4275-aa5f-0efb8fb8920a"
+          "text": "0496c67e-5490-40eb-afea-df4135cceb67",
+          "value": "0496c67e-5490-40eb-afea-df4135cceb67"
         },
         "datasource": "cdc-server",
         "definition": "label_values(ticdc_processor_resolved_ts, changefeed)",
@@ -1371,7 +1960,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -1402,5 +1991,5 @@
   "timezone": "",
   "title": "ticdc",
   "uid": "YiGL8hBZz",
-  "version": 3
+  "version": 15
 }

--- a/ticdc.json
+++ b/ticdc.json
@@ -18,7 +18,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 18,
-  "iteration": 1581473815404,
+  "iteration": 1581499259290,
   "links": [],
   "panels": [
     {
@@ -1663,7 +1663,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(ticdc_sink_exec_dml_count{changefeed=\"$changefeed\"}[5m])) by (instance)",
+          "expr": "sum (rate(ticdc_sink_txn_batch_size_sum{changefeed=\"$changefeed\"}[5m])) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",
@@ -1924,7 +1924,7 @@
       }
     }
   ],
-  "refresh": "10s",
+  "refresh": false,
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -1933,8 +1933,6 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "tags": [],
           "text": "0496c67e-5490-40eb-afea-df4135cceb67",
           "value": "0496c67e-5490-40eb-afea-df4135cceb67"
         },
@@ -1960,8 +1958,8 @@
     ]
   },
   "time": {
-    "from": "now-30m",
-    "to": "now"
+    "from": "2020-02-12T02:04:32.048Z",
+    "to": "2020-02-12T02:55:57.097Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -1991,5 +1989,5 @@
   "timezone": "",
   "title": "ticdc",
   "uid": "YiGL8hBZz",
-  "version": 15
+  "version": 16
 }


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We need to monitor the data replication qps in data link, especially for each event channel 

### What is changed and how it works?

- Add more metrics to monitor data replication speed
- Update relative grafana template config

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
