### PR TITLE
span frontier adjust tree node synchronously

### DIFF
--- a/cdc/puller/span_frontier.go
+++ b/cdc/puller/span_frontier.go
@@ -176,7 +176,7 @@ func makeSpanFrontier(spans ...util.Span) *spanFrontier {
 
 		s.idAlloc++
 
-		err := s.tree.Insert(e, true)
+		err := s.tree.Insert(e, false)
 		if err != nil {
 			panic(err)
 		}
@@ -184,7 +184,6 @@ func makeSpanFrontier(spans ...util.Span) *spanFrontier {
 		heap.Push(&s.minHeap, e)
 	}
 
-	s.tree.AdjustRanges()
 	return s
 }
 
@@ -267,7 +266,7 @@ func (s *spanFrontier) insert(span util.Span, ts uint64) {
 	// Delete old ones
 	for i := range overlap {
 		e := overlap[i].(*spanFrontierEntry)
-		err := s.tree.Delete(e, true)
+		err := s.tree.Delete(e, false)
 		if err != nil {
 			panic(err)
 		}
@@ -276,14 +275,12 @@ func (s *spanFrontier) insert(span util.Span, ts uint64) {
 
 	// Insert new ones
 	for i := range toInsert {
-		err := s.tree.Insert(&toInsert[i], true)
+		err := s.tree.Insert(&toInsert[i], false)
 		if err != nil {
 			panic(err)
 		}
 		heap.Push(&s.minHeap, &toInsert[i])
 	}
-
-	s.tree.AdjustRanges()
 }
 
 // Entries visit all traced spans.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

A quick fix for #282 

### What is changed and how it works?
- firstly we can adjust the tree synchronously when we delete an element
- secondly comparing with `fast` insert way and `non-fast` insert way, found the `non-fast` insert way costs less CPU from flamegraph

| operation way       | puller.(*spanFrontier).insert | interval.(*Tree).Delete | interval.(*Tree).Insert | interval.(*Tree).AdjustRanges |
| ------------------- | ----------------------------- | ----------------------- | ----------------------- | ----------------------------- |
| fast insert way     | 17.17%                        | 4.50%                   | 0.96%                   | 9.42%                         |
| non fast insert way | 11.61%                        | 6.15%                   | 2.98%                   | -                             |

The replication speed seems reasonable after this PR

<img width="1312" alt="Screen Shot 2020-02-24 at 19 04 15" src="https://user-images.githubusercontent.com/1527315/75147574-93f03700-5738-11ea-9f88-83072ba7ef37.png">

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 The `fast` parameter is not as wished, we should dig into the implement of https://github.com/biogo/store/tree/master/interval later