### PR TITLE
capture: print log after the processor being started

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -145,8 +145,6 @@ func (c *Capture) Start(ctx context.Context) (err error) {
 						zap.Error(err))
 					return err
 				}
-				log.Info("run processor", zap.String("captureid", c.info.ID),
-					zap.String("changefeedid", task.ChangeFeedID))
 				if _, ok := c.processors[task.ChangeFeedID]; !ok {
 					p, err := runProcessor(cctx, c.pdEndpoints, *cf, task.ChangeFeedID,
 						c.info.ID, task.CheckpointTS)
@@ -157,6 +155,7 @@ func (c *Capture) Start(ctx context.Context) (err error) {
 							zap.Error(err))
 						return err
 					}
+					log.Info("run processor", zap.String("captureid", c.info.ID), zap.String("changefeedid", task.ChangeFeedID))
 					c.processors[task.ChangeFeedID] = p
 				}
 			} else if ev.Op == TaskOpDelete {


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

print the log message after a processor is created
