### PR TITLE
kv-client: add grpc window size config

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -40,9 +40,11 @@ import (
 )
 
 const (
-	dialTimeout           = 10 * time.Second
-	maxRetry              = 10
-	tikvRequestMaxBackoff = 20000 // Maximum total sleep time(in ms)
+	dialTimeout               = 10 * time.Second
+	maxRetry                  = 10
+	tikvRequestMaxBackoff     = 20000 // Maximum total sleep time(in ms)
+	grpcInitialWindowSize     = 1 << 30
+	grpcInitialConnWindowSize = 1 << 30
 )
 
 type singleRegionInfo struct {
@@ -112,6 +114,8 @@ func (c *CDCClient) getConn(
 	conn, err = grpc.DialContext(
 		ctx,
 		addr,
+		grpc.WithInitialWindowSize(grpcInitialWindowSize),
+		grpc.WithInitialConnWindowSize(grpcInitialConnWindowSize),
 		grpc.WithInsecure(),
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: gbackoff.Config{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The default gRPC window size is 64K, we can use a large value to increase the throughput.
ref: https://www.jianshu.com/p/48ad37e8b4ed

### What is changed and how it works?
change `InitialWindowSize` and `InitialConnWindowSize` to 1GB

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

throughput increased by approximately 40%
before:
<img width="547" alt="Screen Shot 2020-02-18 at 18 49 28" src="https://user-images.githubusercontent.com/1527315/74729459-77a75280-527f-11ea-9762-fbb51e168d2d.png">

after:
<img width="543" alt="Screen Shot 2020-02-18 at 18 13 10" src="https://user-images.githubusercontent.com/1527315/74729375-53e40c80-527f-11ea-9a10-2694c4d13696.png">

