### PR TITLE
fix owner panic when update task status failed

### DIFF
--- a/cdc/roles/storage/etcd.go
+++ b/cdc/roles/storage/etcd.go
@@ -268,7 +268,7 @@ func (ow *OwnerTaskStatusEtcdWriter) Write(
 			log.Info("outdated table infos, update table and retry")
 			newInfo, err = ow.updateInfo(ctx, changefeedID, captureID, info)
 			switch errors.Cause(err) {
-			case model.ErrFindPLockNotCommit:
+			case model.ErrFindPLockNotCommit, model.ErrTaskStatusNotExists:
 				return backoff.Permanent(err)
 			case nil:
 				return errors.Trace(model.ErrWriteTaskStatusConlict)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/443

### What is changed and how it works?

`TaskStatus` may be deleted during owner update task status.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test