### PR TITLE
util: Add RegionRangeLock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/edwingeng/deque v0.0.0-20191220032131-8596380dee17
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
+	github.com/google/btree v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect

--- a/pkg/util/region_range_lock.go
+++ b/pkg/util/region_range_lock.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/btree"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"go.uber.org/zap"
 )
 
@@ -103,16 +102,6 @@ func (m *RangeTsMap) GetMin(startKey, endKey []byte) uint64 {
 		return true
 	})
 	return ts
-}
-
-func (m *RangeTsMap) String() string {
-	result := ""
-	m.m.Ascend(func(i btree.Item) bool {
-		e := i.(*rangeTsEntry)
-		result += fmt.Sprintf("%v %v %v\n", e.ts, oracle.GetTimeFromTS(e.ts), hex.EncodeToString(e.startKey))
-		return true
-	})
-	return result
 }
 
 type rangeLockEntry struct {
@@ -306,7 +295,7 @@ func (l *RegionRangeLock) UnlockRange(startKey, endKey []byte, version uint64, c
 
 	i := l.rangeLock.Delete(entry)
 	if i == nil {
-		panic("impossible")
+		panic("impossible (entry just get from BTree disappeared)")
 	}
 	l.rangeCheckpointTs.Set(startKey, endKey, checkpointTs)
 	log.Info("unlocked range", zap.Uint64("lockID", l.id), zap.Uint64("regionID", entry.regionID),

--- a/pkg/util/region_range_lock.go
+++ b/pkg/util/region_range_lock.go
@@ -1,0 +1,337 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/btree"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/store/tikv/oracle"
+	"go.uber.org/zap"
+)
+
+type rangeTsEntry struct {
+	// Only startKey is necessary. End key can be inferred by the next item since the map always keeps a continuous
+	// range.
+	startKey []byte
+	ts       uint64
+}
+
+func rangeTsEntryWithKey(key []byte) *rangeTsEntry {
+	return &rangeTsEntry{
+		startKey: key,
+	}
+}
+
+func (e *rangeTsEntry) Less(than btree.Item) bool {
+	return bytes.Compare(e.startKey, than.(*rangeTsEntry).startKey) < 0
+}
+
+// RangeTsMap represents a map from key range to a timestamp. It supports range set and calculating min value among a
+// a specified range.
+type RangeTsMap struct {
+	m *btree.BTree
+}
+
+// NewRangeTsMap creates a RangeTsMap.
+func NewRangeTsMap() *RangeTsMap {
+	return &RangeTsMap{
+		m: btree.New(16),
+	}
+}
+
+// Set sets the corresponding ts of the given range to the specified value.
+func (m *RangeTsMap) Set(startKey, endKey []byte, ts uint64) {
+	if m.m.Get(rangeTsEntryWithKey(endKey)) == nil {
+		// To calculate the minimal ts, the default value is math.MaxUint64
+		tailTs := uint64(math.MaxUint64)
+		m.m.DescendLessOrEqual(rangeTsEntryWithKey(endKey), func(i btree.Item) bool {
+			tailTs = i.(*rangeTsEntry).ts
+			return false
+		})
+		m.m.ReplaceOrInsert(&rangeTsEntry{
+			startKey: endKey,
+			ts:       tailTs,
+		})
+	}
+
+	entriesToDelete := make([]*rangeTsEntry, 0)
+	m.m.AscendRange(rangeTsEntryWithKey(startKey), rangeTsEntryWithKey(endKey), func(i btree.Item) bool {
+		entriesToDelete = append(entriesToDelete, i.(*rangeTsEntry))
+		return true
+	})
+
+	for _, e := range entriesToDelete {
+		m.m.Delete(e)
+	}
+
+	m.m.ReplaceOrInsert(&rangeTsEntry{
+		startKey: startKey,
+		ts:       ts,
+	})
+}
+
+// GetMin gets the min ts value among the given range. endKey must be greater than startKey.
+func (m *RangeTsMap) GetMin(startKey, endKey []byte) uint64 {
+	var ts uint64 = math.MaxUint64
+	m.m.DescendLessOrEqual(rangeTsEntryWithKey(startKey), func(i btree.Item) bool {
+		ts = i.(*rangeTsEntry).ts
+		return false
+	})
+	m.m.AscendRange(rangeTsEntryWithKey(startKey), rangeTsEntryWithKey(endKey), func(i btree.Item) bool {
+		thisTs := i.(*rangeTsEntry).ts
+		if ts > thisTs {
+			ts = thisTs
+		}
+		return true
+	})
+	return ts
+}
+
+func (m *RangeTsMap) String() string {
+	result := ""
+	m.m.Ascend(func(i btree.Item) bool {
+		e := i.(*rangeTsEntry)
+		result += fmt.Sprintf("%v %v %v\n", e.ts, oracle.GetTimeFromTS(e.ts), hex.EncodeToString(e.startKey))
+		return true
+	})
+	return result
+}
+
+type rangeLockEntry struct {
+	startKey []byte
+	endKey   []byte
+	regionID uint64
+	version  uint64
+	waiters  []chan<- interface{}
+}
+
+func rangeLockEntryWithKey(key []byte) *rangeLockEntry {
+	return &rangeLockEntry{
+		startKey: key,
+	}
+}
+
+func (e *rangeLockEntry) Less(than btree.Item) bool {
+	return bytes.Compare(e.startKey, than.(*rangeLockEntry).startKey) < 0
+}
+
+var currentID uint64 = 0
+
+func allocID() uint64 {
+	return atomic.AddUint64(&currentID, 1)
+}
+
+// RegionRangeLock is specifically used for kv client to manage exclusive region ranges. Acquiring lock will be blocked
+// if part of its range is already locked. It also manages checkpoint ts of all ranges. The ranges are marked by a
+// version number, which should comes from the Region's Epoch version. The version is used to compare which range is
+// new and which is old if two ranges are overlapping.
+type RegionRangeLock struct {
+	mu                sync.Mutex
+	rangeCheckpointTs *RangeTsMap
+	rangeLock         *btree.BTree
+	// ID to identify different RegionRangeLock instances, so logs of different instances can be distinguished.
+	id uint64
+}
+
+// NewRegionRangeLock creates a new RegionRangeLock.
+func NewRegionRangeLock() *RegionRangeLock {
+	return &RegionRangeLock{
+		rangeCheckpointTs: NewRangeTsMap(),
+		rangeLock:         btree.New(16),
+		id:                allocID(),
+	}
+}
+
+func (l *RegionRangeLock) getOverlappedEntries(startKey, endKey []byte) []*rangeLockEntry {
+	overlappingRanges := make([]*rangeLockEntry, 0)
+	l.rangeLock.DescendLessOrEqual(rangeLockEntryWithKey(startKey), func(i btree.Item) bool {
+		entry := i.(*rangeLockEntry)
+		if bytes.Compare(entry.startKey, startKey) < 0 &&
+			bytes.Compare(startKey, entry.endKey) < 0 {
+			overlappingRanges = append(overlappingRanges, entry)
+		}
+		return false
+	})
+	l.rangeLock.AscendRange(rangeLockEntryWithKey(startKey), rangeLockEntryWithKey(endKey), func(i btree.Item) bool {
+		overlappingRanges = append(overlappingRanges, i.(*rangeLockEntry))
+		return true
+	})
+
+	return overlappingRanges
+}
+
+func (l *RegionRangeLock) tryLockRange(startKey, endKey []byte, regionID, version uint64) (LockRangeResult, []<-chan interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	overlappingRanges := l.getOverlappedEntries(startKey, endKey)
+
+	if len(overlappingRanges) == 0 {
+		checkpointTs := l.rangeCheckpointTs.GetMin(startKey, endKey)
+		l.rangeLock.ReplaceOrInsert(&rangeLockEntry{
+			startKey: startKey,
+			endKey:   endKey,
+			regionID: regionID,
+			version:  version,
+		})
+
+		log.Info("range locked", zap.Uint64("lockID", l.id), zap.Uint64("regionID", regionID),
+			zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)))
+
+		return LockRangeResult{
+			Status:       LockRangeStatusSuccess,
+			CheckpointTs: checkpointTs,
+		}, nil
+	}
+
+	// Format overlapping ranges for printing log
+	var overlapStr []string
+	for _, r := range overlappingRanges {
+		overlapStr = append(overlapStr, fmt.Sprintf("regionID: %v, ver: %v, start: %v, end: %v",
+			r.regionID, r.version, hex.EncodeToString(r.startKey), hex.EncodeToString(r.endKey))) //DEBUG
+	}
+
+	isStale := false
+	for _, r := range overlappingRanges {
+		if r.version >= version {
+			isStale = true
+			break
+		}
+	}
+	if isStale {
+		retryRanges := make([]Span, 0)
+		currentRangeStartKey := startKey
+
+		log.Info("tryLockRange stale", zap.Uint64("lockID", l.id), zap.Uint64("regionID", regionID),
+			zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)), zap.Strings("allOverlapping", overlapStr)) //DEBUG
+
+		for _, r := range overlappingRanges {
+			if bytes.Compare(currentRangeStartKey, r.startKey) < 0 {
+				retryRanges = append(retryRanges, Span{Start: currentRangeStartKey, End: r.startKey})
+			}
+			currentRangeStartKey = r.endKey
+		}
+		if bytes.Compare(currentRangeStartKey, endKey) < 0 {
+			retryRanges = append(retryRanges, Span{Start: currentRangeStartKey, End: endKey})
+		}
+
+		return LockRangeResult{
+			Status:      LockRangeStatusStale,
+			RetryRanges: retryRanges,
+		}, nil
+	}
+
+	var signalChs []<-chan interface{}
+
+	for _, r := range overlappingRanges {
+		ch := make(chan interface{}, 1)
+		signalChs = append(signalChs, ch)
+		r.waiters = append(r.waiters, ch)
+
+	}
+
+	log.Info("lock range blocked", zap.Uint64("lockID", l.id), zap.Uint64("regionID", regionID),
+		zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)), zap.Strings("blockedBy", overlapStr)) //DEBUG
+
+	return LockRangeResult{
+		Status: LockRangeStatusWait,
+	}, signalChs
+}
+
+// LockRange locks a range with specified version.
+func (l *RegionRangeLock) LockRange(startKey, endKey []byte, regionID, version uint64) LockRangeResult {
+	res, signalChs := l.tryLockRange(startKey, endKey, regionID, version)
+
+	if res.Status != LockRangeStatusWait {
+		return res
+	}
+
+	res.WaitFn = func() LockRangeResult {
+		signalChs1 := signalChs
+		var res1 LockRangeResult
+		for {
+			for _, ch := range signalChs1 {
+				<-ch
+			}
+			res1, signalChs1 = l.tryLockRange(startKey, endKey, regionID, version)
+			if res1.Status != LockRangeStatusWait {
+				return res1
+			}
+		}
+	}
+
+	return res
+}
+
+// UnlockRange unlocks a range and update checkpointTs of the range to specivied value.
+func (l *RegionRangeLock) UnlockRange(startKey, endKey []byte, version uint64, checkpointTs uint64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	item := l.rangeLock.Get(rangeLockEntryWithKey(startKey))
+
+	if item == nil {
+		panic(fmt.Sprintf("unlocking a not locked range: [%v, %v), version %v",
+			hex.EncodeToString(startKey), hex.EncodeToString(endKey), version))
+	}
+
+	entry := item.(*rangeLockEntry)
+	if entry.version != version || !bytes.Equal(entry.endKey, endKey) {
+		panic(fmt.Sprintf("unlocking region not match the locked region. "+
+			"Locked: [%v, %v), version %v; Unlocking: [%v, %v), %v",
+			entry.startKey, entry.endKey, entry.version, startKey, endKey, version))
+	}
+
+	for _, ch := range entry.waiters {
+		ch <- nil
+	}
+
+	i := l.rangeLock.Delete(entry)
+	if i == nil {
+		panic("impossible")
+	}
+	l.rangeCheckpointTs.Set(startKey, endKey, checkpointTs)
+	log.Info("unlocked range", zap.Uint64("lockID", l.id), zap.Uint64("regionID", entry.regionID),
+		zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)))
+}
+
+const (
+	// LockRangeStatusSuccess means a LockRange operation succeeded.
+	LockRangeStatusSuccess = 0
+	// LockRangeStatusWait means a LockRange operation is blocked and should wait for it being finished.
+	LockRangeStatusWait = 1
+	// LockRangeStatusStale means a LockRange operation is rejected because of the range's version is stale.
+	LockRangeStatusStale = 2
+)
+
+// LockRangeResult represents the result of LockRange method of RegionRangeLock.
+// If Status is LockRangeStatusSuccess, the CheckpointTs field will be the minimal checkpoint ts among the locked
+// range.
+// If Status is LockRangeStatusWait, it means the lock cannot be acquired immediately. WaitFn must be invoked to
+// continue waiting and acquiring the lock.
+// If Status is LockRangeStatusStale, it means the LockRange request is stale because there's already a overlapping
+// locked range, whose version is greater or equals to the requested one.
+type LockRangeResult struct {
+	Status       int
+	CheckpointTs uint64
+	WaitFn       func() LockRangeResult
+	RetryRanges  []Span
+}

