### PR TITLE
kv-client: increase upper limit of retry count.

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	dialTimeout               = 10 * time.Second
-	maxRetry                  = 10
+	maxRetry                  = 100
 	tikvRequestMaxBackoff     = 20000 // Maximum total sleep time(in ms)
 	grpcInitialWindowSize     = 1 << 30
 	grpcInitialConnWindowSize = 1 << 30
@@ -283,7 +283,7 @@ func (c *CDCClient) getConn(ctx context.Context, addr string) (*grpc.ClientConn,
 }
 
 func (c *CDCClient) newStream(ctx context.Context, addr string) (stream cdcpb.ChangeData_EventFeedClient, err error) {
-	err = retry.Run(500*time.Millisecond, 10, func() error {
+	err = retry.Run(50*time.Millisecond, 20, func() error {
 		conn, err := c.getConn(ctx, addr)
 		if err != nil {
 			return errors.Trace(err)
@@ -757,7 +757,7 @@ func (s *eventFeedSession) divideAndSendEventFeedToRegions(
 			regions []*tikv.Region
 			err     error
 		)
-		retryErr := retry.Run(500*time.Millisecond, maxRetry,
+		retryErr := retry.Run(50*time.Millisecond, maxRetry,
 			func() error {
 				scanT0 := time.Now()
 				bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -43,8 +43,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const defaultWorkerCount = 16
-const defaultMaxTxnRow = 256
+const (
+	defaultWorkerCount     = 16
+	defaultMaxTxnRow       = 256
+	defaultDMLMaxRetryTime = 20
+	defaultDDLMaxRetryTime = 20
+)
 
 var (
 	printStatusInterval = 30 * time.Second
@@ -114,7 +118,7 @@ func (s *mysqlSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 		)
 		return nil
 	}
-	err := s.execDDLWithMaxRetries(ctx, ddl, 5)
+	err := s.execDDLWithMaxRetries(ctx, ddl, defaultDDLMaxRetryTime)
 	return errors.Trace(err)
 }
 
@@ -502,7 +506,7 @@ func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(s.execDMLWithMaxRetries(ctx, sqls, values, 10))
+	return errors.Trace(s.execDMLWithMaxRetries(ctx, sqls, values, defaultDMLMaxRetryTime))
 }
 
 func (s *mysqlSink) prepareReplace(schema, table string, cols map[string]*model.Column) (string, []interface{}, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`ScanRegions` API of PD may return incorrect information in some extreme cases, it is better to retry more than returns an error in kv client

### What is changed and how it works?

increase the upper limit of retry count


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
