### PR TITLE
Add dry run opt and quick fix for slow handle txn

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -53,7 +53,7 @@ type OwnerDDLHandler interface {
 	PullDDL() (resolvedTs uint64, jobs []*model.DDL, err error)
 
 	// ExecDDL executes the ddl job
-	ExecDDL(ctx context.Context, sinkURI string, txn model.Txn) error
+	ExecDDL(ctx context.Context, sinkURI string, opts map[string]string, txn model.Txn) error
 
 	// Close cancels the executing of OwnerDDLHandler and releases resource
 	Close() error
@@ -863,7 +863,7 @@ func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.C
 				zap.Uint64("ts", todoDDLJob.Job.BinlogInfo.FinishedTS),
 			)
 		} else {
-			err = c.ddlHandler.ExecDDL(ctx, c.info.SinkURI, ddlTxn)
+			err = c.ddlHandler.ExecDDL(ctx, c.info.SinkURI, c.info.Opts, ddlTxn)
 			// If DDL executing failed, pause the changefeed and print log, rather
 			// than return an error and break the running of this owner.
 			if err != nil {

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -106,7 +106,7 @@ func (h *ddlHandler) PullDDL() (uint64, []*model.DDL, error) {
 }
 
 // ExecDDL implements roles.OwnerDDLHandler interface.
-func (h *ddlHandler) ExecDDL(ctx context.Context, sinkURI string, txn model.Txn) error {
+func (h *ddlHandler) ExecDDL(ctx context.Context, sinkURI string, opts map[string]string, txn model.Txn) error {
 	// TODO cache the sink
 	// TODO handle other target database, kile kafka, file
 	db, err := sql.Open("mysql", sinkURI)

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -77,7 +77,7 @@ func (h *handlerForPrueDMLTest) PullDDL() (resolvedTs uint64, ddl []*model.DDL, 
 	return uint64(math.MaxUint64), nil, nil
 }
 
-func (h *handlerForPrueDMLTest) ExecDDL(context.Context, string, model.Txn) error {
+func (h *handlerForPrueDMLTest) ExecDDL(context.Context, string, map[string]string, model.Txn) error {
 	panic("unreachable")
 }
 
@@ -228,7 +228,7 @@ func (h *handlerForDDLTest) PullDDL() (resolvedTs uint64, jobs []*model.DDL, err
 	return h.ddlResolvedTs[h.ddlIndex], []*model.DDL{h.ddls[h.ddlIndex]}, nil
 }
 
-func (h *handlerForDDLTest) ExecDDL(ctx context.Context, sinkURI string, txn model.Txn) error {
+func (h *handlerForDDLTest) ExecDDL(ctx context.Context, sinkURI string, _ map[string]string, txn model.Txn) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.ddlExpectIndex++

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -639,6 +639,8 @@ func (p *processor) syncResolved(ctx context.Context) error {
 
 	defer close(p.executedTxns)
 
+	flushTick := time.NewTicker(flushDMLsInterval)
+
 	for {
 		select {
 		case rawTxn, ok := <-p.ddlJobsCh:
@@ -705,11 +707,10 @@ func (p *processor) syncResolved(ctx context.Context) error {
 			}
 			log.Info("syncResolved stopped")
 			return ctx.Err()
-		default:
+		case <-flushTick.C:
 			if err := flush(ctx); err != nil {
 				return errors.Trace(err)
 			}
-			time.Sleep(flushDMLsInterval)
 		}
 	}
 }

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -25,12 +25,14 @@ func init() {
 
 	cliCmd.Flags().StringVar(&pdAddress, "pd-addr", "localhost:2379", "address of PD")
 	cliCmd.Flags().Uint64Var(&startTs, "start-ts", 0, "start ts of changefeed")
-	cliCmd.Flags().Uint64Var(&startTs, "target-ts", 0, "target ts of changefeed")
+	cliCmd.Flags().Uint64Var(&targetTs, "target-ts", 0, "target ts of changefeed")
 	cliCmd.Flags().StringVar(&sinkURI, "sink-uri", "root@tcp(127.0.0.1:3306)/", "sink uri")
 	cliCmd.Flags().StringVar(&configFile, "config", "", "path of the configuration file")
+	cliCmd.Flags().StringSliceVar(&opts, "opts", nil, "in key=value format")
 }
 
 var (
+	opts       []string
 	pdAddress  string
 	startTs    uint64
 	targetTs   uint64
@@ -90,6 +92,23 @@ var cliCmd = &cobra.Command{
 			TargetTs:   targetTs,
 			Config:     cfg,
 		}
+
+		for _, opt := range opts {
+			s := strings.Split(opt, "=")
+			if len(s) <= 0 || len(s) > 2 {
+				fmt.Printf("omit opt: %s", opt)
+			}
+
+			var key string
+			var value string
+
+			key = s[0]
+			if len(s) > 1 {
+				value = s[1]
+			}
+			detail.Opts[key] = value
+		}
+
 		d, err := detail.Marshal()
 		if err != nil {
 			return err

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -22,6 +22,7 @@ if [ "${1-}" = '--debug' ]; then
     cdc server --log-file $WORK_DIR/cdc.log --log-level debug --status-addr 0.0.0.0:8300 > $WORK_DIR/cdc.log 2>&1 &
     sleep 1
     cdc cli
+	# cdc cli --opts "_dry-run="
 
     echo 'You may now debug from another terminal. Press [ENTER] to exit.'
     read line

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,7 +19,7 @@ if [ "${1-}" = '--debug' ]; then
     TEST_NAME="debug" \
     start_tidb_cluster $WORK_DIR
 
-    cdc server --log-file $WORK_DIR/cdc.log --log-level debug > $WORK_DIR/cdc.log 2>&1 &
+    cdc server --log-file $WORK_DIR/cdc.log --log-level debug --status-addr 0.0.0.0:8300 > $WORK_DIR/cdc.log 2>&1 &
     sleep 1
     cdc cli
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #277 fix  #270 

### What is changed and how it works?
- add dry-run for mysql sink
- a quick fix for slow handle in process txn caused by sleep and doing nothing.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes



Side effects

 

Related changes


