### PR TITLE
Refactor/capture watcher

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -187,7 +187,7 @@ func (c *Capture) Close(ctx context.Context) error {
 
 // register registers the capture information in etcd
 func (c *Capture) register(ctx context.Context) error {
-	return errors.Trace(c.etcdClient.PutCaptureInfo(ctx, c.info))
+	return errors.Trace(c.etcdClient.PutCaptureInfo(ctx, c.info, c.session.Lease()))
 }
 
 func createTiStore(urls string) (tidbkv.Storage, error) {

--- a/cdc/capture_info_test.go
+++ b/cdc/capture_info_test.go
@@ -68,7 +68,7 @@ func (ci *captureInfoSuite) TestPutDeleteGet(c *check.C) {
 	info = &model.CaptureInfo{
 		ID: id,
 	}
-	err = ci.client.PutCaptureInfo(ctx, info)
+	err = ci.client.PutCaptureInfo(ctx, info, 0)
 	c.Assert(err, check.IsNil)
 
 	// get again,
@@ -99,7 +99,7 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 	ctx := context.Background()
 	var err error
 	// put info1
-	err = ci.client.PutCaptureInfo(ctx, info1)
+	err = ci.client.PutCaptureInfo(ctx, info1, 0)
 	c.Assert(err, check.IsNil)
 
 	watchCtx, watchCancel := context.WithCancel(ctx)
@@ -150,7 +150,7 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 
 	// put info2 and info3
 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr", "1*return"), check.IsNil)
-	err = ci.client.PutCaptureInfo(ctx, info2)
+	err = ci.client.PutCaptureInfo(ctx, info2, 0)
 	c.Assert(err, check.IsNil)
 	resp := mustGetResp()
 	c.Assert(resp, check.IsNil)
@@ -158,7 +158,7 @@ func (ci *captureInfoSuite) TestWatch(c *check.C) {
 	checkCaptureLen(2)
 	c.Assert(failpoint.Disable("github.com/pingcap/ticdc/cdc/WatchCaptureInfoCompactionErr"), check.IsNil)
 
-	err = ci.client.PutCaptureInfo(ctx, info3)
+	err = ci.client.PutCaptureInfo(ctx, info3, 0)
 	c.Assert(err, check.IsNil)
 	resp = mustGetResp()
 	c.Assert(resp.IsDelete, check.IsFalse)

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -183,8 +183,8 @@ func (c CDCEtcdClient) GetAllProcessors(ctx context.Context) (int64, []*model.Pr
 }
 
 // GetProcessors returns the ProcessorInfo list for a change feed
-func (c CDCEtcdClient) GetProcessors(ctx context.Context, changeFeedID string) (int64, []*model.ProcessorInfo, error) {
-	prefix := ProcessorInfoKeyPrefix + "/" + changeFeedID
+func (c CDCEtcdClient) GetProcessors(ctx context.Context, captureID string) (int64, []*model.ProcessorInfo, error) {
+	prefix := ProcessorInfoKeyPrefix + "/" + captureID
 	return c.getProcessorsFromPrefix(ctx, prefix)
 }
 

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -421,14 +421,14 @@ func (c CDCEtcdClient) DeleteTaskStatus(
 }
 
 // PutCaptureInfo put capture info into etcd.
-func (c CDCEtcdClient) PutCaptureInfo(ctx context.Context, info *model.CaptureInfo) error {
+func (c CDCEtcdClient) PutCaptureInfo(ctx context.Context, info *model.CaptureInfo, leaseID clientv3.LeaseID) error {
 	data, err := info.Marshal()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	key := GetEtcdKeyCaptureInfo(info.ID)
-	_, err = c.Client.Put(ctx, key, string(data))
+	_, err = c.Client.Put(ctx, key, string(data), clientv3.WithLease(leaseID))
 	return errors.Trace(err)
 }
 

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -476,33 +476,6 @@ func (o *ownerImpl) removeCapture(info *model.CaptureInfo) {
 	defer o.l.Unlock()
 
 	delete(o.captures, info.ID)
-
-	for _, feed := range o.changeFeeds {
-		pinfo, ok := feed.taskStatus[info.ID]
-		if !ok {
-			continue
-		}
-		pos, ok := feed.taskPositions[info.ID]
-		if !ok {
-			continue
-		}
-
-		for _, table := range pinfo.TableInfos {
-			feed.orphanTables[table.ID] = model.ProcessTableInfo{
-				ID:      table.ID,
-				StartTs: pos.CheckPointTs,
-			}
-		}
-
-		ctx := context.TODO()
-		if err := o.etcdClient.DeleteTaskStatus(ctx, feed.id, info.ID); err != nil {
-			log.Warn("failed to delete task status", zap.Error(err))
-		}
-		if err := o.etcdClient.DeleteTaskPosition(ctx, feed.id, info.ID); err != nil {
-			log.Warn("failed to delete task position", zap.Error(err))
-		}
-
-	}
 }
 
 func (o *ownerImpl) resetCaptureInfoWatcher(ctx context.Context) error {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1301,6 +1301,7 @@ func (o *ownerImpl) cleanUpStaleTasks(ctx context.Context) error {
 				if err := o.etcdClient.DeleteTaskPosition(ctx, changeFeedID, captureID); err != nil {
 					return errors.Trace(err)
 				}
+				log.Debug("cleanup stale task", zap.String("captureid", captureID), zap.String("changefeedid", changeFeedID))
 			}
 		}
 	}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1011,9 +1011,6 @@ func (o *ownerImpl) Run(ctx context.Context, tickTime time.Duration) error {
 			if ownerChanged {
 				// Do something initialize when the capture becomes an owner.
 				ownerChanged = false
-				// Start a routine to keep watching on the liveness of
-				// processors.
-				o.startProcessorInfoWatcher(ctx)
 
 				// When an owner crashed, its processors crashed too,
 				// clean up the tasks for these processors.
@@ -1021,6 +1018,10 @@ func (o *ownerImpl) Run(ctx context.Context, tickTime time.Duration) error {
 					log.Error("clean up stale tasks failed",
 						zap.Error(err))
 				}
+
+				// Start a routine to keep watching on the liveness of
+				// processors.
+				o.startProcessorInfoWatcher(ctx)
 			}
 
 			err := o.run(ctx)

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1280,20 +1280,20 @@ func (o *ownerImpl) cleanUpStaleTasks(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 	for changeFeedID := range changefeeds {
-		_, processors, err := o.etcdClient.GetProcessors(ctx, changeFeedID)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		active := make(map[string]*model.ProcessorInfo)
-		for _, p := range processors {
-			active[p.CaptureID] = p
-		}
 		statuses, err := o.etcdClient.GetAllTaskStatus(ctx, changeFeedID)
 		if err != nil {
 			return errors.Trace(err)
 		}
 
+		active := make(map[string]*model.ProcessorInfo)
 		for captureID := range statuses {
+			_, processors, err := o.etcdClient.GetProcessors(ctx, captureID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			for _, p := range processors {
+				active[p.CaptureID] = p
+			}
 			if _, ok := active[captureID]; !ok {
 				if err := o.etcdClient.DeleteTaskStatus(ctx, changeFeedID, captureID); err != nil {
 					return errors.Trace(err)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -701,8 +701,7 @@ func (p *processor) stop(ctx context.Context) error {
 	}
 	p.tablesMu.Unlock()
 	p.session.Close()
-	_ = p.deregister(ctx)
-	return errors.Trace(p.etcdCli.DeleteTaskStatus(ctx, p.changefeedID, p.captureID))
+	return errors.Trace(p.deregister(ctx))
 }
 
 func (p *processor) register(ctx context.Context) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the problem that the rebalance does not work sometimes.

### What is changed and how it works?

* Keep the processor status when a processor is stopped because it would be handled by the owner
* Fix a bug in `cleanUpStaleTasks` for using a wrong key
* Keep the processor status when a capture deletion is detected, it should be handled by the processor watcher.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
