### PR TITLE
changefeed: can execute DDL when min resovled ts equels to ddl finished ts

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -524,7 +524,7 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 	for len(c.ddlJobHistory) > 0 && c.ddlJobHistory[0].BinlogInfo.FinishedTS <= c.ddlExecutedTs {
 		c.ddlJobHistory = c.ddlJobHistory[1:]
 	}
-	if len(c.ddlJobHistory) > 0 && minResolvedTs > c.ddlJobHistory[0].BinlogInfo.FinishedTS {
+	if len(c.ddlJobHistory) > 0 && minResolvedTs >= c.ddlJobHistory[0].BinlogInfo.FinishedTS {
 		minResolvedTs = c.ddlJobHistory[0].BinlogInfo.FinishedTS
 		c.ddlState = model.ChangeFeedWaitToExecDDL
 	}


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

maybe a little optimization, DNM

### What is changed and how it works?
owner can execute DDL if `minResolvedTs` equals to DDL finished ts

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test