### PR TITLE
Add region active monitor and more metrics for region

### DIFF
--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -67,6 +67,20 @@ var (
 			Name:      "region_count",
 			Help:      "active region count",
 		}, []string{"capture", "changefeed", "table"})
+	regionActiveKvCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "region_active_kv_count",
+			Help:      "region with active kv received count",
+		}, []string{"capture", "changefeed", "table"})
+	regionActiveResolveCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "region_active_resolve_count",
+			Help:      "region with active resolve received count",
+		}, []string{"capture", "changefeed", "table"})
 )
 
 // InitMetrics registers all metrics in the kv package
@@ -78,4 +92,6 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(pullEventCounter)
 	registry.MustRegister(sendEventCounter)
 	registry.MustRegister(regionCountGauge)
+	registry.MustRegister(regionActiveKvCountGauge)
+	registry.MustRegister(regionActiveResolveCountGauge)
 }

--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -60,6 +60,13 @@ var (
 			Name:      "send_event_count",
 			Help:      "event count sent to event channel by this puller",
 		}, []string{"type", "capture", "changefeed"})
+	regionCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "region_count",
+			Help:      "active region count",
+		}, []string{"capture", "changefeed", "table"})
 )
 
 // InitMetrics registers all metrics in the kv package
@@ -70,4 +77,5 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(eventFeedGauge)
 	registry.MustRegister(pullEventCounter)
 	registry.MustRegister(sendEventCounter)
+	registry.MustRegister(regionCountGauge)
 }

--- a/cdc/kv/monitor.go
+++ b/cdc/kv/monitor.go
@@ -1,0 +1,95 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/pkg/util"
+	"go.uber.org/zap"
+)
+
+// regionActive records the activeness of a region
+type regionActive struct {
+	sync.RWMutex
+	regionID      uint64
+	threshold     int64
+	lastKv        time.Time
+	lastResolve   time.Time
+	kvActive      bool
+	resolveActive bool
+}
+
+func newRegionActive(regionID uint64, threshold int64) *regionActive {
+	now := time.Now()
+	return &regionActive{
+		regionID:      regionID,
+		lastKv:        now,
+		lastResolve:   now,
+		threshold:     threshold,
+		kvActive:      true,
+		resolveActive: true,
+	}
+}
+
+func (aw *regionActive) SetKv() {
+	aw.Lock()
+	aw.lastKv = time.Now()
+	aw.Unlock()
+}
+
+func (aw *regionActive) SetResolve() {
+	aw.Lock()
+	aw.lastResolve = time.Now()
+	aw.Unlock()
+}
+
+func (aw *regionActive) Check(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	captureID := util.GetValueFromCtx(ctx, util.CtxKeyCaptureID)
+	changefeedID := util.GetValueFromCtx(ctx, util.CtxKeyChangefeedID)
+	tableID := util.GetValueFromCtx(ctx, util.CtxKeyTableID)
+
+	aw.RLock()
+	defer aw.RUnlock()
+	now := time.Now()
+	kv := now.Unix() - aw.lastKv.Unix()
+	resolve := now.Unix() - aw.lastResolve.Unix()
+	if kv >= aw.threshold && aw.kvActive {
+		aw.kvActive = false
+		regionActiveKvCountGauge.WithLabelValues(captureID, changefeedID, tableID).Dec()
+	}
+	if kv < aw.threshold && !aw.kvActive {
+		aw.kvActive = true
+		regionActiveKvCountGauge.WithLabelValues(captureID, changefeedID, tableID).Inc()
+	}
+	if resolve >= aw.threshold {
+		log.Warn("region resolve not active", zap.Uint64("region", aw.regionID), zap.Int64("resolve duration", resolve))
+		if aw.resolveActive {
+			aw.resolveActive = false
+			regionActiveResolveCountGauge.WithLabelValues(captureID, changefeedID, tableID).Dec()
+		}
+	} else if !aw.resolveActive {
+		aw.resolveActive = true
+		regionActiveResolveCountGauge.WithLabelValues(captureID, changefeedID, tableID).Inc()
+	}
+}

