### PR TITLE
*: fix wrong timezone when env `TZ` is not set

### DIFF
--- a/cdc/server.go
+++ b/cdc/server.go
@@ -44,7 +44,7 @@ var defaultServerOptions = options{
 	pdEndpoints: "http://127.0.0.1:2379",
 	statusHost:  "127.0.0.1",
 	statusPort:  defaultStatusPort,
-	timezone:    time.Local,
+	timezone:    nil,
 	gcTTL:       DefaultCDCGCSafePointTTL,
 }
 

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -265,7 +265,6 @@ var defaultParams = params{
 }
 
 func configureSinkURI(dsnCfg *dmysql.Config, tz *time.Location) (string, error) {
-	dsnCfg.Loc = tz
 	if dsnCfg.Params == nil {
 		dsnCfg.Params = make(map[string]string, 1)
 	}

--- a/pkg/util/tz.go
+++ b/pkg/util/tz.go
@@ -26,6 +26,9 @@ func GetLocalTimezone() (*time.Location, error) {
 	if err != nil {
 		return nil, err
 	}
+	// the linked path of `/etc/localtime`
+	// MacOS: /var/db/timezone/zoneinfo/Asia/Shanghai
+	// Linux: /etc/usr/share/zoneinfo/Asia/Shanghai
 	tzName := path.Join(path.Base(path.Dir(str)), path.Base(str))
 	return time.LoadLocation(tzName)
 }

--- a/pkg/util/tz.go
+++ b/pkg/util/tz.go
@@ -7,6 +7,7 @@ import (
 	"time"
 )
 
+// GetTimezone returns the timezone specified by the name
 func GetTimezone(name string) (*time.Location, error) {
 	switch strings.ToLower(name) {
 	case "", "system", "local":
@@ -16,6 +17,7 @@ func GetTimezone(name string) (*time.Location, error) {
 	}
 }
 
+// GetTimezone returns the timezone in local system
 func GetLocalTimezone() (*time.Location, error) {
 	if time.Local.String() != "Local" {
 		return time.Local, nil

--- a/pkg/util/tz.go
+++ b/pkg/util/tz.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+func GetTimezone(name string) (*time.Location, error) {
+	switch strings.ToLower(name) {
+	case "", "system", "local":
+		return GetLocalTimezone()
+	default:
+		return time.LoadLocation(name)
+	}
+}
+
+func GetLocalTimezone() (*time.Location, error) {
+	if time.Local.String() != "Local" {
+		return time.Local, nil
+	}
+	str, err := os.Readlink("/etc/localtime")
+	if err != nil {
+		return nil, err
+	}
+	tzName := path.Join(path.Base(path.Dir(str)), path.Base(str))
+	return time.LoadLocation(tzName)
+}

--- a/pkg/util/tz.go
+++ b/pkg/util/tz.go
@@ -17,7 +17,7 @@ func GetTimezone(name string) (*time.Location, error) {
 	}
 }
 
-// GetTimezone returns the timezone in local system
+// GetLocalTimezone returns the timezone in local system
 func GetLocalTimezone() (*time.Location, error) {
 	if time.Local.String() != "Local" {
 		return time.Local, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If the environment `TZ` is not set , the value of `time.Local.String()` is `Local`, 
when we try to connect to mysql using `Local` timezone, we will get an error: `Error 1298: Unknown or incorrect time zone: 'Local'`

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test