### PR TITLE
manager: use a less TTL value

### DIFF
--- a/cdc/roles/manager.go
+++ b/cdc/roles/manager.go
@@ -98,7 +98,7 @@ func (m *ownerManager) IsOwner() bool {
 }
 
 // ManagerSessionTTLSeconds is the etcd session's TTL in seconds. It's exported for testing.
-var ManagerSessionTTLSeconds = 60
+var ManagerSessionTTLSeconds = 5
 
 // setManagerSessionTTL sets the ManagerSessionTTLSeconds value, it's used for testing.
 func setManagerSessionTTL() error {


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Etcd uses 1s as the election timeout by default, this proves
the TTL could be a few seconds in the LAN environment. To speed
up the election of the owner, we reduce the session TTL to 5s.

### What is changed and how it works?

Reduce 1ManagerSessionTTLSeconds` from 60 to 5

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
