### PR TITLE
ci: add availability into the jenkins test

### DIFF
--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -1,4 +1,4 @@
-test_case_names = ["simple", "cdc", "multi_capture", "split_region", "row_format", "tiflash"]
+test_case_names = ["simple", "cdc", "multi_capture", "split_region", "row_format", "tiflash", "availability"]
 
 def prepare_binaries() {
     stage('Prepare Binaries') {


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

Add `availability` into the Jenkins integration test