### PR TITLE
Fix/capture suicide

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -669,9 +669,9 @@ func (o *Owner) startCaptureWatcher(ctx context.Context) {
 				if ctx.Err() != nil {
 					if errors.Cause(ctx.Err()) != context.Canceled {
 						// The context error indicates the termination of the owner
-						log.Error("watch processor failed", zap.Error(ctx.Err()))
+						log.Error("watch capture failed", zap.Error(ctx.Err()))
 					} else {
-						log.Info("watch processor exited")
+						log.Info("watch capture exited")
 					}
 					return
 				}

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.uber.org/zap"
@@ -140,7 +141,11 @@ func (s *Server) run(ctx context.Context) (err error) {
 			}
 			s.owner = owner
 			if err := owner.Run(ctx, ownerRunInterval); err != nil {
-				log.Error("run owner failed", zap.Error(err))
+				if errors.Cause(err) != context.Canceled {
+					log.Error("run owner failed", zap.Error(err))
+				} else {
+					log.Info("owner exited")
+				}
 				return
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When there is no task event for the capture, it can not suicide when its session expires.

### What is changed and how it works?

Use a `select ... case` to avoid blocking on watching events

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)