### PR TITLE
file-sorter: fix unsorted files gc, add auto resolved ts output

### DIFF
--- a/tests/file_sort/conf/workload
+++ b/tests/file_sort/conf/workload
@@ -1,5 +1,5 @@
-threadcount=4
-recordcount=345
+threadcount=10
+recordcount=30000
 operationcount=0
 workload=core
 

--- a/tests/file_sort/conf/workload
+++ b/tests/file_sort/conf/workload
@@ -1,5 +1,5 @@
 threadcount=10
-recordcount=30000
+recordcount=20000
 operationcount=0
 workload=core
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix several bugs in file sorter

- unsorted files can't be removed before sorted files are generated.
- file sorter only outputs resolved ts event when a round of sort finishes, which does not meet our requirement. As the data accumulated before this resolved ts may cause OOM 


### What is changed and how it works?

- Remove unsorted files together with the sorted files
- As events are sorted, we can output a resolved ts event periodically, we output auto resolved ts event after sending every 1000 rows now.
- use more data in file sort integration test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test