### PR TITLE
kv-client: use correct region in log

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -770,17 +770,17 @@ func (s *eventFeedSession) divideAndSendEventFeedToRegions(
 				for _, region := range regions {
 					if region.GetMeta() == nil {
 						err = errors.New("meta not exists in region")
-						log.Warn("batch load region", zap.Reflect("span", nextSpan), zap.Reflect("regions", regions), zap.Error(err))
+						log.Warn("batch load region", zap.Reflect("span", nextSpan), zap.Error(err))
 						return err
 					}
 					metas = append(metas, region.GetMeta())
 				}
 				if !util.CheckRegionsLeftCover(metas, nextSpan) {
-					err = errors.New("regions not completely left cover span")
-					log.Warn("ScanRegions", zap.Reflect("span", nextSpan), zap.Reflect("regions", regions), zap.Error(err))
+					err = errors.Errorf("regions not completely left cover span, span %v regions: %v", nextSpan, metas)
+					log.Warn("ScanRegions", zap.Reflect("span", nextSpan), zap.Reflect("regions", metas), zap.Error(err))
 					return err
 				}
-				log.Debug("ScanRegions", zap.Reflect("span", nextSpan), zap.Reflect("regions", regions))
+				log.Debug("ScanRegions", zap.Reflect("span", nextSpan), zap.Reflect("regions", metas))
 				return nil
 			})
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
region information is not recorded correctly when `regions not completely left cover span` error happens

### What is changed and how it works?
record the region meta

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test