### PR TITLE
schema: fix snapshot getter blocks too long when cdc exits

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -146,7 +146,7 @@ func (m *mounterImpl) codecWorker(ctx context.Context) error {
 			continue
 		}
 		startTime := time.Now()
-		rowEvent, err := m.unmarshalAndMountRowChanged(pEvent.RawKV)
+		rowEvent, err := m.unmarshalAndMountRowChanged(ctx, pEvent.RawKV)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -177,7 +177,7 @@ func (m *mounterImpl) collectMetrics(ctx context.Context) {
 	}
 }
 
-func (m *mounterImpl) unmarshalAndMountRowChanged(raw *model.RawKVEntry) (*model.RowChangedEvent, error) {
+func (m *mounterImpl) unmarshalAndMountRowChanged(ctx context.Context, raw *model.RawKVEntry) (*model.RowChangedEvent, error) {
 	if !bytes.HasPrefix(raw.Key, tablePrefix) {
 		return nil, nil
 	}
@@ -190,7 +190,7 @@ func (m *mounterImpl) unmarshalAndMountRowChanged(raw *model.RawKVEntry) (*model
 		TableID: tableID,
 		Delete:  raw.OpType == model.OpTypeDelete,
 	}
-	snap, err := m.schemaStorage.GetSnapshot(raw.Ts)
+	snap, err := m.schemaStorage.GetSnapshot(ctx, raw.Ts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When we have workload in upstream and kill CDC server, the server doesn't exit immediately but hangs.

```
goroutine 549 [select]:
github.com/cenkalti/backoff.RetryNotify(0xc00131ac20, 0x23d3c20, 0xc007ab1600, 0x0, 0x0, 0x0)
        github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:60 +0x1e6
github.com/cenkalti/backoff.Retry(...)
        github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:24
github.com/pingcap/ticdc/pkg/retry.Run(0x989680, 0x19, 0xc00131ac78, 0xc00279b1a9, 0xa)
        github.com/pingcap/ticdc@/pkg/retry/retry.go:30 +0xb8
github.com/pingcap/ticdc/cdc/entry.(*SchemaStorage).GetSnapshot(0xc0014425c0, 0x5c5c9dbee50066b, 0x20, 0xc00279b1a9, 0xa)
        github.com/pingcap/ticdc@/cdc/entry/schema_storage.go:579 +0x81
github.com/pingcap/ticdc/cdc/entry.(*mounterImpl).unmarshalAndMountRowChanged(0xc00143ba30, 0xc00900e980, 0x3a9e560, 0x1, 0x1)
        github.com/pingcap/ticdc@/cdc/entry/mounter.go:193 +0x102
github.com/pingcap/ticdc/cdc/entry.(*mounterImpl).codecWorker(0xc00143ba30, 0x2401ca0, 0xc0000ca6c0, 0x0, 0x0)
        github.com/pingcap/ticdc@/cdc/entry/mounter.go:149 +0x30d
github.com/pingcap/ticdc/cdc/entry.(*mounterImpl).Run.func2(0xc00109f768, 0x0)
        github.com/pingcap/ticdc@/cdc/entry/mounter.go:125 +0x3c
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc001146450, 0xc000b7aa00)
        golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:57 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
        golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:54 +0x66
```

### What is changed and how it works?

add `context` control to `schemaStorage.GetSnapshot`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test