### PR TITLE
kv/client: Print log when region worker channel is stuck

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -977,23 +977,11 @@ func (s *eventFeedSession) receiveFromStream(
 				continue
 			}
 
-			hangTime := time.Duration(0)
-			ticker := time.NewTicker(time.Minute)
-		HangTimeCheckLoop:
-			for {
-				select {
-				case state.eventCh <- event:
-					break HangTimeCheckLoop
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-ticker.C:
-					hangTime += time.Minute
-					log.Warn("event received from tikv cannot be sent to region worker for too long time",
-						zap.String("addr", addr), zap.Uint64("regionID", event.GetRegionId()),
-						zap.Uint64("requestID", event.GetRequestId()), zap.Duration("duration", hangTime))
-				}
+			select {
+			case state.eventCh <- event:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
-			ticker.Stop()
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR tries to print some log when the channel to a region's worker cannot be sent or received for too long time.

But actually I'm not sure the performance overhead to create the timer.

### What is changed and how it works?

This PR tries to print some log when the channel to a region's worker cannot be sent or received for too long time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Example:
```
[2020/04/03 10:35:07.812 +00:00] [WARN] [client.go:1062] ["region not receiving event from tikv for too long time"] [regionID=8] [span="{\"Start\":\"bURETEpvYkxp/3N0AAAAAAAA+QAAAAAAAABs\",\"End\":\"bURETEpvYkxp/3N0AAAAAAAA+QAAAAAAAABt\"}"] [duration=5m0s]
[2020/04/03 10:35:07.815 +00:00] [WARN] [client.go:1062] ["region not receiving event from tikv for too long time"] [regionID=8] [span="{\"Start\":\"bURETEpvYkFk/2RJZHhMaXN0/wAAAAAAAAAA9wAAAAAAAABs\",\"End\":\"bURETEpvYkFk/2RJZHhMaXN0/wAAAAAAAAAA9wAAAAAAAABt\"}"] [duration=5m0s]
[2020/04/03 10:35:07.815 +00:00] [WARN] [client.go:1062] ["region not receiving event from tikv for too long time"] [regionID=8] [span="{\"Start\":\"bURETEpvYkxp/3N0AAAAAAAA+QAAAAAAAABs\",\"End\":\"bURETEpvYkxp/3N0AAAAAAAA+QAAAAAAAABt\"}"] [duration=5m0s]
[2020/04/03 10:35:07.815 +00:00] [WARN] [client.go:1062] ["region not receiving event from tikv for too long time"] [regionID=8] [span="{\"Start\":\"bURETEpvYkFk/2RJZHhMaXN0/wAAAAAAAAAA9wAAAAAAAABs\",\"End\":\"bURETEpvYkFk/2RJZHhMaXN0/wAAAAAAAAAA9wAAAAAAAABt\"}"] [duration=5m0s]
```

Code changes


Side effects

 - Possible performance regression

Related changes
