### PR TITLE
bug fix: set changedfeed id into sink options mistakenly

### DIFF
--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -339,7 +339,7 @@ func realRunProcessor(
 	}
 	opts[sink.OptChangefeedID] = changefeedID
 	opts[sink.OptCaptureID] = captureID
-	sink, err := sink.NewSink(info.SinkURI, info.Opts)
+	sink, err := sink.NewSink(info.SinkURI, opts)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
set changedfeed id into sink options mistakenly
### What is changed and how it works?

