### PR TITLE
task: use start-ts if changefeed status doesn't exist

### DIFF
--- a/cdc/task.go
+++ b/cdc/task.go
@@ -174,12 +174,8 @@ func (w *TaskWatcher) parseTask(ctx context.Context,
 		return nil, err
 	}
 	status, err := w.capture.etcdClient.GetChangeFeedStatus(ctx, changeFeedID)
-	if err != nil {
-		if errors.Cause(err) == model.ErrChangeFeedNotExists {
-			status = &model.ChangeFeedStatus{}
-		} else {
-			return nil, err
-		}
+	if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
+		return nil, err
 	}
 	checkpointTs := cf.GetCheckpointTs(status)
 	return &Task{ChangeFeedID: changeFeedID, CheckpointTS: checkpointTs}, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in a test happens to find following bug

```
[2020/05/08 23:07:59.271 +08:00] [INFO] [processor.go:144] ["start processor with startts"] [startts=0]
[2020/05/08 23:07:59.272 +08:00] [INFO] [store.go:68] ["new store"] [path="tikv://localhost:2379?disableGC=true"]
[2020/05/08 23:07:59.272 +08:00] [INFO] [client.go:141] ["[pd] create pd client with endpoints"] [pd-address="[localhost:2379]"]
[2020/05/08 23:07:59.278 +08:00] [INFO] [base_client.go:226] ["[pd] update member urls"] [old-urls="[http://localhost:2379]"] [new-urls="[http://127.0.0.1:2379]"]
[2020/05/08 23:07:59.278 +08:00] [INFO] [base_client.go:242] ["[pd] switch leader"] [new-leader=http://127.0.0.1:2379] [old-leader=]
[2020/05/08 23:07:59.279 +08:00] [INFO] [base_client.go:92] ["[pd] init cluster id"] [cluster-id=6821809853986031554]
[2020/05/08 23:07:59.279 +08:00] [INFO] [store.go:74] ["new store with retry success"]
[2020/05/08 23:07:59.279 +08:00] [DEBUG] [scan.go:157] ["txn getData"] [nextStartKey=6d4442730000000000fa0000000000000068] [nextEndKey=6d4442730000000000fa0000000000000069] [reve
rse=false] [txnStartTS=0]
[2020/05/08 23:07:59.280 +08:00] [ERROR] [capture.go:211] ["run processor failed"] [changefeedid=d78db59d-94df-44e2-bd97-2bbe6de4d1cb] [captureid=cf889e37-e9ce-43f5-9d95-2590d26d
8afd]
```

`startts=0` in `[2020/05/08 23:07:59.271 +08:00] [INFO] [processor.go:144] ["start processor with startts"] [startts=0]` means we get an invalid `checkpoint-ts` from [Task](https://github.com/pingcap/ticdc/blob/master/cdc/task.go#L38)

This happens because `changefeed status` and `task` are updated concurrently.
 
### What is changed and how it works?

If `ChangeFeedStatus` is not found, use `start-ts` of the changefeed instead of the `checkpoint-ts`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
