### PR TITLE
owner: fix cleanup tasks in some corner case

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -104,30 +104,45 @@ func (o *Owner) removeCapture(info *model.CaptureInfo) {
 	for _, feed := range o.changeFeeds {
 		task, ok := feed.taskStatus[info.ID]
 		if !ok {
-			log.Warn("task status not found", zap.String("capture", info.ID))
+			log.Warn("task status not found", zap.String("capture", info.ID), zap.String("changefeed", feed.id))
 			continue
 		}
+		var startTs uint64
 		pos, ok := feed.taskPositions[info.ID]
 		if !ok {
-			log.Warn("task position not found", zap.String("capture", info.ID))
-			continue
+			log.Warn("task position not found, fallback to use changefeed checkpointts",
+				zap.String("capture", info.ID), zap.String("changefeed", feed.id))
+			// maybe the processor hasn't added table yet, fallback to use global
+			// checkpoint ts as the start ts of the table.
+			startTs = feed.status.CheckpointTs
 		}
 
 		for _, table := range task.TableInfos {
 			feed.orphanTables[table.ID] = model.ProcessTableInfo{
 				ID:      table.ID,
-				StartTs: pos.CheckPointTs,
+				StartTs: startTs,
 			}
 		}
 
 		ctx := context.TODO()
 		if err := o.etcdClient.DeleteTaskStatus(ctx, feed.id, info.ID); err != nil {
-			log.Warn("failed to delete task status", zap.Error(err))
+			log.Warn("failed to delete task status",
+				zap.String("capture", info.ID), zap.String("changefeed", feed.id), zap.Error(err))
 		}
 		if err := o.etcdClient.DeleteTaskPosition(ctx, feed.id, info.ID); err != nil {
-			log.Warn("failed to delete task position", zap.Error(err))
+			log.Warn("failed to delete task position",
+				zap.String("capture", info.ID), zap.String("changefeed", feed.id), zap.Error(err))
 		}
+	}
+}
 
+func (o *Owner) addOrphanTable(cid string, table model.ProcessTableInfo) {
+	o.l.Lock()
+	defer o.l.Unlock()
+	if cf, ok := o.changeFeeds[cid]; ok {
+		cf.orphanTables[table.ID] = table
+	} else {
+		log.Warn("changefeed not found", zap.String("changefeed", cid))
 	}
 }
 