--- a/cdc/kv/monitor.go
+++ b/cdc/kv/monitor.go
@@ -30,6 +30,7 @@ type regionActive struct {
 	threshold     int64
 	lastKv        time.Time
 	lastResolve   time.Time
+	lastResolveTs uint64
 	kvActive      bool
 	resolveActive bool
 }
@@ -53,9 +54,13 @@ func (aw *regionActive) SetKv() {
 	aw.Unlock()
 }
 
-func (aw *regionActive) SetResolve() {
+func (aw *regionActive) SetResolve(resolvedTs uint64) {
 	aw.Lock()
 	aw.lastResolve = time.Now()
+	if aw.lastResolveTs == resolvedTs {
+		log.Warn("resolve ts not forward", zap.Uint64("region", aw.regionID), zap.Uint64("ts", aw.lastResolveTs))
+	}
+	aw.lastResolveTs = resolvedTs
 	aw.Unlock()
 }
 

--- a/cdc/kv/monitor_test.go
+++ b/cdc/kv/monitor_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"time"
+
+	"github.com/pingcap/check"
+)
+
+type MonitorSuite struct{}
+
+var _ = check.Suite(&MonitorSuite{})
+
+func (s *MonitorSuite) TestRegionActive(c *check.C) {
+	var (
+		ctx       = context.TODO()
+		threshold = int64(1)
+	)
+
+	ra := newRegionActive(1000, threshold)
+	time.Sleep(time.Second * time.Duration(threshold))
+	ra.Check(ctx)
+	c.Assert(ra.resolveActive, check.IsFalse)
+	c.Assert(ra.kvActive, check.IsFalse)
+
+	ra.SetKv()
+	ra.SetResolve()
+	ra.Check(ctx)
+	c.Assert(ra.resolveActive, check.IsTrue)
+	c.Assert(ra.kvActive, check.IsTrue)
+}

--- a/cdc/kv/monitor_test.go
+++ b/cdc/kv/monitor_test.go
@@ -28,17 +28,28 @@ func (s *MonitorSuite) TestRegionActive(c *check.C) {
 	var (
 		ctx       = context.TODO()
 		threshold = int64(1)
+		reconnect = int64(2)
+		rch       = make(chan struct{}, 1)
 	)
 
-	ra := newRegionActive(1000, threshold)
+	ra := newRegionActive(1000, threshold, reconnect)
 	ra.SetKv()
-	ra.SetResolve()
-	ra.Check(ctx)
+	ra.SetResolve(100)
+	ra.Check(ctx, rch)
 	c.Assert(ra.IsResolveActive(), check.IsTrue)
 	c.Assert(ra.IsKvActive(), check.IsTrue)
 
 	time.Sleep(time.Second * time.Duration(threshold))
-	ra.Check(ctx)
+	ra.Check(ctx, rch)
 	c.Assert(ra.IsResolveActive(), check.IsFalse)
 	c.Assert(ra.IsKvActive(), check.IsFalse)
+
+	ra.SetResolve(100)
+	time.Sleep(time.Second * time.Duration(reconnect-threshold))
+	ra.Check(ctx, rch)
+	select {
+	case <-rch:
+	case <-time.After(time.Second):
+		c.Error("failed to recv reconnect notify")
+	}
 }

--- a/cdc/kv/monitor_test.go
+++ b/cdc/kv/monitor_test.go
@@ -31,14 +31,14 @@ func (s *MonitorSuite) TestRegionActive(c *check.C) {
 	)
 
 	ra := newRegionActive(1000, threshold)
-	time.Sleep(time.Second * time.Duration(threshold))
-	ra.Check(ctx)
-	c.Assert(ra.resolveActive, check.IsFalse)
-	c.Assert(ra.kvActive, check.IsFalse)
-
 	ra.SetKv()
 	ra.SetResolve()
 	ra.Check(ctx)
