### PR TITLE
*: add pid in cdc server coverage file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,4 +35,14 @@ Related changes
  - Need to cherry-pick to the release branch
  - Need to update the documentation
  - Need to update the `tidb-cdc/cdc-ansible`
- - Need to be included in the release note
+
+### Release note
+
+<!-- bugfixes or new feature need a release note, must in the form of a list, such as
+
+- owner: add table in batch when start a changefeed to speed up scheduling
+
+or if no need to be included in the release note, just add the folloing line
+
+- No release note
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,7 +42,7 @@ Related changes
 
 - owner: add table in batch when start a changefeed to speed up scheduling
 
-or if no need to be included in the release note, just add the folloing line
+or if no need to be included in the release note, just add the following line
 
 - No release note
 -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://internal.pingcap.net/idc-jenkins/job/build_cdc_master/badge/icon)](https://internal.pingcap.net/idc-jenkins/job/build_cdc_master/)
 [![codecov](https://codecov.io/gh/pingcap/ticdc/branch/master/graph/badge.svg)](https://codecov.io/gh/pingcap/ticdc)
+[![Coverage Status](https://coveralls.io/repos/github/pingcap/ticdc/badge.svg)](https://coveralls.io/github/pingcap/ticdc)
 [![LICENSE](https://img.shields.io/github/license/pingcap/ticdc.svg)](https://github.com/pingcap/ticdc/blob/master/LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pingcap/ticdc)](https://goreportcard.com/report/github.com/pingcap/ticdc)
 
@@ -13,7 +14,9 @@
 
 ## Documentation
 
-TODO
+[Chinese Document](https://pingcap.com/docs-cn/dev/reference/tools/ticdc/overview/)
+
+[English Document](https://pingcap.com/docs/dev/reference/tools/ticdc/overview/)
 
 ## Building
 

--- a/tests/_utils/run_cdc_server
+++ b/tests/_utils/run_cdc_server
@@ -13,5 +13,6 @@ pwd=$pwd
 
 echo "[$(date)] <<<<<< START cdc server in $TEST_NAME case >>>>>>"
 cd $workdir
-$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME$log_suffix.out" server --log-file $workdir/cdc$log_suffix.log --log-level info >> $workdir/stdout$log_suffix.log 2>&1 &
+pid=$(ps -C run_cdc_server -o pid=)
+$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME_$pid.out" server --log-file $workdir/cdc$log_suffix.log --log-level info >> $workdir/stdout$log_suffix.log 2>&1 &
 cd $pwd


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

coverage file could be overwritten in a test case that starts more than one captures, add `pid` to coverage file to distinguish them.

### What is changed and how it works?
- add pid in cdc server coverage file
- update document link in readme
- add coverage report of integration test from coveralls.io

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note