### PR TITLE
puller: fix listen add index ddl

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -246,6 +246,7 @@ func (m *mounterImpl) unmarshalIndexKVEntry(restKey []byte, rawValue []byte, bas
 }
 
 const ddlJobListKey = "DDLJobList"
+const ddlAddIndexJobListKey = "DDLJobAddIdxList"
 
 // UnmarshalDDL unmarshals the ddl job from RawKVEntry
 func UnmarshalDDL(raw *model.RawKVEntry) (*timodel.Job, error) {
@@ -260,7 +261,7 @@ func UnmarshalDDL(raw *model.RawKVEntry) (*timodel.Job, error) {
 		return nil, nil
 	}
 	k := meta.(metaListData)
-	if k.key != ddlJobListKey {
+	if k.key != ddlJobListKey && k.key != ddlAddIndexJobListKey {
 		return nil, nil
 	}
 	job := &timodel.Job{}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -679,9 +679,6 @@ func (c *changeFeed) pullDDLJob() error {
 	}
 	c.ddlResolvedTs = ddlResolvedTs
 	c.ddlJobHistory = append(c.ddlJobHistory, ddlJobs...)
-	for _, ddl := range ddlJobs {
-		log.Warn("owner find ddl job", zap.Reflect("job", ddl))
-	}
 	return nil
 }
 

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -679,6 +679,9 @@ func (c *changeFeed) pullDDLJob() error {
 	}
 	c.ddlResolvedTs = ddlResolvedTs
 	c.ddlJobHistory = append(c.ddlJobHistory, ddlJobs...)
+	for _, ddl := range ddlJobs {
+		log.Warn("owner find ddl job", zap.Reflect("job", ddl))
+	}
 	return nil
 }
 

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -44,7 +44,7 @@ type ddlHandler struct {
 func newDDLHandler(pdCli pd.Client, checkpointTS uint64) *ddlHandler {
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
-	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan()}, false, nil)
+	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan(), util.GetAddIndexDDLSpan()}, false, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	h := &ddlHandler{
 		puller: puller,

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -17,9 +17,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pingcap/log"
-	"go.uber.org/zap"
-
 	"github.com/pingcap/errors"
 	timodel "github.com/pingcap/parser/model"
 	pd "github.com/pingcap/pd/client"
@@ -84,7 +81,6 @@ func (h *ddlHandler) receiveDDL(rawDDL *model.RawKVEntry) error {
 		h.mu.Unlock()
 		return nil
 	}
-	log.Warn("owner listen origin ddl", zap.ByteString("k", rawDDL.Key), zap.ByteString("v", rawDDL.Value))
 	job, err := entry.UnmarshalDDL(rawDDL)
 	if err != nil {
 		return errors.Trace(err)

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -84,11 +84,11 @@ func (h *ddlHandler) receiveDDL(rawDDL *model.RawKVEntry) error {
 		h.mu.Unlock()
 		return nil
 	}
+	log.Warn("owner listen origin ddl", zap.ByteString("k", rawDDL.Key), zap.ByteString("v", rawDDL.Value))
 	job, err := entry.UnmarshalDDL(rawDDL)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	log.Warn("owner listen origin ddl", zap.Reflect("job", job))
 	if job == nil || entry.SkipJob(job) {
 		return nil
 	}

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"sync"
 
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/pingcap/errors"
 	timodel "github.com/pingcap/parser/model"
 	pd "github.com/pingcap/pd/client"
@@ -85,6 +88,7 @@ func (h *ddlHandler) receiveDDL(rawDDL *model.RawKVEntry) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	log.Warn("owner listen origin ddl", zap.Reflect("job", job))
 	if job == nil || entry.SkipJob(job) {
 		return nil
 	}

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -161,7 +161,7 @@ func NewProcessor(
 
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
-	ddlPuller := puller.NewPuller(pdCli, checkpointTs, []util.Span{util.GetDDLSpan()}, false, limitter)
+	ddlPuller := puller.NewPuller(pdCli, checkpointTs, []util.Span{util.GetDDLSpan(), util.GetAddIndexDDLSpan()}, false, limitter)
 	ddlEventCh := ddlPuller.SortedOutput(ctx)
 	schemaBuilder, err := createSchemaBuilder(pdEndpoints, ddlEventCh)
 	if err != nil {

--- a/pkg/util/span.go
+++ b/pkg/util/span.go
@@ -57,12 +57,21 @@ func GetTableSpan(tableID int64, needEncode bool) Span {
 
 // GetDDLSpan returns the span to watch for DDL related events
 func GetDDLSpan() Span {
+	return getMetaListKey("DDLJobList")
+}
+
+// GetAddIndexDDLSpan returns the span to watch for Add Index DDL related events
+func GetAddIndexDDLSpan() Span {
+	return getMetaListKey("DDLJobAddIdxList")
+}
+
+func getMetaListKey(key string) Span {
 	metaPrefix := []byte("m")
-	ddlJobListKey := []byte("DDLJobList")
+	metaKey := []byte(key)
 	listData := 'l'
-	start := make([]byte, 0, len(metaPrefix)+len(ddlJobListKey)+8)
+	start := make([]byte, 0, len(metaPrefix)+len(metaKey)+8)
 	start = append(start, metaPrefix...)
-	start = codec.EncodeBytes(start, ddlJobListKey)
+	start = codec.EncodeBytes(start, metaKey)
 	start = codec.EncodeUint(start, uint64(listData))
 	end := make([]byte, len(start))
 	copy(end, start)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When TiDB need execute a Add Index DDL, TiDB will put the DDL Job into `DDLJobAddIdxList`, but not `DDLJobList`, so ddl puller should listen both `DDLJobList` and `DDLJobAddIdxList`.
fixed #369
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
I will replenish integration tests in next PR