### PR TITLE
kvclient: Reduce unnecessary operations when start a event feed

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -113,9 +113,9 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	wch := taskWatcher.Watch(ctx)
 	for {
 		// Panic when the session is done unexpectedly, it means the
-		// server does not send heatbeats in time, or network interrupted
-		// In this case, the state of the capture is underminded,
-		// the task may have or have not been reblanced, the owner
+		// server does not send heartbeats in time, or network interrupted
+		// In this case, the state of the capture is undermined,
+		// the task may have or have not been rebalanced, the owner
 		// may be or not be held. It is unsafe to let goroutines
 		// continue, especially the goroutine to replicate data.
 		select {

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1024,6 +1024,7 @@ func (s *eventFeedSession) singleEventFeed(
 	matcher := newMatcher()
 	advanceCheckTicker := time.NewTicker(time.Second * 5)
 	lastReceivedEventTime := time.Now()
+	startFeedTime := time.Now()
 	var lastResolvedTs uint64
 
 	for {
@@ -1033,6 +1034,9 @@ func (s *eventFeedSession) singleEventFeed(
 		case <-ctx.Done():
 			return atomic.LoadUint64(&checkpointTs), ctx.Err()
 		case <-advanceCheckTicker.C:
+			if time.Since(startFeedTime) < 20*time.Second {
+				continue
+			}
 			sinceLastEvent := time.Since(lastReceivedEventTime)
 			if sinceLastEvent > time.Second*20 {
 				log.Warn("region not receiving event from tikv for too long time",

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -480,9 +480,11 @@ loop:
 			return ctx.Err()
 		case <-time.After(tickTime):
 			err := o.run(ctx)
-			// owner may be evicted during running, ignore the context canceled error directly
-			if err != nil && errors.Cause(err) != context.Canceled {
-				return err
+			if err != nil {
+				if errors.Cause(err) != context.Canceled {
+					log.Error("owner exited with error", zap.Error(err))
+				}
+				break loop
 			}
 		}
 	}

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -623,6 +623,7 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 	log.Debug("Add table", zap.Int64("tableID", tableID), zap.Uint64("startTs", startTs))
 	if _, ok := p.tables[tableID]; ok {
 		log.Warn("Ignore existing table", zap.Int64("ID", tableID))
+		return
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -121,7 +121,7 @@ func (s *Server) run(ctx context.Context) (err error) {
 			// the parent caller
 			err = ErrSuicide
 		} else if r != nil {
-			panic(r)
+			log.Error("server exited with panic", zap.Reflect("panic info", r))
 		}
 	}()
 	defer cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Reduce unnecessary operations when start a event feed

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test