### PR TITLE
Reduce the RTO by watching the liveness of processors

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -187,8 +187,7 @@ func (c *Capture) Close(ctx context.Context) error {
 
 // register registers the capture information in etcd
 func (c *Capture) register(ctx context.Context) error {
-	return errors.Trace(c.etcdClient.PutCaptureInfo(ctx, c.info,
-		c.session.Lease()))
+	return errors.Trace(c.etcdClient.PutCaptureInfo(ctx, c.info))
 }
 
 func createTiStore(urls string) (tidbkv.Storage, error) {

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/store"
 	"github.com/pingcap/tidb/store/tikv"
 	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
 	"go.etcd.io/etcd/mvcc"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -42,6 +43,7 @@ import (
 const (
 	ownerRunInterval    = time.Millisecond * 500
 	cfWatcherRetryDelay = time.Millisecond * 500
+	captureSessionTTL   = 3
 )
 
 // Capture represents a Capture server, it monitors the changefeed information in etcd and schedules Task on it.
@@ -55,11 +57,14 @@ type Capture struct {
 	procLock   sync.Mutex
 
 	info *model.CaptureInfo
+
+	// session keeps alive between the capture and etcd
+	session *concurrency.Session
 }
 
 // NewCapture returns a new Capture instance
 func NewCapture(pdEndpoints []string) (c *Capture, err error) {
-	ectdCli, err := clientv3.New(clientv3.Config{
+	etcdCli, err := clientv3.New(clientv3.Config{
 		Endpoints:   pdEndpoints,
 		DialTimeout: 5 * time.Second,
 		DialOptions: []grpc.DialOption{
@@ -77,7 +82,12 @@ func NewCapture(pdEndpoints []string) (c *Capture, err error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "new etcd client")
 	}
-	cli := kv.NewCDCEtcdClient(ectdCli)
+	sess, err := concurrency.NewSession(etcdCli,
+		concurrency.WithTTL(captureSessionTTL))
+	if err != nil {
+		return nil, errors.Annotate(err, "create capture session")
+	}
+	cli := kv.NewCDCEtcdClient(etcdCli)
 	id := uuid.New().String()
 	info := &model.CaptureInfo{
 		ID: id,
@@ -96,6 +106,7 @@ func NewCapture(pdEndpoints []string) (c *Capture, err error) {
 		processors:   make(map[string]*processor),
 		pdEndpoints:  pdEndpoints,
 		etcdClient:   cli,
+		session:      sess,
 		ownerManager: manager,
 		ownerWorker:  worker,
 		info:         info,
@@ -176,7 +187,8 @@ func (c *Capture) Close(ctx context.Context) error {
 
 // register registers the capture information in etcd
 func (c *Capture) register(ctx context.Context) error {
-	return errors.Trace(c.etcdClient.PutCaptureInfo(ctx, c.info))
+	return errors.Trace(c.etcdClient.PutCaptureInfo(ctx, c.info,
+		c.session.Lease()))
 }
 
 func createTiStore(urls string) (tidbkv.Storage, error) {

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -421,14 +421,14 @@ func (c CDCEtcdClient) DeleteTaskStatus(
 }
 
 // PutCaptureInfo put capture info into etcd.
-func (c CDCEtcdClient) PutCaptureInfo(ctx context.Context, info *model.CaptureInfo, leaseID clientv3.LeaseID) error {
+func (c CDCEtcdClient) PutCaptureInfo(ctx context.Context, info *model.CaptureInfo) error {
 	data, err := info.Marshal()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	key := GetEtcdKeyCaptureInfo(info.ID)
-	_, err = c.Client.Put(ctx, key, string(data), clientv3.WithLease(leaseID))
+	_, err = c.Client.Put(ctx, key, string(data))
 	return errors.Trace(err)
 }
 

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -249,3 +249,186 @@ func (s *etcdSuite) TestPutAllChangeFeedStatus(c *check.C) {
 		}
 	}
 }
+
+func (s *etcdSuite) TestGetEtcdKeyProcessorInfo(c *check.C) {
+	tests := []struct {
+		cid string // capture id
+		pid string // processor id
+		key string // generated key
+	}{
+		{"a", "b", ProcessorInfoKeyPrefix + "/a/b"},
+		{"", "b", ProcessorInfoKeyPrefix + "//b"},
+		{"a", "", ProcessorInfoKeyPrefix + "/a/"},
+		{"", "", ProcessorInfoKeyPrefix + "//"},
+	}
+
+	for _, t := range tests {
+		c.Assert(GetEtcdKeyProcessorInfo(t.cid, t.pid), check.Equals, t.key)
+	}
+}
+
+func setupProcessors(s *etcdSuite, c *check.C) clientv3.LeaseID {
+	ctx := context.Background()
+	lease, err := s.client.Client.Grant(ctx, 3600)
+	c.Assert(err, check.IsNil)
+	// setup processors:
+	//   a/b
+	//   a/c
+	//   d/e
+	c.Assert(s.client.PutProcessorInfo(ctx, "a", &model.ProcessorInfo{
+		ID: "b",
+	}, lease.ID), check.IsNil)
+
+	c.Assert(s.client.PutProcessorInfo(ctx, "a", &model.ProcessorInfo{
+		ID: "c",
+	}, lease.ID), check.IsNil)
+
+	c.Assert(s.client.PutProcessorInfo(ctx, "d", &model.ProcessorInfo{
+		ID: "e",
+	}, lease.ID), check.IsNil)
+	return lease.ID
+}
+func teardownProcessors(s *etcdSuite, c *check.C, leaseID clientv3.LeaseID) {
+	ctx := context.Background()
+	c.Assert(s.client.DeleteProcessorInfo(ctx, "a", "b"), check.IsNil)
+	c.Assert(s.client.DeleteProcessorInfo(ctx, "a", "c"), check.IsNil)
+	c.Assert(s.client.DeleteProcessorInfo(ctx, "d", "e"), check.IsNil)
+	s.client.Client.Revoke(ctx, leaseID)
+}
+func (s *etcdSuite) TestGetProcessorsFromPrefix(c *check.C) {
+	ctx := context.Background()
+	leaseID := setupProcessors(s, c)
+	defer teardownProcessors(s, c, leaseID)
+
+	tests := []struct {
+		prefix     string
+		processors []*model.ProcessorInfo
+	}{
+		// list all processors
+		{ProcessorInfoKeyPrefix, []*model.ProcessorInfo{
+			{ID: "b"},
+			{ID: "c"},
+			{ID: "e"},
+		}},
+
+		// list processors for capture "a"
+		{ProcessorInfoKeyPrefix + "/a/", []*model.ProcessorInfo{
+			{ID: "b"},
+			{ID: "c"},
+		}},
+
+		// list processors for capture "d"
+		{ProcessorInfoKeyPrefix + "/d/", []*model.ProcessorInfo{
+			{ID: "e"},
+		}},
+
+		// list processors for a non-exist capture "f"
+		{ProcessorInfoKeyPrefix + "/f/", nil},
+	}
+
+	for _, t := range tests {
+		c.Log("testing on ", t.prefix)
+		rev, processors, err := s.client.getProcessorsFromPrefix(ctx, t.prefix)
+		c.Assert(rev, check.Greater, int64(0))
+		c.Assert(err, check.IsNil)
+		if t.processors != nil {
+			c.Assert(len(processors), check.Equals, len(t.processors))
+			for i, p := range processors {
+				c.Assert(p.ID, check.Equals, t.processors[i].ID)
+			}
+
+		} else {
+			c.Assert(processors, check.IsNil)
+		}
+	}
+}
+
+func (s *etcdSuite) TestGetProcessors(c *check.C) {
+	ctx := context.Background()
+	leaseID := setupProcessors(s, c)
+	defer teardownProcessors(s, c, leaseID)
+
+	tests := []struct {
+		cid        string // capture id
+		processors []*model.ProcessorInfo
+	}{
+		// list processors for capture "a"
+		{"a", []*model.ProcessorInfo{
+			{ID: "b"},
+			{ID: "c"},
+		}},
+
+		// list processors for capture "d"
+		{"d", []*model.ProcessorInfo{
+			{ID: "e"},
+		}},
+
+		// list processors for a non-exist capture "f"
+		{"f", nil},
+	}
+	for _, t := range tests {
+		c.Log("testing on ", t.cid)
+		rev, processors, err := s.client.GetProcessors(ctx, t.cid)
+		c.Assert(rev, check.Greater, int64(0))
+		c.Assert(err, check.IsNil)
+		if t.processors != nil {
+			c.Assert(len(processors), check.Equals, len(t.processors))
+			for i, p := range processors {
+				c.Assert(p.ID, check.Equals, t.processors[i].ID)
+			}
+
+		} else {
+			c.Assert(processors, check.IsNil)
+		}
+	}
+}
+
+func (s *etcdSuite) TestGetAllProcessors(c *check.C) {
+	ctx := context.Background()
+	leaseID := setupProcessors(s, c)
+	defer teardownProcessors(s, c, leaseID)
+	rev, processors, err := s.client.GetAllProcessors(ctx)
+	c.Assert(rev, check.Greater, int64(0))
+	c.Assert(err, check.IsNil)
+	ids := []string{"b", "c", "e"}
+	for i, p := range processors {
+		c.Assert(p.ID, check.Equals, ids[i])
+	}
+}
+
+func (s *etcdSuite) TestPutProcessorInfo(c *check.C) {
+	ctx := context.Background()
+	lease, err := s.client.Client.Grant(ctx, 3600)
+	c.Assert(err, check.IsNil)
+
+	tests := []struct {
+		cid       string
+		processor *model.ProcessorInfo
+	}{
+		{"a", &model.ProcessorInfo{ID: "b"}},
+		{"a", &model.ProcessorInfo{ID: "c"}},
+		{"d", &model.ProcessorInfo{ID: "e"}},
+	}
+
+	for _, t := range tests {
+		c.Assert(s.client.PutProcessorInfo(ctx, t.cid, t.processor, lease.ID), check.IsNil)
+	}
+}
+
+func (s *etcdSuite) TestDeleteProcessorInfo(c *check.C) {
+	ctx := context.Background()
+	setupProcessors(s, c)
+	processors := []*model.ProcessorInfo{
+		{CaptureID: "a", ID: "b"},
+		{CaptureID: "a", ID: "c"},
+		{CaptureID: "d", ID: "e"},
+	}
+	for _, p := range processors {
+		c.Assert(s.client.DeleteProcessorInfo(ctx, p.CaptureID, p.ID), check.IsNil)
+	}
+
+	rev, procs, err := s.client.GetAllProcessors(ctx)
+	c.Assert(rev, check.Greater, int64(0))
+	c.Assert(procs, check.IsNil)
+	c.Assert(err, check.IsNil)
+}

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -293,7 +293,8 @@ func teardownProcessors(s *etcdSuite, c *check.C, leaseID clientv3.LeaseID) {
 	c.Assert(s.client.DeleteProcessorInfo(ctx, "a", "b"), check.IsNil)
 	c.Assert(s.client.DeleteProcessorInfo(ctx, "a", "c"), check.IsNil)
 	c.Assert(s.client.DeleteProcessorInfo(ctx, "d", "e"), check.IsNil)
-	s.client.Client.Revoke(ctx, leaseID)
+	_, err := s.client.Client.Revoke(ctx, leaseID)
+	c.Assert(err, check.IsNil)
 }
 func (s *etcdSuite) TestGetProcessorsFromPrefix(c *check.C) {
 	ctx := context.Background()

--- a/cdc/model/processor.go
+++ b/cdc/model/processor.go
@@ -1,4 +1,4 @@
-// Copyright 2019 PingCAP, Inc.
+// Copyright 2020 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cdc/model/processor.go
+++ b/cdc/model/processor.go
@@ -1,0 +1,43 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+
+	"github.com/pingcap/errors"
+)
+
+// ProcessorInfo store in etcd.
+type ProcessorInfo struct {
+	ID           string `json:"id"`
+	CaptureID    string `json:"capture-id"`
+	ChangeFeedID string `json:"changefeed-id"`
+}
+
+// Marshal using json.Marshal.
+func (c *ProcessorInfo) Marshal() ([]byte, error) {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return data, nil
+}
+
+// Unmarshal from binary data.
+func (c *ProcessorInfo) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, c)
+	return errors.Annotatef(err, "Unmarshal data: %v", data)
+}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -403,6 +403,7 @@ func NewOwner(pdEndpoints []string, cli kv.CDCEtcdClient, manager roles.Manager)
 		pdEndpoints:        pdEndpoints,
 		pdClient:           pdClient,
 		changeFeeds:        make(map[model.ChangeFeedID]*changeFeed),
+		activeProcessors:   make(map[string]*model.ProcessorInfo),
 		cfRWriter:          cli,
 		etcdClient:         cli,
 		manager:            manager,

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1161,7 +1161,7 @@ func (o *ownerImpl) watchProcessorInfo(ctx context.Context) error {
 	// the etcd events may be compacted.
 	o.rebuildProcessorEvents(ctx, processors)
 
-	log.Info("watching processors",
+	log.Info("monitoring processors",
 		zap.String("key", kv.ProcessorInfoKeyPrefix),
 		zap.Int64("rev", rev))
 	ch := o.etcdClient.Client.Watch(ctx, kv.ProcessorInfoKeyPrefix,
@@ -1176,6 +1176,8 @@ func (o *ownerImpl) watchProcessorInfo(ctx context.Context) error {
 			p := &model.ProcessorInfo{}
 			switch ev.Type {
 			case clientv3.EventTypeDelete:
+				log.Debug("processor deletion event",
+					zap.ByteString("value", ev.Kv.Value))
 				if err := p.Unmarshal(ev.Kv.Value); err != nil {
 					return errors.Trace(err)
 				}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1240,10 +1240,8 @@ func (o *ownerImpl) startProcessorInfoWatcher(ctx context.Context) {
 	// the owner steps down, the ownerCtx would be canceled.
 	ownerCtx, cancel := context.WithCancel(ctx)
 	go func() {
-		select {
-		case <-o.manager.RetireNotify():
-			cancel()
-		}
+		<-o.manager.RetireNotify()
+		cancel()
 	}()
 	log.Info("start to watch processors")
 	go func() {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -434,8 +434,12 @@ func (o *ownerImpl) handleMarkdownProcessor(ctx context.Context) {
 			continue
 		}
 		for _, tbl := range snap.Tables {
+			log.Debug("readd table", zap.Uint64("tid", tbl.ID),
+				zap.Uint64("startts", tbl.StartTs))
 			changefeed.reAddTable(tbl.ID, tbl.StartTs)
 		}
+		log.Debug("delete task status for down processor",
+			zap.String("captureid", snap.CaptureID))
 		err := o.etcdClient.DeleteTaskStatus(ctx, snap.CfID, snap.CaptureID)
 		if err != nil {
 			log.Warn("failed to delete processor info",
@@ -1107,7 +1111,7 @@ func (o *ownerImpl) markProcessorDown(ctx context.Context,
 	if !exist {
 		log.Warn("unkown processor deletion detected",
 			zap.String("processorid", p.ID),
-			zap.String("captureid", p.CaptureID))
+			zap.String("capture", p.CaptureID))
 		return nil
 	}
 	snap := status.Snapshot(p.ChangeFeedID,

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1098,21 +1098,26 @@ func (o *ownerImpl) markProcessorDown(ctx context.Context,
 	pos, exist := positions[p.CaptureID]
 	if !exist {
 		log.Warn("unkown processor deletion detected",
-			zap.String("processorID", p.ID),
-			zap.String("captureID", p.CaptureID))
+			zap.String("processorid", p.ID),
+			zap.String("captureid", p.CaptureID))
 		return nil
 	}
 	// lookup the task position for the processor
 	status, exist := statuses[p.CaptureID]
 	if !exist {
 		log.Warn("unkown processor deletion detected",
-			zap.String("processorID", p.ID),
-			zap.String("captureID", p.CaptureID))
+			zap.String("processorid", p.ID),
+			zap.String("captureid", p.CaptureID))
 		return nil
 	}
 	snap := status.Snapshot(p.ChangeFeedID,
 		p.CaptureID,
 		pos.CheckPointTs)
+	log.Info("mark processor down",
+		zap.String("processorid", p.ID),
+		zap.String("captureid", p.CaptureID),
+		zap.String("changefeed", p.ChangeFeedID),
+		zap.Reflect("tables", snap.Tables))
 	o.processorLock.Lock()
 	o.markDownProcessor = append(o.markDownProcessor, snap)
 	delete(o.activeProcessors, p.ID)

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1249,8 +1249,8 @@ func (o *ownerImpl) startProcessorInfoWatcher(ctx context.Context) {
 			if err := o.watchProcessorInfo(ownerCtx); err != nil {
 				// When the watching routine returns, the error must not
 				// be nil, it may be caused by a temporary error or a context
-				// error(ctx.Err())
-				if ctx.Err() != nil {
+				// error(ownerCtx.Err())
+				if ownerCtx.Err() != nil {
 					// The context error indicates the termination of the owner
 					log.Error("watch processor failed", zap.Error(ctx.Err()))
 					return

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1245,18 +1245,20 @@ func (o *ownerImpl) startProcessorInfoWatcher(ctx context.Context) {
 	}()
 	log.Info("start to watch processors")
 	go func() {
-		if err := o.watchProcessorInfo(ownerCtx); err != nil {
-			// When the watching routine returns, the error must not
-			// be nil, it may be caused by a temporary error or a context
-			// error(ctx.Err())
-			if ctx.Err() != nil {
-				// The context error indicates the termination of the owner
-				log.Error("watch processor failed", zap.Error(ctx.Err()))
-				return
+		for {
+			if err := o.watchProcessorInfo(ownerCtx); err != nil {
+				// When the watching routine returns, the error must not
+				// be nil, it may be caused by a temporary error or a context
+				// error(ctx.Err())
+				if ctx.Err() != nil {
+					// The context error indicates the termination of the owner
+					log.Error("watch processor failed", zap.Error(ctx.Err()))
+					return
+				}
+				log.Warn("watch processor returned", zap.Error(err))
+				// Otherwise, a temporary error occured(ErrCompact),
+				// restart the watching routine.
 			}
-			log.Warn("watch processor returned", zap.Error(err))
-			// Otherwise, a temporary error occured(ErrCompact),
-			// restart the watching routine.
 		}
 	}()
 }

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -41,7 +41,6 @@ import (
 )
 
 const (
-	markProcessorDownTime      = time.Minute
 	captureInfoWatchRetryDelay = time.Millisecond * 500
 )
 
@@ -1187,7 +1186,9 @@ func (o *ownerImpl) watchProcessorInfo(ctx context.Context) error {
 	// before watching, rebuild events according to
 	// the existed processors. This is necessary because
 	// the etcd events may be compacted.
-	o.rebuildProcessorEvents(ctx, processors)
+	if err := o.rebuildProcessorEvents(ctx, processors); err != nil {
+		return errors.Trace(err)
+	}
 
 	log.Info("monitoring processors",
 		zap.String("key", kv.ProcessorInfoKeyPrefix),

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -422,6 +422,8 @@ func (o *ownerImpl) addCapture(info *model.CaptureInfo) {
 }
 
 func (o *ownerImpl) handleMarkdownProcessor(ctx context.Context) {
+	o.processorLock.Lock()
+	defer o.processorLock.Unlock()
 	var deletedCapture = make(map[string]struct{})
 	remainProcs := make([]*model.ProcInfoSnap, 0)
 	for _, snap := range o.markDownProcessor {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1171,7 +1171,7 @@ func (o *ownerImpl) watchProcessorInfo(ctx context.Context) error {
 			p := &model.ProcessorInfo{}
 			switch ev.Type {
 			case clientv3.EventTypeDelete:
-				if err := p.Unmarshal(ev.PrevKv.Value); err != nil {
+				if err := p.Unmarshal(ev.Kv.Value); err != nil {
 					return errors.Trace(err)
 				}
 				if err := o.markProcessorDown(ctx, p); err != nil {

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -189,6 +189,7 @@ func (s *ownerSuite) TestPureDML(c *check.C) {
 		cancelWatchCapture: cancel,
 		changeFeeds:        changeFeeds,
 		cfRWriter:          handler,
+		etcdClient:         s.client,
 		manager:            manager,
 	}
 	s.owner = owner
@@ -408,8 +409,9 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 		changeFeeds:        changeFeeds,
 
 		// ddlHandler: handler,
-		cfRWriter: handler,
-		manager:   manager,
+		etcdClient: s.client,
+		cfRWriter:  handler,
+		manager:    manager,
 	}
 	s.owner = owner
 	err = owner.Run(ctx, 50*time.Millisecond)

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -166,11 +166,10 @@ func (s *ownerSuite) TestPureDML(c *check.C) {
 
 	changeFeeds := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed": {
-			tables:                  tables,
-			status:                  &model.ChangeFeedStatus{},
-			processorLastUpdateTime: make(map[string]time.Time),
-			targetTs:                100,
-			ddlState:                model.ChangeFeedSyncDML,
+			tables:   tables,
+			status:   &model.ChangeFeedStatus{},
+			targetTs: 100,
+			ddlState: model.ChangeFeedSyncDML,
 			taskStatus: model.ProcessorsInfos{
 				"capture_1": {},
 				"capture_2": {},
@@ -383,12 +382,11 @@ func (s *ownerSuite) TestDDL(c *check.C) {
 	c.Assert(err, check.IsNil)
 	changeFeeds := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed": {
-			tables:                  tables,
-			info:                    &model.ChangeFeedInfo{},
-			status:                  &model.ChangeFeedStatus{},
-			processorLastUpdateTime: make(map[string]time.Time),
-			targetTs:                100,
-			ddlState:                model.ChangeFeedSyncDML,
+			tables:   tables,
+			info:     &model.ChangeFeedInfo{},
+			status:   &model.ChangeFeedStatus{},
+			targetTs: 100,
+			ddlState: model.ChangeFeedSyncDML,
 			taskStatus: model.ProcessorsInfos{
 				"capture_1": {},
 				"capture_2": {},

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -62,6 +62,8 @@ const (
 
 	// defaultMemBufferCapacity is the default memory buffer per change feed.
 	defaultMemBufferCapacity int64 = 10 * 1024 * 1024 * 1024 // 10G
+
+	defaultProcessorSessionTTL = 3 // 3 seconds
 )
 
 var (
@@ -221,7 +223,8 @@ func NewProcessor(ctx context.Context, pdEndpoints []string, changefeed model.Ch
 	if err != nil {
 		return nil, errors.Annotate(err, "new etcd client")
 	}
-	sess, err := concurrency.NewSession(etcdCli)
+	sess, err := concurrency.NewSession(etcdCli,
+		concurrency.WithTTL(defaultProcessorSessionTTL))
 	if err != nil {
 		return nil, errors.Annotate(err, "new etcd session")
 	}

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -310,12 +310,14 @@ func (p *processor) Run(ctx context.Context, errCh chan<- error) {
 		return p.pullDDLJob(cctx)
 	})
 
+	if err := p.register(ctx); err != nil {
+		errCh <- err
+	}
 	go func() {
-		p.register(ctx)
 		if err := wg.Wait(); err != nil {
 			errCh <- err
 		}
-		p.deregister(ctx)
+		_ = p.deregister(ctx)
 	}()
 }
 
@@ -899,7 +901,7 @@ func (p *processor) stop(ctx context.Context) error {
 	}
 	p.tablesMu.Unlock()
 	p.session.Close()
-	p.deregister(ctx)
+	_ = p.deregister(ctx)
 	return errors.Trace(p.etcdCli.DeleteTaskStatus(ctx, p.changefeedID, p.captureID))
 }
 

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -225,7 +225,8 @@ func (w *ProcessorWatcher) Watch(ctx context.Context, errCh chan<- error, cb pro
 		rl := rate.NewLimiter(0.1, 5)
 		revision := getResp.Header.Revision
 		// wait for key to appear
-		log.Info("watching processors", zap.String("key", key),
+		log.Info("waiting dispatching tasks",
+			zap.String("key", key),
 			zap.Int64("rev", revision))
 		watchCh := w.etcdCli.Client.Watch(ctx, key, clientv3.WithRev(revision))
 	waitKeyLoop:

--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -225,6 +225,8 @@ func (w *ProcessorWatcher) Watch(ctx context.Context, errCh chan<- error, cb pro
 		rl := rate.NewLimiter(0.1, 5)
 		revision := getResp.Header.Revision
 		// wait for key to appear
+		log.Info("watching processors", zap.String("key", key),
+			zap.Int64("rev", revision))
 		watchCh := w.etcdCli.Client.Watch(ctx, key, clientv3.WithRev(revision))
 	waitKeyLoop:
 		for {

--- a/cmd/ctrl.go
+++ b/cmd/ctrl.go
@@ -149,7 +149,7 @@ var ctrlCmd = &cobra.Command{
 			}
 			return jsonPrint(captures)
 		case CtrlQueryProcessors:
-			_, processors, err := cli.GetProcessors(context.Background())
+			_, processors, err := cli.GetAllProcessors(context.Background())
 			if err != nil {
 				return err
 			}

--- a/cmd/ctrl.go
+++ b/cmd/ctrl.go
@@ -46,6 +46,8 @@ const (
 	CtrlClearAll = "clear-all"
 	// get tso from pd
 	CtrlGetTso = "get-tso"
+	// query the processor list
+	CtrlQueryProcessors = "query-processor-list"
 )
 
 func init() {
@@ -146,6 +148,13 @@ var ctrlCmd = &cobra.Command{
 				captures = append(captures, &capture{ID: c.ID, IsOwner: isOwner})
 			}
 			return jsonPrint(captures)
+		case CtrlQueryProcessors:
+			_, processors, err := cli.GetProcessors(context.Background())
+			if err != nil {
+				return err
+			}
+			return jsonPrint(processors)
+
 		case CtrlQuerySubCf:
 			_, info, err := cli.GetTaskStatus(context.Background(), ctrlCfID, ctrlCaptureID)
 			if err != nil && err != concurrency.ErrElectionNoLeader {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The owner periodically checks the task status and marks the processor down if the task is not updated in time.  When a processor is marked down, the task associated with it is rebalanced to other processors.
As issue #269 says, when there is something wrong with the upstream(TiDB/TiKV) or network, the processor receives no more data to update the task status, the processor will be marked as down which is a false positive.

The PR introduces a session for each processor that keeps alive with a lease. Each processor is assigned an ID which constructs a key registered in the Etcd. When a processor stops, the lease expires, and the key will be deleted. The owner keeps watching on the key， and when a key is found deleted, the processor is marked as down.

### Current problems and the future plan
* The session for capture is only used for the election. It is not attached to the CaptureID, so when a capture crashed, it could not be detected by the owner.
* It is not necessary to create a session for each processor, it has the same lifetime of the capture, so it should use the session of the capture.

Create one session for the capture and then it can be shared with the election and processors.

### What is changed and how it works?

* Create a session when a processor started.
* Assign an ID for each processor
* Mark the processor down when a processor is stopped by watch the deletion of the processor key.
* Add `query-processor-list` for ctl command.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has persistent data change (new added)