-	c.Assert(ra.resolveActive, check.IsTrue)
-	c.Assert(ra.kvActive, check.IsTrue)
+	c.Assert(ra.IsResolveActive(), check.IsTrue)
+	c.Assert(ra.IsKvActive(), check.IsTrue)
+
+	time.Sleep(time.Second * time.Duration(threshold))
+	ra.Check(ctx)
+	c.Assert(ra.IsResolveActive(), check.IsFalse)
+	c.Assert(ra.IsKvActive(), check.IsFalse)
 }

--- a/cdc/puller/buffer.go
+++ b/cdc/puller/buffer.go
@@ -127,6 +127,16 @@ func (b *memBuffer) Get(ctx context.Context) (model.RegionFeedEvent, error) {
 	}
 }
 
+// Size returns the byte size used by buffer
+func (b *memBuffer) Size() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limitter != nil {
+		return b.limitter.ResourceSize()
+	}
+	return 0
+}
+
 var sizeOfVal = unsafe.Sizeof(model.RawKVEntry{})
 var sizeOfResolve = unsafe.Sizeof(model.ResolvedSpan{})
 
@@ -163,4 +173,9 @@ func (rl *BlurResourceLimitter) Add(n int64) {
 // OverBucget retun true if over budget.
 func (rl *BlurResourceLimitter) OverBucget() bool {
 	return atomic.LoadInt64(&rl.used) >= atomic.LoadInt64(&rl.budget)
+}
+
+// ResourceSize returns the used byte size of limmter
+func (rl *BlurResourceLimitter) ResourceSize() int64 {
+	return atomic.LoadInt64(&rl.used)
 }

--- a/cdc/puller/metrics.go
+++ b/cdc/puller/metrics.go
@@ -38,12 +38,19 @@ var (
 			Help:      "The number of txns resolved in one go.",
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 16),
 		})
-	entryBufferSizeGauge = prometheus.NewGaugeVec(
+	entryMemBufferSizeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "puller",
+			Name:      "entry_mem_buffer_size",
+			Help:      "Puller entry unlimited memory buffer size",
+		}, []string{"capture", "changefeed"})
+	entryChanBufferSizeGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "ticdc",
 			Subsystem: "puller",
 			Name:      "entry_buffer_size",
-			Help:      "Puller entry buffer size",
+			Help:      "Puller entry channel buffer size",
 		}, []string{"capture", "changefeed"})
 	eventChanSizeGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -66,7 +73,8 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(kvEventCounter)
 	registry.MustRegister(txnCollectCounter)
 	registry.MustRegister(resolvedTxnsBatchSize)
-	registry.MustRegister(entryBufferSizeGauge)
+	registry.MustRegister(entryMemBufferSizeGauge)
+	registry.MustRegister(entryChanBufferSizeGauge)
 	registry.MustRegister(eventChanSizeGauge)
 	registry.MustRegister(trackerSizeGauge)
 }

--- a/cdc/puller/metrics.go
+++ b/cdc/puller/metrics.go
@@ -52,6 +52,13 @@ var (
 			Name:      "event_chan_size",
 			Help:      "Puller event channel size",
 		}, []string{"capture", "changefeed"})
+	trackerSizeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "puller",
+			Name:      "tracker_span_size",
+			Help:      "tracker span size collected in a puller",
+		}, []string{"capture", "changefeed", "table"})
 )
 
 // InitMetrics registers all metrics in this file
@@ -61,4 +68,5 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(resolvedTxnsBatchSize)
 	registry.MustRegister(entryBufferSizeGauge)
 	registry.MustRegister(eventChanSizeGauge)
+	registry.MustRegister(trackerSizeGauge)
 }

--- a/cdc/puller/mock_puller.go
+++ b/cdc/puller/mock_puller.go
@@ -161,6 +161,16 @@ func (p *mockPuller) Output() ChanBuffer {
 	panic("unreachable")
 }
 
