### PR TITLE
sink: add retry mechanism for dml execution

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -36,6 +37,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/util"
 	tddl "github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/infoschema"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
@@ -62,6 +64,9 @@ type mysqlSink struct {
 	unresolvedRows   map[string][]*model.RowChangedEvent
 
 	count uint64
+
+	metricExecTxnHis   prometheus.Observer
+	metricExecBatchHis prometheus.Observer
 }
 
 func (s *mysqlSink) EmitResolvedEvent(ctx context.Context, ts uint64) error {
@@ -336,6 +341,9 @@ func newMySQLSink(sinkURI *url.URL, dsn *dmysql.Config, filter *util.Filter, opt
 	sink.db.SetMaxIdleConns(params.workerCount)
 	sink.db.SetMaxOpenConns(params.workerCount)
 
+	sink.metricExecTxnHis = execTxnHistogram.WithLabelValues(params.captureID, params.changefeedID)
+	sink.metricExecBatchHis = execBatchHistogram.WithLabelValues(params.captureID, params.changefeedID)
+
 	return sink, nil
 }
 
@@ -429,13 +437,43 @@ func (s *mysqlSink) PrintStatus(ctx context.Context) error {
 	}
 }
 
-func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent) error {
-	startTime := time.Now()
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
+func (s *mysqlSink) execDMLWithMaxRetries(ctx context.Context, sqls []string, values [][]interface{}, maxRetries uint64) error {
+	checkTxnErr := func(err error) error {
+		if errors.Cause(err) == context.Canceled {
+			return backoff.Permanent(err)
+		}
 		return errors.Trace(err)
 	}
+	return retry.Run(500*time.Millisecond, maxRetries,
+		func() error {
+			startTime := time.Now()
+			tx, err := s.db.BeginTx(ctx, nil)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			for i, query := range sqls {
+				args := values[i]
+				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+					return checkTxnErr(err)
+				}
+				log.Debug("exec row", zap.String("sql", query), zap.Any("args", args))
+			}
+			if err = tx.Commit(); err != nil {
+				return checkTxnErr(err)
+			}
+			s.metricExecTxnHis.Observe(time.Since(startTime).Seconds())
+			s.metricExecBatchHis.Observe(float64(len(sqls)))
+			atomic.AddUint64(&s.count, uint64(len(sqls)))
+			log.Debug("Exec Rows succeeded", zap.String("changefeed", s.params.changefeedID), zap.Int("num of Rows", len(sqls)))
+			return nil
+		},
+	)
+}
 
+// prepareDMLs converts model.RowChangedEvent list to query string list and args list
+func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent) ([]string, [][]interface{}, error) {
+	sqls := make([]string, 0, len(rows))
+	values := make([][]interface{}, 0, len(rows))
 	for _, row := range rows {
 		var query string
 		var args []interface{}
@@ -446,29 +484,20 @@ func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent)
 			query, args, err = s.prepareReplace(row.Schema, row.Table, row.Columns)
 		}
 		if err != nil {
-			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Error("Failed to rollback", zap.Error(err))
-			}
-			return errors.Trace(err)
+			return nil, nil, errors.Trace(err)
 		}
-		log.Debug("exec row", zap.String("sql", query), zap.Any("args", args))
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Error("Failed to rollback", zap.String("sql", query), zap.Error(err))
-			}
-			log.Info("exec row failed", zap.String("sql", query), zap.Any("args", args))
-			return errors.Annotatef(err, "row commitTs: %d", row.Ts)
-		}
+		sqls = append(sqls, query)
+		values = append(values, args)
 	}
+	return sqls, values, nil
+}
 
-	if err = tx.Commit(); err != nil {
+func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent) error {
+	sqls, values, err := s.prepareDMLs(rows)
+	if err != nil {
 		return errors.Trace(err)
 	}
-	execTxnHistogram.WithLabelValues(s.params.captureID, s.params.changefeedID).Observe(time.Since(startTime).Seconds())
-	execBatchHistogram.WithLabelValues(s.params.captureID, s.params.changefeedID).Observe(float64(len(rows)))
-	atomic.AddUint64(&s.count, uint64(len(rows)))
-	log.Debug("Exec Rows succeeded", zap.Int("num of Rows", len(rows)))
-	return nil
+	return errors.Trace(s.execDMLWithMaxRetries(ctx, sqls, values, 10))
 }
 
 func (s *mysqlSink) prepareReplace(schema, table string, cols map[string]*model.Column) (string, []interface{}, error) {

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -1,4 +1,4 @@
-test_case_names = ["simple", "cdc", "multi_capture", "split_region", "row_format", "tiflash", "availability", "ddl_sequence"]
+test_case_names = ["simple", "cdc", "multi_capture", "split_region", "row_format", "tiflash", "availability", "ddl_sequence", "sink_retry"]
 
 def prepare_binaries() {
     stage('Prepare Binaries') {

--- a/tests/sink_retry/conf/diff_config.toml
+++ b/tests/sink_retry/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "sink_retry"
+    tables = ["usertable"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/sink_retry/conf/workload
+++ b/tests/sink_retry/conf/workload
@@ -1,0 +1,13 @@
+threadcount=2
+recordcount=10
+operationcount=0
+workload=core
+
+readallfields=true
+
+readproportion=0
+updateproportion=0
+scanproportion=0
+insertproportion=0
+
+requestdistribution=uniform

--- a/tests/sink_retry/run.sh
+++ b/tests/sink_retry/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+CDC_COUNT=3
+DB_COUNT=4
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+    start_tidb_cluster $WORK_DIR
+
+    cd $WORK_DIR
+
+    # record tso before we create tables to skip the system table DDLs
+    start_ts=$(cdc cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
+    go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=sink_retry
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/sink/MySQLSinkTxnRandomError=2%return(true)'
+    run_cdc_server $WORK_DIR $CDC_BINARY
+
+    TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        mysql) ;&
+        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+    esac
+    cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+
+    check_table_exists "sink_retry.USERTABLE" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=sink_retry
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/sink_retry/run.sh
+++ b/tests/sink_retry/run.sh
@@ -18,10 +18,10 @@ function run() {
 
     cd $WORK_DIR
 
-    # record tso before we create tables to skip the system table DDLs
     start_ts=$(cdc cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
+    run_sql "CREATE DATABASE sink_retry;"
     go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=sink_retry
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/sink/MySQLSinkTxnRandomError=2%return(true)'
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sink/MySQLSinkTxnRandomError=5%return(true)'
     run_cdc_server $WORK_DIR $CDC_BINARY
 
     TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We have no retry mechanism in MySQL sink, as our DML SQLs in MySQL sink are reentrant, we can simply retry on errors.

### What is changed and how it works?

retry when transaction execution meets error in MySQL sink

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
