### PR TITLE
puller: fix sorter may panic because of bad usage of chan

### DIFF
--- a/cdc/puller/entry_sorter.go
+++ b/cdc/puller/entry_sorter.go
@@ -62,7 +62,6 @@ func (es *EntrySorter) Run(ctx context.Context) {
 			case <-ctx.Done():
 				atomic.StoreInt32(&es.closed, 1)
 				close(es.output)
-				close(es.resolvedCh)
 				return
 			case resolvedTs := <-es.resolvedCh:
 				es.lock.Lock()

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -98,6 +98,7 @@ func (p *pullerImpl) SortedOutput(ctx context.Context) <-chan *model.RawKVEntry 
 	sorter := NewEntrySorter()
 	go func() {
 		sorter.Run(ctx)
+		defer close(sorter.resolvedCh)
 		for {
 			be, err := p.chanBuffer.Get(ctx)
 			if err != nil {

--- a/cdc/sink/mqProducer/kafka.go
+++ b/cdc/sink/mqProducer/kafka.go
@@ -231,6 +231,11 @@ func newSaramaConfig(ctx context.Context, c KafkaConfig) (*sarama.Config, error)
 
 	config.Producer.Retry.Max = 10000
 	config.Producer.Retry.Backoff = 500 * time.Millisecond
+
+	config.Admin.Retry.Max = 100
+	config.Admin.Retry.Backoff = 500 * time.Millisecond
+	config.Admin.Timeout = 10 * time.Second
+
 	return config, err
 }
 

--- a/cdc/sink/mqProducer/kafka.go
+++ b/cdc/sink/mqProducer/kafka.go
@@ -232,7 +232,7 @@ func newSaramaConfig(ctx context.Context, c KafkaConfig) (*sarama.Config, error)
 	config.Producer.Retry.Max = 10000
 	config.Producer.Retry.Backoff = 500 * time.Millisecond
 
-	config.Admin.Retry.Max = 100
+	config.Admin.Retry.Max = 10000
 	config.Admin.Retry.Backoff = 500 * time.Millisecond
 	config.Admin.Timeout = 10 * time.Second
 

--- a/cdc/sink/mqProducer/kafka.go
+++ b/cdc/sink/mqProducer/kafka.go
@@ -174,11 +174,11 @@ func NewKafkaSaramaProducer(ctx context.Context, address string, topic string, c
 			partitionNum = 4
 			log.Warn("topic not found and partition number is not specified, using default partition number", zap.String("topic", topic), zap.Int32("partition_num", partitionNum))
 		}
+		log.Info("create a topic", zap.String("topic", topic), zap.Int32("partition_num", partitionNum), zap.Int16("replication_factor", config.ReplicationFactor))
 		err := admin.CreateTopic(topic, &sarama.TopicDetail{
 			NumPartitions:     partitionNum,
 			ReplicationFactor: config.ReplicationFactor,
 		}, false)
-		log.Info("create a topic", zap.String("topic", topic), zap.Int32("partition_num", partitionNum), zap.Int16("replication_factor", config.ReplicationFactor))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -234,7 +234,7 @@ func newSaramaConfig(ctx context.Context, c KafkaConfig) (*sarama.Config, error)
 
 	config.Admin.Retry.Max = 10000
 	config.Admin.Retry.Backoff = 500 * time.Millisecond
-	config.Admin.Timeout = 10 * time.Second
+	config.Admin.Timeout = 20 * time.Second
 
 	return config, err
 }

--- a/kafka_consumer/main.go
+++ b/kafka_consumer/main.go
@@ -128,7 +128,7 @@ func waitTopicCreated(address []string, topic string, cfg *sarama.Config) error 
 		return errors.Trace(err)
 	}
 	defer admin.Close()
-	for i := 0; i <= 10; i++ {
+	for i := 0; i <= 30; i++ {
 		topics, err := admin.ListTopics()
 		if err != nil {
 			return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #384 

### What is changed and how it works?

One general principle of using Go channels is that we should only close a channel in a sender goroutine if the sender is the only sender of the channel.

So we close the `resolvedCh` belongs to a sorter in the sender goroutine.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
