### PR TITLE
processor: refine log output when stopped by admin command

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -69,6 +69,7 @@ type processor struct {
 	changefeedID string
 	changefeed   model.ChangeFeedInfo
 	limitter     *puller.BlurResourceLimitter
+	stopped      int32
 
 	pdCli     pd.Client
 	kvStorage tidbkv.Storage
@@ -261,8 +262,10 @@ func (p *processor) positionWorker(ctx context.Context) error {
 		t0Update := time.Now()
 		err := retry.Run(500*time.Millisecond, 3, func() error {
 			inErr := p.updateInfo(ctx)
-			if errors.Cause(inErr) == model.ErrAdminStopProcessor {
-				return backoff.Permanent(inErr)
+			if inErr != nil {
+				if p.isStopped() || errors.Cause(inErr) == model.ErrAdminStopProcessor {
+					return backoff.Permanent(errors.Trace(model.ErrAdminStopProcessor))
+				}
 			}
 			return inErr
 		})
@@ -278,9 +281,11 @@ func (p *processor) positionWorker(ctx context.Context) error {
 		resolveTsTick.Stop()
 		checkpointTsTick.Stop()
 
-		err := updateInfo()
-		if err != nil && errors.Cause(err) != context.Canceled {
-			log.Error("failed to update info", zap.Error(err))
+		if !p.isStopped() {
+			err := updateInfo()
+			if err != nil && errors.Cause(err) != context.Canceled {
+				log.Warn("failed to update info before exit", zap.Error(err))
+			}
 		}
 
 		log.Info("Local resolved worker exited")
@@ -747,16 +752,22 @@ func (p *processor) addTable(ctx context.Context, tableID int64, startTs uint64)
 }
 
 func (p *processor) stop(ctx context.Context) error {
+	log.Info("stop processor", zap.String("id", p.id), zap.String("capture", p.captureID), zap.String("changefeed", p.changefeedID))
 	p.tablesMu.Lock()
 	for _, tbl := range p.tables {
 		tbl.cancel()
 	}
 	p.tablesMu.Unlock()
+	atomic.StoreInt32(&p.stopped, 1)
 
 	if err := p.etcdCli.DeleteTaskPosition(ctx, p.changefeedID, p.captureID); err != nil {
 		return err
 	}
 	return p.etcdCli.DeleteTaskStatus(ctx, p.changefeedID, p.captureID)
+}
+
+func (p *processor) isStopped() bool {
+	return atomic.LoadInt32(&p.stopped) == 1
 }
 
 // runProcessor creates a new processor then starts it.
@@ -798,16 +809,15 @@ func runProcessor(
 
 	go func() {
 		err := <-errCh
-		if errors.Cause(err) != context.Canceled {
+		cause := errors.Cause(err)
+		if cause != nil && cause != context.Canceled && cause != model.ErrAdminStopProcessor {
+			processorErrorCounter.WithLabelValues(changefeedID, captureID).Inc()
 			log.Error("error on running processor",
 				zap.String("captureid", captureID),
 				zap.String("changefeedid", changefeedID),
 				zap.String("processorid", processor.id),
 				zap.Error(err))
 		} else {
-			if err != nil {
-				processorErrorCounter.WithLabelValues(changefeedID, captureID).Inc()
-			}
 			log.Info("processor exited",
 				zap.String("captureid", captureID),
 				zap.String("changefeedid", changefeedID),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

processor can be stopped by the admin command, which should not update info and log error. Fix #543

### What is changed and how it works?

- add a flag to record whether the processor is stopped.
- treat `model.ErrAdminStopProcessor` when processor exits.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
