### PR TITLE
close ticker to fix ticker resource leak

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1023,6 +1023,7 @@ func (s *eventFeedSession) singleEventFeed(
 
 	matcher := newMatcher()
 	advanceCheckTicker := time.NewTicker(time.Second * 5)
+	defer advanceCheckTicker.Stop()
 	lastReceivedEventTime := time.Now()
 	startFeedTime := time.Now()
 	var lastResolvedTs uint64

--- a/cdc/sink/mqProducer/kafka.go
+++ b/cdc/sink/mqProducer/kafka.go
@@ -210,6 +210,7 @@ func (k *kafkaSaramaProducer) runWorker(ctx context.Context) error {
 					Observe(float64(len(key) + len(value)))
 			}
 			tick := time.NewTicker(500 * time.Millisecond)
+			defer tick.Stop()
 			for {
 				var msg kafkaMsg
 				var err error


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in a region merge test, found a lot of CPU is consumed by `runtime.siftdownTimer`.

<img width="1052" alt="Screen Shot 2020-04-23 at 11 13 49" src="https://user-images.githubusercontent.com/1527315/80055125-85b17200-8553-11ea-9820-846bb1987590.png">


### What is changed and how it works?

We should close ticker when the routine that ticker is running in exits. 

before:

<img width="575" alt="Screen Shot 2020-04-23 at 07 41 45" src="https://user-images.githubusercontent.com/1527315/80072599-0c2c7a80-8579-11ea-8039-3da9f671adb0.png">

after:

<img width="918" alt="Screen Shot 2020-04-23 at 15 41 17" src="https://user-images.githubusercontent.com/1527315/80072626-16e70f80-8579-11ea-8d64-e8f200ef88da.png">


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test