### PR TITLE
kv/client: Reduce some logs

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -741,7 +741,7 @@ func (s *eventFeedSession) partialRegionFeed(
 		zap.Reflect("regionID", state.sri.verID.GetID()),
 		zap.Reflect("span", state.sri.span),
 		zap.Uint64("checkpoint", ts),
-		zap.Error(err))
+		zap.String("error", err.Error()))
 
 	state.sri.ts = ts
 

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -56,7 +56,6 @@ func (k *mqSink) EmitResolvedEvent(ctx context.Context, ts uint64) error {
 }
 
 func (k *mqSink) EmitCheckpointEvent(ctx context.Context, ts uint64) error {
-	log.Info("emit checkpoint event", zap.Uint64("ts", ts))
 	err := k.mqProducer.SyncBroadcastMessage(ctx, model.NewResolvedMessage(ts), nil)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/util/region_range_lock.go
+++ b/pkg/util/region_range_lock.go
@@ -182,7 +182,7 @@ func (l *RegionRangeLock) tryLockRange(startKey, endKey []byte, regionID, versio
 			version:  version,
 		})
 
-		log.Debug("range locked", zap.Uint64("lockID", l.id), zap.Uint64("regionID", regionID),
+		log.Info("range locked", zap.Uint64("lockID", l.id), zap.Uint64("regionID", regionID),
 			zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)))
 
 		return LockRangeResult{
@@ -298,7 +298,7 @@ func (l *RegionRangeLock) UnlockRange(startKey, endKey []byte, version uint64, c
 		panic("impossible (entry just get from BTree disappeared)")
 	}
 	l.rangeCheckpointTs.Set(startKey, endKey, checkpointTs)
-	log.Debug("unlocked range", zap.Uint64("lockID", l.id), zap.Uint64("regionID", entry.regionID),
+	log.Info("unlocked range", zap.Uint64("lockID", l.id), zap.Uint64("regionID", entry.regionID),
 		zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)))
 }
 

--- a/pkg/util/region_range_lock.go
+++ b/pkg/util/region_range_lock.go
@@ -182,7 +182,7 @@ func (l *RegionRangeLock) tryLockRange(startKey, endKey []byte, regionID, versio
 			version:  version,
 		})
 
-		log.Info("range locked", zap.Uint64("lockID", l.id), zap.Uint64("regionID", regionID),
+		log.Debug("range locked", zap.Uint64("lockID", l.id), zap.Uint64("regionID", regionID),
 			zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)))
 
 		return LockRangeResult{
@@ -298,7 +298,7 @@ func (l *RegionRangeLock) UnlockRange(startKey, endKey []byte, version uint64, c
 		panic("impossible (entry just get from BTree disappeared)")
 	}
 	l.rangeCheckpointTs.Set(startKey, endKey, checkpointTs)
-	log.Info("unlocked range", zap.Uint64("lockID", l.id), zap.Uint64("regionID", entry.regionID),
+	log.Debug("unlocked range", zap.Uint64("lockID", l.id), zap.Uint64("regionID", entry.regionID),
 		zap.String("startKey", hex.EncodeToString(startKey)), zap.String("endKey", hex.EncodeToString(endKey)))
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR tries to reduce the amount of logs printed by kv/client.
It's possible that this change makes it harder to investigate when a CDC server runs under INFO log level meets problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
