### PR TITLE
schema: recount ineligible table set when start the changefeed

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -151,6 +151,7 @@ func (o *Owner) newChangeFeed(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	schemaStorage.FlushIneligibleTables()
 
 	ddlHandler := newDDLHandler(o.pdClient, kvStore, checkpointTs)
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -288,6 +288,7 @@ func verifyTables(ctx context.Context, cfg *util.ReplicaConfig) (ineligibleTable
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	schemaStorage.FlushIneligibleTables()
 
 	snap := schemaStorage.GetLastSnapshot()
 	for tID, tableName := range snap.CloneTables() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
recount ineligible table set when start the changefeed

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test