### PR TITLE
puller: fix cache file name but no sorted file created in file sorter

### DIFF
--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -314,6 +314,10 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 			evs = append(evs, ev)
 			idx = idx + 8 + dataLen
 		}
+		// event count in unsorted file may be zero
+		if len(evs) == 0 {
+			return "", nil
+		}
 		sort.Slice(evs, func(i, j int) bool {
 			return evs[i].Ts < evs[j].Ts
 		})

--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -110,10 +110,10 @@ func (cache *fileCache) gc() {
 	defer cache.fileLock.Unlock()
 	for _, f := range cache.toRemoveFiles {
 		fpath := filepath.Join(cache.dir, f)
-		if _, err := os.Stat(fpath); err != nil {
+		if _, err := os.Stat(fpath); err == nil {
 			err2 := os.Remove(fpath)
 			if err2 != nil {
-				log.Warn("remove file failed", zap.Error(err))
+				log.Warn("remove file failed", zap.Error(err2))
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If there are no events in an unsorted file, file sorter creates a new sorted file name but doesn't create the sorted file

### What is changed and how it works?

Just don't create a new sorted file name if there is no event at all

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test