--- a/pkg/util/region_range_lock_test.go
+++ b/pkg/util/region_range_lock_test.go
@@ -1,0 +1,139 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/pingcap/check"
+	"math"
+)
+
+type regionRangeLockSuit struct{}
+
+var _ = check.Suite(&regionRangeLockSuit{})
+
+func mustSuccess(c *check.C, res LockRangeResult, expectedCheckpointTs uint64) {
+	c.Assert(res.Status, check.Equals, LockRangeStatusSuccess)
+	c.Assert(res.CheckpointTs, check.Equals, expectedCheckpointTs)
+}
+
+func mustStale(c *check.C, res LockRangeResult, expectedRetryRanges ...Span) {
+	c.Assert(res.Status, check.Equals, LockRangeStatusStale)
+	c.Assert(res.RetryRanges, check.DeepEquals, expectedRetryRanges)
+}
+
+func mustWaitFn(c *check.C, res LockRangeResult) func() LockRangeResult {
+	c.Assert(res.Status, check.Equals, LockRangeStatusWait)
+	return res.WaitFn
+}
+
+func mustLockRangeSuccess(c *check.C, l *RegionRangeLock, startKey, endKey string, version uint64, expectedCheckpointTs uint64) {
+	res := l.LockRange([]byte(startKey), []byte(endKey), 1, version)
+	mustSuccess(c, res, expectedCheckpointTs)
+}
+
+func mustLockRangeStale(c *check.C, l *RegionRangeLock, startKey, endKey string, version uint64, expectRetrySpans ...string) {
+	res := l.LockRange([]byte(startKey), []byte(endKey), 1, version)
+	spans := make([]Span, 0)
+	for i := 0; i < len(expectRetrySpans); i += 2 {
+		spans = append(spans, Span{Start: []byte(expectRetrySpans[i]), End: []byte(expectRetrySpans[i+1])})
+	}
+	mustStale(c, res, spans...)
+}
+
+func mustLockRangeWait(c *check.C, l *RegionRangeLock, startKey, endKey string, version uint64) func() LockRangeResult {
+	res := l.LockRange([]byte(startKey), []byte(endKey), 1, version)
+	return mustWaitFn(c, res)
+}
+
+func unlockRange(l *RegionRangeLock, startKey, endKey string, version uint64, checkpointTs uint64) {
+	l.UnlockRange([]byte(startKey), []byte(endKey), version, checkpointTs)
+}
+
+func (s *regionRangeLockSuit) TestRegionRangeLock(c *check.C) {
+	l := NewRegionRangeLock()
+	mustLockRangeSuccess(c, l, "a", "e", 1, math.MaxUint64)
+	unlockRange(l, "a", "e", 1, 100)
+
+	mustLockRangeSuccess(c, l, "a", "e", 2, 100)
+	mustLockRangeStale(c, l, "a", "e", 2)
+	wait := mustLockRangeWait(c, l, "a", "h", 3)
+
+	unlockRange(l, "a", "e", 2, 110)
+	res := wait()
+	mustSuccess(c, res, 110)
+	unlockRange(l, "a", "h", 3, 120)
+}
+
+func (s *regionRangeLockSuit) TestRegionRangeLockStale(c *check.C) {
+	l := NewRegionRangeLock()
+	mustLockRangeSuccess(c, l, "c", "g", 10, math.MaxUint64)
+	mustLockRangeSuccess(c, l, "j", "n", 8, math.MaxUint64)
+
+	mustLockRangeStale(c, l, "c", "g", 10)
+	mustLockRangeStale(c, l, "c", "i", 9, "g", "i")
+	mustLockRangeStale(c, l, "a", "z", 9, "a", "c", "g", "j", "n", "z")
+	mustLockRangeStale(c, l, "a", "e", 9, "a", "c")
+	mustLockRangeStale(c, l, "e", "h", 9, "g", "h")
+	mustLockRangeStale(c, l, "e", "k", 9, "g", "j")
+	mustLockRangeSuccess(c, l, "g", "j", 1, math.MaxUint64)
+	unlockRange(l, "g", "j", 1, 2)
+	unlockRange(l, "c", "g", 10, 5)
+	unlockRange(l, "j", "n", 8, 8)
+	mustLockRangeSuccess(c, l, "a", "z", 11, 2)
+	unlockRange(l, "a", "z", 11, 2)
+}
+
+func (s *regionRangeLockSuit) TestRangeTsMap(c *check.C) {
+	m := NewRangeTsMap()
+
+	mustGetMin := func(startKey, endKey string, expectedTs uint64) {
+		ts := m.GetMin([]byte(startKey), []byte(endKey))
+		c.Assert(ts, check.Equals, expectedTs)
+	}
+	set := func(startKey, endKey string, ts uint64) {
+		m.Set([]byte(startKey), []byte(endKey), ts)
+	}
+
+	mustGetMin("a", "z", math.MaxUint64)
+	set("b", "e", 100)
+	mustGetMin("a", "z", 100)
+	mustGetMin("b", "e", 100)
+	mustGetMin("a", "c", 100)
+	mustGetMin("d", "f", 100)
+	mustGetMin("a", "b", math.MaxUint64)
+	mustGetMin("e", "f", math.MaxUint64)
+	mustGetMin("a", "b\x00", 100)
+
+	set("d", "g", 80)
+	mustGetMin("d", "g", 80)
+	mustGetMin("a", "z", 80)
+	mustGetMin("d", "e", 80)
+	mustGetMin("a", "d", 100)
+
+	set("c", "f", 120)
+	mustGetMin("c", "f", 120)
+	mustGetMin("c", "d", 120)
+	mustGetMin("d", "e", 120)
+	mustGetMin("e", "f", 120)
+	mustGetMin("b", "e", 100)
+	mustGetMin("a", "z", 80)
+
+	set("c", "f", 130)
+	mustGetMin("c", "f", 130)
+	mustGetMin("c", "d", 130)
+	mustGetMin("d", "e", 130)
+	mustGetMin("e", "f", 130)
+	mustGetMin("b", "e", 100)
+	mustGetMin("a", "z", 80)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR adds a util named RegionRangeLock, which is a simple range and can also maintains minimal checkpointTs by range and identify stale acquire-lock operation by checking the version of the region's epoch.

This PR is part of https://github.com/pingcap/ticdc/pull/385 , which supports region merge.

### What is changed and how it works?

Added new util RegionRangeLock.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - No.
