### PR TITLE
owner: only dispatch stale task status during clean up

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -623,28 +623,8 @@ func (o *Owner) cleanUpStaleTasks(ctx context.Context, captures []*model.Capture
 		// in most cases statuses and positions have the same keys, or positions
 		// are more than statuses, as we always delete task status first.
 		captureIDs := make(map[string]struct{}, len(statuses))
-		for captureID, status := range statuses {
+		for captureID := range statuses {
 			captureIDs[captureID] = struct{}{}
-			pos, taskPosFound := positions[captureID]
-			if !taskPosFound {
-				log.Warn("task position not found, fallback to use original start ts",
-					zap.String("capture", captureID),
-					zap.String("changefeed", changeFeedID),
-					zap.Reflect("task status", status),
-				)
-			}
-			for _, table := range status.TableInfos {
-				var startTs uint64
-				if taskPosFound {
-					startTs = pos.CheckPointTs
-				} else {
-					startTs = table.StartTs
-				}
-				o.addOrphanTable(changeFeedID, model.ProcessTableInfo{
-					ID:      table.ID,
-					StartTs: startTs,
-				})
-			}
 		}
 		for captureID := range positions {
 			captureIDs[captureID] = struct{}{}
@@ -652,6 +632,30 @@ func (o *Owner) cleanUpStaleTasks(ctx context.Context, captures []*model.Capture
 
 		for captureID := range captureIDs {
 			if _, ok := active[captureID]; !ok {
+				status, ok1 := statuses[captureID]
+				if ok1 {
+					pos, taskPosFound := positions[captureID]
+					if !taskPosFound {
+						log.Warn("task position not found, fallback to use original start ts",
+							zap.String("capture", captureID),
+							zap.String("changefeed", changeFeedID),
+							zap.Reflect("task status", status),
+						)
+					}
+					for _, table := range status.TableInfos {
+						var startTs uint64
+						if taskPosFound {
+							startTs = pos.CheckPointTs
+						} else {
+							startTs = table.StartTs
+						}
+						o.addOrphanTable(changeFeedID, model.ProcessTableInfo{
+							ID:      table.ID,
+							StartTs: startTs,
+						})
+					}
+				}
+
 				if err := o.etcdClient.DeleteTaskStatus(ctx, changeFeedID, captureID); err != nil {
 					return errors.Trace(err)
 				}

--- a/tests/_utils/run_cdc_server
+++ b/tests/_utils/run_cdc_server
@@ -13,6 +13,6 @@ pwd=$pwd
 
 echo "[$(date)] <<<<<< START cdc server in $TEST_NAME case >>>>>>"
 cd $workdir
-pid=$(ps -C run_cdc_server -o pid=)
-$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME_$pid.out" server --log-file $workdir/cdc$log_suffix.log --log-level info >> $workdir/stdout$log_suffix.log 2>&1 &
+pid=$(ps -C run_cdc_server -o pid=|tr -d '[:space:]')
+$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME.$pid.out" server --log-file $workdir/cdc$log_suffix.log --log-level info >> $workdir/stdout$log_suffix.log 2>&1 &
 cd $pwd


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/544

### What is changed and how it works?

- Should filter task status belonging to active capture.
- Also fix a variable name in test script, as `_` will be interpreted as a part of bash variable

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
### Release note

- No release note
