### PR TITLE
Fix lowercase schema name in ddl mounter

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -207,6 +207,14 @@ func fetchHandleValue(tableInfo *schema.TableInfo, recordID int64) (pkCoID int64
 
 func (m *Mounter) mountDDL(jobEntry *ddlJobKVEntry) (*model.DDL, error) {
 	databaseName := jobEntry.Job.SchemaName
+	// schema name in raw ddl job entry is always lowercase, try to find the
+	// correct value from schema storage
+	if m.schemaStorage != nil {
+		schemaName, ok := m.schemaStorage.SchemaByID(jobEntry.Job.SchemaID)
+		if ok {
+			databaseName = schemaName.Name.String()
+		}
+	}
 	var tableName string
 	table := jobEntry.Job.BinlogInfo.TableInfo
 	if table == nil {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -551,7 +551,7 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 		return nil, errors.Annotate(err, "handle ddl job failed")
 	}
 
-	ddlHandler := newDDLHandler(o.pdClient, checkpointTs)
+	ddlHandler := newDDLHandler(o.pdClient, checkpointTs, schemaStorage)
 
 	existingTables := make(map[uint64]uint64)
 	for captureID, taskStatus := range processorsInfos {
@@ -836,6 +836,7 @@ func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.C
 	// Execute DDL Job asynchronously
 	c.ddlState = model.ChangeFeedExecDDL
 	log.Debug("apply job", zap.Stringer("job", todoDDLJob.Job),
+		zap.String("schema", todoDDLJob.Job.SchemaName),
 		zap.String("query", todoDDLJob.Job.Query),
 		zap.Uint64("ts", todoDDLJob.Job.BinlogInfo.FinishedTS))
 

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller"
+	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/ticdc/cdc/sink"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.uber.org/zap"
@@ -42,13 +43,13 @@ type ddlHandler struct {
 	cancel func()
 }
 
-func newDDLHandler(pdCli pd.Client, checkpointTS uint64) *ddlHandler {
+func newDDLHandler(pdCli pd.Client, checkpointTS uint64, s *schema.Storage) *ddlHandler {
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
 	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan()}, false, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	// TODO get time loc from config
-	txnMounter := entry.NewTxnMounter(nil)
+	txnMounter := entry.NewTxnMounter(s)
 	h := &ddlHandler{
 		puller:  puller,
 		cancel:  cancel,

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -166,6 +166,7 @@ func (s *mysqlSink) execDDLWithMaxRetries(ctx context.Context, ddl *model.DDL, m
 	return retry.Run(func() error {
 		err := s.execDDL(ctx, ddl)
 		if isIgnorableDDLError(err) {
+			log.Warn("exec DDL returns ignorable error", zap.Error(err))
 			return nil
 		}
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

QA found a bug that CDC couldn't replicate `CREATE TABLE` when the schema name is not all lowercase.
The root cause is TiDB stores the `CREATE TABLE` DDL history with a lowercase schema name.

### What is changed and how it works?

Find the correct schema name from the `SchemaStorage` when we mount a DDL

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
