### PR TITLE
bug fix: fix schema builder may remove unapplied DDL job

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -126,13 +126,14 @@ func (m *mounterImpl) Run(ctx context.Context) error {
 			return errors.Trace(ctx.Err())
 		}
 
+		log.Info("processor HandlePreviousDDLJobIfNeed", zap.Uint64("ts", rawRow.Ts))
+		err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts, true)
+
 		if rawRow.OpType == model.OpTypeResolved {
 			m.output <- &model.RowChangedEvent{Resolved: true, Ts: rawRow.Ts}
 			continue
 		}
 
-		log.Info("processor HandlePreviousDDLJobIfNeed", zap.Uint64("ts", rawRow.Ts))
-		err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts, true)
 		switch errors.Cause(err) {
 		case nil:
 		case model.ErrUnresolved:

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -115,6 +115,9 @@ func (m *mounterImpl) Run(ctx context.Context) error {
 			return errors.Trace(ctx.Err())
 		case rawRow = <-m.rawRowChangedCh:
 		}
+		if rawRow == nil {
+			continue
+		}
 
 		if err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts); err != nil {
 			return errors.Trace(err)

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -196,6 +196,7 @@ func (m *mounterImpl) unmarshalAndMountRowChanged(raw *model.RawKVEntry) (*model
 func (m *mounterImpl) unmarshalRowKVEntry(restKey []byte, rawValue []byte, base baseKVEntry) (*rowKVEntry, error) {
 	tableID := base.TableID
 	tableInfo, exist := m.schemaStorage.TableByID(tableID)
+	log.Info("unmarshalRowKVEntry", zap.Reflect("tableInfo", tableInfo))
 	if !exist {
 		if m.schemaStorage.IsTruncateTableID(tableID) {
 			log.Debug("skip the DML of truncated table", zap.Uint64("ts", base.Ts), zap.Int64("tableID", tableID))
@@ -282,6 +283,7 @@ func (m *mounterImpl) mountRowKVEntry(row *rowKVEntry) (*model.RowChangedEvent, 
 	if !exist {
 		return nil, errors.NotFoundf("table in schema storage, id: %d", row.TableID)
 	}
+	log.Info("mountRowKVEntry", zap.Reflect("tableInfo", tableInfo), zap.Reflect("tableName", tableName))
 
 	if row.Delete && !tableInfo.PKIsHandle {
 		return nil, nil

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -126,8 +126,7 @@ func (m *mounterImpl) Run(ctx context.Context) error {
 			return errors.Trace(ctx.Err())
 		}
 
-		log.Info("processor HandlePreviousDDLJobIfNeed", zap.Uint64("ts", rawRow.Ts))
-		err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts, true)
+		err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts)
 
 		if rawRow.OpType == model.OpTypeResolved {
 			m.output <- &model.RowChangedEvent{Resolved: true, Ts: rawRow.Ts}
@@ -198,7 +197,6 @@ func (m *mounterImpl) unmarshalAndMountRowChanged(raw *model.RawKVEntry) (*model
 func (m *mounterImpl) unmarshalRowKVEntry(restKey []byte, rawValue []byte, base baseKVEntry) (*rowKVEntry, error) {
 	tableID := base.TableID
 	tableInfo, exist := m.schemaStorage.TableByID(tableID)
-	log.Info("unmarshalRowKVEntry", zap.Reflect("tableInfo", tableInfo))
 	if !exist {
 		if m.schemaStorage.IsTruncateTableID(tableID) {
 			log.Debug("skip the DML of truncated table", zap.Uint64("ts", base.Ts), zap.Int64("tableID", tableID))
@@ -285,7 +283,6 @@ func (m *mounterImpl) mountRowKVEntry(row *rowKVEntry) (*model.RowChangedEvent, 
 	if !exist {
 		return nil, errors.NotFoundf("table in schema storage, id: %d", row.TableID)
 	}
-	log.Info("mountRowKVEntry", zap.Reflect("tableInfo", tableInfo), zap.Reflect("tableName", tableName))
 
 	if row.Delete && !tableInfo.PKIsHandle {
 		return nil, nil

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -131,7 +131,8 @@ func (m *mounterImpl) Run(ctx context.Context) error {
 			continue
 		}
 
-		err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts)
+		log.Info("processor HandlePreviousDDLJobIfNeed", zap.Uint64("ts", rawRow.Ts))
+		err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts, true)
 		switch errors.Cause(err) {
 		case nil:
 		case model.ErrUnresolved:

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -19,7 +19,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -109,38 +108,21 @@ func NewMounter(rawRowChangedCh <-chan *model.RawKVEntry, schemaStorage *Storage
 }
 
 func (m *mounterImpl) Run(ctx context.Context) error {
-	var lastRowChangedEvent *model.RawKVEntry
 	for {
 		var rawRow *model.RawKVEntry
-		if lastRowChangedEvent != nil {
-			rawRow = lastRowChangedEvent
-			lastRowChangedEvent = nil
-		} else {
-			select {
-			case <-ctx.Done():
-				return errors.Trace(ctx.Err())
-			case rawRow = <-m.rawRowChangedCh:
-			}
-		}
-		if rawRow == nil {
+		select {
+		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
+		case rawRow = <-m.rawRowChangedCh:
 		}
 
-		err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts)
+		if err := m.schemaStorage.HandlePreviousDDLJobIfNeed(rawRow.Ts); err != nil {
+			return errors.Trace(err)
+		}
 
 		if rawRow.OpType == model.OpTypeResolved {
 			m.output <- &model.RowChangedEvent{Resolved: true, Ts: rawRow.Ts}
 			continue
-		}
-
-		switch errors.Cause(err) {
-		case nil:
-		case model.ErrUnresolved:
-			lastRowChangedEvent = rawRow
-			time.Sleep(50 * time.Millisecond)
-			continue
-		default:
-			return errors.Cause(err)
 		}
 
 		event, err := m.unmarshalAndMountRowChanged(rawRow)

--- a/cdc/entry/schema_builder.go
+++ b/cdc/entry/schema_builder.go
@@ -196,10 +196,10 @@ func (b *StorageBuilder) DoGc(ts uint64) error {
 	}
 	b.baseStorageMu.Lock()
 	defer b.baseStorageMu.Unlock()
-	//err := b.baseStorage.HandlePreviousDDLJobIfNeed(ts, false)
-	//if err != nil {
-	//	return errors.Trace(err)
-	//}
+	err := b.baseStorage.HandlePreviousDDLJobIfNeed(ts, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	//b.jobList.RemoveOverdueJobs(ts)
 	return nil
 }

--- a/cdc/entry/schema_builder.go
+++ b/cdc/entry/schema_builder.go
@@ -196,10 +196,10 @@ func (b *StorageBuilder) DoGc(ts uint64) error {
 	}
 	b.baseStorageMu.Lock()
 	defer b.baseStorageMu.Unlock()
-	err := b.baseStorage.HandlePreviousDDLJobIfNeed(ts, false)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	b.jobList.RemoveOverdueJobs(ts)
+	//err := b.baseStorage.HandlePreviousDDLJobIfNeed(ts, false)
+	//if err != nil {
+	//	return errors.Trace(err)
+	//}
+	//b.jobList.RemoveOverdueJobs(ts)
 	return nil
 }

--- a/cdc/entry/schema_builder.go
+++ b/cdc/entry/schema_builder.go
@@ -170,7 +170,7 @@ func (b *StorageBuilder) Build(ts uint64) (*Storage, error) {
 	b.baseStorageMu.Unlock()
 
 	err := retry.Run(func() error {
-		err := c.HandlePreviousDDLJobIfNeed(ts)
+		err := c.HandlePreviousDDLJobIfNeed(ts, false)
 		if errors.Cause(err) != model.ErrUnresolved {
 			return backoff.Permanent(err)
 		}
@@ -196,7 +196,7 @@ func (b *StorageBuilder) DoGc(ts uint64) error {
 	}
 	b.baseStorageMu.Lock()
 	defer b.baseStorageMu.Unlock()
-	err := b.baseStorage.HandlePreviousDDLJobIfNeed(ts)
+	err := b.baseStorage.HandlePreviousDDLJobIfNeed(ts, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -604,7 +604,7 @@ func (s *Storage) HandleDDL(job *timodel.Job) (schemaName string, tableName stri
 		if binlogInfo == nil {
 			return "", "", "", errors.NotFoundf("table %d", job.TableID)
 		}
-		tbInfo := binlogInfo.TableInfo
+		tbInfo := binlogInfo.TableInfo.Clone()
 		if tbInfo == nil {
 			return "", "", "", errors.NotFoundf("table %d", job.TableID)
 		}

--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -439,6 +439,9 @@ func (s *Storage) HandlePreviousDDLJobIfNeed(commitTs uint64, processor bool) er
 	}
 	currentJob, jobs := s.jobList.FetchNextJobs(s.currentJob, commitTs)
 	for _, job := range jobs {
+		if processor {
+			log.Info("jobs in HandlePreviousDDLJobIfNeed processor", zap.Reflect("job", job))
+		}
 		if SkipJob(job) {
 			log.Info("skip DDL job because the job isn't synced and done", zap.Stringer("job", job))
 			continue

--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -433,7 +433,7 @@ func (s *Storage) removeTable(tableID int64) error {
 }
 
 // HandlePreviousDDLJobIfNeed apply all jobs with FinishedTS less or equals `commitTs`.
-func (s *Storage) HandlePreviousDDLJobIfNeed(commitTs uint64) error {
+func (s *Storage) HandlePreviousDDLJobIfNeed(commitTs uint64, processor bool) error {
 	if commitTs > atomic.LoadUint64(s.resolvedTs) {
 		return model.ErrUnresolved
 	}
@@ -446,6 +446,9 @@ func (s *Storage) HandlePreviousDDLJobIfNeed(commitTs uint64) error {
 		if job.BinlogInfo.FinishedTS <= s.lastHandledTs {
 			log.Debug("skip DDL job because the job is already handled", zap.Stringer("job", job))
 			continue
+		}
+		if processor {
+			log.Info("handle ", zap.Reflect("job", job))
 		}
 		_, _, _, err := s.HandleDDL(job)
 		if err != nil {

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -29,5 +29,5 @@ var (
 	ErrAdminStopProcessor     = errors.New("stop processor by admin command")
 	ErrExecDDLFailed          = errors.New("exec DDL failed")
 	ErrCaptureNotExist        = errors.New("capture not exists")
-	ErrUnresolved             = errors.New("the ts more than resolvedTs")
+	ErrUnresolved             = errors.New("unresolved")
 )

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -600,8 +600,8 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 	}()
 	storage, err := p.schemaBuilder.Build(startTs)
 	if err != nil {
-		log.Error("failed to build schema storage", zap.Error(err))
 		p.errCh <- errors.Trace(err)
+		return
 	}
 	// start mounter
 	mounter := entry.NewMounter(puller.SortedOutput(ctx), storage)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -600,6 +600,7 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 	}()
 	storage, err := p.schemaBuilder.Build(startTs)
 	if err != nil {
+		log.Error("failed to build schema storage", zap.Error(err))
 		p.errCh <- errors.Trace(err)
 	}
 	// start mounter


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
we maintain an undo ddl job queue in schema builder, if all of the schema storage loaded a DDL job, we can remove this job from the undo queue.
The ddl jobs will be removed if the ts of ddl is smaller or equal than checkpoint TS. but there may be an unapplied job which ts is equal with checkpoint TS. we remove it by mistake.

fixed #373 #372 #355 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test