### PR TITLE
[WIP] client: Implement batch client (removed goroutine for each regoin)

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -609,7 +609,7 @@ func (c *CDCClient) singleEventFeed(
 
 		if event == nil {
 			log.Debug("singleEventFeed closed by error")
-			return atomic.LoadUint64(&checkpointTs), nil
+			return atomic.LoadUint64(&checkpointTs), errors.New("single event feed aborted")
 		}
 
 		log.Debug("singleEventFeed got event", zap.Stringer("event", event))

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -149,6 +149,7 @@ func (c *CDCClient) getConn(
 			Timeout:             3 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(32*1024*1024)),
 	)
 	cancel()
 
@@ -244,6 +245,7 @@ MainLoop:
 			}
 			if rpcCtx == nil {
 				// The region info is invalid. Retry the span.
+				log.Debug("cannot get rpcCtx, retry span", zap.Reflect("span", sri.span))
 				err = c.divideAndSendEventFeedToRegions(ctx, sri.span, sri.ts, regionCh)
 				if err != nil {
 					return errors.Trace(err)

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -467,7 +467,7 @@ func (c *CDCClient) receiveFromStream(
 	for {
 		cevent, err := stream.Recv()
 
-		log.Debug("recv ChangeDataEvent", zap.Stringer("event", cevent))
+		//log.Debug("recv ChangeDataEvent", zap.Stringer("event", cevent))
 
 		// TODO: Should we have better way to handle the errors?
 		if err != nil {
@@ -647,7 +647,9 @@ func (s *regionFeedState) singleEventFeed(
 		return atomic.LoadUint64(&s.checkpointTs), true, err
 	}
 
-	log.Debug("singleEventFeed got event", zap.Stringer("event", event))
+	if _, isEntry := event.Event.(*cdcpb.Event_Entries_); !isEntry {
+		log.Debug("singleEventFeed got event", zap.Stringer("event", event))
+	}
 
 	eventSize.WithLabelValues(s.captureID).Observe(float64(event.Event.Size()))
 	switch x := event.Event.(type) {

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -223,9 +223,10 @@ func (c *CDCClient) dispatchRequest(
 	eventCh chan<- *model.RegionFeedEvent,
 ) error {
 	streams := make(map[string]cdcpb.ChangeData_EventFeedClient)
-	// Stores regionHandlerSet for each stream, and each regionHandlerSet keeps the channels of each regions in a stream.
-	regionInfoMap := make(map[uint64]singleRegionInfo)
-	regionInfoMapMu := &sync.RWMutex{}
+	// Stores dispatched region info for each stream, and each regionHandlerSet keeps the channels of each regions in a
+	// stream.
+	pendingRegionsMaps := make(map[string]map[uint64]singleRegionInfo)
+	pendingRegionsMus := make(map[string]*sync.Mutex)
 
 MainLoop:
 	for {
@@ -271,13 +272,28 @@ MainLoop:
 			// TODO: Make sure there will not be goroutine leak.
 			// TODO: Here we use region id to index the regionInfo. However, in case that region merge is enabled, there
 			// may be multiple streams to the same regions. Maybe we need to add a requestID field to the protocol for it.
-			regionInfoMapMu.Lock()
-			if _, ok := regionInfoMap[sri.verID.GetID()]; ok {
+
+			// Get the mutex of the addr
+			pendingRegionsMu, ok := pendingRegionsMus[rpcCtx.Addr]
+			if !ok {
+				pendingRegionsMu = &sync.Mutex{}
+				pendingRegionsMus[rpcCtx.Addr] = pendingRegionsMu
+			}
+
+			// Get the set of pending regions of the stream
+			pendingRegions, ok := pendingRegionsMaps[rpcCtx.Addr]
+			if !ok {
+				pendingRegions = make(map[uint64]singleRegionInfo)
+				pendingRegionsMaps[rpcCtx.Addr] = pendingRegions
+			}
+
+			pendingRegionsMu.Lock()
+			if _, ok := pendingRegions[sri.verID.GetID()]; ok {
 				log.Error("region is already pending for the first response while trying to send another request. region merge mast have happened which we didn't support yet",
 					zap.Uint64("regionID", sri.verID.GetID()))
 			}
-			regionInfoMap[sri.verID.GetID()] = sri
-			regionInfoMapMu.Unlock()
+			pendingRegions[sri.verID.GetID()] = sri
+			pendingRegionsMu.Unlock()
 
 			stream, ok := streams[rpcCtx.Addr]
 			// Establish the stream if it has not been connected yet.
@@ -289,7 +305,7 @@ MainLoop:
 				streams[rpcCtx.Addr] = stream
 
 				g.Go(func() error {
-					return c.receiveFromStream(ctx, g, rpcCtx.Addr, rpcCtx.GetStoreID(), stream, regionCh, eventCh, errCh, regionInfoMap, regionInfoMapMu)
+					return c.receiveFromStream(ctx, g, rpcCtx.Addr, rpcCtx.GetStoreID(), stream, regionCh, eventCh, errCh, pendingRegions, pendingRegionsMu)
 				})
 			}
 
@@ -461,9 +477,25 @@ func (c *CDCClient) receiveFromStream(
 	regionCh <-chan singleRegionInfo,
 	eventCh chan<- *model.RegionFeedEvent,
 	errCh chan<- regionErrorInfo,
-	regionInfoMap map[uint64]singleRegionInfo,
-	regionInfoMapMu *sync.RWMutex,
+	pendingRegions map[uint64]singleRegionInfo,
+	pendingRegoinsMu *sync.Mutex,
 ) error {
+	// Cancel the pending regions if the stream failed.
+	defer func() {
+		for id, r := range pendingRegions {
+			select {
+			case <-ctx.Done():
+				return
+			case errCh <- regionErrorInfo{
+				singleRegionInfo: r,
+				err:              errors.New("pending region cancelled due to stream disconnecting"),
+			}:
+			}
+
+			delete(pendingRegions, id)
+		}
+	}()
+
 	regionStates := make(map[uint64]*regionFeedState)
 
 	for {
@@ -497,15 +529,15 @@ func (c *CDCClient) receiveFromStream(
 			state, ok := regionStates[event.RegionId]
 			if !ok {
 				// Fetch the region info
-				regionInfoMapMu.Lock()
-				sri, ok := regionInfoMap[event.RegionId]
+				pendingRegoinsMu.Lock()
+				sri, ok := pendingRegions[event.RegionId]
 				if !ok {
-					regionInfoMapMu.Unlock()
+					pendingRegoinsMu.Unlock()
 					log.Warn("drop event due to region stopped", zap.Uint64("regionID", event.RegionId))
 					continue
 				}
-				delete(regionInfoMap, event.RegionId)
-				regionInfoMapMu.Unlock()
+				delete(pendingRegions, event.RegionId)
+				pendingRegoinsMu.Unlock()
 
 				state, err = newRegionFeedState(ctx, sri, errCh, eventCh)
 				if err != nil {

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -498,7 +498,7 @@ func (c *CDCClient) receiveFromStream(
 				regionInfoMapMu.Lock()
 				sri, ok := regionInfoMap[event.RegionId]
 				if !ok {
-					regionInfoMapMu.RUnlock()
+					regionInfoMapMu.Unlock()
 					log.Warn("drop event due to region stopped", zap.Uint64("regionID", event.RegionId))
 					continue
 				}
@@ -605,7 +605,7 @@ func (s *regionFeedState) onReceiveEvent(
 		return false
 	}
 
-	// TODO: `close` does `wg.Wait`. Do we need to avoid blocking the curernt thread?
+	// TODO: `close` does `wg.Wait`. Do we need to avoid blocking the current thread?
 	s.sorter.close()
 
 	log.Debug("singleEventFeed quit")

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -408,20 +408,26 @@ func (c *CDCClient) handleError(ctx context.Context, errInfo regionErrorInfo, re
 	err := errInfo.err
 	switch eerr := errors.Cause(err).(type) {
 	case *eventError:
-		if notLeader := eerr.GetNotLeader(); notLeader != nil {
+		innerErr := eerr.err
+		if notLeader := innerErr.GetNotLeader(); notLeader != nil {
 			eventFeedErrorCounter.WithLabelValues("NotLeader").Inc()
 			// TODO: Handle the case that notleader.GetLeader() is nil.
 			c.regionCache.UpdateLeader(errInfo.verID, notLeader.GetLeader().GetStoreId(), errInfo.rpcCtx.PeerIdx)
-		} else if eerr.GetEpochNotMatch() != nil {
+		} else if innerErr.GetEpochNotMatch() != nil {
 			// TODO: If only confver is updated, we don't need to reload the region from region cache.
 			eventFeedErrorCounter.WithLabelValues("EpochNotMatch").Inc()
 			return c.divideAndSendEventFeedToRegions(ctx, errInfo.span, errInfo.ts, regionCh)
-		} else if eerr.GetRegionNotFound() != nil {
+		} else if innerErr.GetRegionNotFound() != nil {
 			eventFeedErrorCounter.WithLabelValues("RegionNotFound").Inc()
 			return c.divideAndSendEventFeedToRegions(ctx, errInfo.span, errInfo.ts, regionCh)
+		} else if duplicatedRequest := innerErr.GetDuplicateRequest(); duplicatedRequest != nil {
+			eventFeedErrorCounter.WithLabelValues("DuplicateRequest").Inc()
+			log.Error("tikv reported duplicated request to the same region. region merge should happened which is not supported",
+				zap.Uint64("regionID", duplicatedRequest.RegionId))
+			return nil
 		} else {
 			eventFeedErrorCounter.WithLabelValues("Unknown").Inc()
-			log.Warn("receive empty or unknown error msg", zap.Stringer("error", eerr))
+			log.Warn("receive empty or unknown error msg", zap.Stringer("error", innerErr))
 		}
 	default:
 		bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
@@ -731,8 +737,8 @@ func (s *regionFeedState) singleEventFeed(
 		}
 	case *cdcpb.Event_Admin_:
 		log.Info("receive admin event", zap.Stringer("event", event))
-	case *cdcpb.Event_Error_:
-		return atomic.LoadUint64(&s.checkpointTs), true, errors.Trace(&eventError{Event_Error: x.Error})
+	case *cdcpb.Event_Error:
+		return atomic.LoadUint64(&s.checkpointTs), true, errors.Trace(&eventError{err: x.Error})
 	case *cdcpb.Event_ResolvedTs:
 		if atomic.LoadUint32(&s.initialized) == 0 {
 			return atomic.LoadUint64(&s.checkpointTs), false, nil
@@ -769,10 +775,10 @@ func updateCheckpointTS(checkpointTs *uint64, newValue uint64) {
 
 // eventError wrap cdcpb.Event_Error to implements error interface.
 type eventError struct {
-	*cdcpb.Event_Error
+	err *cdcpb.Error
 }
 
 // Error implement error interface.
 func (e *eventError) Error() string {
-	return e.Event_Error.String()
+	return e.err.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,10 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/edwingeng/deque v0.0.0-20191220032131-8596380dee17
 	github.com/go-sql-driver/mysql v1.4.1
-	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway v1.12.1 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
@@ -44,3 +42,5 @@ require (
 	google.golang.org/grpc v1.26.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )
+
+replace github.com/pingcap/kvproto => github.com/5kbpers/kvproto v0.0.0-20200227032152-a306adeafc1d

--- a/go.mod
+++ b/go.mod
@@ -43,4 +43,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )
 
-replace github.com/pingcap/kvproto => github.com/5kbpers/kvproto v0.0.0-20200227032152-a306adeafc1d
+replace github.com/pingcap/kvproto => github.com/5kbpers/kvproto v0.0.0-20200305092240-062a1db7be9d

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/5kbpers/kvproto v0.0.0-20200227032152-a306adeafc1d h1:nbI3771CUPQdtY3MC+fR59WJndUyKjG+lCdEsAzgpbs=
+github.com/5kbpers/kvproto v0.0.0-20200227032152-a306adeafc1d/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
@@ -97,7 +99,6 @@ github.com/go-sql-driver/mysql v0.0.0-20170715192408-3955978caca4/go.mod h1:zAC/
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
@@ -110,7 +111,6 @@ github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 h1:5ZkaAPbicIKTF2I64qf5Fh8Aa83Q/dnOafMYV0OMwjA=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -240,10 +240,6 @@ github.com/pingcap/fn v0.0.0-20191016082858-07623b84a47d h1:rCmRK0lCRrHMUbS99BKF
 github.com/pingcap/fn v0.0.0-20191016082858-07623b84a47d/go.mod h1:fMRU1BA1y+r89AxUoaAar4JjrhUkVDt0o0Np6V8XbDQ=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20191213111810-93cb7c623c8b/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20200108025604-a4dc183d2af5 h1:RUxQExD5yubAjWGnw8kcxfO9abbiVHIE1rbuCyQCWDE=
-github.com/pingcap/kvproto v0.0.0-20200108025604-a4dc183d2af5/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
@@ -399,7 +395,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -467,13 +462,11 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.2 h1:j8RI1yW0SkI+paT6uGwMlrMI/6zwYA6/CFil8rxOzGI=
 google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190905072037-92dd089d5514/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20200113173426-e1de0a7b01eb h1:EsMpWw4S8DM2QYm5idfmmWsv2N57GWi2tx3p96Gpja4=
 google.golang.org/genproto v0.0.0-20200113173426-e1de0a7b01eb/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
-google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/5kbpers/kvproto v0.0.0-20200227032152-a306adeafc1d h1:nbI3771CUPQdtY3MC+fR59WJndUyKjG+lCdEsAzgpbs=
-github.com/5kbpers/kvproto v0.0.0-20200227032152-a306adeafc1d/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/5kbpers/kvproto v0.0.0-20200305092240-062a1db7be9d h1:ii9JtVgmiHH9wVedWty8U+c1sdANcpTl7v3mkRGxVB8=
+github.com/5kbpers/kvproto v0.0.0-20200305092240-062a1db7be9d/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -15,7 +15,7 @@ function prepare() {
     cd $WORK_DIR
 
     # record tso before we create tables to skip the system table DDLs
-    start_ts=$(cdc ctrl --cmd=get-tso http://$UP_PD_HOST:$UP_PD_PORT)
+    start_ts=$(cdc ctrl --cmd=get-tso --pd-addr http://$UP_PD_HOST:$UP_PD_PORT)
 
     run_sql "CREATE table test.simple1(id int primary key, val int);"
     run_sql "CREATE table test.simple2(id int primary key, val int);"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This is a branch based on https://github.com/pingcap/ticdc/pull/308 and solves the same problem.

### What is changed and how it works?

This pr is mostly same as https://github.com/pingcap/ticdc/pull/308 .The difference is: regions' states are not maintained in their own goroutine, but in the receiver goroutine for each stream. This reduces goroutines, but in a same stream a region may block others.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

Side effects

 - Increased code complexity
 - Breaking backward compatibility
