### PR TITLE
task: fix to parse task when the status is not created

### DIFF
--- a/cdc/task.go
+++ b/cdc/task.go
@@ -15,8 +15,8 @@ package cdc
 
 import (
 	"context"
-	"errors"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/model"
 	"go.etcd.io/etcd/clientv3"
@@ -169,7 +169,11 @@ func (w *TaskWatcher) parseTask(ctx context.Context,
 	}
 	status, err := w.capture.etcdClient.GetChangeFeedStatus(ctx, changeFeedID)
 	if err != nil {
-		return nil, err
+		if errors.Cause(err) == model.ErrTaskStatusNotExists {
+			status = &model.ChangeFeedStatus{}
+		} else {
+			return nil, err
+		}
 	}
 	checkpointTs := cf.GetCheckpointTs(status)
 	return &Task{ChangeFeedID: changeFeedID, CheckpointTS: checkpointTs}, nil

--- a/cdc/task.go
+++ b/cdc/task.go
@@ -169,7 +169,7 @@ func (w *TaskWatcher) parseTask(ctx context.Context,
 	}
 	status, err := w.capture.etcdClient.GetChangeFeedStatus(ctx, changeFeedID)
 	if err != nil {
-		if errors.Cause(err) == model.ErrTaskStatusNotExists {
+		if errors.Cause(err) == model.ErrChangeFeedNotExists {
 			status = &model.ChangeFeedStatus{}
 		} else {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When a task is dispatched before a change feed status is created, a newfound task can not be parsed.

### What is changed and how it works?

When a change feed status is not created, use a default value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
