### PR TITLE
owner: fix resouce cleanup when an owner exits

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -496,6 +496,10 @@ func (o *Owner) Close(ctx context.Context, stepDown func(ctx context.Context) er
 // Run the owner
 // TODO avoid this tick style, this means we get `tickTime` latency here.
 func (o *Owner) Run(ctx context.Context, tickTime time.Duration) error {
+	failpoint.Inject("owner-run-with-error", func() {
+		failpoint.Return(errors.New("owner run with injected error"))
+	})
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -124,7 +124,7 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := s.run(ctx); errors.Cause(err) != ErrSuicide {
 			return err
 		}
-		log.Info("server recovered")
+		log.Info("server recovered", zap.String("capture", s.capture.info.ID))
 	}
 }
 
@@ -159,7 +159,7 @@ func (s *Server) campaignOwnerLoop(ctx context.Context) error {
 			err2 := s.capture.Resign(ctx)
 			if err2 != nil {
 				// if regisn owner failed, return error to let capture exits
-				return errors.Annotatef(err, "regign owner failed, capture: %s", s.capture.info.ID)
+				return errors.Annotatef(err, "resign owner failed, capture: %s", s.capture.info.ID)
 			}
 			log.Warn("run owner failed", zap.Error(err))
 		}

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -159,7 +159,7 @@ func (s *Server) campaignOwnerLoop(ctx context.Context) error {
 			err2 := s.capture.Resign(ctx)
 			if err2 != nil {
 				// if regisn owner failed, return error to let capture exits
-				return errors.Annotatef(err, "resign owner failed, capture: %s", s.capture.info.ID)
+				return errors.Annotatef(err2, "resign owner failed, capture: %s", s.capture.info.ID)
 			}
 			log.Warn("run owner failed", zap.Error(err))
 		}

--- a/tests/availability/owner.sh
+++ b/tests/availability/owner.sh
@@ -146,12 +146,12 @@ function test_owner_cleanup_stale_tasks() {
     run_cdc_server $WORK_DIR $CDC_BINARY
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
 
-    run_sql "INSERT INTO test.availability(id, val) VALUES (1, 1);"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=1 and val=1'
-    run_sql "UPDATE test.availability set val = 22 where id = 1;"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=1 and val=22'
-    run_sql "DELETE from test.availability where id=1;"
-    ensure $MAX_RETRIES empty 'select id, val from test.availability where id=1'
+    run_sql "INSERT INTO test.availability1(id, val) VALUES (1, 1);"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=1 and val=1'
+    run_sql "UPDATE test.availability1 set val = 22 where id = 1;"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=1 and val=22'
+    run_sql "DELETE from test.availability1 where id=1;"
+    ensure $MAX_RETRIES empty 'select id, val from test.availability1 where id=1'
 
     echo "test_owner_cleanup_stale_tasks pass"
     cleanup_process $CDC_BINARY

--- a/tests/availability/owner.sh
+++ b/tests/availability/owner.sh
@@ -187,5 +187,6 @@ function test_owner_retryable_error() {
     ensure $MAX_RETRIES "ps -C $CDC_BINARY -o pid= | awk '{print \$1}' | wc -l | grep 1"
 
     echo "test_owner_retryable_error pass"
+    export GO_FAILPOINTS=''
     cleanup_process $CDC_BINARY
 }

--- a/tests/availability/owner.sh
+++ b/tests/availability/owner.sh
@@ -14,6 +14,7 @@ function test_owner_ha() {
     test_hang_up_owner
     test_expire_owner
     test_owner_cleanup_stale_tasks
+    test_owner_retryable_error
 }
 # test_kill_owner starts two captures and kill the owner
 # we expect the live capture will be elected as the new
@@ -148,5 +149,42 @@ function test_owner_cleanup_stale_tasks() {
     ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=1 and val=22'
     run_sql "DELETE from test.availability where id=1;"
     ensure $MAX_RETRIES empty 'select id, val from test.availability where id=1'
+
+    echo "test_owner_cleanup_stale_tasks pass"
+    cleanup_process $CDC_BINARY
+}
+
+# test some retryable error meeting in the campaign owner loop
+function test_owner_retryable_error() {
+    echo "run test case test_owner_retryable_error"
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/capture-campaign-compacted-error=1*return(true)'
+
+    # start a capture server
+    run_cdc_server $WORK_DIR $CDC_BINARY server1
+    # ensure the server become the owner
+    ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
+    owner_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}')
+    owner_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}')
+    echo "owner pid:" $owner_pid
+    echo "owner id" $owner_id
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/owner-run-with-error=1*return(true);github.com/pingcap/ticdc/cdc/capture-resign-failed=1*return(true);'
+
+    # run another server
+    run_cdc_server $WORK_DIR $CDC_BINARY server2
+    ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep id"
+    capture_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}' | grep -v "$owner_pid")
+    capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
+    echo "capture_id:" $capture_id
+
+    # resign the first capture, the second capture campaigns to be owner.
+    # but we inject two errors, the second capture owner runs with error and then
+    # resign owner also failed, so the second capture will exit
+    curl -X POST http://127.0.0.1:8300/capture/owner/resign
+    ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep $owner_id -A1 | grep '\"is-owner\": true'"
+    ps -C $CDC_BINARY -o pid= | awk '{print $1}' | wc -l | check_contains "1"
+
+    echo "test_owner_retryable_error pass"
     cleanup_process $CDC_BINARY
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/523

### What is changed and how it works?

- remove the panic mechanism in capture, just return the `Suicide` error when etcd session is done.
- make `campaignOwnerLoop` as a background routine, in most failure cases (including err compacted, `s.capture.Campaign` failed, owner Run failed), we don't return error directly, just run another campaign loop

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release Note

- Fix owner may not run the main work loop because some errors are not handled correctly.