### PR TITLE
Makefile: fix running test for go 1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ SHELL	 := /usr/bin/env bash
 
 GO       := GO111MODULE=on go
 GOBUILD  := CGO_ENABLED=0 $(GO) build $(BUILD_FLAG) -trimpath
+ifeq ($(GOVERSION114), 1)
+GOTEST   := CGO_ENABLED=1 $(GO) test -p 3 --race -gcflags=all=-d=checkptr=0
+else
 GOTEST   := CGO_ENABLED=1 $(GO) test -p 3 --race
+endif
 
 ARCH  := "`uname -s`"
 LINUX := "Linux"


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fail to run test for go 1.14
https://github.com/pingcap/ticdc/issues/305

### What is changed and how it works?
A workaround that setting `GOVERSION114=1` before running test for go 1.14

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```bash
GOVERSION114=1 make test
```

