### PR TITLE
increase chan size, fix grafana template

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -30,6 +30,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultOutputChanSize = 128000
+)
+
 type baseKVEntry struct {
 	Ts       uint64
 	TableID  int64
@@ -103,7 +107,7 @@ func NewMounter(rawRowChangedCh <-chan *model.RawKVEntry, schemaStorage *Storage
 	return &mounterImpl{
 		schemaStorage:   schemaStorage,
 		rawRowChangedCh: rawRowChangedCh,
-		output:          make(chan *model.RowChangedEvent),
+		output:          make(chan *model.RowChangedEvent, defaultOutputChanSize),
 	}
 }
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -52,7 +52,7 @@ const (
 	waitGlobalResolvedTsDelay   = time.Millisecond * 500
 	waitFallbackResolvedTsDelay = time.Millisecond * 500
 
-	defaultOutputChanSize = 128
+	defaultOutputChanSize = 128000
 
 	// defaultMemBufferCapacity is the default memory buffer per change feed.
 	defaultMemBufferCapacity int64 = 10 * 1024 * 1024 * 1024 // 10G

--- a/cdc/puller/buffer.go
+++ b/cdc/puller/buffer.go
@@ -16,7 +16,7 @@ import (
 var ErrReachLimit = errors.New("reach limit")
 
 const (
-	defaultBufferSize = 128
+	defaultBufferSize = 128000
 )
 
 // EventBuffer in a interface for communicating kv entries.

--- a/cdc/puller/entry_sorter.go
+++ b/cdc/puller/entry_sorter.go
@@ -25,8 +25,8 @@ type EntrySorter struct {
 // NewEntrySorter creates a new EntrySorter
 func NewEntrySorter() *EntrySorter {
 	return &EntrySorter{
-		resolvedCh: make(chan uint64, 1024),
-		output:     make(chan *model.RawKVEntry, 128),
+		resolvedCh: make(chan uint64, 12800),
+		output:     make(chan *model.RawKVEntry, 128000),
 	}
 }
 

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultPullerEventChanSize = 128
+	defaultPullerEventChanSize = 128000
 )
 
 // Puller pull data from tikv and push changes into a buffer

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -55,7 +55,7 @@ func newMqSink(mqProducer mqProducer.Producer, filter *util.Filter, opts map[str
 		sinkCheckpointTsCh: make(chan struct {
 			ts    uint64
 			index uint64
-		}, 128),
+		}, 128000),
 		filter:       filter,
 		changefeedID: changefeedID,
 		captureID:    captureID,

--- a/ticdc.json
+++ b/ticdc.json
@@ -2099,6 +2099,7 @@
       }
     },
     {
+      "datasource": "cdc-server",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -2191,6 +2192,7 @@
       }
     },
     {
+      "datasource": "cdc-server",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

As we have an unlimited buffer between puller and TiKV, we could increase channel buffer size as large as possible.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
