### PR TITLE
kv-client: support p-c out of order before initialized

### DIFF
--- a/cdc/kv/matcher.go
+++ b/cdc/kv/matcher.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/cdcpb"
 )
 
@@ -30,12 +29,12 @@ func (m *matcher) putPrewriteRow(row *cdcpb.Event_Row) {
 	m.unmatchedValue[newMatchKey(row)] = row.GetValue()
 }
 
-func (m *matcher) matchRow(row *cdcpb.Event_Row) ([]byte, error) {
+func (m *matcher) matchRow(row *cdcpb.Event_Row) ([]byte, bool) {
 	if value, exist := m.unmatchedValue[newMatchKey(row)]; exist {
 		delete(m.unmatchedValue, newMatchKey(row))
-		return value, nil
+		return value, true
 	}
-	return nil, errors.NotFoundf("prewrite row, startTs:%d", row.GetStartTs())
+	return nil, false
 }
 
 func (m *matcher) cacheCommitRow(row *cdcpb.Event_Row) {

--- a/cdc/kv/matcher.go
+++ b/cdc/kv/matcher.go
@@ -8,6 +8,7 @@ import (
 type matcher struct {
 	// TODO : clear the single prewrite
 	unmatchedValue map[matchKey][]byte
+	cachedCommit   []*cdcpb.Event_Row
 }
 
 type matchKey struct {
@@ -35,7 +36,14 @@ func (m *matcher) matchRow(row *cdcpb.Event_Row) ([]byte, error) {
 		return value, nil
 	}
 	return nil, errors.NotFoundf("prewrite row, startTs:%d", row.GetStartTs())
+}
 
+func (m *matcher) cacheCommitRow(row *cdcpb.Event_Row) {
+	m.cachedCommit = append(m.cachedCommit, row)
+}
+
+func (m *matcher) clearCacheCommit() {
+	m.cachedCommit = nil
 }
 
 func (m *matcher) rollbackRow(row *cdcpb.Event_Row) {

--- a/cdc/kv/matcher_test.go
+++ b/cdc/kv/matcher_test.go
@@ -29,13 +29,13 @@ func (s *MatcherSuite) TestMatcher(c *check.C) {
 		StartTs: 1,
 		Key:     []byte("k1"),
 	}
-	_, err := matcher.matchRow(commitRow1)
-	c.Assert(err, check.ErrorMatches, "*not found*")
+	_, ok := matcher.matchRow(commitRow1)
+	c.Assert(ok, check.IsFalse)
 	commitRow2 := &cdcpb.Event_Row{
 		StartTs: 2,
 		Key:     []byte("k1"),
 	}
-	value2, err := matcher.matchRow(commitRow2)
-	c.Assert(err, check.IsNil)
+	value2, ok := matcher.matchRow(commitRow2)
+	c.Assert(ok, check.IsTrue)
 	c.Assert(value2, check.BytesEquals, []byte("v2"))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

commit log may come before prewrite log, if the incremental scan has not finished.


### What is changed and how it works?

use a cache to store the unmatched commit log before initialized


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
