### PR TITLE
fix last sorted file assignment in file sorter

### DIFF
--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -136,12 +136,12 @@ func (cache *fileCache) prepareSorting() ([]string, bool) {
 	return files, true
 }
 
-func (cache *fileCache) finishSorting(lastSortedFile string, toRemoveFiles []string) {
+func (cache *fileCache) finishSorting(newLastSortedFile string, toRemoveFiles []string) {
 	cache.fileLock.Lock()
 	defer cache.fileLock.Unlock()
 	atomic.StoreInt32(&cache.sorting, 0)
 	cache.toRemoveFiles = append(cache.toRemoveFiles, toRemoveFiles...)
-	cache.lastSortedFile = lastSortedFile
+	cache.lastSortedFile = newLastSortedFile
 }
 
 func (cache *fileCache) flush(ctx context.Context, entries []*model.PolymorphicEvent) error {
@@ -428,12 +428,11 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 			return errors.Trace(err)
 		}
 	}
-	lastSortedFile := ""
-	if lastSortedFileUpdated {
-		fs.cache.lastSortedFile = newLastSortedFile
+	if !lastSortedFileUpdated {
+		newLastSortedFile = ""
 	}
 
-	fs.cache.finishSorting(lastSortedFile, toRemoveFiles)
+	fs.cache.finishSorting(newLastSortedFile, toRemoveFiles)
 	fs.output(ctx, model.NewResolvedPolymorphicEvent(resolvedTs))
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`lastSortedFile` is not correctly assigned

### What is changed and how it works?

Use correct assignment logic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test