### PR TITLE
puller: use a more efficient EntryGroup

### DIFF
--- a/cdc/puller/entry_group.go
+++ b/cdc/puller/entry_group.go
@@ -1,0 +1,64 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package puller
+
+import (
+	"sort"
+
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+// EntryGroup stores RawKVEntry and corresponding ts
+type EntryGroup struct {
+	entriesMap map[uint64][]*model.RawKVEntry
+	sortedTs   []uint64
+}
+
+// NewEntryGroup creates a new EntryGroup
+func NewEntryGroup() *EntryGroup {
+	return &EntryGroup{
+		entriesMap: make(map[uint64][]*model.RawKVEntry),
+		sortedTs:   make([]uint64, 0),
+	}
+}
+
+// AddEntry adds an RawKVEntry to the EntryGroup, this method *IS NOT* thread safe.
+func (eg *EntryGroup) AddEntry(ts uint64, entry *model.RawKVEntry) {
+	i := sort.Search(len(eg.sortedTs), func(i int) bool { return eg.sortedTs[i] >= ts })
+	if i < len(eg.sortedTs) && eg.sortedTs[i] == ts {
+		eg.entriesMap[ts] = append(eg.entriesMap[ts], entry)
+	} else {
+		eg.sortedTs = append(eg.sortedTs, 0)
+		copy(eg.sortedTs[i+1:], eg.sortedTs[i:])
+		eg.sortedTs[i] = ts
+		eg.entriesMap[ts] = []*model.RawKVEntry{entry}
+	}
+}
+
+// Consume retrieves all RawKVEntry with ts no larger than resolvedTs,
+// returns RawTxn list sorted by ts according these RawKVEntry and
+// removes these RawKVEntry from EntryGroup. This method *IS NOT* thread safe.
+func (eg *EntryGroup) Consume(resolvedTs uint64) (txns []model.RawTxn) {
+	i := 0
+	for ; i < len(eg.sortedTs); i++ {
+		ts := eg.sortedTs[i]
+		if ts > resolvedTs {
+			break
+		}
+		txns = append(txns, model.RawTxn{Ts: ts, Entries: eg.entriesMap[ts]})
+		delete(eg.entriesMap, ts)
+	}
+	eg.sortedTs = eg.sortedTs[i:]
+	return
+}

--- a/cdc/puller/entry_group.go
+++ b/cdc/puller/entry_group.go
@@ -29,7 +29,6 @@ type EntryGroup struct {
 func NewEntryGroup() *EntryGroup {
 	return &EntryGroup{
 		entriesMap: make(map[uint64][]*model.RawKVEntry),
-		sortedTs:   make([]uint64, 0),
 	}
 }
 

--- a/cdc/puller/entry_group_test.go
+++ b/cdc/puller/entry_group_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package puller
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+type mockEntryGroupSuite struct{}
+
+var _ = check.Suite(&mockEntryGroupSuite{})
+
+func (s *mockEntryGroupSuite) TestEntryGroup(c *check.C) {
+	testCases := []struct {
+		input       []*model.RawKVEntry
+		resolvedTs  uint64
+		expectTxns  []model.RawTxn
+		remainEntry int
+	}{
+		{
+			input:       []*model.RawKVEntry{{Ts: 1}, {Ts: 2}, {Ts: 4}, {Ts: 2}},
+			resolvedTs:  0,
+			expectTxns:  nil,
+			remainEntry: 3,
+		},
+		{
+			input:      []*model.RawKVEntry{{Ts: 3}, {Ts: 2}, {Ts: 5}},
+			resolvedTs: 3,
+			expectTxns: []model.RawTxn{
+				{Ts: 1, Entries: []*model.RawKVEntry{{Ts: 1}}},
+				{Ts: 2, Entries: []*model.RawKVEntry{{Ts: 2}, {Ts: 2}, {Ts: 2}}},
+				{Ts: 3, Entries: []*model.RawKVEntry{{Ts: 3}}},
+			},
+			remainEntry: 2,
+		},
+		{
+			input:      nil,
+			resolvedTs: 6,
+			expectTxns: []model.RawTxn{
+				{Ts: 4, Entries: []*model.RawKVEntry{{Ts: 4}}},
+				{Ts: 5, Entries: []*model.RawKVEntry{{Ts: 5}}},
+			},
+			remainEntry: 0,
+		},
+		{
+			input:       []*model.RawKVEntry{{Ts: 7}},
+			resolvedTs:  6,
+			expectTxns:  nil,
+			remainEntry: 1,
+		},
+	}
+	eg := NewEntryGroup()
+	for _, tc := range testCases {
+		for _, entry := range tc.input {
+			eg.AddEntry(entry.Ts, entry)
+		}
+		txns := eg.Consume(tc.resolvedTs)
+		c.Check(txns, check.DeepEquals, tc.expectTxns)
+		c.Check(eg.sortedTs, check.HasLen, tc.remainEntry)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The original `EntryMap` implement is not very efficient, there exists too many unnecessary map iteration because not all KV entries in the `EntryMap` need to be retrieved each time.

### What is changed and how it works?
Add a simple `EntryGroup` struct, including an entry map and a sorted ts slice. We can retrieve entries via the sorted ts slice more efficient

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

before: CollectRawTxns: 88.52% **map operation: 64.76%**
<img width="1059" alt="Screen Shot 2020-02-13 at 12 26 08" src="https://user-images.githubusercontent.com/1527315/74510618-20337a80-4f3f-11ea-8cbd-c7c3478161b6.png">

after: CollectRawTxns: CollectRawTxns: 11.16%, **EntryGroup operation: 0.84%**
<img width="1068" alt="Screen Shot 2020-02-14 at 15 33 33" src="https://user-images.githubusercontent.com/1527315/74510760-67217000-4f3f-11ea-9e82-5d4b5bff4ae8.png">


