### PR TITLE
kv/client: Add backoff on regoin error

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -735,6 +735,8 @@ func (s *eventFeedSession) partialRegionFeed(
 
 	// We need to ensure when the error is handled, `isStopped` must be set. So set it before sending the error.
 	state.markStopped()
+	// Avoid too many kv clients retry at the same time.
+	time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
 	return s.onRegionFail(ctx, regionErrorInfo{
 		singleRegionInfo: state.sri,
 		err:              err,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR reduces the frequency of retrying when region meets error.

### What is changed and how it works?

Adds a simple sleep before continue handling the region error when the error occurs in `partialRegionFeed`. This significantly reduced NotLeader and RPCCtxUnavailable.
This mechanism used to exist before implementing batch streaming, but was removed when we were hurrying to finish the batch streaming. Add it back now.

By the way, since bugs shows up more frequently without this mechanism, I think it would be a good idea that we add a hidden config for it, so that we can skip the waiting and retry immediately when we are testing correctness of CDC, and in this way it's easier to trigger bugs.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

![image](https://user-images.githubusercontent.com/9948422/78654930-dee49900-78f7-11ea-817d-17d02b1a5e91.png)

(Left: before; Right: after).