@@ -457,14 +472,6 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 }
 
 func (o *Owner) throne(ctx context.Context) error {
-	// When an owner crashed, its processors crashed too,
-	// clean up the tasks for these processors.
-	if err := o.cleanUpStaleTasks(ctx); err != nil {
-		log.Error("clean up stale tasks failed",
-			zap.Error(err))
-		return err
-	}
-
 	// Start a routine to keep watching on the liveness of
 	// captures.
 	o.startCaptureWatcher(ctx)
@@ -596,17 +603,12 @@ func (o *Owner) writeDebugInfo(w io.Writer) {
 // When a new owner is elected, it does not know the events occurs before, like
 // processor deletion. In this case, the new owner should check if the task
 // status is stale because of the processor deletion.
-func (o *Owner) cleanUpStaleTasks(ctx context.Context) error {
+func (o *Owner) cleanUpStaleTasks(ctx context.Context, captures []*model.CaptureInfo) error {
 	_, changefeeds, err := o.etcdClient.GetChangeFeeds(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	active := make(map[string]struct{})
-	_, captures, err := o.etcdClient.GetCaptures(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	for _, c := range captures {
 		active[c.ID] = struct{}{}
 	}
@@ -619,10 +621,26 @@ func (o *Owner) cleanUpStaleTasks(ctx context.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		// in most cases statuses and positions have the same keys
+		// in most cases statuses and positions have the same keys, or positions
+		// are more than statuses, as we always delete task status first.
 		captureIDs := make(map[string]struct{}, len(statuses))
-		for captureID := range statuses {
+		for captureID, status := range statuses {
 			captureIDs[captureID] = struct{}{}
+			pos, ok := positions[captureID]
+			if !ok {
+				log.Warn("find task status, but task position not found",
+					zap.String("capture", captureID),
+					zap.String("changefeed", changeFeedID),
+					zap.Reflect("task status", status),
+				)
+				continue
+			}
+			for _, table := range status.TableInfos {
+				o.addOrphanTable(changeFeedID, model.ProcessTableInfo{
+					ID:      table.ID,
+					StartTs: pos.CheckPointTs,
+				})
+			}
 		}
 		for captureID := range positions {
 			captureIDs[captureID] = struct{}{}
@@ -645,6 +663,8 @@ func (o *Owner) cleanUpStaleTasks(ctx context.Context) error {
 
 func (o *Owner) watchCapture(ctx context.Context) error {
 	ctx = clientv3.WithRequireLeader(ctx)
+
+	failpoint.Inject("sleep-before-watch-capture", nil)
 
 	// When an owner just starts, changefeed information is not updated at once.
 	// Supposing a crased capture should be removed now, the owner will miss deleting
@@ -720,7 +740,18 @@ func (o *Owner) rebuildCaptureEvents(ctx context.Context, captures []*model.Capt
 			o.removeCapture(c)
 		}
 	}
-	return nil
+	// clean up stale tasks each time before watch capture event starts,
+	// for two reasons:
+	// 1. when a new owner is elected, it must clean up stale task status and positions.
+	// 2. when error happens in owner's capture event watch, the owner just resets
+	//    the watch loop, with the following two steps:
+	//    1) load all captures from PD, having a revision for data
+	//	  2) start a new watch from revision in step1
+	//    the step-2 may meet an error such as ErrCompacted, and we will continue
+	//    from step-1, however other capture may crash just after step-2 returns
+	//    and before step-1 starts, the longer time gap between step-2 to step-1,
+	//    missing a crashed capture is more likey to happen.
+	return errors.Trace(o.cleanUpStaleTasks(ctx, captures))
 }
 
 func (o *Owner) startCaptureWatcher(ctx context.Context) {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -109,7 +109,9 @@ func (o *Owner) removeCapture(info *model.CaptureInfo) {
 		}
 		var startTs uint64
 		pos, ok := feed.taskPositions[info.ID]
-		if !ok {
+		if ok {
+			startTs = pos.CheckPointTs
+		} else {
 			log.Warn("task position not found, fallback to use changefeed checkpointts",
 				zap.String("capture", info.ID), zap.String("changefeed", feed.id))
 			// maybe the processor hasn't added table yet, fallback to use global

--- a/tests/availability/capture.sh
+++ b/tests/availability/capture.sh
@@ -15,7 +15,7 @@ function sql_check() {
 
     # check table availability.
     echo "run sql_check", ${DOWN_TIDB_HOST}
-    run_sql "SELECT id, val FROM test.availability;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} &&
+    run_sql "SELECT id, val FROM test.availability1;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} &&
         check_contains "id: 1" &&
         check_contains "val: 1" &&
         check_contains "id: 2" &&
@@ -66,10 +66,10 @@ function test_kill_capture() {
     echo "owner id" $owner_id
 
     # wait for the tables to appear
-    check_table_exists test.availability ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 20
+    check_table_exists test.availability1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 20
 
-    run_sql "INSERT INTO test.availability(id, val) VALUES (1, 1);"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=1 and val=1'
+    run_sql "INSERT INTO test.availability1(id, val) VALUES (1, 1);"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=1 and val=1'
 
     # start the second capture
     run_cdc_server $WORK_DIR $CDC_BINARY
@@ -79,8 +79,8 @@ function test_kill_capture() {
     # kill the owner
     kill -9 $owner_pid
 
-    run_sql "INSERT INTO test.availability(id, val) VALUES (2, 2);"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=2 and val=2'
+    run_sql "INSERT INTO test.availability1(id, val) VALUES (2, 2);"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=2 and val=2'
 
     cleanup_process $CDC_BINARY
 }
@@ -107,8 +107,8 @@ function test_hang_up_capture() {
     capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
 
     kill -STOP $owner_pid
-    run_sql "INSERT INTO test.availability(id, val) VALUES (3, 3);"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=3 and val=3'
+    run_sql "INSERT INTO test.availability1(id, val) VALUES (3, 3);"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=3 and val=3'
     kill -CONT $owner_pid
     cleanup_process $CDC_BINARY
 }
@@ -140,8 +140,8 @@ function test_expire_capture() {
     kill -SIGCONT $owner_pid
     echo "process status:" $(ps -h -p $owner_pid -o "s")
 
-    run_sql "UPDATE test.availability set val = 22 where id = 2;"
-    run_sql "DELETE from test.availability where id = 3;"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=2 and val=22'
+    run_sql "UPDATE test.availability1 set val = 22 where id = 2;"
+    run_sql "DELETE from test.availability1 where id = 3;"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=2 and val=22'
     cleanup_process $CDC_BINARY
 }

--- a/tests/availability/owner.sh
+++ b/tests/availability/owner.sh
@@ -13,7 +13,9 @@ function test_owner_ha() {
     test_kill_owner
     test_hang_up_owner
     test_expire_owner
-    test_owner_cleanup_stale_tasks
+    # FIXME: this test case should be owner crashed during task cleanup
+    # test_owner_cleanup_stale_tasks
+    test_gap_between_watch_capture
 }
 # test_kill_owner starts two captures and kill the owner
 # we expect the live capture will be elected as the new
@@ -142,11 +144,50 @@ function test_owner_cleanup_stale_tasks() {
     run_cdc_server $WORK_DIR $CDC_BINARY
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
 
-    run_sql "INSERT INTO test.availability(id, val) VALUES (1, 1);"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=1 and val=1'
-    run_sql "UPDATE test.availability set val = 22 where id = 1;"
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=1 and val=22'
-    run_sql "DELETE from test.availability where id=1;"
-    ensure $MAX_RETRIES empty 'select id, val from test.availability where id=1'
+    run_sql "INSERT INTO test.availability1(id, val) VALUES (1, 1);"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=1 and val=1'
+    run_sql "UPDATE test.availability1 set val = 22 where id = 1;"
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=1 and val=22'
+    run_sql "DELETE from test.availability1 where id=1;"
+    ensure $MAX_RETRIES empty 'select id, val from test.availability1 where id=1'
+    cleanup_process $CDC_BINARY
+}
+
+function test_gap_between_watch_capture() {
+    echo "run test case test_gap_between_watch_capture"
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sleep-before-watch-capture=1*sleep(6000)'
+
+    # start a capture server
+    run_cdc_server $WORK_DIR $CDC_BINARY
+    # ensure the server become the owner
+    ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
+    owner_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}')
+    owner_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}')
+    echo "owner pid:" $owner_pid
+    echo "owner id" $owner_id
+
+    # run another server
+    run_cdc_server $WORK_DIR $CDC_BINARY
+    ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep id"
+    capture_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}' | grep -v "$owner_pid")
+    capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
+    echo "capture_id:" $capture_id
+
+    kill -SIGKILL $capture_pid
+    # wait capture info expires
+    sleep 3
+
+    for i in $(seq 1 3); do
+        run_sql "INSERT INTO test.availability$i(id, val) VALUES (1, 1);"
+        ensure $MAX_RETRIES nonempty "select id, val from test.availability$i where id=1 and val=1"
+        run_sql "UPDATE test.availability$i set val = 22 where id = 1;"
+        ensure $MAX_RETRIES nonempty "select id, val from test.availability$i where id=1 and val=22"
+        run_sql "DELETE from test.availability$i where id=1;"
+        ensure $MAX_RETRIES empty "select id, val from test.availability$i where id=1"
+    done
+
+    export GO_FAILPOINTS=''
+    echo "test_gap_between_watch_capture pass"
     cleanup_process $CDC_BINARY
 }

--- a/tests/availability/processor.sh
+++ b/tests/availability/processor.sh
@@ -35,11 +35,11 @@ function test_stop_processor() {
     # use ensure to wait for the change feed loading into memory from etcd
     ensure $MAX_RETRIES "curl -s -d \"cf-id=$changefeed&admin-job=1\" http://127.0.0.1:8300/capture/owner/admin | grep true"
 
-    run_sql "INSERT INTO test.availability(id, val) VALUES (4, 4);"
+    run_sql "INSERT INTO test.availability1(id, val) VALUES (4, 4);"
 
     # resume the change feed job
     curl -d "cf-id=$changefeed&admin-job=2" http://127.0.0.1:8300/capture/owner/admin
-    ensure $MAX_RETRIES nonempty 'select id, val from test.availability where id=4 and val=4'
+    ensure $MAX_RETRIES nonempty 'select id, val from test.availability1 where id=4 and val=4'
 
     echo "test_stop_processor pass"
     cleanup_process $CDC_BINARY

--- a/tests/availability/run.sh
+++ b/tests/availability/run.sh
@@ -23,7 +23,9 @@ function prepare() {
     # record tso before we create tables to skip the system table DDLs
     start_ts=$(cdc cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
 
-    run_sql "CREATE table test.availability(id int primary key, val int);"
+    run_sql "CREATE table test.availability1(id int primary key, val int);"
+    run_sql "CREATE table test.availability2(id int primary key, val int);"
+    run_sql "CREATE table test.availability3(id int primary key, val int);"
 
     cdc cli changefeed create --start-ts=$start_ts --sink-uri="mysql://root@127.0.0.1:3306/"
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix bug found in https://github.com/pingcap/ticdc/issues/530

TODO: there exists another bug, if owner has cleaned up task status (either in `removeCapture` or in `cleanUpStaleTasks`),  but the owner crashes before the orphan tables are dispatched, the orphan tables will be ignored. Will solve it in another PR.

### What is changed and how it works?

- clean up stale task each time before watch capture event starts
- re-balance tables when cleaning up stale tasks

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test