### PR TITLE
unittest: add failpoint for watchers

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	pd "github.com/pingcap/pd/v4/client"
 	"github.com/pingcap/ticdc/cdc/entry"
@@ -32,6 +33,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/mvcc"
 	"go.uber.org/zap"
 )
 
@@ -615,7 +617,11 @@ func (o *Owner) watchCapture(ctx context.Context) error {
 		clientv3.WithPrevKV())
 
 	for resp := range ch {
-		if resp.Err() != nil {
+		err := resp.Err()
+		failpoint.Inject("restart-capture-watch", func() {
+			err = mvcc.ErrCompacted
+		})
+		if err != nil {
 			return errors.Trace(resp.Err())
 		}
 		for _, ev := range resp.Events {

--- a/cdc/task_test.go
+++ b/cdc/task_test.go
@@ -167,7 +167,7 @@ func (s *taskSuite) TestWatch(c *check.C) {
 	ch := s.w.Watch(context.Background())
 
 	// Trigger the ErrCompacted error
-	failpoint.Enable("github.com/pingcap/ticdc/cdc.restart_task_watch", "50%off")
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc.restart_task_watch", "50%off"), check.IsNil)
 
 	// Put task changefeed-1
 	c.Assert(client.PutTaskStatus(s.c.Ctx(), "changefeed-1",

--- a/cdc/task_test.go
+++ b/cdc/task_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/etcd"
@@ -164,6 +165,9 @@ func (s *taskSuite) TestWatch(c *check.C) {
 
 	// Watch with a normal context
 	ch := s.w.Watch(context.Background())
+
+	// Trigger the ErrCompacted error
+	failpoint.Enable("github.com/pingcap/ticdc/cdc.restart_task_watch", "50%off")
 
 	// Put task changefeed-1
 	c.Assert(client.PutTaskStatus(s.c.Ctx(), "changefeed-1",

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
+	github.com/pingcap/failpoint v0.0.0-20200210140405-f8f9fb234798
 	github.com/pingcap/kvproto v0.0.0-20200330093347-98f910b71904
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
 	github.com/pingcap/parser v0.0.0-20200326020624-68d423641be5


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Closes #409 

Add failpoint for the task watcher and the capture watcher

### What is changed and how it works?

Add failpoint to trigger an ErrCompacted error

**Notice that the unit test for the capture watcher is not added, because the whole test file has been commented out.**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
