### PR TITLE
Add mem buffer for kv event.

### DIFF
--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -45,7 +45,7 @@ type ddlHandler struct {
 func newDDLHandler(pdCli pd.Client, checkpointTS uint64) *ddlHandler {
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
-	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan()}, false)
+	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan()}, false, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	// TODO get time loc from config
 	txnMounter := entry.NewTxnMounter(nil)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -57,6 +57,9 @@ const (
 
 	defaultInputTxnChanSize  = 1
 	defaultOutputTxnChanSize = 64
+
+	// defaultMemBufferCapacity is the default memory buffer per change feed.
+	defaultMemBufferCapacity int64 = 10 * 1024 * 1024 * 1024 // 10G
 )
 
 var (
@@ -145,6 +148,7 @@ type processor struct {
 	captureID    string
 	changefeedID string
 	changefeed   model.ChangeFeedInfo
+	limitter     *puller.BlurResourceLimitter
 	filter       *txnFilter
 
 	pdCli   pd.Client
@@ -224,9 +228,11 @@ func NewProcessor(ctx context.Context, pdEndpoints []string, changefeed model.Ch
 		return nil, errors.Annotate(err, "failed to create ts RWriter")
 	}
 
+	limitter := puller.NewBlurResourceLimmter(defaultMemBufferCapacity)
+
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
-	ddlPuller := puller.NewPuller(pdCli, checkpointTs, []util.Span{util.GetDDLSpan()}, false)
+	ddlPuller := puller.NewPuller(pdCli, checkpointTs, []util.Span{util.GetDDLSpan()}, false, limitter)
 
 	mounter := fNewMounter(schemaStorage)
 
@@ -241,6 +247,7 @@ func NewProcessor(ctx context.Context, pdEndpoints []string, changefeed model.Ch
 	}
 
 	p := &processor{
+		limitter:      limitter,
 		captureID:     captureID,
 		changefeedID:  changefeedID,
 		changefeed:    changefeed,
@@ -820,7 +827,7 @@ func (p *processor) startPuller(ctx context.Context, span util.Span, checkpointT
 
 	// The key in DML kv pair returned from TiKV is not memcompariable encoded,
 	// so we set `needEncode` to true.
-	puller := puller.NewPuller(p.pdCli, checkpointTs, []util.Span{span}, true)
+	puller := puller.NewPuller(p.pdCli, checkpointTs, []util.Span{span}, true, p.limitter)
 
 	errg.Go(func() error {
 		return puller.Run(ctx)

--- a/cdc/puller/buffer.go
+++ b/cdc/puller/buffer.go
@@ -21,7 +21,7 @@ const (
 
 // EventBuffer in a interface for communicating kv entries.
 type EventBuffer interface {
-	// AddEntry adds an entry to the buffer, return ErrReachLimit if reach bucget limit.
+	// AddEntry adds an entry to the buffer, return ErrReachLimit if reach budget limit.
 	AddEntry(ctx context.Context, entry model.RegionFeedEvent) error
 	Get(ctx context.Context) (model.RegionFeedEvent, error)
 }
@@ -144,14 +144,14 @@ func entrySize(e model.RegionFeedEvent) int {
 
 // BlurResourceLimitter limit resource use.
 type BlurResourceLimitter struct {
-	bucget int64
+	budget int64
 	used   int64
 }
 
 // NewBlurResourceLimmter create a BlurResourceLimitter.
-func NewBlurResourceLimmter(bucget int64) *BlurResourceLimitter {
+func NewBlurResourceLimmter(budget int64) *BlurResourceLimitter {
 	return &BlurResourceLimitter{
-		bucget: bucget,
+		budget: budget,
 	}
 }
 
@@ -160,7 +160,7 @@ func (rl *BlurResourceLimitter) Add(n int64) {
 	atomic.AddInt64(&rl.used, n)
 }
 
-// OverBucget retun true if over bucget.
+// OverBucget retun true if over budget.
 func (rl *BlurResourceLimitter) OverBucget() bool {
-	return atomic.LoadInt64(&rl.used) >= atomic.LoadInt64(&rl.bucget)
+	return atomic.LoadInt64(&rl.used) >= atomic.LoadInt64(&rl.budget)
 }

--- a/cdc/puller/buffer.go
+++ b/cdc/puller/buffer.go
@@ -2,23 +2,41 @@ package puller
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"unsafe"
 
+	"github.com/edwingeng/deque"
+	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/model"
 )
+
+// ErrReachLimit represents the buffer reach limit.
+var ErrReachLimit = errors.New("reach limit")
 
 const (
 	defaultBufferSize = 8
 )
 
-// Buffer buffers kv entries
-type Buffer chan model.RegionFeedEvent
+// EventBuffer in a interface for communicating kv entries.
+type EventBuffer interface {
+	// AddEntry adds an entry to the buffer, return ErrReachLimit if reach bucget limit.
+	AddEntry(ctx context.Context, entry model.RegionFeedEvent) error
+	Get(ctx context.Context) (model.RegionFeedEvent, error)
+}
 
-func makeBuffer() Buffer {
-	return make(Buffer, defaultBufferSize)
+// ChanBuffer buffers kv entries
+type ChanBuffer chan model.RegionFeedEvent
+
+var _ EventBuffer = makeChanBuffer()
+
+func makeChanBuffer() ChanBuffer {
+	return make(ChanBuffer, defaultBufferSize)
 }
 
 // AddEntry adds an entry to the buffer
-func (b Buffer) AddEntry(ctx context.Context, entry model.RegionFeedEvent) error {
+func (b ChanBuffer) AddEntry(ctx context.Context, entry model.RegionFeedEvent) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -28,7 +46,7 @@ func (b Buffer) AddEntry(ctx context.Context, entry model.RegionFeedEvent) error
 }
 
 // Get waits for an entry from the input channel but will stop with respect to the context
-func (b Buffer) Get(ctx context.Context) (model.RegionFeedEvent, error) {
+func (b ChanBuffer) Get(ctx context.Context) (model.RegionFeedEvent, error) {
 	select {
 	case <-ctx.Done():
 		return model.RegionFeedEvent{}, ctx.Err()
@@ -37,4 +55,112 @@ func (b Buffer) Get(ctx context.Context) (model.RegionFeedEvent, error) {
 	}
 }
 
-// TODO limit memory buffer
+var _ EventBuffer = &memBuffer{}
+
+type memBuffer struct {
+	limitter *BlurResourceLimitter
+
+	mu struct {
+		sync.Mutex
+		entries deque.Deque
+	}
+	signalCh chan struct{}
+}
+
+// Passing nil will make a unlimited  buffer.
+func makeMemBuffer(limitter *BlurResourceLimitter) *memBuffer {
+	return &memBuffer{
+		limitter: limitter,
+		mu: struct {
+			sync.Mutex
+			entries deque.Deque
+		}{
+			entries: deque.NewDeque(),
+		},
+
+		signalCh: make(chan struct{}, 1),
+	}
+}
+
+// AddEntry implements EventBuffer interface.
+func (b *memBuffer) AddEntry(ctx context.Context, entry model.RegionFeedEvent) error {
+	b.mu.Lock()
+	if b.limitter != nil && b.limitter.OverBucget() {
+		b.mu.Unlock()
+		return ErrReachLimit
+	}
+
+	b.mu.entries.PushBack(entry)
+	if b.limitter != nil {
+		b.limitter.Add(int64(entrySize(entry)))
+	}
+	b.mu.Unlock()
+
+	select {
+	case b.signalCh <- struct{}{}:
+	default:
+	}
+
+	return nil
+}
+
+// Get implements EventBuffer interface.
+func (b *memBuffer) Get(ctx context.Context) (model.RegionFeedEvent, error) {
+	for {
+		b.mu.Lock()
+		if !b.mu.entries.Empty() {
+			e := b.mu.entries.PopFront().(model.RegionFeedEvent)
+			if b.limitter != nil {
+				b.limitter.Add(int64(-entrySize(e)))
+			}
+			b.mu.Unlock()
+			return e, nil
+		}
+
+		b.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return model.RegionFeedEvent{}, ctx.Err()
+		case <-b.signalCh:
+		}
+	}
+}
+
+var sizeOfVal = unsafe.Sizeof(model.RawKVEntry{})
+var sizeOfResolve = unsafe.Sizeof(model.ResolvedSpan{})
+
+func entrySize(e model.RegionFeedEvent) int {
+	if e.Val != nil {
+		return int(sizeOfVal) + len(e.Val.Key) + len(e.Val.Value)
+	} else if e.Resolved != nil {
+		return int(sizeOfResolve)
+	} else {
+		log.Fatal("unknow event type")
+	}
+
+	return 0
+}
+
+// BlurResourceLimitter limit resource use.
+type BlurResourceLimitter struct {
+	bucget int64
+	used   int64
+}
+
+// NewBlurResourceLimmter create a BlurResourceLimitter.
+func NewBlurResourceLimmter(bucget int64) *BlurResourceLimitter {
+	return &BlurResourceLimitter{
+		bucget: bucget,
+	}
+}
+
+// Add used resource into limmter
+func (rl *BlurResourceLimitter) Add(n int64) {
+	atomic.AddInt64(&rl.used, n)
+}
+
+// OverBucget retun true if over bucget.
+func (rl *BlurResourceLimitter) OverBucget() bool {
+	return atomic.LoadInt64(&rl.used) >= atomic.LoadInt64(&rl.bucget)
+}

--- a/cdc/puller/mock_puller.go
+++ b/cdc/puller/mock_puller.go
@@ -157,7 +157,7 @@ func (p *mockPuller) CollectRawTxns(ctx context.Context, outputFn func(context.C
 	}
 }
 
-func (p *mockPuller) Output() Buffer {
+func (p *mockPuller) Output() ChanBuffer {
 	panic("unreachable")
 }
 

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -97,7 +97,7 @@ var pullCmd = &cobra.Command{
 		g, ctx := errgroup.WithContext(context.Background())
 		ts := oracle.ComposeTS(time.Now().Unix()*1000, 0)
 
-		ddlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetDDLSpan()}, false)
+		ddlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetDDLSpan()}, false, nil)
 		ddlBuf := ddlPuller.Output()
 		g.Go(func() error {
 			return ddlPuller.Run(ctx)
@@ -119,7 +119,7 @@ var pullCmd = &cobra.Command{
 			return
 		}
 		for _, tid := range tableIDs {
-			dmlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetTableSpan(tid, true)}, true)
+			dmlPuller := puller.NewPuller(cli, ts, []util.Span{util.GetTableSpan(tid, true)}, true, nil)
 			dmlBuf := dmlPuller.Output()
 			g.Go(func() error {
 				return dmlPuller.Run(ctx)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/biogo/store v0.0.0-20190426020002-884f370e325d
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/edwingeng/deque v0.0.0-20191220032131-8596380dee17
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/dustin/go-humanize v0.0.0-20180421182945-02af3965c54e/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/edwingeng/deque v0.0.0-20191220032131-8596380dee17 h1:8i9x3Q4hW1kLE4ScsOtUlwVHT76LKhkmOw9zbDxnyUc=
+github.com/edwingeng/deque v0.0.0-20191220032131-8596380dee17/go.mod h1:3Ys1pJhyVaB6iWigv4o2r6Ug1GZmfDWqvqmO6bjojg0=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 h1:clC1lXBpe2kTj2VHdaIu9ajZQe4kcEY9j0NsnDDBZ3o=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #271 

### What is changed and how it works?
Add a limit memory buffer for kv event, consume the kv event
ASAP, once reach limited memory buffer will pull.Run will return error
and processor.Run will fail.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 temporarily change the default mem buffer value to a low value and will reach the `ErrReachLimit` case. 
```
107 [2020/02/24 19:20:29.829 +08:00] [INFO] [capture.go:117] ["stop to run processor"] ["changefeed id"=5ccf8990-2145-4baf-8286-2d07fb6d2de3] [error="reach limit"] [errorVerbose="reach limit\ngithub.com/pingcap/errors.AddStack\n\tgithub.com/pingcap/errors@v0.11.5-0.2    0190809092503-95897b64e011/errors.go:174\ngithub.com/pingcap/errors.Trace\n\tgithub.com/pingcap/errors@v0.11.5-0.20190809092503-95897b64e011/juju_adaptor.go:15\ngithub.com/pingcap/ticdc/cdc/puller.(*pullerImpl).Run.func2\n\tgithub.com/pingcap/ticdc@/cdc/puller/pu    ller.go:130\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:57\nruntime.goexit\n\truntime/asm_amd64.s:1357"]
108 [2020/02/24 19:20:30.407 +08:00] [DEBUG] [client.go:216] ["singleEventFeed quit"]
```

Code changes



Side effects

