### PR TITLE
sink: fix Run in black hole sink

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1279,9 +1279,12 @@ func (o *ownerImpl) startProcessorInfoWatcher(ctx context.Context) {
 				// When the watching routine returns, the error must not
 				// be nil, it may be caused by a temporary error or a context
 				// error(ownerCtx.Err())
-				if ownerCtx.Err() != nil {
+				err2 := ownerCtx.Err()
+				if err2 != nil {
 					// The context error indicates the termination of the owner
-					log.Error("watch processor failed", zap.Error(ownerCtx.Err()))
+					if errors.Cause(err2) != context.Canceled {
+						log.Error("watch processor failed", zap.Error(err2))
+					}
 					return
 				}
 				log.Warn("watch processor returned", zap.Error(err))

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -605,7 +605,7 @@ func (o *ownerImpl) newChangeFeed(
 	}
 	go func() {
 		ctx := util.SetOwnerInCtx(context.TODO())
-		if err := sink.Run(ctx); errors.Cause(err) != context.Canceled {
+		if err := sink.Run(ctx); err != nil && errors.Cause(err) != context.Canceled {
 			log.Error("failed to close sink", zap.Error(err))
 		}
 	}()

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -494,6 +494,9 @@ func (p *processor) globalStatusWorker(ctx context.Context) error {
 			var err error
 			changefeedStatus, err = p.tsRWriter.GetChangeFeedStatus(ctx)
 			if err != nil {
+				if errors.Cause(err) == context.Canceled {
+					return backoff.Permanent(err)
+				}
 				log.Error("Global resolved worker: read global resolved ts failed", zap.Error(err))
 			}
 			return err

--- a/cdc/sink/black_hole.go
+++ b/cdc/sink/black_hole.go
@@ -39,8 +39,6 @@ func (b *blackHoleSink) Run(ctx context.Context) error {
 			atomic.StoreUint64(&b.checkpointTs, globalResolvedTs)
 		}
 	}
-	log.Info("newBlackHoleSink exits")
-	return ctx.Err()
 }
 
 func (b *blackHoleSink) EmitResolvedEvent(ctx context.Context, ts uint64) error {

--- a/cdc/sink/black_hole.go
+++ b/cdc/sink/black_hole.go
@@ -19,7 +19,8 @@ type blackHoleSink struct {
 }
 
 func (b *blackHoleSink) Run(ctx context.Context) error {
-	return nil
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func (b *blackHoleSink) EmitResolvedEvent(ctx context.Context, ts uint64) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

the `blackhole` sink returns immediately after `Run`, besides the `resolved ts` is not handled very well.

### What is changed and how it works?

- wait for context done in `Run`
- refine some error handler
- use the same resolved logic in MySQL sink

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
