### PR TITLE
kv-client: add gRPC conn array

### DIFF
--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"context"
 	"math/rand"
 	"sync"
 	"testing"
@@ -58,4 +59,19 @@ func (s *clientSuite) TestUpdateCheckpointTS(c *check.C) {
 		}
 	}
 	c.Assert(checkpointTS, check.Equals, maxValue)
+}
+
+func (s *clientSuite) TestConnArray(c *check.C) {
+	addr := "127.0.0.1:2379"
+	ca, err := newConnArray(context.TODO(), 2, addr)
+	c.Assert(err, check.IsNil)
+
+	conn1 := ca.Get()
+	conn2 := ca.Get()
+	c.Assert(conn1, check.Not(check.Equals), conn2)
+
+	conn3 := ca.Get()
+	c.Assert(conn1, check.Equals, conn3)
+
+	ca.Close()
 }

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -61,7 +61,11 @@ func (s *clientSuite) TestUpdateCheckpointTS(c *check.C) {
 	c.Assert(checkpointTS, check.Equals, maxValue)
 }
 
-func (s *clientSuite) TestConnArray(c *check.C) {
+// Use etcdSuite for some special reasons, the embed etcd uses zap as the only candidate
+// logger and in the logger initializtion it also initializes the grpclog/loggerv2, which
+// is not a thread-safe operation and it must be called before any gRPC functions
+// ref: https://github.com/grpc/grpc-go/blob/master/grpclog/loggerv2.go#L67-L72
+func (s *etcdSuite) TestConnArray(c *check.C) {
 	addr := "127.0.0.1:2379"
 	ca, err := newConnArray(context.TODO(), 2, addr)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add a gRPC conn array to manage multiple gRPC connections. On the one hand, we can bypass the 1024 conn limit in TiKV temporarily. On the other hand, after the new implementation of EventFeed API we still need connection array for higher throughput.

### What is changed and how it works?

Add a struct to keep connections, and use connections in a round-robin way.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test