### PR TITLE
processor: handle row-based changed event in processor, part 3

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -21,20 +21,19 @@ import (
 	"sync"
 	"time"
 
-	"go.etcd.io/etcd/mvcc/mvccpb"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	pmodel "github.com/pingcap/parser/model"
+	timodel "github.com/pingcap/parser/model"
 	pd "github.com/pingcap/pd/client"
+	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/roles"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
-	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.etcd.io/etcd/clientv3/concurrency"
 	"go.etcd.io/etcd/mvcc"
+	"go.etcd.io/etcd/mvcc/mvccpb"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 )
@@ -50,10 +49,10 @@ type tableIDMap = map[uint64]struct{}
 // which can pull ddl jobs and execute ddl jobs
 type OwnerDDLHandler interface {
 	// PullDDL pulls the ddl jobs and returns resolvedTs of DDL Puller and job list.
-	PullDDL() (resolvedTs uint64, jobs []*model.DDL, err error)
+	PullDDL() (resolvedTs uint64, jobs []*timodel.Job, err error)
 
 	// ExecDDL executes the ddl job
-	ExecDDL(ctx context.Context, sinkURI string, opts map[string]string, txn model.Txn) error
+	ExecDDL(ctx context.Context, sinkURI string, opts map[string]string, ddl *model.DDLEvent) error
 
 	// Close cancels the executing of OwnerDDLHandler and releases resource
 	Close() error
@@ -84,7 +83,7 @@ type changeFeed struct {
 	info   *model.ChangeFeedInfo
 	status *model.ChangeFeedStatus
 
-	schema                  *schema.Storage
+	schema                  *entry.Storage
 	ddlState                model.ChangeFeedDDLState
 	targetTs                uint64
 	taskStatus              model.ProcessorsInfos
@@ -94,10 +93,11 @@ type changeFeed struct {
 
 	ddlHandler    OwnerDDLHandler
 	ddlResolvedTs uint64
-	ddlJobHistory []*model.DDL
+	ddlJobHistory []*timodel.Job
+	ddlExecutedTs uint64
 
 	schemas       map[uint64]tableIDMap
-	tables        map[uint64]schema.TableName
+	tables        map[uint64]entry.TableName
 	orphanTables  map[uint64]model.ProcessTableInfo
 	toCleanTables map[uint64]struct{}
 	infoWriter    *storage.OwnerTaskStatusEtcdWriter
@@ -112,7 +112,7 @@ func (c *changeFeed) String() string {
 
 	if len(c.ddlJobHistory) > 0 {
 		job := c.ddlJobHistory[0]
-		s += fmt.Sprintf("next to exec job: %s query: %s\n\n", job, job.Job.Query)
+		s += fmt.Sprintf("next to exec job: %s query: %s\n\n", job, job.Query)
 	}
 
 	return s
@@ -159,7 +159,7 @@ func (c *changeFeed) reAddTable(id, startTs uint64) {
 	}
 }
 
-func (c *changeFeed) addTable(sid, tid, startTs uint64, table schema.TableName) {
+func (c *changeFeed) addTable(sid, tid, startTs uint64, table entry.TableName) {
 	if c.filter.ShouldIgnoreTable(table.Schema, table.Table) {
 		return
 	}
@@ -331,7 +331,7 @@ func (c *changeFeed) banlanceOrphanTables(ctx context.Context, captures map[stri
 	}
 }
 
-func (c *changeFeed) applyJob(job *pmodel.Job) error {
+func (c *changeFeed) applyJob(job *timodel.Job) error {
 	log.Info("apply job", zap.String("sql", job.Query), zap.Int64("job id", job.ID))
 
 	schamaName, tableName, _, err := c.schema.HandleDDL(job)
@@ -342,25 +342,25 @@ func (c *changeFeed) applyJob(job *pmodel.Job) error {
 	schemaID := uint64(job.SchemaID)
 	// case table id set may change
 	switch job.Type {
-	case pmodel.ActionCreateSchema:
+	case timodel.ActionCreateSchema:
 		c.addSchema(schemaID)
-	case pmodel.ActionDropSchema:
+	case timodel.ActionDropSchema:
 		c.dropSchema(schemaID)
-	case pmodel.ActionCreateTable, pmodel.ActionRecoverTable:
+	case timodel.ActionCreateTable, timodel.ActionRecoverTable:
 		addID := uint64(job.BinlogInfo.TableInfo.ID)
-		c.addTable(schemaID, addID, job.BinlogInfo.FinishedTS, schema.TableName{Schema: schamaName, Table: tableName})
-	case pmodel.ActionDropTable:
+		c.addTable(schemaID, addID, job.BinlogInfo.FinishedTS, entry.TableName{Schema: schamaName, Table: tableName})
+	case timodel.ActionDropTable:
 		dropID := uint64(job.TableID)
 		c.removeTable(schemaID, dropID)
-	case pmodel.ActionRenameTable:
+	case timodel.ActionRenameTable:
 		// no id change just update name
-		c.tables[uint64(job.TableID)] = schema.TableName{Schema: schamaName, Table: tableName}
-	case pmodel.ActionTruncateTable:
+		c.tables[uint64(job.TableID)] = entry.TableName{Schema: schamaName, Table: tableName}
+	case timodel.ActionTruncateTable:
 		dropID := uint64(job.TableID)
 		c.removeTable(schemaID, dropID)
 
 		addID := uint64(job.BinlogInfo.TableInfo.ID)
-		c.addTable(schemaID, addID, job.BinlogInfo.FinishedTS, schema.TableName{Schema: schamaName, Table: tableName})
+		c.addTable(schemaID, addID, job.BinlogInfo.FinishedTS, entry.TableName{Schema: schamaName, Table: tableName})
 	}
 
 	return nil
@@ -537,18 +537,30 @@ func (o *ownerImpl) handleWatchCapture() error {
 	return nil
 }
 
-func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.ProcessorsInfos, taskPositions map[string]*model.TaskPosition, info *model.ChangeFeedInfo, checkpointTs uint64) (*changeFeed, error) {
+func (o *ownerImpl) newChangeFeed(
+	id model.ChangeFeedID,
+	processorsInfos model.ProcessorsInfos,
+	taskPositions map[string]*model.TaskPosition,
+	info *model.ChangeFeedInfo,
+	checkpointTs uint64) (*changeFeed, error) {
 	log.Info("Find new changefeed", zap.Reflect("info", info),
 		zap.String("id", id), zap.Uint64("checkpoint ts", checkpointTs))
 
-	schemaStorage, err := createSchemaStore(o.pdEndpoints)
+	jobs, err := getHistoryDDLJobs(o.pdEndpoints)
 	if err != nil {
-		return nil, errors.Annotate(err, "create schema store failed")
+		return nil, errors.Trace(err)
 	}
 
-	err = schemaStorage.HandlePreviousDDLJobIfNeed(checkpointTs)
-	if err != nil {
-		return nil, errors.Annotate(err, "handle ddl job failed")
+	schemaStorage := entry.NewSingleStorage()
+
+	for _, job := range jobs {
+		if job.BinlogInfo.FinishedTS > checkpointTs {
+			break
+		}
+		_, _, _, err := schemaStorage.HandleDDL(job)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	ddlHandler := newDDLHandler(o.pdClient, checkpointTs)
@@ -573,7 +585,7 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 	}
 
 	schemas := make(map[uint64]tableIDMap)
-	tables := make(map[uint64]schema.TableName)
+	tables := make(map[uint64]entry.TableName)
 	orphanTables := make(map[uint64]model.ProcessTableInfo)
 	for tid, table := range schemaStorage.CloneTables() {
 		if filter.ShouldIgnoreTable(table.Schema, table.Table) {
@@ -616,6 +628,8 @@ func (o *ownerImpl) newChangeFeed(id model.ChangeFeedID, processorsInfos model.P
 			CheckpointTs: checkpointTs,
 		},
 		ddlState:      model.ChangeFeedSyncDML,
+		ddlJobHistory: jobs,
+		ddlExecutedTs: checkpointTs,
 		targetTs:      info.GetTargetTs(),
 		taskStatus:    processorsInfos,
 		taskPositions: taskPositions,
@@ -723,7 +737,7 @@ func (c *changeFeed) calcResolvedTs() error {
 	minResolvedTs := c.targetTs
 	minCheckpointTs := c.targetTs
 
-	if len(c.tables) == 0 {
+	if len(c.taskPositions) == 0 {
 		minCheckpointTs = c.status.CheckpointTs
 	} else {
 		// calc the min of all resolvedTs in captures
@@ -754,8 +768,11 @@ func (c *changeFeed) calcResolvedTs() error {
 
 	// if minResolvedTs is greater than the finishedTS of ddl job which is not executed,
 	// we need to execute this ddl job
-	if len(c.ddlJobHistory) > 0 && minResolvedTs > c.ddlJobHistory[0].Job.BinlogInfo.FinishedTS {
-		minResolvedTs = c.ddlJobHistory[0].Job.BinlogInfo.FinishedTS
+	for len(c.ddlJobHistory) > 0 && c.ddlJobHistory[0].BinlogInfo.FinishedTS <= c.ddlExecutedTs {
+		c.ddlJobHistory = c.ddlJobHistory[1:]
+	}
+	if len(c.ddlJobHistory) > 0 && minResolvedTs > c.ddlJobHistory[0].BinlogInfo.FinishedTS {
+		minResolvedTs = c.ddlJobHistory[0].BinlogInfo.FinishedTS
 		c.ddlState = model.ChangeFeedWaitToExecDDL
 	}
 
@@ -825,59 +842,54 @@ func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.C
 
 	// Check if all the checkpointTs of capture are achieving global resolvedTs(which is equal to todoDDLJob.FinishedTS)
 	for cid, pInfo := range c.taskPositions {
-		if pInfo.CheckPointTs != todoDDLJob.Job.BinlogInfo.FinishedTS {
+		if pInfo.CheckPointTs != todoDDLJob.BinlogInfo.FinishedTS {
 			log.Debug("wait checkpoint ts", zap.String("cid", cid),
 				zap.Uint64("checkpoint ts", pInfo.CheckPointTs),
-				zap.Uint64("finish ts", todoDDLJob.Job.BinlogInfo.FinishedTS))
+				zap.Uint64("finish ts", todoDDLJob.BinlogInfo.FinishedTS))
 			return nil
 		}
 	}
 
 	// Execute DDL Job asynchronously
 	c.ddlState = model.ChangeFeedExecDDL
-	log.Debug("apply job", zap.Stringer("job", todoDDLJob.Job),
-		zap.String("query", todoDDLJob.Job.Query),
-		zap.Uint64("ts", todoDDLJob.Job.BinlogInfo.FinishedTS))
+	log.Debug("apply job", zap.Stringer("job", todoDDLJob),
+		zap.String("query", todoDDLJob.Query),
+		zap.Uint64("ts", todoDDLJob.BinlogInfo.FinishedTS))
 
-	err := c.applyJob(todoDDLJob.Job)
+	err := c.applyJob(todoDDLJob)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	c.banlanceOrphanTables(context.Background(), captures)
-	ddlTxn := model.Txn{Ts: todoDDLJob.Job.BinlogInfo.FinishedTS, DDL: todoDDLJob}
-	if c.filter.ShouldIgnoreTxn(&ddlTxn) {
+	ddlEvent := &model.DDLEvent{
+		Ts:     todoDDLJob.BinlogInfo.FinishedTS,
+		Query:  todoDDLJob.Query,
+		Schema: todoDDLJob.SchemaName,
+		Table:  todoDDLJob.BinlogInfo.TableInfo.Name.O,
+	}
+	if c.filter.ShouldIgnoreDDLEvent(ddlEvent) {
 		log.Info(
-			"DDL txn ignored",
-			zap.Int64("ID", todoDDLJob.Job.ID),
-			zap.String("query", todoDDLJob.Job.Query),
-			zap.Uint64("ts", ddlTxn.Ts),
+			"DDL event ignored",
+			zap.Int64("ID", todoDDLJob.ID),
+			zap.String("query", todoDDLJob.Query),
+			zap.Uint64("ts", ddlEvent.Ts),
 		)
 	} else {
-		c.filter.FilterTxn(&ddlTxn)
-		if ddlTxn.DDL == nil {
-			log.Warn(
-				"DDL ignored",
-				zap.Int64("ID", todoDDLJob.Job.ID),
-				zap.String("query", todoDDLJob.Job.Query),
-				zap.Uint64("ts", todoDDLJob.Job.BinlogInfo.FinishedTS),
-			)
-		} else {
-			err = c.ddlHandler.ExecDDL(ctx, c.info.SinkURI, c.info.Opts, ddlTxn)
-			// If DDL executing failed, pause the changefeed and print log, rather
-			// than return an error and break the running of this owner.
-			if err != nil {
-				c.ddlState = model.ChangeFeedDDLExecuteFailed
-				log.Error("Execute DDL failed",
-					zap.String("ChangeFeedID", c.id),
-					zap.Error(err),
-					zap.Reflect("ddlJob", todoDDLJob))
-				return errors.Trace(model.ErrExecDDLFailed)
-			}
-			log.Info("Execute DDL succeeded",
+		err = c.ddlHandler.ExecDDL(ctx, c.info.SinkURI, c.info.Opts, ddlEvent)
+		// If DDL executing failed, pause the changefeed and print log, rather
+		// than return an error and break the running of this owner.
+		if err != nil {
+			c.ddlState = model.ChangeFeedDDLExecuteFailed
+			log.Error("Execute DDL failed",
 				zap.String("ChangeFeedID", c.id),
+				zap.Error(err),
 				zap.Reflect("ddlJob", todoDDLJob))
+			return errors.Trace(model.ErrExecDDLFailed)
 		}
+		log.Info("Execute DDL succeeded",
+			zap.String("ChangeFeedID", c.id),
+			zap.Reflect("ddlJob", todoDDLJob))
 	}
 	if c.ddlState != model.ChangeFeedExecDDL {
 		log.Fatal("changeFeedState must be ChangeFeedExecDDL when DDL is executed",
@@ -885,6 +897,7 @@ func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.C
 			zap.String("ChangeFeedDDLState", c.ddlState.String()))
 	}
 	c.ddlJobHistory = c.ddlJobHistory[1:]
+	c.ddlExecutedTs = todoDDLJob.BinlogInfo.FinishedTS
 	c.ddlState = model.ChangeFeedSyncDML
 	return nil
 }

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pingcap/ticdc/cdc/entry"
+
 	"go.etcd.io/etcd/mvcc/mvccpb"
 
 	"github.com/google/uuid"
@@ -18,7 +20,6 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/roles"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
-	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.etcd.io/etcd/clientv3"
@@ -162,7 +163,7 @@ func (s *ownerSuite) TestPureDML(c *check.C) {
 		c:                c,
 	}
 
-	tables := map[uint64]schema.TableName{1: {Schema: "any"}}
+	tables := map[uint64]entry.TableName{1: {Schema: "any"}}
 
 	changeFeeds := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed": {
@@ -377,7 +378,7 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 		c:      c,
 	}
 
-	tables := map[uint64]schema.TableName{1: {Schema: "any"}}
+	tables := map[uint64]entry.TableName{1: {Schema: "any"}}
 
 	filter, err := newTxnFilter(&model.ReplicaConfig{})
 	c.Assert(err, check.IsNil)
@@ -650,7 +651,7 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 			{},
 		}
 
-		expectTables = []map[uint64]schema.TableName{
+		expectTables = []map[uint64]entry.TableName{
 			{},
 			{47: {Schema: "test", Table: "t1"}},
 			{47: {Schema: "test", Table: "t1"}, 49: {Schema: "test", Table: "t2"}},
@@ -660,14 +661,14 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 			{},
 		}
 	)
-	schemaStorage, err := schema.NewStorage(nil)
+	schemaStorage, err := entry.NewStorage(nil)
 	c.Assert(err, check.IsNil)
 	filter, err := newTxnFilter(&model.ReplicaConfig{})
 	c.Assert(err, check.IsNil)
 	cf := &changeFeed{
 		schema:        schemaStorage,
 		schemas:       make(map[uint64]map[uint64]struct{}),
-		tables:        make(map[uint64]schema.TableName),
+		tables:        make(map[uint64]entry.TableName),
 		orphanTables:  make(map[uint64]model.ProcessTableInfo),
 		toCleanTables: make(map[uint64]struct{}),
 		filter:        filter,

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,7 +35,6 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
-	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/ticdc/cdc/sink"
 	"github.com/pingcap/ticdc/pkg/retry"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -53,26 +53,18 @@ const (
 	updateInfoInterval        = time.Millisecond * 500
 	resolveTsInterval         = time.Millisecond * 500
 	waitGlobalResolvedTsDelay = time.Millisecond * 500
-	flushDMLsInterval         = time.Millisecond * 10
 
-	defaultInputTxnChanSize  = 128
-	defaultOutputTxnChanSize = 128
+	defaultOutputChanSize = 128
 
 	// defaultMemBufferCapacity is the default memory buffer per change feed.
 	defaultMemBufferCapacity int64 = 10 * 1024 * 1024 * 1024 // 10G
 )
 
 var (
-	fCreateSchema = createSchemaStore
 	fNewPDCli     = pd.NewClient
 	fNewTsRWriter = createTsRWriter
-	fNewMounter   = newMounter
 	fNewMySQLSink = sink.NewMySQLSink
 )
-
-type mounter interface {
-	Mount(rawTxn model.RawTxn) (model.Txn, error)
-}
 
 type txnChannel struct {
 	inputTxn   <-chan model.RawTxn
@@ -154,17 +146,13 @@ type processor struct {
 	pdCli   pd.Client
 	etcdCli kv.CDCEtcdClient
 
-	mounter       mounter
-	schemaStorage *schema.Storage
-	sink          sink.Sink
+	sink sink.Sink
 
-	ddlPuller    puller.Puller
-	ddlJobsCh    chan model.RawTxn
-	ddlResolveTS uint64
+	ddlPuller     puller.Puller
+	schemaBuilder *entry.StorageBuilder
 
-	tsRWriter    storage.ProcessorTsRWriter
-	resolvedTxns chan model.RawTxn
-	executedTxns chan model.RawTxn
+	tsRWriter storage.ProcessorTsRWriter
+	output    chan *model.RowChangedEvent
 
 	status   *model.TaskStatus
 	position *model.TaskPosition
@@ -178,10 +166,9 @@ type processor struct {
 
 type tableInfo struct {
 	id         int64
-	puller     puller.CancellablePuller
-	inputChan  *txnChannel
-	inputTxn   chan model.RawTxn
+	mounter    entry.Mounter
 	resolvedTS uint64
+	cancel     context.CancelFunc
 }
 
 func (t *tableInfo) loadResolvedTS() uint64 {
@@ -193,7 +180,13 @@ func (t *tableInfo) storeResolvedTS(ts uint64) {
 }
 
 // NewProcessor creates and returns a processor for the specified change feed
-func NewProcessor(ctx context.Context, pdEndpoints []string, changefeed model.ChangeFeedInfo, changefeedID, captureID string, checkpointTs uint64) (*processor, error) {
+func NewProcessor(
+	ctx context.Context,
+	pdEndpoints []string,
+	changefeed model.ChangeFeedInfo,
+	sink sink.Sink,
+	changefeedID, captureID string,
+	checkpointTs uint64) (*processor, error) {
 	pdCli, err := fNewPDCli(pdEndpoints, pd.SecurityOption{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "create pd client failed, addr: %v", pdEndpoints)
@@ -218,10 +211,6 @@ func NewProcessor(ctx context.Context, pdEndpoints []string, changefeed model.Ch
 		return nil, errors.Annotate(err, "new etcd client")
 	}
 	cdcEtcdCli := kv.NewCDCEtcdClient(etcdCli)
-	schemaStorage, err := fCreateSchema(pdEndpoints)
-	if err != nil {
-		return nil, err
-	}
 
 	tsRWriter, err := fNewTsRWriter(cdcEtcdCli, changefeedID, captureID)
 	if err != nil {
@@ -233,15 +222,8 @@ func NewProcessor(ctx context.Context, pdEndpoints []string, changefeed model.Ch
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
 	ddlPuller := puller.NewPuller(pdCli, checkpointTs, []util.Span{util.GetDDLSpan()}, false, limitter)
-
-	mounter := fNewMounter(schemaStorage)
-
-	sink, err := fNewMySQLSink(changefeed.SinkURI, schemaStorage, changefeed.Opts)
-	if err != nil {
-		return nil, err
-	}
-
-	filter, err := newTxnFilter(changefeed.GetConfig())
+	ddlEventCh := ddlPuller.SortedOutput(ctx)
+	schemaBuilder, err := createSchemaBuilder(pdEndpoints, ddlEventCh)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -253,18 +235,14 @@ func NewProcessor(ctx context.Context, pdEndpoints []string, changefeed model.Ch
 		changefeed:    changefeed,
 		pdCli:         pdCli,
 		etcdCli:       cdcEtcdCli,
-		mounter:       mounter,
-		schemaStorage: schemaStorage,
 		sink:          sink,
 		ddlPuller:     ddlPuller,
-		filter:        filter,
+		schemaBuilder: schemaBuilder,
 
-		tsRWriter:    tsRWriter,
-		status:       tsRWriter.GetTaskStatus(),
-		position:     &model.TaskPosition{},
-		resolvedTxns: make(chan model.RawTxn, 1),
-		executedTxns: make(chan model.RawTxn, 1),
-		ddlJobsCh:    make(chan model.RawTxn, 16),
+		tsRWriter: tsRWriter,
+		status:    tsRWriter.GetTaskStatus(),
+		position:  &model.TaskPosition{CheckPointTs: checkpointTs},
+		output:    make(chan *model.RowChangedEvent, defaultOutputChanSize),
 
 		tables: make(map[int64]*tableInfo),
 	}
@@ -282,11 +260,11 @@ func (p *processor) Run(ctx context.Context, errCh chan<- error) {
 	p.errCh = errCh
 
 	wg.Go(func() error {
-		return p.localResolvedWorker(cctx)
+		return p.positionWorker(cctx)
 	})
 
 	wg.Go(func() error {
-		return p.globalResolvedWorker(cctx)
+		return p.globalStatusWorker(cctx)
 	})
 
 	wg.Go(func() error {
@@ -294,7 +272,11 @@ func (p *processor) Run(ctx context.Context, errCh chan<- error) {
 	})
 
 	wg.Go(func() error {
-		return p.pullDDLJob(cctx)
+		return p.ddlPuller.Run(cctx)
+	})
+
+	wg.Go(func() error {
+		return p.schemaBuilder.Run(cctx)
 	})
 
 	go func() {
@@ -333,24 +315,43 @@ func (p *processor) writeDebugInfo(w io.Writer) {
 // 2, update checkpoint ts by consuming entry from p.executedTxns.
 // 3, sync TaskStatus between in memory and storage.
 // 4, check admin command in TaskStatus and apply corresponding command
-func (p *processor) localResolvedWorker(ctx context.Context) error {
+func (p *processor) positionWorker(ctx context.Context) error {
 	updateInfoTick := time.NewTicker(updateInfoInterval)
-	defer updateInfoTick.Stop()
-
 	resolveTsTick := time.NewTicker(resolveTsInterval)
-	defer resolveTsTick.Stop()
+	checkpointTsTick := time.NewTicker(resolveTsInterval)
+
+	updateInfo := func() error {
+		t0Update := time.Now()
+		err := retry.Run(func() error {
+			inErr := p.updateInfo(ctx)
+			if errors.Cause(inErr) == model.ErrAdminStopProcessor {
+				return backoff.Permanent(inErr)
+			}
+			return inErr
+		}, 3)
+		updateInfoDuration.WithLabelValues(p.captureID).Observe(time.Since(t0Update).Seconds())
+		if err != nil {
+			return errors.Annotate(err, "failed to update info")
+		}
+		return nil
+	}
+
+	defer func() {
+		updateInfoTick.Stop()
+		resolveTsTick.Stop()
+		checkpointTsTick.Stop()
+
+		err := updateInfo()
+		if err != nil {
+			log.Error("failed to update info", zap.Error(err))
+		}
+
+		log.Info("Local resolved worker exited")
+	}()
 
 	for {
 		select {
 		case <-ctx.Done():
-			timedCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-			err := p.updateInfo(timedCtx)
-			if err != nil {
-				log.Error("failed to update info", zap.Error(err))
-			}
-			cancel()
-
-			log.Info("Local resolved worker exited")
 			return ctx.Err()
 		case <-resolveTsTick.C:
 			p.tablesMu.Lock()
@@ -360,8 +361,7 @@ func (p *processor) localResolvedWorker(ctx context.Context) error {
 				continue
 			}
 
-			minResolvedTs := atomic.LoadUint64(&p.ddlResolveTS)
-
+			minResolvedTs := uint64(math.MaxUint64)
 			for _, table := range p.tables {
 				ts := table.loadResolvedTS()
 				tableResolvedTsGauge.WithLabelValues(p.changefeedID, p.captureID, strconv.FormatInt(table.id, 10)).Set(float64(oracle.ExtractPhysical(ts)))
@@ -371,29 +371,29 @@ func (p *processor) localResolvedWorker(ctx context.Context) error {
 				}
 			}
 			p.tablesMu.Unlock()
+			// some puller still haven't received the row changed data
+			if minResolvedTs == 0 {
+				continue
+			}
+
 			p.position.ResolvedTs = minResolvedTs
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case p.output <- &model.RowChangedEvent{Resolved: true, Ts: minResolvedTs}:
+			}
 			resolvedTsGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(oracle.ExtractPhysical(minResolvedTs)))
-		case e, ok := <-p.executedTxns:
-			if !ok {
-				log.Info("Resolved worker exited")
-				return nil
+		case <-checkpointTsTick.C:
+			checkpointTs := p.sink.CheckpointTs()
+			if p.position.CheckPointTs > checkpointTs {
+				continue
 			}
-			if e.IsResolved {
-				p.position.CheckPointTs = e.Ts
-				checkpointTsGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(oracle.ExtractPhysical(e.Ts)))
-			}
+			p.position.CheckPointTs = checkpointTs
+			checkpointTsGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(oracle.ExtractPhysical(checkpointTs)))
 		case <-updateInfoTick.C:
-			t0Update := time.Now()
-			err := retry.Run(func() error {
-				inErr := p.updateInfo(ctx)
-				if errors.Cause(inErr) == model.ErrAdminStopProcessor {
-					return backoff.Permanent(inErr)
-				}
-				return inErr
-			}, 3)
-			updateInfoDuration.WithLabelValues(p.captureID).Observe(time.Since(t0Update).Seconds())
+			err := updateInfo()
 			if err != nil {
-				return errors.Annotate(err, "failed to update info")
+				return errors.Trace(err)
 			}
 		}
 	}
@@ -489,7 +489,7 @@ func (p *processor) removeTable(tableID int64) {
 		return
 	}
 
-	table.puller.Cancel()
+	table.cancel()
 	delete(p.tables, tableID)
 	tableIDStr := strconv.FormatInt(tableID, 10)
 	tableInputChanSizeGauge.DeleteLabelValues(p.changefeedID, p.captureID, tableIDStr)
@@ -521,16 +521,14 @@ func (p *processor) handleTables(ctx context.Context, oldInfo, newInfo *model.Ta
 	}
 }
 
-// globalResolvedWorker read global resolve ts from changefeed level info and forward `tableInputChans` regularly.
-func (p *processor) globalResolvedWorker(ctx context.Context) error {
-	log.Info("Global resolved worker started")
+// globalStatusWorker read global resolve ts from changefeed level info and forward `tableInputChans` regularly.
+func (p *processor) globalStatusWorker(ctx context.Context) error {
+	log.Info("Global status worker started")
 
 	var (
-		globalResolvedTs     uint64
-		lastGlobalResolvedTs uint64
+		changefeedStatus     *model.ChangeFeedStatus
+		lastChangefeedStatus *model.ChangeFeedStatus
 	)
-
-	defer close(p.resolvedTxns)
 
 	retryCfg := backoff.WithMaxRetries(
 		backoff.WithContext(
@@ -546,7 +544,7 @@ func (p *processor) globalResolvedWorker(ctx context.Context) error {
 		}
 		err := backoff.Retry(func() error {
 			var err error
-			globalResolvedTs, err = p.tsRWriter.ReadGlobalResolvedTs(ctx)
+			changefeedStatus, err = p.tsRWriter.GetChangeFeedStatus(ctx)
 			if err != nil {
 				log.Error("Global resolved worker: read global resolved ts failed", zap.Error(err))
 			}
@@ -556,177 +554,65 @@ func (p *processor) globalResolvedWorker(ctx context.Context) error {
 			return errors.Trace(err)
 		}
 
-		if lastGlobalResolvedTs == globalResolvedTs {
+		if lastChangefeedStatus != nil &&
+			lastChangefeedStatus.ResolvedTs == changefeedStatus.ResolvedTs &&
+			lastChangefeedStatus.CheckpointTs == changefeedStatus.CheckpointTs {
 			time.Sleep(waitGlobalResolvedTsDelay)
 			continue
 		}
 
-		lastGlobalResolvedTs = globalResolvedTs
-
-		wg, cctx := errgroup.WithContext(ctx)
-
-		p.tablesMu.Lock()
-		for _, table := range p.tables {
-			input := table.inputChan
-			wg.Go(func() error {
-				// TODO: Forward should return an error if it's canceled
-				input.Forward(cctx, globalResolvedTs, p.resolvedTxns)
-				return nil
-			})
-		}
-		p.tablesMu.Unlock()
-
-		err = wg.Wait()
+		lastChangefeedStatus = changefeedStatus
+		err = p.sink.EmitResolvedEvent(ctx, changefeedStatus.ResolvedTs)
 		if err != nil {
 			return errors.Trace(err)
 		}
-
-		select {
-		case <-ctx.Done():
-			return errors.Trace(ctx.Err())
-		case p.resolvedTxns <- model.RawTxn{
-			Ts:         globalResolvedTs,
-			IsResolved: true,
-		}:
+		err = p.sink.EmitCheckpointEvent(ctx, changefeedStatus.CheckpointTs)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = p.schemaBuilder.DoGc(changefeedStatus.CheckpointTs)
+		if err != nil {
+			return errors.Trace(err)
 		}
 	}
-}
-
-// pullDDLJob push ddl job into `p.ddlJobsCh`.
-func (p *processor) pullDDLJob(ctx context.Context) error {
-	defer close(p.ddlJobsCh)
-	errg, ctx := errgroup.WithContext(ctx)
-
-	errg.Go(func() error {
-		return p.ddlPuller.Run(ctx)
-	})
-
-	errg.Go(func() error {
-		err := p.ddlPuller.CollectRawTxns(ctx, func(ctxInner context.Context, rawTxn model.RawTxn) error {
-			select {
-			case <-ctxInner.Done():
-				return ctxInner.Err()
-			case p.ddlJobsCh <- rawTxn:
-				return nil
-			}
-		})
-		if err != nil {
-			return errors.Annotate(err, "span: ddl")
-		}
-		return nil
-	})
-	return errg.Wait()
 }
 
 // syncResolved handle `p.ddlJobsCh` and `p.resolvedTxns`
 func (p *processor) syncResolved(ctx context.Context) error {
-	const bulkLimit = 128
-	var lastResolved model.RawTxn
-	pendingTxns := make([]model.Txn, 0, bulkLimit)
-
-	flush := func(ctx2 context.Context) error {
-		forwardResolved := func() {
-			if lastResolved.Ts > 0 {
-				select {
-				case p.executedTxns <- lastResolved:
-				case <-ctx2.Done():
-				}
-			}
-		}
-		if len(pendingTxns) == 0 {
-			forwardResolved()
-			return nil
-		}
-		if err := p.sink.EmitDMLs(ctx2, pendingTxns...); err != nil {
-			return errors.Trace(err)
-		}
-		log.Info("DMLs Flushed", zap.Any("resolved", lastResolved), zap.Int("bulk", len(pendingTxns)))
-		forwardResolved()
-		txnCounter.WithLabelValues("executed", p.changefeedID, p.captureID).Add(float64(len(pendingTxns)))
-		pendingTxns = pendingTxns[:0]
-		return nil
-	}
-
-	defer close(p.executedTxns)
-
-	flushTick := time.NewTicker(flushDMLsInterval)
-
+	defer log.Info("syncResolved stopped")
 	for {
 		select {
-		case rawTxn, ok := <-p.ddlJobsCh:
-			if !ok {
-				return nil
-			}
-			if rawTxn.IsFake() {
-				atomic.StoreUint64(&p.ddlResolveTS, rawTxn.Ts)
-				continue
-			}
-			t, err := p.mounter.Mount(rawTxn)
+		case row := <-p.output:
+			err := p.sink.EmitRowChangedEvent(ctx, row)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if !t.IsDDL() {
-				if t.IsDML() {
-					log.Warn("Receive DML txn from ddlJobsCh", zap.Any("txn", t))
-				}
-				continue
-			}
-			p.schemaStorage.AddJob(t.DDL.Job)
-			if err := flush(ctx); err != nil {
-				return errors.Trace(err)
-			}
-			atomic.StoreUint64(&p.ddlResolveTS, rawTxn.Ts)
-		case rawTxn, ok := <-p.resolvedTxns:
-			if !ok {
-				return nil
-			}
-			if rawTxn.IsResolved {
-				lastResolved = rawTxn
-				continue
-			}
-
-			if err := p.schemaStorage.HandlePreviousDDLJobIfNeed(rawTxn.Ts); err != nil {
-				return errors.Trace(err)
-			}
-			txn, err := p.mounter.Mount(rawTxn)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			if p.filter.ShouldIgnoreTxn(&txn) {
-				log.Info("DML txn ignored", zap.Uint64("ts", txn.Ts))
-				continue
-			}
-			p.filter.FilterTxn(&txn)
-			if len(txn.DMLs) == 0 {
-				continue
-			}
-			pendingTxns = append(pendingTxns, txn)
-			if len(pendingTxns) >= bulkLimit {
-				if err := flush(ctx); err != nil {
-					return errors.Trace(err)
-				}
-			}
+			// should filter in sink
+			//if p.filter.ShouldIgnoreTxn(&txn) {
+			//	log.Info("DML txn ignored", zap.Uint64("ts", txn.Ts))
+			//	continue
+			//}
+			//p.filter.FilterTxn(&txn)
 		case <-ctx.Done():
-			err := ctx.Err()
-			if err == context.Canceled {
-				timedCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-				if err := flush(timedCtx); err != nil {
-					log.Error("Failed to flush Txns before quiting", zap.Error(err))
-				}
-				cancel()
-			}
-			log.Info("syncResolved stopped")
 			return ctx.Err()
-		case <-flushTick.C:
-			if err := flush(ctx); err != nil {
-				return errors.Trace(err)
-			}
 		}
 	}
 }
 
-func createSchemaStore(pdEndpoints []string) (*schema.Storage, error) {
-	// here we create another pb client,we should reuse them
+func createSchemaBuilder(pdEndpoints []string, ddlEventCh <-chan *model.RawKVEntry) (*entry.StorageBuilder, error) {
+	jobs, err := getHistoryDDLJobs(pdEndpoints)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	builder, err := entry.NewStorageBuilder(jobs, ddlEventCh)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return builder, nil
+}
+
+func getHistoryDDLJobs(pdEndpoints []string) ([]*timodel.Job, error) {
+	// TODO here we create another pb client,we should reuse them
 	kvStore, err := createTiStore(strings.Join(pdEndpoints, ","))
 	if err != nil {
 		return nil, err
@@ -746,11 +632,7 @@ func createSchemaStore(pdEndpoints []string) (*schema.Storage, error) {
 		}
 		jobs = append(jobs, job)
 	}
-	schemaStorage, err := schema.NewStorage(jobs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return schemaStorage, nil
+	return jobs, nil
 }
 
 func resetFinishedTs(kvStore tikv.Storage, job *timodel.Job) error {
@@ -804,88 +686,67 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 		log.Warn("Ignore existing table", zap.Int64("ID", tableID))
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
 	table := &tableInfo{
-		id:       tableID,
-		inputTxn: make(chan model.RawTxn, defaultInputTxnChanSize),
+		id:     tableID,
+		cancel: cancel,
 	}
 
-	tc := newTxnChannel(table.inputTxn, defaultOutputTxnChanSize, func(resolvedTs uint64) {
-		table.storeResolvedTS(resolvedTs)
-	})
-	table.inputChan = tc
-
-	span := util.GetTableSpan(tableID, true)
-
-	ctx, cancel := context.WithCancel(ctx)
-	plr := p.startPuller(ctx, span, startTs, table.inputTxn, p.errCh)
-	table.puller = puller.CancellablePuller{Puller: plr, Cancel: cancel}
-	p.collectMetrics(ctx, tableID, tc)
-
-	p.tables[tableID] = table
-	syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureID).Inc()
-}
-
-func (p *processor) collectMetrics(ctx context.Context, tableID int64, tc *txnChannel) {
-	go func() {
-		for {
-			tableIDStr := strconv.FormatInt(tableID, 10)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Minute):
-				tableInputChanSizeGauge.WithLabelValues(p.changefeedID, p.captureID, tableIDStr).Set(float64(len(tc.inputTxn)))
-				tableOutputChanSizeGauge.WithLabelValues(p.changefeedID, p.captureID, tableIDStr).Set(float64(len(tc.outputTxn)))
-			}
-		}
-	}()
-}
-
-// startPuller start pull data with span and push resolved txn into txnChan in timestamp increasing order.
-func (p *processor) startPuller(ctx context.Context, span util.Span, checkpointTs uint64, txnChan chan<- model.RawTxn, errCh chan<- error) puller.Puller {
-	// Set it up so that one failed goroutine cancels all others sharing the same ctx
-	errg, ctx := errgroup.WithContext(ctx)
-
+	// start table puller
 	// The key in DML kv pair returned from TiKV is not memcompariable encoded,
 	// so we set `needEncode` to true.
-	puller := puller.NewPuller(p.pdCli, checkpointTs, []util.Span{span}, true, p.limitter)
-
-	errg.Go(func() error {
-		return puller.Run(ctx)
-	})
-
-	errg.Go(func() error {
-		defer close(txnChan)
-		err := puller.CollectRawTxns(ctx, func(ctxInner context.Context, rawTxn model.RawTxn) error {
-			select {
-			case <-ctxInner.Done():
-				return ctxInner.Err()
-			case txnChan <- rawTxn:
-				txnCounter.WithLabelValues("received", p.changefeedID, p.captureID).Inc()
-				return nil
-			}
-		})
-		return errors.Annotatef(err, "span: %v", span)
-	})
-
+	span := util.GetTableSpan(tableID, true)
+	puller := puller.NewPuller(p.pdCli, startTs, []util.Span{span}, true, p.limitter)
 	go func() {
-		err := errg.Wait()
+		err := puller.Run(ctx)
 		if errors.Cause(err) != context.Canceled {
-			errCh <- err
+			p.errCh <- err
 		}
 	}()
 
-	return puller
+	// start mounter
+	mounter := entry.NewMounter(puller.SortedOutput(ctx), p.schemaBuilder)
+	go func() {
+		err := mounter.Run(ctx)
+		if errors.Cause(err) != context.Canceled {
+			p.errCh <- err
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				if errors.Cause(ctx.Err()) != context.Canceled {
+					p.errCh <- ctx.Err()
+				}
+				return
+			case row := <-mounter.Output():
+				if row.Resolved {
+					table.storeResolvedTS(row.Ts)
+					log.Info("storeResolvedTS", zap.Uint64("ts", row.Ts))
+					continue
+				}
+				select {
+				case <-ctx.Done():
+					if errors.Cause(ctx.Err()) != context.Canceled {
+						p.errCh <- ctx.Err()
+					}
+					return
+				case p.output <- row:
+				}
+			}
+		}
+	}()
+	table.mounter = mounter
+	p.tables[tableID] = table
+	syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureID).Inc()
 }
 
 func (p *processor) stop(ctx context.Context) error {
 	p.tablesMu.Lock()
 	for _, tbl := range p.tables {
-		tbl.puller.Cancel()
+		tbl.cancel()
 	}
 	p.tablesMu.Unlock()
 	return errors.Trace(p.etcdCli.DeleteTaskStatus(ctx, p.changefeedID, p.captureID))
-}
-
-func newMounter(schema *schema.Storage) mounter {
-	return entry.NewTxnMounter(schema)
 }

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -19,12 +19,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pingcap/ticdc/cdc/entry"
+
 	"github.com/pingcap/check"
 	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
-	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/ticdc/cdc/sink"
 	"github.com/pingcap/ticdc/pkg/etcd"
 )
@@ -125,7 +126,7 @@ func (p *processorSuite) TestProcessor(c *check.C) {
 
 func runCase(c *check.C, cases *processorTestCase) {
 	origFSchema := fCreateSchema
-	fCreateSchema = func(pdEndpoints []string) (*schema.Storage, error) {
+	fCreateSchema = func(pdEndpoints []string) (*entry.Storage, error) {
 		return nil, nil
 	}
 	origFNewPD := fNewPDCli
@@ -137,7 +138,7 @@ func runCase(c *check.C, cases *processorTestCase) {
 		return &mockTsRWriter{}, nil
 	}
 	origFNewMounter := fNewMounter
-	fNewMounter = func(schema *schema.Storage) mounter {
+	fNewMounter = func(schema *entry.Storage) mounter {
 		return mockMounter{}
 	}
 	origFNewSink := fNewMySQLSink

--- a/cdc/roles/storage/etcd.go
+++ b/cdc/roles/storage/etcd.go
@@ -31,8 +31,8 @@ import (
 
 // ProcessorTsRWriter reads or writes the resolvedTs and checkpointTs from the storage
 type ProcessorTsRWriter interface {
-	// ReadGlobalResolvedTs read the bloable resolved ts.
-	ReadGlobalResolvedTs(ctx context.Context) (uint64, error)
+	// GetChangeFeedStatus read the changefeed status.
+	GetChangeFeedStatus(ctx context.Context) (*model.ChangeFeedStatus, error)
 
 	// WritePosition update taskPosition into storage, return model.ErrWriteTsConflict if in last learn taskPosition is out dated and must call UpdateInfo.
 	WritePosition(ctx context.Context, taskPosition *model.TaskPosition) error
@@ -137,12 +137,8 @@ func (rw *ProcessorTsEtcdRWriter) WriteInfoIntoStorage(
 }
 
 // ReadGlobalResolvedTs reads the global resolvedTs from etcd
-func (rw *ProcessorTsEtcdRWriter) ReadGlobalResolvedTs(ctx context.Context) (uint64, error) {
-	info, err := rw.etcdClient.GetChangeFeedStatus(ctx, rw.changefeedID)
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	return info.ResolvedTs, nil
+func (rw *ProcessorTsEtcdRWriter) GetChangeFeedStatus(ctx context.Context) (*model.ChangeFeedStatus, error) {
+	return rw.etcdClient.GetChangeFeedStatus(ctx, rw.changefeedID)
 }
 
 // GetTaskStatus returns the in memory cache of *model.TaskStatus stored in ProcessorTsEtcdRWriter

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -19,6 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/ticdc/cdc/sink"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
@@ -328,11 +330,11 @@ func realRunProcessor(
 	checkpointTs uint64,
 	cb processorCallback,
 ) error {
-	processor, err := NewProcessor(ctx, pdEndpoints, info, changefeedID, captureID, checkpointTs)
+	sink := sink.NewBlackHoleSink()
+	processor, err := NewProcessor(ctx, pdEndpoints, info, sink, changefeedID, captureID, checkpointTs)
 	if err != nil {
 		return err
 	}
-
 	log.Info("start to run processor", zap.String("changefeed id", changefeedID))
 
 	if cb != nil {

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/ticdc/cdc/entry"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pingcap/ticdc/pkg/retry"
@@ -31,7 +33,6 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/ticdc/pkg/util"
 	tddl "github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/infoschema"
@@ -46,6 +47,26 @@ type mysqlSink struct {
 	db         *sql.DB
 	infoGetter TableInfoGetter
 	ddlOnly    bool
+}
+
+func (s *mysqlSink) EmitResolvedEvent(ctx context.Context, ts uint64) error {
+	panic("implement me")
+}
+
+func (s *mysqlSink) EmitCheckpointEvent(ctx context.Context, ts uint64) error {
+	panic("implement me")
+}
+
+func (s *mysqlSink) EmitRowChangedEvent(ctx context.Context, txn ...*model.RowChangedEvent) error {
+	panic("implement me")
+}
+
+func (s *mysqlSink) EmitDDLEvent(ctx context.Context, txn *model.DDLEvent) error {
+	panic("implement me")
+}
+
+func (s *mysqlSink) CheckpointTs() uint64 {
+	panic("implement me")
 }
 
 var _ Sink = &mysqlSink{}
@@ -316,7 +337,7 @@ func (s *mysqlSink) prepareDelete(dml *model.DML) (string, []interface{}, error)
 	return sql, args, nil
 }
 
-func formatValues(table *schema.TableInfo, colVals map[string]types.Datum) error {
+func formatValues(table *entry.TableInfo, colVals map[string]types.Datum) error {
 	columns := table.WritableColumns()
 	// TODO get table infos from txn for emit interface
 	for _, col := range columns {
@@ -365,7 +386,7 @@ func whereValues(colVals map[string]types.Datum, names []string) (values []types
 	return
 }
 
-func whereSlice(table *schema.TableInfo, colVals map[string]types.Datum) (colNames []string, args []types.Datum) {
+func whereSlice(table *entry.TableInfo, colVals map[string]types.Datum) (colNames []string, args []types.Datum) {
 	// Try to use unique key values when available
 	for _, idxCols := range table.GetUniqueKeys() {
 		values := whereValues(colVals, idxCols)

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -18,6 +18,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/pingcap/ticdc/cdc/entry"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/check"
@@ -25,7 +27,6 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/types"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/cdc/schema"
 	"github.com/pingcap/tidb/infoschema"
 	dbtypes "github.com/pingcap/tidb/types"
 )
@@ -107,8 +108,8 @@ func (s EmitSuite) TestShouldIgnoreCertainDDLError(c *check.C) {
 type tableHelper struct {
 }
 
-func (h *tableHelper) TableByID(id int64) (info *schema.TableInfo, ok bool) {
-	return schema.WrapTableInfo(&timodel.TableInfo{
+func (h *tableHelper) TableByID(id int64) (info *entry.TableInfo, ok bool) {
+	return entry.WrapTableInfo(&timodel.TableInfo{
 		Columns: []*timodel.ColumnInfo{
 			{
 				Name:  timodel.CIStr{O: "id"},
@@ -132,7 +133,7 @@ func (h *tableHelper) TableByID(id int64) (info *schema.TableInfo, ok bool) {
 	}), true
 }
 
-func (h *tableHelper) GetTableByName(schema, table string) (*schema.TableInfo, bool) {
+func (h *tableHelper) GetTableByName(schema, table string) (*entry.TableInfo, bool) {
 	return h.TableByID(42)
 }
 

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -15,24 +15,76 @@ package sink
 
 import (
 	"context"
+	"sync/atomic"
+
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
+	"github.com/pingcap/ticdc/cdc/entry"
 
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/cdc/schema"
 )
 
 // Sink is an abstraction for anything that a changefeed may emit into.
 type Sink interface {
+	EmitResolvedEvent(ctx context.Context, ts uint64) error
+	EmitCheckpointEvent(ctx context.Context, ts uint64) error
 	// EmitDMLs saves the specified DMLs to the sink backend
-	EmitDMLs(ctx context.Context, txn ...model.Txn) error
+	EmitRowChangedEvent(ctx context.Context, txn ...*model.RowChangedEvent) error
 	// EmitDDL saves the specified DDL to the sink backend
-	EmitDDL(ctx context.Context, txn model.Txn) error
+	EmitDDLEvent(ctx context.Context, txn *model.DDLEvent) error
+	CheckpointTs() uint64
 	// Close does not guarantee delivery of outstanding messages.
 	Close() error
 }
 
 // TableInfoGetter is used to get table info by table id of TiDB
 type TableInfoGetter interface {
-	TableByID(id int64) (info *schema.TableInfo, ok bool)
+	TableByID(id int64) (info *entry.TableInfo, ok bool)
 	GetTableIDByName(schema, table string) (int64, bool)
-	GetTableByName(schema, table string) (info *schema.TableInfo, ok bool)
+	GetTableByName(schema, table string) (info *entry.TableInfo, ok bool)
+}
+
+func NewBlackHoleSink() *blackHoleSink {
+	return &blackHoleSink{}
+}
+
+type blackHoleSink struct {
+	checkpointTs uint64
+}
+
+func (b *blackHoleSink) EmitResolvedEvent(ctx context.Context, ts uint64) error {
+	log.Info("BlockHoleSink: Resolved Event", zap.Uint64("resolved ts", ts))
+	return nil
+}
+
+func (b *blackHoleSink) EmitCheckpointEvent(ctx context.Context, ts uint64) error {
+	log.Info("BlockHoleSink: Checkpoint Event", zap.Uint64("checkpoint ts", ts))
+	return nil
+}
+
+func (b *blackHoleSink) EmitRowChangedEvent(ctx context.Context, rows ...*model.RowChangedEvent) error {
+	for _, row := range rows {
+		if row.Resolved {
+			if row.Ts <= b.checkpointTs {
+				return nil
+			}
+			atomic.StoreUint64(&b.checkpointTs, row.Ts)
+		}
+		log.Info("BlockHoleSink: Row Changed Event", zap.Any("row", row))
+	}
+	return nil
+}
+
+func (b *blackHoleSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
+	log.Info("BlockHoleSink: DDL Event", zap.Any("ddl", ddl))
+	return nil
+}
+
+func (b *blackHoleSink) CheckpointTs() uint64 {
+	return atomic.LoadUint64(&b.checkpointTs)
+}
+
+func (b *blackHoleSink) Close() error {
+	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
handle row-based changed event in processor

### What is changed and how it works?

* processor receives globalResolvedTS and sends to sink, but not to block row changed event
* every `tableInfo` holds a mounter 