### PR TITLE
sink: refine mysql log, remove redundant SQL count log

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -221,6 +221,10 @@ func (p *processor) Run(ctx context.Context, errCh chan<- error) {
 		return p.schemaBuilder.Run(cctx)
 	})
 
+	wg.Go(func() error {
+		return p.sink.PrintStatus(cctx)
+	})
+
 	if err := p.register(ctx); err != nil {
 		errCh <- err
 	}

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -333,7 +333,13 @@ func realRunProcessor(
 	checkpointTs uint64,
 	cb processorCallback,
 ) error {
-	sink, err := sink.NewMySQLSink(info.SinkURI, info.Opts)
+	opts := make(map[string]string, len(info.Opts)+2)
+	for k, v := range info.Opts {
+		opts[k] = v
+	}
+	opts[sink.OptChangefeedID] = changefeedID
+	opts[sink.OptCaptureID] = captureID
+	sink, err := sink.NewMySQLSink(info.SinkURI, opts)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -22,6 +22,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// Sink options keys
+const (
+	OptDryRun       = "_dry_run"
+	OptChangefeedID = "_changefeed_id"
+	OptCaptureID    = "_capture_id"
+)
+
 // Sink is an abstraction for anything that a changefeed may emit into.
 type Sink interface {
 	EmitResolvedEvent(ctx context.Context, ts uint64) error

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -34,6 +34,8 @@ type Sink interface {
 	Run(ctx context.Context) error
 	// Close does not guarantee delivery of outstanding messages.
 	Close() error
+	// PrintStatus prints necessary status periodically
+	PrintStatus(ctx context.Context) error
 }
 
 // NewBlackHoleSink creates a block hole sink
@@ -75,5 +77,10 @@ func (b *blackHoleSink) CheckpointTs() uint64 {
 }
 
 func (b *blackHoleSink) Close() error {
+	return nil
+}
+
+func (b *blackHoleSink) PrintStatus(ctx context.Context) error {
+	<-ctx.Done()
 	return nil
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -22,7 +22,7 @@ if [ "${1-}" = '--debug' ]; then
     cdc server --log-file $WORK_DIR/cdc.log --log-level debug --status-addr 0.0.0.0:8300 > $WORK_DIR/stdout.log 2>&1 &
     sleep 1
     cdc cli
-	# cdc cli --opts "_dry-run="
+	# cdc cli --opts "_dry_run="
 
     echo 'You may now debug from another terminal. Press [ENTER] to exit.'
     read line


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

sink prints too much logs in each exec DML loop

### What is changed and how it works?

- remove log for each time that MySQL sink executes DMLs, instead of a periodically print status

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
