### PR TITLE
fix restore table panic

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -200,6 +200,10 @@ func (c *changeFeed) tryBalance(ctx context.Context, captures map[string]*model.
 }
 
 func (c *changeFeed) restoreTableInfos(infoSnapshot *model.TaskStatus, captureID string) {
+	// the capture information maybe deleted during table cleaning
+	if _, ok := c.taskStatus[captureID]; !ok {
+		log.Warn("ignore restore table info, task status for capture not found", zap.String("captureID", captureID))
+	}
 	c.taskStatus[captureID].TableInfos = infoSnapshot.TableInfos
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #414

This may happen as following

- The CDC-A(owner) processes a `drop table` DDL, where the table originally locates at CDC-B.
- Before CDC-A writes new `taskStatus` into etcd, the CDC-B crashes, capture watcher in CDC-A finds it, and delete the `taskStatus` of CDC-B
- `c.taskStatus[captureID]` is nil and panic.

### What is changed and how it works?
 We could just ignore it and in the next round there will be no more `taskStatus` for CDC-B

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test