+func (p *mockPuller) CollectMetrics(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(time.Minute):
+		}
+	}
+}
+
 // NewMockPullerManager creates and sets up a mock puller manager
 func NewMockPullerManager(c *check.C, newRowFormat bool) *MockPullerManager {
 	m := &MockPullerManager{

--- a/cdc/puller/span_frontier.go
+++ b/cdc/puller/span_frontier.go
@@ -187,6 +187,11 @@ func makeSpanFrontier(spans ...util.Span) *spanFrontier {
 	return s
 }
 
+// Size returns the span count in spanFrontier
+func (s *spanFrontier) Size() int {
+	return s.tree.Len()
+}
+
 // Frontier return the minimum tiemstamp.
 func (s *spanFrontier) Frontier() uint64 {
 	if s.minHeap.Len() == 0 {

--- a/cdc/puller/txn_test.go
+++ b/cdc/puller/txn_test.go
@@ -43,6 +43,10 @@ func (t *mockTracker) Frontier() uint64 {
 	return 1
 }
 
+func (t *mockTracker) Size() int {
+	return 1
+}
+
 var _ = check.Suite(&CollectRawTxnsSuite{})
 
 func (cs *CollectRawTxnsSuite) TestShouldOutputTxnsInOrder(c *check.C) {

--- a/cdc/roles/storage/etcd.go
+++ b/cdc/roles/storage/etcd.go
@@ -246,7 +246,7 @@ func (ow *OwnerTaskStatusEtcdWriter) Write(
 	if writePLock {
 		newInfo.TablePLock = &model.TableLock{
 			Ts:        oracle.EncodeTSO(time.Now().UnixNano() / int64(time.Millisecond)),
-			CreatorID: util.CaptureIDFromCtx(ctx),
+			CreatorID: util.GetValueFromCtx(ctx, util.CtxKeyCaptureID),
 		}
 	}
 

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -312,7 +312,7 @@ func realRunProcessorWatcher(
 	}
 	checkpointTs := info.GetCheckpointTs(status)
 	sw := NewProcessorWatcher(changefeedID, captureID, pdEndpoints, etcdCli, info, checkpointTs)
-	ctx = util.PutChangefeedIDInCtx(ctx, changefeedID)
+	ctx = util.PutValueInCtx(ctx, util.CtxKeyChangefeedID, changefeedID)
 	sw.wg.Add(1)
 	go sw.Watch(ctx, errCh, cb)
 	return sw, nil

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -93,7 +93,7 @@ func NewServer(opt ...ServerOption) (*Server, error) {
 // Run runs the server.
 func (s *Server) Run(ctx context.Context) error {
 	s.startStatusHTTP()
-	ctx = util.PutCaptureIDInCtx(ctx, s.capture.info.ID)
+	ctx = util.PutValueInCtx(ctx, util.CtxKeyCaptureID, s.capture.info.ID)
 	return s.capture.Start(ctx)
 }
 

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -241,8 +241,8 @@ func (s *mysqlSink) execDMLs(ctx context.Context, dmls []*model.DML) error {
 	if err = tx.Commit(); err != nil {
 		return errors.Trace(err)
 	}
-	captureID := util.CaptureIDFromCtx(ctx)
-	changefeedID := util.ChangefeedIDFromCtx(ctx)
+	captureID := util.GetValueFromCtx(ctx, util.CtxKeyCaptureID)
+	changefeedID := util.GetValueFromCtx(ctx, util.CtxKeyChangefeedID)
 	execTxnHistogram.WithLabelValues(captureID, changefeedID).Observe(time.Since(startTime).Seconds())
 	execBatchHistogram.WithLabelValues(captureID, changefeedID).Observe(float64(len(dmls)))
 	log.Info("Exec DML succeeded", zap.Int("num of DMLs", len(dmls)))

--- a/pkg/util/ctx.go
+++ b/pkg/util/ctx.go
@@ -18,36 +18,22 @@ import "context"
 type ctxKey string
 
 const (
-	ctxKeyCaptureID    = ctxKey("captureID")
-	ctxKeyChangefeedID = ctxKey("changefeedID")
+	CtxKeyCaptureID    = ctxKey("captureID")
+	CtxKeyChangefeedID = ctxKey("changefeedID")
+	CtxKeyTableID      = ctxKey("tableID")
 )
 
-// CaptureIDFromCtx returns a capture ID stored in the specified context.
-// It returns an empty string if there's no valid capture ID found.
-func CaptureIDFromCtx(ctx context.Context) string {
-	captureID, ok := ctx.Value(ctxKeyCaptureID).(string)
+// GetValueFromCtx returns a string value stored in context based on given ctxKey.
+// It returns an empty string if there's no valid ctxKey found.
+func GetValueFromCtx(ctx context.Context, key ctxKey) string {
+	value, ok := ctx.Value(key).(string)
 	if !ok {
 		return ""
 	}
-	return captureID
+	return value
 }
 
-// PutCaptureIDInCtx returns a new child context with the specified capture ID stored.
-func PutCaptureIDInCtx(ctx context.Context, captureID string) context.Context {
-	return context.WithValue(ctx, ctxKeyCaptureID, captureID)
-}
-
-// ChangefeedIDFromCtx returns a changefeedID stored in the specified context.
-// It returns an empty string if there's no valid changefeed ID found.
-func ChangefeedIDFromCtx(ctx context.Context) string {
-	changefeedID, ok := ctx.Value(ctxKeyChangefeedID).(string)
-	if !ok {
-		return ""
-	}
-	return changefeedID
-}
-
-// PutChangefeedIDInCtx returns a new child context with the specified changefeed ID stored.
-func PutChangefeedIDInCtx(ctx context.Context, changefeedID string) context.Context {
-	return context.WithValue(ctx, ctxKeyChangefeedID, changefeedID)
+// PutValueInCtx returns a new child context with the specified value stored.
+func PutValueInCtx(ctx context.Context, key ctxKey, value string) context.Context {
+	return context.WithValue(ctx, key, value)
 }

--- a/pkg/util/ctx.go
+++ b/pkg/util/ctx.go
@@ -17,6 +17,7 @@ import "context"
 
 type ctxKey string
 
+// list of context key
 const (
 	CtxKeyCaptureID    = ctxKey("captureID")
 	CtxKeyChangefeedID = ctxKey("changefeedID")

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -23,24 +23,15 @@ type ctxValueSuite struct{}
 
 var _ = check.Suite(&ctxValueSuite{})
 
-func (s *ctxValueSuite) TestShouldReturnCaptureID(c *check.C) {
-	ctx := PutCaptureIDInCtx(context.Background(), "ello")
-	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "ello")
+func (s *ctxValueSuite) TestGetValueFromCtx(c *check.C) {
+	captureID := "test-capture"
+	ctx := PutValueInCtx(context.Background(), CtxKeyCaptureID, captureID)
+	c.Assert(GetValueFromCtx(ctx, CtxKeyCaptureID), check.Equals, captureID)
 }
 
-func (s *ctxValueSuite) TestCaptureIDNotSet(c *check.C) {
-	c.Assert(CaptureIDFromCtx(context.Background()), check.Equals, "")
-	ctx := context.WithValue(context.Background(), ctxKeyCaptureID, 1321)
-	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "")
-}
+func (s *ctxValueSuite) TestGetValueInvalid(c *check.C) {
+	c.Assert(GetValueFromCtx(context.Background(), CtxKeyCaptureID), check.Equals, "")
+	ctx := context.WithValue(context.Background(), CtxKeyCaptureID, 1321)
+	c.Assert(GetValueFromCtx(ctx, CtxKeyCaptureID), check.Equals, "")
 
-func (s *ctxValueSuite) TestShouldReturnChangefeedID(c *check.C) {
-	ctx := PutChangefeedIDInCtx(context.Background(), "ello")
-	c.Assert(ChangefeedIDFromCtx(ctx), check.Equals, "ello")
-}
-
-func (s *ctxValueSuite) TestChangefeedIDNotSet(c *check.C) {
-	c.Assert(ChangefeedIDFromCtx(context.Background()), check.Equals, "")
-	ctx := context.WithValue(context.Background(), ctxKeyChangefeedID, 1321)
-	c.Assert(ChangefeedIDFromCtx(ctx), check.Equals, "")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Sometimes the replication doesn't forward, we need to add some observation for region health.

### What is changed and how it works?

- add a simple active monitor to kv client
- add more Prometheus metrics for region and memory buffer in puller


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test