### PR TITLE
sink/mysql: remove default schema in mysql dsn

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -296,7 +296,7 @@ func newMySQLSink(sinkURI *url.URL, dsn *dmysql.Config, filter *util.Filter, opt
 		}
 
 		// Assume all the timestamp type is in the UTC zone when passing into mysql sink.
-		dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/test?interpolateParams=true&multiStatements=true&time_zone=UTC", username,
+		dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/?interpolateParams=true&multiStatements=true&time_zone=UTC", username,
 			password, sinkURI.Hostname(), port)
 		var err error
 		db, err = sql.Open("mysql", dsn)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/320

### What is changed and how it works?

the schema `test` may not exist in downstream, we can omit schema name in MySQL DSN

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test