### PR TITLE
bug fix: panic about schema builder

### DIFF
--- a/cdc/entry/schema_builder.go
+++ b/cdc/entry/schema_builder.go
@@ -189,8 +189,9 @@ func (b *StorageBuilder) GetResolvedTs() uint64 {
 
 // DoGc removes the jobs which of finishedTs is less then gcTs
 func (b *StorageBuilder) DoGc(ts uint64) error {
-	if ts > atomic.LoadUint64(&b.resolvedTs) {
-		log.Warn("gcTs is greater than resolvedTs in StorageBuilder", zap.Uint64("gcTs", ts))
+	resolvedTs := atomic.LoadUint64(&b.resolvedTs)
+	if ts > resolvedTs {
+		log.Warn("gcTs is greater than resolvedTs in StorageBuilder", zap.Uint64("gcTs", ts), zap.Uint64("resolvedTs", resolvedTs))
 		return nil
 	}
 	b.baseStorageMu.Lock()

--- a/cdc/entry/schema_builder.go
+++ b/cdc/entry/schema_builder.go
@@ -190,7 +190,8 @@ func (b *StorageBuilder) GetResolvedTs() uint64 {
 // DoGc removes the jobs which of finishedTs is less then gcTs
 func (b *StorageBuilder) DoGc(ts uint64) error {
 	if ts > atomic.LoadUint64(&b.resolvedTs) {
-		log.Fatal("gcTs is greater than resolvedTs in StorageBuilder, please report a bug", zap.Uint64("gcTs", ts))
+		log.Warn("gcTs is greater than resolvedTs in StorageBuilder", zap.Uint64("gcTs", ts))
+		return nil
 	}
 	b.baseStorageMu.Lock()
 	defer b.baseStorageMu.Unlock()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when we add a table with start-ts, we can't guarantee that `start-ts` is less than `checkpointts`,  `DoGC` function of `schema builder` will panic



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test