### PR TITLE
sink: remove verbose log if DDL execution is successful

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -133,7 +133,9 @@ func (s *mysqlSink) execDDLWithMaxRetries(ctx context.Context, ddl *model.DDLEve
 			if errors.Cause(err) == context.Canceled {
 				return backoff.Permanent(err)
 			}
-			log.Warn("execute DDL with error, retry later", zap.String("query", ddl.Query), zap.Error(err))
+			if err != nil {
+				log.Warn("execute DDL with error, retry later", zap.String("query", ddl.Query), zap.Error(err))
+			}
 			return err
 		})
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
currently cdc always logs a warning log when executing DDL

### What is changed and how it works?

only log warning when err is not nil

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test