### PR TITLE
*: decouple util from model

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
 	"github.com/pingcap/ticdc/cdc/sink"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/filter"
 	"go.etcd.io/etcd/mvcc/mvccpb"
 	"go.uber.org/zap"
 )
@@ -72,7 +72,7 @@ type changeFeed struct {
 	targetTs      uint64
 	taskStatus    model.ProcessorsInfos
 	taskPositions map[string]*model.TaskPosition
-	filter        *util.Filter
+	filter        *filter.Filter
 	sink          sink.Sink
 
 	ddlHandler    OwnerDDLHandler

--- a/cdc/entry/kv_entry_test.go
+++ b/cdc/entry/kv_entry_test.go
@@ -27,7 +27,7 @@ func (s *kvEntrySuite) testCreateTable(c *check.C, newRowFormat bool) {
 
 	pm.MustExec("create table test.test1(id varchar(255) primary key, a int, index i1 (a))")
 
-	plr := pm.CreatePuller(0, []util.Span{util.GetDDLSpan()})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetDDLSpan()})
 	existDDLJobHistoryKVEntry := false
 
 	// create another context with canceled, we can close this puller but not affect puller manager
@@ -81,7 +81,7 @@ func (s *kvEntrySuite) testCreateTable(c *check.C, newRowFormat bool) {
 
 	pm.MustExec("create table test.test2(id int primary key, b varchar(255) unique key)")
 
-	plr = pm.CreatePuller(0, []util.Span{util.GetDDLSpan()})
+	plr = pm.CreatePuller(0, []regionspan.Span{regionspan.GetDDLSpan()})
 	existDDLJobHistoryKVEntry = false
 	plrCtx, plrCancel = context.WithCancel(ctx)
 	err = plr.CollectRawTxns(plrCtx, func(ctx context.Context, rawTxn model.RawTxn) error {
@@ -130,7 +130,7 @@ func (s *kvEntrySuite) testPkIsNotHandleDML(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("test", "test1")
 	tableID := tableInfo.ID
 
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into test.test1 values('ttt',666)")
 	expect := []kvEntry{
@@ -210,7 +210,7 @@ func (s *kvEntrySuite) testPkIsHandleDML(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("test", "test2")
 	tableID := tableInfo.ID
 
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into test.test2 values(666,'aaa')")
 	expect := []kvEntry{
@@ -283,7 +283,7 @@ func (s *kvEntrySuite) testUkWithNull(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("test", "test2")
 	tableID := tableInfo.ID
 
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into test.test2 values(null, 'aa', '1996-11-20')")
 	time, err := types.ParseDate(nil, "1996-11-20")
@@ -391,7 +391,7 @@ func (s *kvEntrySuite) testUkWithNoPk(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("test", "cdc_uk_with_no_pk")
 	tableID := tableInfo.ID
 
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("INSERT INTO test.cdc_uk_with_no_pk(id, a1, a3) VALUES(5, 6, NULL);")
 	expect := []kvEntry{

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -384,7 +384,7 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *TableInfo, row *rowKVEntry) (*m
 	}
 	event.Delete = row.Delete
 	event.Columns = values
-	event.Keys = genMultipleKeys(tableInfo.TableInfo, values, util.QuoteSchema(event.Schema, event.Table))
+	event.Keys = genMultipleKeys(tableInfo.TableInfo, values, model.QuoteSchema(event.Schema, event.Table))
 	return event, nil
 }
 
@@ -430,7 +430,7 @@ func (m *mounterImpl) mountIndexKVEntry(tableInfo *TableInfo, idx *indexKVEntry)
 		IndieMarkCol: tableInfo.IndieMarkCol,
 		Delete:       true,
 		Columns:      values,
-		Keys:         genMultipleKeys(tableInfo.TableInfo, values, util.QuoteSchema(tableInfo.TableName.Schema, tableInfo.TableName.Table)),
+		Keys:         genMultipleKeys(tableInfo.TableInfo, values, model.QuoteSchema(tableInfo.TableName.Schema, tableInfo.TableName.Table)),
 	}, nil
 }
 

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -24,7 +24,7 @@ func setUpPullerAndSchema(ctx context.Context, c *check.C, newRowFormat bool, sq
 	for _, sql := range sqls {
 		pm.MustExec(sql)
 	}
-	ddlPlr := pm.CreatePuller(0, []util.Span{util.GetDDLSpan()})
+	ddlPlr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetDDLSpan()})
 	go func() {
 		err := ddlPlr.Run(ctx)
 		if err != nil && errors.Cause(err) != context.Canceled {
@@ -68,7 +68,7 @@ func (cs *mountTxnsSuite) testInsertPkNotHandle(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("testDB", "test1")
 	tableID := tableInfo.ID
 	mounter := NewTxnMounter(schema)
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.test1 values('ttt',6)")
 	rawTxn := getFirstRealTxn(ctx, c, plr)
@@ -145,7 +145,7 @@ func (cs *mountTxnsSuite) testIncompleteRow(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("testDB", "test1")
 	tableID := tableInfo.ID
 	mounter := NewTxnMounter(schema)
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.test1(id) values (16),(32);")
 	rawTxn := getFirstRealTxn(ctx, c, plr)
@@ -206,7 +206,7 @@ func (cs *mountTxnsSuite) testInsertPkIsHandle(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("testDB", "test1")
 	tableID := tableInfo.ID
 	mounter := NewTxnMounter(schema)
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.test1 values(777,888)")
 	rawTxn := getFirstRealTxn(ctx, c, plr)
@@ -299,7 +299,7 @@ func (cs *mountTxnsSuite) testUk(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("testDB", "test1")
 	tableID := tableInfo.ID
 	mounter := NewTxnMounter(schema)
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.test1 values(1, 2, 3, 4, 5, 6)")
 	rawTxn := getFirstRealTxn(ctx, c, plr)
@@ -402,7 +402,7 @@ func (cs *mountTxnsSuite) testLargeInteger(c *check.C, newRowFormat bool) {
 	tableInfo := pm.GetTableInfo("testDB", "large_int")
 	tableID := tableInfo.ID
 	mounter := NewTxnMounter(schema)
-	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.large_int values(?, ?)", uint64(math.MaxUint64), 123)
 	rawTxn := getFirstRealTxn(ctx, c, plr)
@@ -432,7 +432,7 @@ func (cs *mountTxnsSuite) testLargeInteger(c *check.C, newRowFormat bool) {
 	tableInfo = pm.GetTableInfo("testDB", "large_int")
 	tableID = tableInfo.ID
 	mounter = NewTxnMounter(schema)
-	plr = pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
+	plr = pm.CreatePuller(0, []regionspan.Span{regionspan.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.large_int values(?, ?)", int64(math.MinInt64), 123)
 	rawTxn = getFirstRealTxn(ctx, c, plr)

--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -29,8 +29,8 @@ import (
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/retry"
-	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/tidb/util/rowcodec"
 	"go.uber.org/zap"
 )
@@ -584,11 +584,11 @@ type SchemaStorage struct {
 	gcTs       uint64
 	resolvedTs uint64
 
-	filter *util.Filter
+	filter *filter.Filter
 }
 
 // NewSchemaStorage creates a new schema storage
-func NewSchemaStorage(jobs []*timodel.Job, filter *util.Filter) (*SchemaStorage, error) {
+func NewSchemaStorage(jobs []*timodel.Job, filter *filter.Filter) (*SchemaStorage, error) {
 	schema := &SchemaStorage{filter: filter}
 	for _, job := range jobs {
 		if err := schema.HandleDDLJob(job); err != nil {

--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/mvcc/mvccpb"
 )
@@ -120,7 +119,7 @@ func (c CDCEtcdClient) GetChangeFeeds(ctx context.Context) (int64, map[string]*m
 	revision := resp.Header.Revision
 	details := make(map[string]*mvccpb.KeyValue, resp.Count)
 	for _, kv := range resp.Kvs {
-		id, err := util.ExtractKeySuffix(string(kv.Key))
+		id, err := model.ExtractKeySuffix(string(kv.Key))
 		if err != nil {
 			return 0, nil, err
 		}
@@ -208,12 +207,12 @@ func (c CDCEtcdClient) GetAllTaskPositions(ctx context.Context, changefeedID str
 	}
 	positions := make(map[string]*model.TaskPosition, resp.Count)
 	for _, rawKv := range resp.Kvs {
-		changeFeed, err := util.ExtractKeySuffix(string(rawKv.Key))
+		changeFeed, err := model.ExtractKeySuffix(string(rawKv.Key))
 		if err != nil {
 			return nil, err
 		}
 		endIndex := len(rawKv.Key) - len(changeFeed) - 1
-		captureID, err := util.ExtractKeySuffix(string(rawKv.Key[0:endIndex]))
+		captureID, err := model.ExtractKeySuffix(string(rawKv.Key[0:endIndex]))
 		if err != nil {
 			return nil, err
 		}
@@ -239,12 +238,12 @@ func (c CDCEtcdClient) GetProcessors(ctx context.Context) ([]*model.ProcInfoSnap
 	}
 	infos := make([]*model.ProcInfoSnap, 0, resp.Count)
 	for _, rawKv := range resp.Kvs {
-		changefeedID, err := util.ExtractKeySuffix(string(rawKv.Key))
+		changefeedID, err := model.ExtractKeySuffix(string(rawKv.Key))
 		if err != nil {
 			return nil, err
 		}
 		endIndex := len(rawKv.Key) - len(changefeedID) - 1
-		captureID, err := util.ExtractKeySuffix(string(rawKv.Key[0:endIndex]))
+		captureID, err := model.ExtractKeySuffix(string(rawKv.Key[0:endIndex]))
 		if err != nil {
 			return nil, err
 		}
@@ -266,12 +265,12 @@ func (c CDCEtcdClient) GetAllTaskStatus(ctx context.Context, changefeedID string
 	}
 	pinfo := make(map[string]*model.TaskStatus, resp.Count)
 	for _, rawKv := range resp.Kvs {
-		changeFeed, err := util.ExtractKeySuffix(string(rawKv.Key))
+		changeFeed, err := model.ExtractKeySuffix(string(rawKv.Key))
 		if err != nil {
 			return nil, err
 		}
 		endIndex := len(rawKv.Key) - len(changeFeed) - 1
-		captureID, err := util.ExtractKeySuffix(string(rawKv.Key[0:endIndex]))
+		captureID, err := model.ExtractKeySuffix(string(rawKv.Key[0:endIndex]))
 		if err != nil {
 			return nil, err
 		}

--- a/cdc/kv/testing.go
+++ b/cdc/kv/testing.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pingcap/log"
 	pd "github.com/pingcap/pd/v4/client"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store"
 	"github.com/pingcap/tidb/store/tikv"
@@ -60,7 +60,7 @@ func newEventChecker(t require.TestingT) *eventChecker {
 				if e.Val != nil {
 					// check if the value event break the checkpoint guarantee
 					for _, cp := range ec.checkpoints {
-						if !util.KeyInSpan(e.Val.Key, cp.Span) ||
+						if !regionspan.KeyInSpan(e.Val.Key, cp.Span) ||
 							e.Val.Ts > cp.ResolvedTs {
 							continue
 						}
@@ -135,7 +135,7 @@ func TestSplit(t require.TestingT, pdCli pd.Client, storage kv.Storage) {
 	startTS := mustGetTimestamp(t, storage)
 
 	go func() {
-		err := cli.EventFeed(ctx, util.Span{Start: nil, End: nil}, startTS, eventCh)
+		err := cli.EventFeed(ctx, regionspan.Span{Start: nil, End: nil}, startTS, eventCh)
 		require.Equal(t, err, context.Canceled)
 	}()
 
@@ -222,7 +222,7 @@ func TestGetKVSimple(t require.TestingT, pdCli pd.Client, storage kv.Storage) {
 	startTS := mustGetTimestamp(t, storage)
 
 	go func() {
-		err := cli.EventFeed(ctx, util.Span{Start: nil, End: nil}, startTS, checker.eventCh)
+		err := cli.EventFeed(ctx, regionspan.Span{Start: nil, End: nil}, startTS, checker.eventCh)
 		require.Equal(t, err, context.Canceled)
 	}()
 
@@ -244,7 +244,7 @@ func TestGetKVSimple(t require.TestingT, pdCli pd.Client, storage kv.Storage) {
 		if i == 1 {
 			checker = newEventChecker(t)
 			go func() {
-				err := cli.EventFeed(ctx, util.Span{Start: nil, End: nil}, startTS, checker.eventCh)
+				err := cli.EventFeed(ctx, regionspan.Span{Start: nil, End: nil}, startTS, checker.eventCh)
 				require.Equal(t, err, context.Canceled)
 			}()
 		}

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -18,7 +18,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/filter"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/store/tikv/oracle"
@@ -47,13 +47,13 @@ type ChangeFeedInfo struct {
 	Engine       SortEngine   `json:"sort-engine"`
 	SortDir      string       `json:"sort-dir"`
 
-	Config *util.ReplicaConfig `json:"config"`
+	Config *filter.ReplicaConfig `json:"config"`
 }
 
 // GetConfig returns ReplicaConfig.
-func (info *ChangeFeedInfo) GetConfig() *util.ReplicaConfig {
+func (info *ChangeFeedInfo) GetConfig() *filter.ReplicaConfig {
 	if info.Config == nil {
-		info.Config = &util.ReplicaConfig{}
+		info.Config = &filter.ReplicaConfig{}
 	}
 	return info.Config
 }

--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -3,7 +3,7 @@ package model
 import (
 	"fmt"
 
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 )
 
 // OpType for the kv, delete or put
@@ -38,7 +38,7 @@ func (e *RegionFeedEvent) GetValue() interface{} {
 // ResolvedSpan guarantees all the KV value event
 // with commit ts less than ResolvedTs has been emitted.
 type ResolvedSpan struct {
-	Span       util.Span
+	Span       regionspan.Span
 	ResolvedTs uint64
 }
 

--- a/cdc/model/string.go
+++ b/cdc/model/string.go
@@ -1,4 +1,4 @@
-package util
+package model
 
 import (
 	"fmt"

--- a/cdc/model/string_test.go
+++ b/cdc/model/string_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package model
 
 import (
 	"github.com/pingcap/check"

--- a/cdc/model/txn.go
+++ b/cdc/model/txn.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"github.com/pingcap/parser/model"
-	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -41,7 +40,7 @@ type DML struct {
 
 // TableName returns the fully qualified name of the DML's table
 func (dml *DML) TableName() string {
-	return util.QuoteSchema(dml.Database, dml.Table)
+	return QuoteSchema(dml.Database, dml.Table)
 }
 
 // DDL holds the ddl info

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
 	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
@@ -151,7 +152,7 @@ func (o *Owner) newChangeFeed(
 		return nil, errors.Trace(err)
 	}
 
-	filter, err := util.NewFilter(info.GetConfig())
+	filter, err := filter.NewFilter(info.GetConfig())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 	"github.com/pingcap/ticdc/pkg/util"
 	"golang.org/x/sync/errgroup"
 )
@@ -43,7 +44,7 @@ type ddlHandler struct {
 func newDDLHandler(pdCli pd.Client, kvStorage tidbkv.Storage, checkpointTS uint64) *ddlHandler {
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
-	plr := puller.NewPuller(pdCli, kvStorage, checkpointTS, []util.Span{util.GetDDLSpan(), util.GetAddIndexDDLSpan()}, false, nil)
+	plr := puller.NewPuller(pdCli, kvStorage, checkpointTS, []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}, false, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	h := &ddlHandler{
 		puller: plr,

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -37,6 +37,8 @@ import (
 	"github.com/pingcap/ticdc/cdc/puller"
 	"github.com/pingcap/ticdc/cdc/roles/storage"
 	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/filter"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 	"github.com/pingcap/ticdc/pkg/retry"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/tidb/store/tikv/oracle"
@@ -138,9 +140,9 @@ func newProcessor(
 	// The key in DDL kv pair returned from TiKV is already memcompariable encoded,
 	// so we set `needEncode` to false.
 	log.Info("start processor with startts", zap.Uint64("startts", checkpointTs))
-	ddlPuller := puller.NewPuller(pdCli, kvStorage, checkpointTs, []util.Span{util.GetDDLSpan(), util.GetAddIndexDDLSpan()}, false, limitter)
+	ddlPuller := puller.NewPuller(pdCli, kvStorage, checkpointTs, []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}, false, limitter)
 	ctx = util.PutTableIDInCtx(ctx, 0)
-	filter, err := util.NewFilter(changefeed.GetConfig())
+	filter, err := filter.NewFilter(changefeed.GetConfig())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -598,7 +600,7 @@ func (p *processor) collectMetrics(ctx context.Context, tableID int64) {
 	}()
 }
 
-func createSchemaStorage(pdEndpoints []string, filter *util.Filter) (*entry.SchemaStorage, error) {
+func createSchemaStorage(pdEndpoints []string, filter *filter.Filter) (*entry.SchemaStorage, error) {
 	// TODO here we create another pb client,we should reuse them
 	kvStore, err := kv.CreateTiStore(strings.Join(pdEndpoints, ","))
 	if err != nil {
@@ -636,8 +638,8 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 	// start table puller
 	// The key in DML kv pair returned from TiKV is not memcompariable encoded,
 	// so we set `needEncode` to true.
-	span := util.GetTableSpan(tableID, true)
-	plr := puller.NewPuller(p.pdCli, p.kvStorage, startTs, []util.Span{span}, true, p.limitter)
+	span := regionspan.GetTableSpan(tableID, true)
+	plr := puller.NewPuller(p.pdCli, p.kvStorage, startTs, []regionspan.Span{span}, true, p.limitter)
 	go func() {
 		err := plr.Run(ctx)
 		if errors.Cause(err) != context.Canceled {
@@ -744,7 +746,7 @@ func runProcessor(
 	opts[sink.OptChangefeedID] = changefeedID
 	opts[sink.OptCaptureID] = captureID
 	ctx = util.PutChangefeedIDInCtx(ctx, changefeedID)
-	filter, err := util.NewFilter(info.GetConfig())
+	filter, err := filter.NewFilter(info.GetConfig())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/puller/buffer_test.go
+++ b/cdc/puller/buffer_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 )
 
 type bufferSuite struct{}
@@ -49,7 +49,7 @@ func (bs *bufferSuite) TestCanAddAndReadEntriesInOrder(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = b.AddEntry(ctx, model.RegionFeedEvent{
 		Resolved: &model.ResolvedSpan{
-			Span:       util.Span{},
+			Span:       regionspan.Span{},
 			ResolvedTs: 111,
 		},
 	})
@@ -69,7 +69,7 @@ func (bs *bufferSuite) TestWaitsCanBeCanceled(c *check.C) {
 		for {
 			err := b.AddEntry(timeout, model.RegionFeedEvent{
 				Resolved: &model.ResolvedSpan{
-					Span:       util.Span{},
+					Span:       regionspan.Span{},
 					ResolvedTs: 111,
 				},
 			})

--- a/cdc/puller/frontier/frontier.go
+++ b/cdc/puller/frontier/frontier.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 )
 
 // Frontier checks resolved event of spans and moves the global resolved ts ahead
 type Frontier interface {
-	Forward(span util.Span, ts uint64) bool
+	Forward(span regionspan.Span, ts uint64) bool
 	Frontier() uint64
 }
 
@@ -42,7 +42,7 @@ type spanFrontier struct {
 }
 
 // NewFrontier creates Froniter from the given spans.
-func NewFrontier(spans ...util.Span) Frontier {
+func NewFrontier(spans ...regionspan.Span) Frontier {
 	// spanFrontier don't support use Nil as the maximum key of End range
 	// So we use set it as util.UpperBoundKey, the means the real use case *should not* have a
 	// End key bigger than util.UpperBoundKey
@@ -78,7 +78,7 @@ func (s *spanFrontier) Frontier() uint64 {
 
 // Forward advances the timestamp for a span.
 // True is returned if the frontier advanced.
-func (s *spanFrontier) Forward(span util.Span, ts uint64) bool {
+func (s *spanFrontier) Forward(span regionspan.Span, ts uint64) bool {
 	span = span.Hack()
 
 	pre := s.Frontier()
@@ -86,7 +86,7 @@ func (s *spanFrontier) Forward(span util.Span, ts uint64) bool {
 	return pre < s.Frontier()
 }
 
-func (s *spanFrontier) insert(span util.Span, ts uint64) {
+func (s *spanFrontier) insert(span regionspan.Span, ts uint64) {
 	n := s.list.seek(span.Start)
 
 	if n == nil || bytes.Compare(span.End, n.start) <= 0 {

--- a/cdc/puller/frontier/frontier_bench_test.go
+++ b/cdc/puller/frontier/frontier_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 )
 
 func toCMPBytes(i int) []byte {
@@ -27,9 +27,9 @@ func BenchmarkSpanFrontier(b *testing.B) {
 		n := test.n
 
 		b.Run(test.name, func(b *testing.B) {
-			spans := make([]util.Span, 0, n)
+			spans := make([]regionspan.Span, 0, n)
 			for i := 0; i < n; i++ {
-				span := util.Span{
+				span := regionspan.Span{
 					Start: toCMPBytes(i),
 					End:   toCMPBytes(i + 1),
 				}
@@ -65,14 +65,14 @@ func BenchmarkSpanFrontierOverlap(b *testing.B) {
 
 		for _, step := range steps {
 			b.Run(fmt.Sprintf("%s_%d", test.name, step), func(b *testing.B) {
-				spans := make([]util.Span, 0, n)
-				forward := make([]util.Span, 0, n)
+				spans := make([]regionspan.Span, 0, n)
+				forward := make([]regionspan.Span, 0, n)
 				for i := 0; i < n; i++ {
-					spans = append(spans, util.Span{
+					spans = append(spans, regionspan.Span{
 						Start: toCMPBytes(i),
 						End:   toCMPBytes(i + 1),
 					})
-					forward = append(forward, util.Span{
+					forward = append(forward, regionspan.Span{
 						Start: toCMPBytes(i),
 						End:   toCMPBytes(i + step),
 					})

--- a/cdc/puller/frontier/frontier_test.go
+++ b/cdc/puller/frontier/frontier_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/check"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 )
 
 type spanFrontierSuite struct{}
@@ -33,12 +33,12 @@ func (s *spanFrontierSuite) TestSpanFrontier(c *check.C) {
 	keyC := []byte("c")
 	keyD := []byte("d")
 
-	spAB := util.Span{Start: keyA, End: keyB}
-	spAC := util.Span{Start: keyA, End: keyC}
-	spAD := util.Span{Start: keyA, End: keyD}
-	spBC := util.Span{Start: keyB, End: keyC}
-	spBD := util.Span{Start: keyB, End: keyD}
-	spCD := util.Span{Start: keyC, End: keyD}
+	spAB := regionspan.Span{Start: keyA, End: keyB}
+	spAC := regionspan.Span{Start: keyA, End: keyC}
+	spAD := regionspan.Span{Start: keyA, End: keyD}
+	spBC := regionspan.Span{Start: keyB, End: keyC}
+	spBD := regionspan.Span{Start: keyB, End: keyD}
+	spCD := regionspan.Span{Start: keyC, End: keyD}
 
 	f := NewFrontier(spAD).(*spanFrontier)
 
@@ -47,7 +47,7 @@ func (s *spanFrontierSuite) TestSpanFrontier(c *check.C) {
 
 	// Untracked spans are ignored
 	adv := f.Forward(
-		util.Span{Start: []byte("d"), End: []byte("e")},
+		regionspan.Span{Start: []byte("d"), End: []byte("e")},
 		100,
 	)
 	c.Assert(adv, check.IsFalse)
@@ -56,7 +56,7 @@ func (s *spanFrontierSuite) TestSpanFrontier(c *check.C) {
 
 	// Forward the tracked span space.
 	adv = f.Forward(
-		util.Span{Start: []byte("a"), End: []byte("d")},
+		regionspan.Span{Start: []byte("a"), End: []byte("d")},
 		1,
 	)
 	c.Assert(adv, check.IsTrue)
@@ -65,7 +65,7 @@ func (s *spanFrontierSuite) TestSpanFrontier(c *check.C) {
 
 	// Forward it again
 	adv = f.Forward(
-		util.Span{Start: []byte("a"), End: []byte("d")},
+		regionspan.Span{Start: []byte("a"), End: []byte("d")},
 		2,
 	)
 	c.Assert(adv, check.IsTrue)
@@ -74,7 +74,7 @@ func (s *spanFrontierSuite) TestSpanFrontier(c *check.C) {
 
 	// Forward to old ts is ignored.
 	adv = f.Forward(
-		util.Span{Start: []byte("a"), End: []byte("d")},
+		regionspan.Span{Start: []byte("a"), End: []byte("d")},
 		1,
 	)
 	c.Assert(adv, check.IsFalse)
@@ -142,9 +142,9 @@ func (s *spanFrontierSuite) TestMinMax(c *check.C) {
 	var keyMax []byte = nil
 	var keyMid []byte = []byte("m")
 
-	spMinMid := util.Span{Start: keyMin, End: keyMid}
-	spMidMax := util.Span{Start: keyMid, End: keyMax}
-	spMinMax := util.Span{Start: keyMin, End: keyMax}
+	spMinMid := regionspan.Span{Start: keyMin, End: keyMid}
+	spMidMax := regionspan.Span{Start: keyMid, End: keyMax}
+	spMinMax := regionspan.Span{Start: keyMin, End: keyMax}
 
 	f := NewFrontier(spMinMax).(*spanFrontier)
 	c.Assert(f.Frontier(), check.Equals, uint64(0))
@@ -176,13 +176,13 @@ func (s *spanFrontierSuite) TestSpanFrontierDisjoinSpans(c *check.C) {
 	keyE := []byte("e")
 	keyF := []byte("f")
 
-	spAB := util.Span{Start: keyA, End: keyB}
-	spAD := util.Span{Start: keyA, End: keyD}
-	spAE := util.Span{Start: keyA, End: keyE}
-	spDE := util.Span{Start: keyD, End: keyE}
-	spCE := util.Span{Start: keyC, End: keyE}
-	sp12 := util.Span{Start: key1, End: key2}
-	sp1F := util.Span{Start: key1, End: keyF}
+	spAB := regionspan.Span{Start: keyA, End: keyB}
+	spAD := regionspan.Span{Start: keyA, End: keyD}
+	spAE := regionspan.Span{Start: keyA, End: keyE}
+	spDE := regionspan.Span{Start: keyD, End: keyE}
+	spCE := regionspan.Span{Start: keyC, End: keyE}
+	sp12 := regionspan.Span{Start: key1, End: key2}
+	sp1F := regionspan.Span{Start: key1, End: keyF}
 
 	f := NewFrontier(spAB, spCE).(*spanFrontier)
 	c.Assert(f.Frontier(), check.Equals, uint64(0))

--- a/cdc/puller/mock_puller.go
+++ b/cdc/puller/mock_puller.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pingcap/log"
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 	"github.com/pingcap/tidb/domain"
 	tidbkv "github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
@@ -117,7 +117,7 @@ var _ Puller = &mockPuller{}
 
 type mockPuller struct {
 	pm          *MockPullerManager
-	spans       []util.Span
+	spans       []regionspan.Span
 	resolvedTs  uint64
 	startTs     uint64
 	rawKVOffset int
@@ -138,7 +138,7 @@ func (p *mockPuller) SortedOutput(ctx context.Context) <-chan *model.RawKVEntry 
 					continue
 				}
 				p.resolvedTs = rawKV.Ts
-				if !util.KeyInSpans(rawKV.Key, p.spans, false) {
+				if !regionspan.KeyInSpans(rawKV.Key, p.spans, false) {
 					continue
 				}
 				select {
@@ -223,7 +223,7 @@ func (m *MockPullerManager) setUp(newRowFormat bool) {
 }
 
 // CreatePuller returns a mock puller with the specified start ts and spans
-func (m *MockPullerManager) CreatePuller(startTs uint64, spans []util.Span) Puller {
+func (m *MockPullerManager) CreatePuller(startTs uint64, spans []regionspan.Span) Puller {
 	//return &mockPuller{
 	//	spans:   spans,
 	//	pm:      m,

--- a/cdc/puller/mock_puller_test.go
+++ b/cdc/puller/mock_puller_test.go
@@ -21,7 +21,7 @@ var _ = check.Suite(&mockPullerSuite{})
 
 func (s *mockPullerSuite) TestTxnSort(c *check.C) {
 	pm := NewMockPullerManager(c, true)
-	plr := pm.CreatePuller(0, []util.Span{util.Span{}.Hack()})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.Span{}.Hack()})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := uint64(0)
@@ -45,7 +45,7 @@ func (s *mockPullerSuite) TestTxnSort(c *check.C) {
 
 func (s *mockPullerSuite) TestDDLPuller(c *check.C) {
 	pm := NewMockPullerManager(c, true)
-	plr := pm.CreatePuller(0, []util.Span{util.GetDDLSpan()})
+	plr := pm.CreatePuller(0, []regionspan.Span{regionspan.GetDDLSpan()})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := uint64(0)
@@ -58,7 +58,7 @@ func (s *mockPullerSuite) TestDDLPuller(c *check.C) {
 				return nil
 			}
 			for _, e := range rawTxn.Entries {
-				c.Assert(util.KeyInSpan(e.Key, util.GetDDLSpan()), check.IsTrue)
+				c.Assert(util.KeyInSpan(e.Key, regionspan.GetDDLSpan()), check.IsTrue)
 			}
 			t, err := txnMounter.Mount(rawTxn)
 			c.Assert(err, check.IsNil)
@@ -83,7 +83,7 @@ func (s *mockPullerSuite) TestDDLPuller(c *check.C) {
 
 func (s *mockPullerSuite) TestStartTs(c *check.C) {
 	pm := NewMockPullerManager(c, true)
-	plrA := pm.CreatePuller(0, []util.Span{util.Span{}.Hack()})
+	plrA := pm.CreatePuller(0, []regionspan.Span{regionspan.Span{}.Hack()})
 	ctx, cancel := context.WithCancel(context.Background())
 	ts := uint64(0)
 	var rawTxns []model.RawTxn
@@ -110,7 +110,7 @@ func (s *mockPullerSuite) TestStartTs(c *check.C) {
 	cancel()
 	mu.Lock()
 	index := len(rawTxns) / 2
-	plrB := pm.CreatePuller(rawTxns[index].Ts, []util.Span{util.Span{}.Hack()})
+	plrB := pm.CreatePuller(rawTxns[index].Ts, []regionspan.Span{regionspan.Span{}.Hack()})
 	mu.Unlock()
 	ctx, cancel = context.WithCancel(context.Background())
 	err := plrB.CollectRawTxns(ctx, func(ctx context.Context, txn model.RawTxn) error {

--- a/cdc/sink/dispatcher/interface.go
+++ b/cdc/sink/dispatcher/interface.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/filter"
 	"go.uber.org/zap"
 )
 
@@ -62,7 +62,7 @@ func (s *dispatcherSwitcher) Dispatch(row *model.RowChangedEvent) int32 {
 }
 
 // NewDispatcher creates a new dispatcher
-func NewDispatcher(config *util.ReplicaConfig, partitionNum int32) Dispatcher {
+func NewDispatcher(config *filter.ReplicaConfig, partitionNum int32) Dispatcher {
 	p := &dispatcherSwitcher{
 		caseSensitive:     config.FilterCaseSensitive,
 		partitionNum:      partitionNum,

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -12,6 +12,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/util"
 
 	"github.com/pingcap/log"
@@ -28,7 +29,7 @@ type mqSink struct {
 
 	globalResolvedTs uint64
 	checkpointTs     uint64
-	filter           *util.Filter
+	filter           *filter.Filter
 	dispatcher       dispatcher.Dispatcher
 
 	captureID    string
@@ -37,7 +38,7 @@ type mqSink struct {
 	errCh chan error
 }
 
-func newMqSink(mqProducer mqProducer.Producer, filter *util.Filter, config *util.ReplicaConfig, opts map[string]string) *mqSink {
+func newMqSink(mqProducer mqProducer.Producer, filter *filter.Filter, config *filter.ReplicaConfig, opts map[string]string) *mqSink {
 	return &mqSink{
 		mqProducer:   mqProducer,
 		partitionNum: mqProducer.GetPartitionNum(),
@@ -182,7 +183,7 @@ func (k *mqSink) PrintStatus(ctx context.Context) error {
 	return k.mqProducer.PrintStatus(ctx)
 }
 
-func newKafkaSaramaSink(ctx context.Context, sinkURI *url.URL, filter *util.Filter, replicaConfig *util.ReplicaConfig, opts map[string]string) (*mqSink, error) {
+func newKafkaSaramaSink(ctx context.Context, sinkURI *url.URL, filter *filter.Filter, replicaConfig *filter.ReplicaConfig, opts map[string]string) (*mqSink, error) {
 	config := mqProducer.DefaultKafkaConfig
 
 	scheme := strings.ToLower(sinkURI.Scheme)

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/retry"
 	"github.com/pingcap/ticdc/pkg/util"
 	tddl "github.com/pingcap/tidb/ddl"
@@ -61,7 +62,7 @@ type mysqlSink struct {
 	checkpointTs     uint64
 	params           params
 
-	filter *util.Filter
+	filter *filter.Filter
 
 	globalForwardCh chan struct{}
 
@@ -101,7 +102,7 @@ func (s *mysqlSink) EmitRowChangedEvent(ctx context.Context, rows ...*model.RowC
 			log.Info("Row changed event ignored", zap.Uint64("ts", row.Ts))
 			continue
 		}
-		key := util.QuoteSchema(row.Schema, row.Table)
+		key := model.QuoteSchema(row.Schema, row.Table)
 		s.unresolvedRows[key] = append(s.unresolvedRows[key], row)
 	}
 	if resolvedTs != 0 {
@@ -151,7 +152,7 @@ func (s *mysqlSink) execDDL(ctx context.Context, ddl *model.DDLEvent) error {
 	}
 
 	if shouldSwitchDB {
-		_, err = tx.ExecContext(ctx, "USE "+util.QuoteName(ddl.Schema)+";")
+		_, err = tx.ExecContext(ctx, "USE "+model.QuoteName(ddl.Schema)+";")
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
 				log.Error("Failed to rollback", zap.Error(err))
@@ -280,7 +281,7 @@ func configureSinkURI(dsnCfg *dmysql.Config, tz *time.Location) (string, error) 
 }
 
 // newMySQLSink creates a new MySQL sink using schema storage
-func newMySQLSink(ctx context.Context, sinkURI *url.URL, dsn *dmysql.Config, filter *util.Filter, opts map[string]string) (Sink, error) {
+func newMySQLSink(ctx context.Context, sinkURI *url.URL, dsn *dmysql.Config, filter *filter.Filter, opts map[string]string) (Sink, error) {
 	var db *sql.DB
 	params := defaultParams
 
@@ -605,16 +606,16 @@ func (s *mysqlSink) prepareReplace(schema, table string, cols map[string]*model.
 	}
 
 	colList := "(" + buildColumnList(columnNames) + ")"
-	tblName := util.QuoteSchema(schema, table)
+	tblName := model.QuoteSchema(schema, table)
 	builder.WriteString("REPLACE INTO " + tblName + colList + " VALUES ")
-	builder.WriteString("(" + util.HolderString(len(columnNames)) + ");")
+	builder.WriteString("(" + model.HolderString(len(columnNames)) + ");")
 
 	return builder.String(), args, nil
 }
 
 func (s *mysqlSink) prepareDelete(schema, table string, cols map[string]*model.Column) (string, []interface{}, error) {
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("DELETE FROM %s WHERE ", util.QuoteSchema(schema, table)))
+	builder.WriteString(fmt.Sprintf("DELETE FROM %s WHERE ", model.QuoteSchema(schema, table)))
 
 	colNames, wargs := whereSlice(cols)
 	args := make([]interface{}, 0, len(wargs))
@@ -623,9 +624,9 @@ func (s *mysqlSink) prepareDelete(schema, table string, cols map[string]*model.C
 			builder.WriteString(" AND ")
 		}
 		if wargs[i] == nil {
-			builder.WriteString(util.QuoteName(colNames[i]) + " IS NULL")
+			builder.WriteString(model.QuoteName(colNames[i]) + " IS NULL")
 		} else {
-			builder.WriteString(util.QuoteName(colNames[i]) + " = ?")
+			builder.WriteString(model.QuoteName(colNames[i]) + " = ?")
 			args = append(args, wargs[i])
 		}
 	}
@@ -681,7 +682,7 @@ func buildColumnList(names []string) string {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString(util.QuoteName(name))
+		b.WriteString(model.QuoteName(name))
 
 	}
 

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -21,7 +21,7 @@ import (
 	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/filter"
 )
 
 // Sink options keys
@@ -55,7 +55,7 @@ type Sink interface {
 const DSNScheme = "dsn://"
 
 // NewSink creates a new sink with the sink-uri
-func NewSink(ctx context.Context, sinkURIStr string, filter *util.Filter, config *util.ReplicaConfig, opts map[string]string) (Sink, error) {
+func NewSink(ctx context.Context, sinkURIStr string, filter *filter.Filter, config *filter.ReplicaConfig, opts map[string]string) (Sink, error) {
 	// check if sinkURI is a DSN
 	if strings.HasPrefix(strings.ToLower(sinkURIStr), DSNScheme) {
 		dsnStr := sinkURIStr[len(DSNScheme):]

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/spf13/cobra"
@@ -180,7 +180,7 @@ func newCreateChangefeedCommand() *cobra.Command {
 				return err
 			}
 
-			cfg := new(util.ReplicaConfig)
+			cfg := new(filter.ReplicaConfig)
 			if len(configFile) > 0 {
 				if err := strictDecodeFile(configFile, "cdc", cfg); err != nil {
 					return err
@@ -273,7 +273,7 @@ func verifyStartTs(ctx context.Context, startTs uint64, cli kv.CDCEtcdClient) er
 	return nil
 }
 
-func verifyTables(ctx context.Context, cfg *util.ReplicaConfig, startTs uint64) (ineligibleTables []entry.TableName, err error) {
+func verifyTables(ctx context.Context, cfg *filter.ReplicaConfig, startTs uint64) (ineligibleTables []entry.TableName, err error) {
 	kvStore, err := kv.CreateTiStore(cliPdAddr)
 	if err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func verifyTables(ctx context.Context, cfg *util.ReplicaConfig, startTs uint64) 
 		return nil, errors.Trace(err)
 	}
 
-	filter, err := util.NewFilter(cfg)
+	filter, err := filter.NewFilter(cfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
-	"github.com/pingcap/ticdc/pkg/util"
+	cdcfilter "github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/tidb-tools/pkg/filter"
 )
 
@@ -63,7 +63,7 @@ rule = "rowid"
 	err := ioutil.WriteFile(path, []byte(content), 0644)
 	c.Assert(err, check.IsNil)
 
-	cfg := new(util.ReplicaConfig)
+	cfg := new(cdcfilter.ReplicaConfig)
 	err = strictDecodeFile(path, "cdc", &cfg)
 	c.Assert(err, check.IsNil)
 
@@ -76,7 +76,7 @@ rule = "rowid"
 		{Schema: "sns", Name: "user"},
 		{Schema: "sns", Name: "following"},
 	})
-	c.Assert(cfg.SinkDispatchRules, check.DeepEquals, []*util.DispatchRule{
+	c.Assert(cfg.SinkDispatchRules, check.DeepEquals, []*cdcfilter.DispatchRule{
 		{Table: filter.Table{Schema: "sns", Name: "user"}, Rule: "ts"},
 		{Table: filter.Table{Schema: "sns", Name: "following"}, Rule: "rowid"},
 	})
@@ -112,7 +112,7 @@ rule = "rowid"
 	err := ioutil.WriteFile("changefeed.toml", []byte(content), 0644)
 	c.Assert(err, check.IsNil)
 
-	cfg := new(util.ReplicaConfig)
+	cfg := new(cdcfilter.ReplicaConfig)
 	err = strictDecodeFile("changefeed.toml", "cdc", &cfg)
 	c.Assert(err, check.IsNil)
 
@@ -124,7 +124,7 @@ rule = "rowid"
 		{Schema: "sns", Name: "user"},
 		{Schema: "sns", Name: "following"},
 	})
-	c.Assert(cfg.SinkDispatchRules, check.DeepEquals, []*util.DispatchRule{
+	c.Assert(cfg.SinkDispatchRules, check.DeepEquals, []*cdcfilter.DispatchRule{
 		{Table: filter.Table{Schema: "sns", Name: "user"}, Rule: "ts"},
 		{Table: filter.Table{Schema: "sns", Name: "following"}, Rule: "rowid"},
 	})
@@ -137,7 +137,7 @@ func (s *decodeFileSuite) TestShouldReturnErrForUnknownCfgs(c *check.C) {
 	err := ioutil.WriteFile(path, []byte(content), 0644)
 	c.Assert(err, check.IsNil)
 
-	cfg := new(util.ReplicaConfig)
+	cfg := new(cdcfilter.ReplicaConfig)
 	err = strictDecodeFile(path, "cdc", &cfg)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, ".*unknown config.*")

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
 	github.com/google/btree v1.0.0
-	github.com/google/martian v2.1.0+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
 	github.com/google/btree v1.0.0
+	github.com/google/martian v2.1.0+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
-github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20190930153522-6ce02741cba3 h1:3CYI9xg87xNAD+es02gZxbX/ky4KQeoFBsNOzuoAQZg=
 github.com/google/pprof v0.0.0-20190930153522-6ce02741cba3/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
+github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20190930153522-6ce02741cba3 h1:3CYI9xg87xNAD+es02gZxbX/ky4KQeoFBsNOzuoAQZg=
 github.com/google/pprof v0.0.0-20190930153522-6ce02741cba3/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=

--- a/kafka_consumer/main.go
+++ b/kafka_consumer/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 
+	cdcfilter "github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.uber.org/zap"
 
@@ -265,7 +266,7 @@ func NewConsumer(ctx context.Context) (*Consumer, error) {
 		}
 	}
 	ctx = util.PutTimezoneInCtx(ctx, tz)
-	filter, err := util.NewFilter(&util.ReplicaConfig{})
+	filter, err := cdcfilter.NewFilter(&cdcfilter.ReplicaConfig{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -275,7 +276,7 @@ func NewConsumer(ctx context.Context) (*Consumer, error) {
 		resolvedTs uint64
 	}, kafkaPartitionNum)
 	for i := 0; i < int(kafkaPartitionNum); i++ {
-		s, err := sink.NewSink(ctx, downstreamURIStr, filter, &util.ReplicaConfig{}, nil)
+		s, err := sink.NewSink(ctx, downstreamURIStr, filter, &cdcfilter.ReplicaConfig{}, nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -284,7 +285,7 @@ func NewConsumer(ctx context.Context) (*Consumer, error) {
 			resolvedTs uint64
 		}{Sink: s}
 	}
-	sink, err := sink.NewSink(ctx, downstreamURIStr, filter, &util.ReplicaConfig{}, nil)
+	sink, err := sink.NewSink(ctx, downstreamURIStr, filter, &cdcfilter.ReplicaConfig{}, nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -1,4 +1,4 @@
-package util
+package filter
 
 import (
 	"strings"

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -11,9 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package filter
 
 import (
+	"testing"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb-tools/pkg/filter"
@@ -22,6 +24,8 @@ import (
 type filterSuite struct{}
 
 var _ = check.Suite(&filterSuite{})
+
+func Test(t *testing.T) { check.TestingT(t) }
 
 func (s *filterSuite) TestShouldUseDefaultRules(c *check.C) {
 	filter, err := NewFilter(&ReplicaConfig{})

--- a/pkg/regionspan/region.go
+++ b/pkg/regionspan/region.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package regionspan
 
 import (
 	"sort"

--- a/pkg/regionspan/region_range_lock.go
+++ b/pkg/regionspan/region_range_lock.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package regionspan
 
 import (
 	"bytes"

--- a/pkg/regionspan/region_range_lock_test.go
+++ b/pkg/regionspan/region_range_lock_test.go
@@ -11,11 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package regionspan
 
 import (
-	"github.com/pingcap/check"
 	"math"
+
+	"github.com/pingcap/check"
 )
 
 type regionRangeLockSuit struct{}

--- a/pkg/regionspan/region_test.go
+++ b/pkg/regionspan/region_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package regionspan
 
 import (
 	"github.com/pingcap/check"

--- a/pkg/regionspan/span.go
+++ b/pkg/regionspan/span.go
@@ -1,4 +1,4 @@
-package util
+package regionspan
 
 import (
 	"bytes"

--- a/pkg/regionspan/span_test.go
+++ b/pkg/regionspan/span_test.go
@@ -1,6 +1,8 @@
-package util
+package regionspan
 
 import (
+	"testing"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
@@ -9,6 +11,8 @@ import (
 type spanSuite struct{}
 
 var _ = check.Suite(&spanSuite{})
+
+func Test(t *testing.T) { check.TestingT(t) }
 
 func (s *spanSuite) TestStartCompare(c *check.C) {
 	tests := []struct {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The package model as a fundamental package should not imports package util as util contains many utility functions that are useful in other packages.

It makes #509 easy to manage package imports.

### What is changed and how it works?

* Move span files into pkg/regionspan.
* Move filter files into pkg/filter.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Related changes

 - Need to cherry-pick to the release branch
