### PR TITLE
bug fix: panic in storagebuilder sometimes

### DIFF
--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -91,15 +91,21 @@ type TaskPosition struct {
 }
 
 // Marshal returns the json marshal format of a TaskStatus
-func (ts *TaskPosition) Marshal() (string, error) {
-	data, err := json.Marshal(ts)
+func (tp *TaskPosition) Marshal() (string, error) {
+	data, err := json.Marshal(tp)
 	return string(data), errors.Trace(err)
 }
 
 // Unmarshal unmarshals into *TaskStatus from json marshal byte slice
-func (ts *TaskPosition) Unmarshal(data []byte) error {
-	err := json.Unmarshal(data, ts)
+func (tp *TaskPosition) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, tp)
 	return errors.Annotatef(err, "Unmarshal data: %v", data)
+}
+
+// String implements fmt.Stringer interface.
+func (tp *TaskPosition) String() string {
+	data, _ := tp.Marshal()
+	return string(data)
 }
 
 // TaskStatus records the task information of a capture

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -719,6 +719,8 @@ func (c *changeFeed) calcResolvedTs() error {
 
 	if len(c.taskPositions) == 0 {
 		minCheckpointTs = c.status.CheckpointTs
+	} else if len(c.taskPositions) < len(c.taskStatus) {
+		return nil
 	} else {
 		// calc the min of all resolvedTs in captures
 		for _, position := range c.taskPositions {

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -350,6 +350,7 @@ func (p *processor) updateInfo(ctx context.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	log.Info("update task position", zap.Stringer("status", p.position))
 	statusChanged, err := p.tsRWriter.UpdateInfo(ctx)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
panic in storagebuilder sometimes

### What is changed and how it works?
The information exchange between owner and processor is dependent on `TaskPositions` and `TaskStatus`.
`TaskStatus` is updated by the owner mainly, `TaskPositions` is updated by processors.
When the owner adds a table to the processor, the owner will update `TaskStatus`.  When the processor finds the change of `TaskStatus`, the processor will start table puller and update `TaskPositions`.

If the `TaskStatus` is already updated, but `TablePostitions` is still not updated by the processor, the owner may ignore the checkpointTS of the newest table.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test