### PR TITLE
puller: make the Puller support to output sortedrow-based stream

### DIFF
--- a/cdc/entry/kv_entry_test.go
+++ b/cdc/entry/kv_entry_test.go
@@ -32,7 +32,7 @@ func (s *kvEntrySuite) testCreateTable(c *check.C, newRowFormat bool) {
 
 	// create another context with canceled, we can close this puller but not affect puller manager
 	plrCtx, plrCancel := context.WithCancel(ctx)
-	err := plr.CollectRawTxns(plrCtx, func(ctx context.Context, rawTxn model.RawTxn) error {
+	err := plr.CollectRawTxns(plrCtx, func(ctx context.Context, rawTxn model.RawRowGroup) error {
 		for _, raw := range rawTxn.Entries {
 			entry, err := m.unmarshal(raw)
 			c.Assert(err, check.IsNil)
@@ -84,7 +84,7 @@ func (s *kvEntrySuite) testCreateTable(c *check.C, newRowFormat bool) {
 	plr = pm.CreatePuller(0, []util.Span{util.GetDDLSpan()})
 	existDDLJobHistoryKVEntry = false
 	plrCtx, plrCancel = context.WithCancel(ctx)
-	err = plr.CollectRawTxns(plrCtx, func(ctx context.Context, rawTxn model.RawTxn) error {
+	err = plr.CollectRawTxns(plrCtx, func(ctx context.Context, rawTxn model.RawRowGroup) error {
 		for _, raw := range rawTxn.Entries {
 			entry, err := m.unmarshal(raw)
 			c.Assert(err, check.IsNil)
@@ -453,7 +453,7 @@ func assertIn(c *check.C, item kvEntry, expect []kvEntry) {
 
 func checkDMLKVEntries(ctx context.Context, c *check.C, tableInfo *schema.TableInfo, m *Mounter, plr puller.Puller, expect []kvEntry) {
 	ctx, cancel := context.WithCancel(ctx)
-	err := plr.CollectRawTxns(ctx, func(ctx context.Context, rawTxn model.RawTxn) error {
+	err := plr.CollectRawTxns(ctx, func(ctx context.Context, rawTxn model.RawRowGroup) error {
 		eventSum := 0
 		for _, raw := range rawTxn.Entries {
 			entry, err := m.unmarshal(raw)

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -23,7 +23,7 @@ func NewTxnMounter(schema *schema.Storage) *Mounter {
 }
 
 // Mount parses a raw transaction and returns a transaction
-func (m *Mounter) Mount(rawTxn model.RawTxn) (model.Txn, error) {
+func (m *Mounter) Mount(rawTxn model.RawRowGroup) (model.Txn, error) {
 	t := model.Txn{
 		Ts: rawTxn.Ts,
 	}

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -34,10 +34,10 @@ func setUpPullerAndSchema(ctx context.Context, c *check.C, newRowFormat bool, sq
 	return pm, schemaStorage
 }
 
-func getFirstRealTxn(ctx context.Context, c *check.C, plr puller.Puller) (result model.RawTxn) {
+func getFirstRealTxn(ctx context.Context, c *check.C, plr puller.Puller) (result model.RawRowGroup) {
 	ctx, cancel := context.WithCancel(ctx)
 	var once sync.Once
-	err := plr.CollectRawTxns(ctx, func(ctx context.Context, rawTxn model.RawTxn) error {
+	err := plr.CollectRawTxns(ctx, func(ctx context.Context, rawTxn model.RawRowGroup) error {
 		if rawTxn.IsFake() {
 			return nil
 		}

--- a/cdc/model/txn.go
+++ b/cdc/model/txn.go
@@ -6,15 +6,17 @@ import (
 	"github.com/pingcap/tidb/types"
 )
 
-// RawTxn represents a complete collection of Entries that belong to the same transaction
-type RawTxn struct {
-	Ts         uint64
-	IsResolved bool
-	Entries    []*RawKVEntry
+// RawRowGroup represents a complete collection of Entries that belong to the same transaction
+type RawRowGroup struct {
+	Ts uint64
+	// IsCompleteTxn represents whether the RawRowGroup is a complete transaction
+	IsCompleteTxn bool
+	IsResolved    bool
+	Entries       []*RawKVEntry
 }
 
-// IsFake returns true if this RawTxn is fake txn.
-func (r RawTxn) IsFake() bool {
+// IsFake returns true if this RawRowGroup is fake txn.
+func (r RawRowGroup) IsFake() bool {
 	return len(r.Entries) == 0
 }
 

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -45,7 +45,7 @@ type ddlHandler struct {
 func newDDLHandler(pdCli pd.Client, checkpointTS uint64) *ddlHandler {
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
-	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan()}, false)
+	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan()}, false, true)
 	ctx, cancel := context.WithCancel(context.Background())
 	// TODO get time loc from config
 	txnMounter := entry.NewTxnMounter(nil)
@@ -73,7 +73,7 @@ func newDDLHandler(pdCli pd.Client, checkpointTS uint64) *ddlHandler {
 	return h
 }
 
-func (h *ddlHandler) receiveDDL(ctx context.Context, rawTxn model.RawTxn) error {
+func (h *ddlHandler) receiveDDL(ctx context.Context, rawTxn model.RawRowGroup) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.resolvedTS = rawTxn.Ts

--- a/cdc/puller/entry_group.go
+++ b/cdc/puller/entry_group.go
@@ -38,7 +38,7 @@ func (eg *EntryGroup) AddEntry(ts uint64, entry *model.RawKVEntry) {
 	if i >= len(eg.sortedEntries) || eg.sortedEntries[i].Ts != ts {
 		eg.sortedEntries = append(eg.sortedEntries, nil)
 		copy(eg.sortedEntries[i+1:], eg.sortedEntries[i:])
-		eg.sortedEntries[i] = &model.RawRowGroup{Ts: ts, IsCompleteTxn: eg.collectTxn}
+		eg.sortedEntries[i] = &model.RawRowGroup{Ts: ts, IsCompleteTxn: true}
 	}
 	eg.sortedEntries[i].Entries = append(eg.sortedEntries[i].Entries, entry)
 }

--- a/cdc/puller/entry_group.go
+++ b/cdc/puller/entry_group.go
@@ -55,7 +55,7 @@ func (eg *EntryGroup) Consume(resolvedTs uint64) (txns []model.RawRowGroup) {
 		txns = append(txns, *eg.sortedEntries[i])
 	}
 	if !eg.collectTxn {
-		// find a more efficient way to sort entries
+		// TODO find a more efficient way to sort entries
 		result := model.RawRowGroup{IsCompleteTxn: false}
 		for _, txn := range txns {
 			result.Entries = append(result.Entries, txn.Entries...)

--- a/cdc/puller/entry_group.go
+++ b/cdc/puller/entry_group.go
@@ -21,43 +21,47 @@ import (
 
 // EntryGroup stores RawKVEntry and corresponding ts
 type EntryGroup struct {
-	entriesMap map[uint64][]*model.RawKVEntry
-	sortedTs   []uint64
+	sortedEntries []*model.RawRowGroup
+	collectTxn    bool
 }
 
 // NewEntryGroup creates a new EntryGroup
-func NewEntryGroup() *EntryGroup {
+func NewEntryGroup(collectTxn bool) *EntryGroup {
 	return &EntryGroup{
-		entriesMap: make(map[uint64][]*model.RawKVEntry),
+		collectTxn: collectTxn,
 	}
 }
 
 // AddEntry adds an RawKVEntry to the EntryGroup, this method *IS NOT* thread safe.
 func (eg *EntryGroup) AddEntry(ts uint64, entry *model.RawKVEntry) {
-	i := sort.Search(len(eg.sortedTs), func(i int) bool { return eg.sortedTs[i] >= ts })
-	if i < len(eg.sortedTs) && eg.sortedTs[i] == ts {
-		eg.entriesMap[ts] = append(eg.entriesMap[ts], entry)
-	} else {
-		eg.sortedTs = append(eg.sortedTs, 0)
-		copy(eg.sortedTs[i+1:], eg.sortedTs[i:])
-		eg.sortedTs[i] = ts
-		eg.entriesMap[ts] = []*model.RawKVEntry{entry}
+	i := sort.Search(len(eg.sortedEntries), func(i int) bool { return eg.sortedEntries[i].Ts >= ts })
+	if i >= len(eg.sortedEntries) || eg.sortedEntries[i].Ts != ts {
+		eg.sortedEntries = append(eg.sortedEntries, nil)
+		copy(eg.sortedEntries[i+1:], eg.sortedEntries[i:])
+		eg.sortedEntries[i] = &model.RawRowGroup{Ts: ts, IsCompleteTxn: eg.collectTxn}
 	}
+	eg.sortedEntries[i].Entries = append(eg.sortedEntries[i].Entries, entry)
 }
 
 // Consume retrieves all RawKVEntry with ts no larger than resolvedTs,
 // returns RawTxn list sorted by ts according these RawKVEntry and
 // removes these RawKVEntry from EntryGroup. This method *IS NOT* thread safe.
-func (eg *EntryGroup) Consume(resolvedTs uint64) (txns []model.RawTxn) {
+func (eg *EntryGroup) Consume(resolvedTs uint64) (txns []model.RawRowGroup) {
 	i := 0
-	for ; i < len(eg.sortedTs); i++ {
-		ts := eg.sortedTs[i]
-		if ts > resolvedTs {
+	for ; i < len(eg.sortedEntries); i++ {
+		if eg.sortedEntries[i].Ts > resolvedTs {
 			break
 		}
-		txns = append(txns, model.RawTxn{Ts: ts, Entries: eg.entriesMap[ts]})
-		delete(eg.entriesMap, ts)
+		txns = append(txns, *eg.sortedEntries[i])
 	}
-	eg.sortedTs = eg.sortedTs[i:]
+	if !eg.collectTxn {
+		// find a more efficient way to sort entries
+		result := model.RawRowGroup{IsCompleteTxn: false}
+		for _, txn := range txns {
+			result.Entries = append(result.Entries, txn.Entries...)
+		}
+		txns = []model.RawRowGroup{result}
+	}
+	eg.sortedEntries = eg.sortedEntries[i:]
 	return
 }

--- a/cdc/puller/txn_test.go
+++ b/cdc/puller/txn_test.go
@@ -79,14 +79,14 @@ func (cs *CollectRawTxnsSuite) TestShouldOutputTxnsInOrder(c *check.C) {
 		return e, nil
 	}
 
-	var rawTxns []model.RawTxn
-	output := func(ctx context.Context, txn model.RawTxn) error {
+	var rawTxns []model.RawRowGroup
+	output := func(ctx context.Context, txn model.RawRowGroup) error {
 		rawTxns = append(rawTxns, txn)
 		return nil
 	}
 
 	ctx := context.Background()
-	err := collectRawTxns(ctx, input, output, &mockTracker{})
+	err := collectRawTxns(ctx, input, output, &mockTracker{}, true)
 	c.Assert(err, check.ErrorMatches, "End")
 
 	c.Assert(rawTxns, check.HasLen, 2)
@@ -145,8 +145,8 @@ func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
 		return e, nil
 	}
 
-	var rawTxns []model.RawTxn
-	output := func(ctx context.Context, txn model.RawTxn) error {
+	var rawTxns []model.RawRowGroup
+	output := func(ctx context.Context, txn model.RawRowGroup) error {
 		rawTxns = append(rawTxns, txn)
 		return nil
 	}
@@ -154,7 +154,7 @@ func (cs *CollectRawTxnsSuite) TestShouldConsiderSpanResolvedTs(c *check.C) {
 	ctx := context.Background()
 	// Set up the tracker so that only the last resolve event forwards the global minimum Ts
 	tracker := mockTracker{forwarded: []bool{false, false, true}}
-	err := collectRawTxns(ctx, input, output, &tracker)
+	err := collectRawTxns(ctx, input, output, &tracker, true)
 	c.Assert(err, check.ErrorMatches, "End")
 
 	c.Assert(rawTxns, check.HasLen, 1)
@@ -182,15 +182,15 @@ func (cs *CollectRawTxnsSuite) TestShouldOutputBinlogEvenWhenThereIsNoRealEvent(
 		return e, nil
 	}
 
-	var rawTxns []model.RawTxn
-	output := func(ctx context.Context, txn model.RawTxn) error {
+	var rawTxns []model.RawRowGroup
+	output := func(ctx context.Context, txn model.RawRowGroup) error {
 		rawTxns = append(rawTxns, txn)
 		return nil
 	}
 
 	ctx := context.Background()
 	tracker := mockTracker{forwarded: []bool{true, true}}
-	err := collectRawTxns(ctx, input, output, &tracker)
+	err := collectRawTxns(ctx, input, output, &tracker, true)
 	c.Assert(err, check.ErrorMatches, "End")
 
 	c.Assert(rawTxns, check.HasLen, len(entries))

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -97,7 +97,7 @@ var pullCmd = &cobra.Command{
 		g, ctx := errgroup.WithContext(context.Background())
 		ts := oracle.ComposeTS(time.Now().Unix()*1000, 0)
 
-		ddlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetDDLSpan()}, false)
+		ddlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetDDLSpan()}, false, true)
 		ddlBuf := ddlPuller.Output()
 		g.Go(func() error {
 			return ddlPuller.Run(ctx)
@@ -119,7 +119,7 @@ var pullCmd = &cobra.Command{
 			return
 		}
 		for _, tid := range tableIDs {
-			dmlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetTableSpan(tid, true)}, true)
+			dmlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetTableSpan(tid, true)}, true, true)
 			dmlBuf := dmlPuller.Output()
 			g.Go(func() error {
 				return dmlPuller.Run(ctx)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
make the Puller support to output sortedrow-based stream, preparing for kafka downstream.

### What is changed and how it works?
1. rename RawTxn to RawRowGroup. RawRowGroup can include rows in one Txn or rows in incomplete Txn. The `IsCompleteTxn` field is used to mark if the rows in RawRowGroup are from a complete Txn.
2. Optimized the implementation of `entry_group`, support to output sorted row-based RawRowGroup (current implementation is not efficient enough)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test