### PR TITLE
Support file sort in puller

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -24,6 +24,15 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 )
 
+// SortEngine is the sorter engine
+type SortEngine string
+
+// sort engines
+const (
+	SortInMemory SortEngine = "memory"
+	SortInFile   SortEngine = "file"
+)
+
 // ChangeFeedInfo describes the detail of a ChangeFeed
 type ChangeFeedInfo struct {
 	SinkURI    string            `json:"sink-uri"`
@@ -35,6 +44,8 @@ type ChangeFeedInfo struct {
 	TargetTs uint64 `json:"target-ts"`
 	// used for admin job notification, trigger watch event in capture
 	AdminJobType AdminJobType `json:"admin-job-type"`
+	Engine       SortEngine   `json:"sort-engine"`
+	SortDir      string       `json:"sort-dir"`
 
 	Config *util.ReplicaConfig `json:"config"`
 }

--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -19,10 +19,10 @@ import (
 
 // PolymorphicEvent describes a event can be in multiple states
 type PolymorphicEvent struct {
-	Ts       uint64           `json:"t"`
-	RawKV    *RawKVEntry      `json:"-"`
-	Row      *RowChangedEvent `json:"r"`
-	Finished chan struct{}    `json:"-"`
+	Ts       uint64
+	RawKV    *RawKVEntry
+	Row      *RowChangedEvent
+	finished chan struct{}
 }
 
 // NewPolymorphicEvent creates a new PolymorphicEvent with a raw KV
@@ -33,7 +33,7 @@ func NewPolymorphicEvent(rawKV *RawKVEntry) *PolymorphicEvent {
 	return &PolymorphicEvent{
 		Ts:       rawKV.Ts,
 		RawKV:    rawKV,
-		Finished: make(chan struct{}),
+		finished: make(chan struct{}),
 	}
 }
 
@@ -43,25 +43,25 @@ func NewResolvedPolymorphicEvent(ts uint64) *PolymorphicEvent {
 		Ts:       ts,
 		RawKV:    &RawKVEntry{Ts: ts, OpType: OpTypeResolved},
 		Row:      &RowChangedEvent{Ts: ts, Resolved: true},
-		Finished: nil,
+		finished: nil,
 	}
 }
 
 // PrepareFinished marks the prepare process is finished
 // In prepare process, Mounter will translate raw KV to row data
 func (e *PolymorphicEvent) PrepareFinished() {
-	if e.Finished != nil {
-		close(e.Finished)
+	if e.finished != nil {
+		close(e.finished)
 	}
 }
 
 // WaitPrepare waits for prepare process finished
 func (e *PolymorphicEvent) WaitPrepare(ctx context.Context) error {
-	if e.Finished != nil {
+	if e.finished != nil {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-e.Finished:
+		case <-e.finished:
 		}
 	}
 	return nil

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -12,18 +12,18 @@ import (
 
 // RowChangedEvent represents a row changed event
 type RowChangedEvent struct {
-	Ts       uint64 `json:"t"`
-	Resolved bool   `json:"r"`
+	Ts       uint64
+	Resolved bool
 
-	Schema string `json:"s"`
-	Table  string `json:"a"`
+	Schema string
+	Table  string
 
-	Delete bool `json:"d"`
+	Delete bool
 
 	// if the table of this row only has one unique index(includes primary key),
 	// IndieMarkCol will be set to the name of the unique index
-	IndieMarkCol string             `json:"i"`
-	Columns      map[string]*Column `json:"c"`
+	IndieMarkCol string
+	Columns      map[string]*Column
 }
 
 // ToMqMessage transforms to message key and value

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -12,18 +12,18 @@ import (
 
 // RowChangedEvent represents a row changed event
 type RowChangedEvent struct {
-	Ts       uint64
-	Resolved bool
+	Ts       uint64 `json:"t"`
+	Resolved bool   `json:"r"`
 
-	Schema string
-	Table  string
+	Schema string `json:"s"`
+	Table  string `json:"a"`
 
-	Delete bool
+	Delete bool `json:"d"`
 
 	// if the table of this row only has one unique index(includes primary key),
 	// IndieMarkCol will be set to the name of the unique index
-	IndieMarkCol string
-	Columns      map[string]*Column
+	IndieMarkCol string             `json:"i"`
+	Columns      map[string]*Column `json:"c"`
 }
 
 // ToMqMessage transforms to message key and value

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -636,15 +636,24 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 	// The key in DML kv pair returned from TiKV is not memcompariable encoded,
 	// so we set `needEncode` to true.
 	span := util.GetTableSpan(tableID, true)
-	sorter := puller.NewEntrySorter()
-	puller := puller.NewPuller(p.pdCli, p.kvStorage, startTs, []util.Span{span}, true, p.limitter)
-
+	plr := puller.NewPuller(p.pdCli, p.kvStorage, startTs, []util.Span{span}, true, p.limitter)
 	go func() {
-		err := puller.Run(ctx)
+		err := plr.Run(ctx)
 		if errors.Cause(err) != context.Canceled {
 			p.errCh <- err
 		}
 	}()
+
+	var sorter puller.EventSorter
+	switch p.changefeed.Engine {
+	case model.SortInMemory:
+		sorter = puller.NewEntrySorter()
+	case model.SortInFile:
+		sorter = puller.NewFileSorter(p.changefeed.SortDir)
+	default:
+		p.errCh <- errors.Errorf("unknown sort engine %s", p.changefeed.Engine)
+		return
+	}
 
 	go func() {
 		err := sorter.Run(ctx)
@@ -661,12 +670,12 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 					p.errCh <- ctx.Err()
 				}
 				return
-			case rawKV := <-puller.Output():
+			case rawKV := <-plr.Output():
 				if rawKV == nil {
 					continue
 				}
 				pEvent := model.NewPolymorphicEvent(rawKV)
-				sorter.AddEntry(pEvent)
+				sorter.AddEntry(ctx, pEvent)
 				select {
 				case <-ctx.Done():
 					if errors.Cause(ctx.Err()) != context.Canceled {
@@ -679,7 +688,7 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 				if pEvent == nil {
 					continue
 				}
-				if pEvent.RawKV.OpType == model.OpTypeResolved {
+				if pEvent.RawKV != nil && pEvent.RawKV.OpType == model.OpTypeResolved {
 					table.storeResolvedTS(pEvent.Ts)
 					continue
 				}

--- a/cdc/puller/entry_sorter.go
+++ b/cdc/puller/entry_sorter.go
@@ -150,7 +150,7 @@ func (es *EntrySorter) Run(ctx context.Context) error {
 }
 
 // AddEntry adds an RawKVEntry to the EntryGroup
-func (es *EntrySorter) AddEntry(entry *model.PolymorphicEvent) {
+func (es *EntrySorter) AddEntry(ctx context.Context, entry *model.PolymorphicEvent) {
 	if atomic.LoadInt32(&es.closed) != 0 {
 		return
 	}
@@ -198,7 +198,7 @@ func SortOutput(ctx context.Context, input <-chan *model.RawKVEntry) <-chan *mod
 				if rawKV == nil {
 					continue
 				}
-				sorter.AddEntry(model.NewPolymorphicEvent(rawKV))
+				sorter.AddEntry(ctx, model.NewPolymorphicEvent(rawKV))
 			case sorted := <-sorter.Output():
 				if sorted != nil {
 					output(sorted.RawKV)

--- a/cdc/puller/entry_sorter_test.go
+++ b/cdc/puller/entry_sorter_test.go
@@ -101,9 +101,9 @@ func (s *mockEntrySorterSuite) TestEntrySorter(c *check.C) {
 	}()
 	for _, tc := range testCases {
 		for _, entry := range tc.input {
-			es.AddEntry(model.NewPolymorphicEvent(entry))
+			es.AddEntry(ctx, model.NewPolymorphicEvent(entry))
 		}
-		es.AddEntry(model.NewResolvedPolymorphicEvent(tc.resolvedTs))
+		es.AddEntry(ctx, model.NewResolvedPolymorphicEvent(tc.resolvedTs))
 		for i := 0; i < len(tc.expect); i++ {
 			e := <-es.Output()
 			c.Check(e.RawKV, check.DeepEquals, tc.expect[i])
@@ -134,11 +134,11 @@ func (s *mockEntrySorterSuite) TestEntrySorterRandomly(c *check.C) {
 					Ts:     uint64(int64(resolvedTs) + rand.Int63n(int64(maxTs-resolvedTs))),
 					OpType: opType,
 				}
-				es.AddEntry(model.NewPolymorphicEvent(entry))
+				es.AddEntry(ctx, model.NewPolymorphicEvent(entry))
 			}
-			es.AddEntry(model.NewResolvedPolymorphicEvent(resolvedTs))
+			es.AddEntry(ctx, model.NewResolvedPolymorphicEvent(resolvedTs))
 		}
-		es.AddEntry(model.NewResolvedPolymorphicEvent(maxTs))
+		es.AddEntry(ctx, model.NewResolvedPolymorphicEvent(maxTs))
 	}()
 	var lastTs uint64
 	var resolvedTs uint64
@@ -186,11 +186,11 @@ func BenchmarkSorter(b *testing.B) {
 					Ts:     uint64(int64(resolvedTs) + rand.Int63n(1000)),
 					OpType: opType,
 				}
-				es.AddEntry(model.NewPolymorphicEvent(entry))
+				es.AddEntry(ctx, model.NewPolymorphicEvent(entry))
 			}
-			es.AddEntry(model.NewResolvedPolymorphicEvent(resolvedTs))
+			es.AddEntry(ctx, model.NewResolvedPolymorphicEvent(resolvedTs))
 		}
-		es.AddEntry(model.NewResolvedPolymorphicEvent(maxTs))
+		es.AddEntry(ctx, model.NewResolvedPolymorphicEvent(maxTs))
 	}()
 	var resolvedTs uint64
 	for entry := range es.Output() {

--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -1,0 +1,439 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package puller
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+var (
+	defaultInitFileCount        = 10
+	defaultFileSizeLimit uint64 = 1 << 31 // 2GB per file at most
+)
+
+type fileCache struct {
+	fileLock          sync.Mutex
+	sorting           int32
+	toRemoveFiles     []string
+	unsortedFiles     []string
+	lastSortedFile    string
+	availableFileIdx  []int
+	availableFileSize map[int]uint64
+}
+
+func newFileCache() *fileCache {
+	cache := &fileCache{
+		toRemoveFiles:     make([]string, 0, defaultInitFileCount),
+		unsortedFiles:     make([]string, 0, defaultInitFileCount),
+		availableFileIdx:  make([]int, 0, defaultInitFileCount),
+		availableFileSize: make(map[int]uint64, defaultInitFileCount),
+	}
+	cache.extendUnsortFiles()
+	return cache
+}
+
+func (cache *fileCache) resetUnsortedFiles() {
+	cache.unsortedFiles = make([]string, 0, defaultInitFileCount)
+	cache.availableFileIdx = make([]int, 0, defaultInitFileCount)
+	cache.availableFileSize = make(map[int]uint64, defaultInitFileCount)
+}
+
+func (cache *fileCache) extendUnsortFiles() {
+	fileCountBefore := len(cache.unsortedFiles)
+	for i := fileCountBefore; i < fileCountBefore+defaultInitFileCount; i++ {
+		cache.unsortedFiles = append(cache.unsortedFiles, randomFileName("unsorted"))
+		cache.availableFileIdx = append(cache.availableFileIdx, i)
+		cache.availableFileSize[i] = 0
+	}
+}
+
+// next selects a random file from unsorted files which size is no more than defaultFileSizeLimit
+// if no more available unsorted file, create some new unsorted files
+func (cache *fileCache) next() (int, string) {
+	if len(cache.availableFileIdx) == 0 {
+		cache.extendUnsortFiles()
+	}
+	idx := rand.Intn(len(cache.availableFileIdx))
+	return idx, cache.unsortedFiles[cache.availableFileIdx[idx]]
+}
+
+// increase records new file size of an unsorted file. If the file size exceeds
+// defaultFileSizeLimit after increasing, remove this file from availableFileIdx
+func (cache *fileCache) increase(idx, size int) {
+	fileIdx := cache.availableFileIdx[idx]
+	cache.availableFileSize[fileIdx] += uint64(size)
+	if cache.availableFileSize[fileIdx] > defaultFileSizeLimit {
+		cache.availableFileIdx = append(cache.availableFileIdx[:idx], cache.availableFileIdx[idx+1:]...)
+		delete(cache.availableFileSize, fileIdx)
+	}
+}
+
+// FileSorter accepts out-of-order raw kv entries, sort in local file system
+// and output sorted entries
+type FileSorter struct {
+	dir      string
+	outputCh chan *model.PolymorphicEvent
+	inputCh  chan *model.PolymorphicEvent
+	cache    *fileCache
+}
+
+// flushEventsToFile writes a slice of model.PolymorphicEvent to a given file in sequence
+func flushEventsToFile(ctx context.Context, fullpath string, entries []*model.PolymorphicEvent) (int, error) {
+	if len(entries) == 0 {
+		return 0, nil
+	}
+	buf := bytes.NewBuffer([]byte{})
+	var dataLen [8]byte
+	for _, entry := range entries {
+		err := entry.WaitPrepare(ctx)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		binary.BigEndian.PutUint64(dataLen[:], uint64(len(data)))
+		buf.Write(dataLen[:])
+		buf.Write(data)
+	}
+	f, err := os.OpenFile(fullpath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	w := bufio.NewWriter(f)
+	_, err = w.Write(buf.Bytes())
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	err = w.Flush()
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return buf.Len(), nil
+}
+
+// NewFileSorter creates a new FileSorter
+func NewFileSorter(dir string) *FileSorter {
+	fs := &FileSorter{
+		dir:      dir,
+		outputCh: make(chan *model.PolymorphicEvent, 128000),
+		inputCh:  make(chan *model.PolymorphicEvent, 128000),
+		cache:    newFileCache(),
+	}
+	return fs
+}
+
+// flush writes a slice of model.PolymorphicEvent to a random unsorted file in sequence
+func (fs *FileSorter) flush(ctx context.Context, entries []*model.PolymorphicEvent) error {
+	fs.cache.fileLock.Lock()
+	defer fs.cache.fileLock.Unlock()
+	idx, filename := fs.cache.next()
+	fpath := filepath.Join(fs.dir, filename)
+	dataLen, err := flushEventsToFile(ctx, fpath, entries)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	fs.cache.increase(idx, dataLen)
+	return nil
+}
+
+// sortItem is used in PolymorphicEvent merge procedure from sorted files
+type sortItem struct {
+	entry     *model.PolymorphicEvent
+	fileIndex int
+}
+
+type sortHeap []*sortItem
+
+func (h sortHeap) Len() int           { return len(h) }
+func (h sortHeap) Less(i, j int) bool { return h[i].entry.Ts < h[j].entry.Ts }
+func (h sortHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *sortHeap) Push(x interface{}) {
+	*h = append(*h, x.(*sortItem))
+}
+func (h *sortHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	old[n-1] = nil
+	*h = old[0 : n-1]
+	return x
+}
+
+// readPolymorphicEvent reads a PolymorphicEvent from file reader and also advance reader
+// TODO: batch read
+func readPolymorphicEvent(rd *bufio.Reader) (*model.PolymorphicEvent, error) {
+	var byteLen [8]byte
+	n, err := rd.Read(byteLen[:])
+	if err != nil {
+		if err == io.EOF {
+			return nil, nil
+		}
+		return nil, errors.Trace(err)
+	}
+	if n < 8 {
+		return nil, errors.Errorf("invalid lenth data %s", byteLen)
+	}
+	dataLen := int(binary.BigEndian.Uint64(byteLen[:]))
+
+	data := make([]byte, dataLen)
+	n, err = io.ReadFull(rd, data)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if n != dataLen {
+		return nil, errors.Errorf("truncated data %s n: %d dataLen: %d", data, n, dataLen)
+	}
+
+	ev := &model.PolymorphicEvent{}
+	err = json.Unmarshal(data, &ev)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return ev, nil
+}
+
+func (fs *FileSorter) output(ctx context.Context, entry *model.PolymorphicEvent) {
+	select {
+	case <-ctx.Done():
+		return
+	case fs.outputCh <- entry:
+	}
+}
+
+func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
+	// sortSingleFile reads an unsorted file into memory, sort in memory and rewritten
+	// sorted events ta a new file.
+	sortSingleFile := func(ctx context.Context, filename string) (string, error) {
+		_, err := os.Stat(filename)
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		data, err := ioutil.ReadFile(filepath.Join(fs.dir, filename))
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		evs := make([]*model.PolymorphicEvent, 0)
+		idx := 0
+		for idx < len(data) {
+			dataLen := int(binary.BigEndian.Uint64(data[idx : idx+8]))
+			if idx+8+dataLen > len(data) {
+				return "", errors.New("unsorted file unexpected truncated")
+			}
+			ev := &model.PolymorphicEvent{}
+			err := json.Unmarshal(data[idx+8:idx+8+dataLen], &ev)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			evs = append(evs, ev)
+			idx = idx + 8 + dataLen
+		}
+		sort.Slice(evs, func(i, j int) bool {
+			return evs[i].Ts < evs[j].Ts
+		})
+		batchFlushSize := 10
+		newfile := randomFileName("sorted")
+		newfpath := filepath.Join(fs.dir, newfile)
+		buffer := make([]*model.PolymorphicEvent, 0, batchFlushSize)
+		for _, entry := range evs {
+			buffer = append(buffer, entry)
+			if len(buffer) >= batchFlushSize {
+				_, err := flushEventsToFile(ctx, newfpath, buffer)
+				if err != nil {
+					return "", errors.Trace(err)
+				}
+				buffer = make([]*model.PolymorphicEvent, 0, batchFlushSize)
+			}
+		}
+		if len(buffer) > 0 {
+			_, err := flushEventsToFile(ctx, newfpath, buffer)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+		}
+		return newfile, nil
+	}
+
+	// clear and reset unsorted files, set cache sorting flag to prevent repeated sort
+	fs.cache.fileLock.Lock()
+	if atomic.LoadInt32(&fs.cache.sorting) == 1 {
+		fs.cache.fileLock.Unlock()
+		return nil
+	}
+	atomic.StoreInt32(&fs.cache.sorting, 1)
+	files := make([]string, len(fs.cache.unsortedFiles))
+	copy(files, fs.cache.unsortedFiles)
+	fs.cache.resetUnsortedFiles()
+	fs.cache.fileLock.Unlock()
+
+	// prepare buffer reader of all sorted files
+	readers := make([]*bufio.Reader, 0, len(files)+1)
+	for _, f := range files {
+		sortedFile, err := sortSingleFile(ctx, f)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if sortedFile == "" {
+			continue
+		}
+		fd, err := os.Open(filepath.Join(fs.dir, sortedFile))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rd := bufio.NewReader(fd)
+		readers = append(readers, rd)
+	}
+	if fs.cache.lastSortedFile != "" {
+		fd, err := os.Open(filepath.Join(fs.dir, fs.cache.lastSortedFile))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rd := bufio.NewReader(fd)
+		readers = append(readers, rd)
+	}
+
+	// merge data from all sorted files, output events with ts less than resolvedTs,
+	// the rest events will be rewritten into the new lastSortedFile
+	h := &sortHeap{}
+	heap.Init(h)
+	for i, fd := range readers {
+		ev, err := readPolymorphicEvent(fd)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if ev == nil {
+			continue
+		}
+		heap.Push(h, &sortItem{entry: ev, fileIndex: i})
+	}
+	lastSortedFileIsUsed := false
+	newLastSortedFile := randomFileName("last-sorted")
+	bufferLen := 10
+	buffer := make([]*model.PolymorphicEvent, 0, bufferLen)
+	for h.Len() > 0 {
+		item := heap.Pop(h).(*sortItem)
+		if item.entry.Ts <= resolvedTs {
+			fs.output(ctx, item.entry)
+		} else {
+			lastSortedFileIsUsed = true
+			buffer = append(buffer, item.entry)
+			if len(buffer) > bufferLen {
+				_, err := flushEventsToFile(ctx, filepath.Join(fs.dir, newLastSortedFile), buffer)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				buffer = make([]*model.PolymorphicEvent, 0, bufferLen)
+			}
+		}
+		ev, err := readPolymorphicEvent(readers[item.fileIndex])
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if ev == nil {
+			// all events in this file have been consumed
+			continue
+		}
+		heap.Push(h, &sortItem{entry: ev, fileIndex: item.fileIndex})
+	}
+	if len(buffer) > 0 {
+		_, err := flushEventsToFile(ctx, filepath.Join(fs.dir, newLastSortedFile), buffer)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if lastSortedFileIsUsed {
+		fs.cache.lastSortedFile = newLastSortedFile
+	}
+	atomic.StoreInt32(&fs.cache.sorting, 0)
+	fs.output(ctx, model.NewResolvedPolymorphicEvent(resolvedTs))
+
+	return nil
+}
+
+// Run implements EventSorter.Run, runs in background, sorts and sends sorted events to output channel
+func (fs *FileSorter) Run(ctx context.Context) error {
+	bufferLen := 10
+	buffer := make([]*model.PolymorphicEvent, 0, bufferLen)
+
+	flush := func() error {
+		err := fs.flush(ctx, buffer)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		buffer = make([]*model.PolymorphicEvent, 0, bufferLen)
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev := <-fs.inputCh:
+			if ev.RawKV.OpType == model.OpTypeResolved {
+				err := flush()
+				if err != nil {
+					return errors.Trace(err)
+				}
+				err = fs.rotate(ctx, ev.RawKV.Ts)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				continue
+			}
+			buffer = append(buffer, ev)
+			if len(buffer) >= bufferLen {
+				err := flush()
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
+		}
+	}
+}
+
+// AddEntry adds an RawKVEntry to file sorter cache
+func (fs *FileSorter) AddEntry(ctx context.Context, entry *model.PolymorphicEvent) {
+	select {
+	case <-ctx.Done():
+		return
+	case fs.inputCh <- entry:
+	}
+}
+
+// Output returns the sorted PolymorphicEvent in output channel
+func (fs *FileSorter) Output() <-chan *model.PolymorphicEvent {
+	return fs.outputCh
+}
+
+func randomFileName(prefix string) string {
+	return prefix + "-" + uuid.New().String()
+}

--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -65,9 +65,7 @@ func newFileCache() *fileCache {
 }
 
 func (cache *fileCache) resetUnsortedFiles() {
-	for _, f := range cache.unsortedFiles {
-		cache.toRemoveFiles = append(cache.toRemoveFiles, f)
-	}
+	cache.toRemoveFiles = append(cache.toRemoveFiles, cache.unsortedFiles...)
 	cache.unsortedFiles = make([]string, 0, defaultInitFileCount)
 	cache.availableFileIdx = make([]int, 0, defaultInitFileCount)
 	cache.availableFileSize = make(map[int]uint64, defaultInitFileCount)
@@ -392,9 +390,7 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 
 	fs.cache.fileLock.Lock()
 	atomic.StoreInt32(&fs.cache.sorting, 0)
-	for _, f := range toRemoveFiles {
-		fs.cache.toRemoveFiles = append(fs.cache.toRemoveFiles, f)
-	}
+	fs.cache.toRemoveFiles = append(fs.cache.toRemoveFiles, toRemoveFiles...)
 	fs.cache.fileLock.Unlock()
 	fs.output(ctx, model.NewResolvedPolymorphicEvent(resolvedTs))
 

--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -234,11 +234,12 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 	// sortSingleFile reads an unsorted file into memory, sort in memory and rewritten
 	// sorted events ta a new file.
 	sortSingleFile := func(ctx context.Context, filename string) (string, error) {
-		_, err := os.Stat(filename)
+		fpath := filepath.Join(fs.dir, filename)
+		_, err := os.Stat(fpath)
 		if os.IsNotExist(err) {
 			return "", nil
 		}
-		data, err := ioutil.ReadFile(filepath.Join(fs.dir, filename))
+		data, err := ioutil.ReadFile(fpath)
 		if err != nil {
 			return "", errors.Trace(err)
 		}

--- a/cdc/puller/sorter.go
+++ b/cdc/puller/sorter.go
@@ -1,0 +1,28 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package puller
+
+import (
+	"context"
+
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+// EventSorter accepts unsorted PolymorphicEvents, sort them in background and returns
+// sorted PolymorphicEvents in Output channel
+type EventSorter interface {
+	Run(ctx context.Context) error
+	AddEntry(ctx context.Context, entry *model.PolymorphicEvent)
+	Output() <-chan *model.PolymorphicEvent
+}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -46,6 +46,8 @@ var (
 	configFile string
 	cliPdAddr  string
 	noConfirm  bool
+	sortEngine string
+	sortDir    string
 
 	cdcEtcdCli kv.CDCEtcdClient
 	pdCli      pd.Client
@@ -195,6 +197,8 @@ func newCreateChangefeedCommand() *cobra.Command {
 				StartTs:    startTs,
 				TargetTs:   targetTs,
 				Config:     cfg,
+				Engine:     model.SortEngine(sortEngine),
+				SortDir:    sortDir,
 			}
 
 			ineligibleTables, err := verifyTables(ctx, cfg, startTs)
@@ -247,6 +251,8 @@ func newCreateChangefeedCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&configFile, "config", "", "Path of the configuration file")
 	command.PersistentFlags().StringSliceVar(&opts, "opts", nil, "Extra options, in the `key=value` format")
 	command.PersistentFlags().BoolVar(&noConfirm, "no-confirm", false, "Don't ask user whether to ignore ineligible table")
+	command.PersistentFlags().StringVar(&sortEngine, "sort-engine", "memory", "sort engine used for data sort")
+	command.PersistentFlags().StringVar(&sortDir, "sort-dir", ".", "directory used for file sort")
 
 	return command
 }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -1,5 +1,6 @@
 test_case_names = ["simple", "cdc", "multi_capture", "split_region", "row_format",
-"tiflash", "availability", "ddl_sequence", "sink_retry", "resolve_lock", "drop_many_tables"]
+"tiflash", "availability", "ddl_sequence", "sink_retry", "resolve_lock", "drop_many_tables",
+"file_sort"]
 
 def prepare_binaries() {
     stage('Prepare Binaries') {

--- a/tests/file_sort/conf/diff_config.toml
+++ b/tests/file_sort/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "file_sort"
+    tables = ["usertable"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/file_sort/conf/workload
+++ b/tests/file_sort/conf/workload
@@ -1,0 +1,13 @@
+threadcount=2
+recordcount=10
+operationcount=0
+workload=core
+
+readallfields=true
+
+readproportion=0
+updateproportion=0
+scanproportion=0
+insertproportion=0
+
+requestdistribution=uniform

--- a/tests/file_sort/conf/workload
+++ b/tests/file_sort/conf/workload
@@ -1,5 +1,5 @@
-threadcount=2
-recordcount=10
+threadcount=4
+recordcount=345
 operationcount=0
 workload=core
 

--- a/tests/file_sort/run.sh
+++ b/tests/file_sort/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+CDC_COUNT=3
+DB_COUNT=4
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+    start_tidb_cluster $WORK_DIR
+
+    cd $WORK_DIR
+
+    start_ts=$(cdc cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
+    run_sql "CREATE DATABASE file_sort;"
+    go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=file_sort
+    run_cdc_server $WORK_DIR $CDC_BINARY
+
+    TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        mysql) ;&
+        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    sort_dir="$WORK_DIR/file_sort_cache"
+    mkdir $sort_dir
+    cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --sort-engine="file" --sort-dir="$sort_dir"
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+
+    check_table_exists "file_sort.USERTABLE" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=file_sort
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This is the first part of https://github.com/pingcap/ticdc/issues/466, add a file sort mechanism, a changefeed can use either memory sorter or file sorter

### What is changed and how it works?

- add two kinds of sort engine, memory and file
- define a new interface `EventSorter` in puller, so we don't need to change original replication model.
- file sorter has an `input` cache channel, it reads from `input` channel and flushes events to file until they are all mounted. 
- implement a simple double cache, one is used to sort with files, the other one is used to cache unsorted data to file.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test