### PR TITLE
cmd: add dial timeout and verify sink connection status

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -55,11 +55,13 @@ type Capture struct {
 }
 
 // NewCapture returns a new Capture instance
-func NewCapture(pdEndpoints []string, advertiseAddr string) (c *Capture, err error) {
+func NewCapture(ctx context.Context, pdEndpoints []string, advertiseAddr string) (c *Capture, err error) {
 	etcdCli, err := clientv3.New(clientv3.Config{
 		Endpoints:   pdEndpoints,
+		Context:     ctx,
 		DialTimeout: 5 * time.Second,
 		DialOptions: []grpc.DialOption{
+			grpc.WithBlock(),
 			grpc.WithConnectParams(grpc.ConnectParams{
 				Backoff: backoff.Config{
 					BaseDelay:  time.Second,

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -183,7 +183,7 @@ func (s *Server) campaignOwnerLoop(ctx context.Context) error {
 
 func (s *Server) run(ctx context.Context) (err error) {
 	capture, err := NewCapture(
-		strings.Split(s.opts.pdEndpoints, ","), s.opts.advertiseAddr)
+		ctx, strings.Split(s.opts.pdEndpoints, ","), s.opts.advertiseAddr)
 	if err != nil {
 		return err
 	}

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -297,6 +297,11 @@ func newMySQLSink(ctx context.Context, sinkURI *url.URL, dsn *dmysql.Config, fil
 	if err != nil {
 		return nil, errors.Annotatef(err, "Open database connection failed, dsn: %s", dsnStr)
 	}
+	err = db.PingContext(ctx)
+	if err != nil {
+		return nil, errors.Annotatef(err, "fail to open MySQL connection")
+	}
+
 	log.Info("Start mysql sink", zap.String("dsn", dsnStr))
 
 	db.SetMaxIdleConns(params.workerCount)

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -295,14 +295,14 @@ func newMySQLSink(ctx context.Context, sinkURI *url.URL, dsn *dmysql.Config, fil
 	}
 	db, err := sql.Open("mysql", dsnStr)
 	if err != nil {
-		return nil, errors.Annotatef(err, "Open database connection failed, dsn: %s", dsnStr)
+		return nil, errors.Annotate(err, "Open database connection failed")
 	}
 	err = db.PingContext(ctx)
 	if err != nil {
 		return nil, errors.Annotatef(err, "fail to open MySQL connection")
 	}
 
-	log.Info("Start mysql sink", zap.String("dsn", dsnStr))
+	log.Info("Start mysql sink")
 
 	db.SetMaxIdleConns(params.workerCount)
 	db.SetMaxOpenConns(params.workerCount)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -93,10 +93,9 @@ func newCliCommand() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			etcdCli, err := clientv3.New(clientv3.Config{
 				Endpoints:   []string{cliPdAddr},
-				DialTimeout: 5 * time.Second,
+				DialTimeout: defaultContextTimeoutDuration,
 				DialOptions: []grpc.DialOption{
 					grpc.WithBlock(),
-					grpc.WithTimeout(defaultContextTimeoutDuration),
 					grpc.WithConnectParams(grpc.ConnectParams{
 						Backoff: backoff.Config{
 							BaseDelay:  time.Second,
@@ -116,7 +115,6 @@ func newCliCommand() *cobra.Command {
 			pdCli, err = pd.NewClient([]string{cliPdAddr}, pd.SecurityOption{},
 				pd.WithGRPCDialOptions(
 					grpc.WithBlock(),
-					grpc.WithTimeout(defaultContextTimeoutDuration),
 					grpc.WithConnectParams(grpc.ConnectParams{
 						Backoff: backoff.Config{
 							BaseDelay:  time.Second,

--- a/cmd/client_capture.go
+++ b/cmd/client_capture.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-
 	_ "github.com/go-sql-driver/mysql" // mysql driver
 	"github.com/spf13/cobra"
 )
@@ -24,7 +22,9 @@ func newListCaptureCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List all captures in TiCDC cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			captures, err := getAllCaptures(context.Background())
+			ctx, cancel := contextTimeout()
+			defer cancel()
+			captures, err := getAllCaptures(ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -258,6 +258,7 @@ func newStatisticsChangefeedCommand() *cobra.Command {
 				syscall.SIGQUIT)
 
 			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
 			tick := time.NewTicker(time.Duration(interval) * time.Second)
 			lastTime := time.Now()
 			var lastCount uint64

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -41,7 +41,8 @@ func newAdminChangefeedCommand() []*cobra.Command {
 			Use:   "pause",
 			Short: "Pause a replicaiton task (changefeed)",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				ctx := context.Background()
+				ctx, cancel := contextTimeout()
+				defer cancel()
 				job := model.AdminJob{
 					CfID: changefeedID,
 					Type: model.AdminStop,
@@ -53,7 +54,8 @@ func newAdminChangefeedCommand() []*cobra.Command {
 			Use:   "resume",
 			Short: "Resume a paused replicaiton task (changefeed)",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				ctx := context.Background()
+				ctx, cancel := contextTimeout()
+				defer cancel()
 				job := model.AdminJob{
 					CfID: changefeedID,
 					Type: model.AdminResume,
@@ -65,7 +67,8 @@ func newAdminChangefeedCommand() []*cobra.Command {
 			Use:   "remove",
 			Short: "Remove a replicaiton task (changefeed)",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				ctx := context.Background()
+				ctx, cancel := contextTimeout()
+				defer cancel()
 				job := model.AdminJob{
 					CfID: changefeedID,
 					Type: model.AdminRemove,
@@ -87,7 +90,9 @@ func newListChangefeedCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List all replication tasks (changefeeds) in TiCDC cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, raw, err := cdcEtcdCli.GetChangeFeeds(context.Background())
+			ctx, cancel := contextTimeout()
+			defer cancel()
+			_, raw, err := cdcEtcdCli.GetChangeFeeds(ctx)
 			if err != nil {
 				return err
 			}
@@ -106,15 +111,17 @@ func newQueryChangefeedCommand() *cobra.Command {
 		Use:   "query",
 		Short: "Query information and status of a replicaiton task (changefeed)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			info, err := cdcEtcdCli.GetChangeFeedInfo(context.Background(), changefeedID)
+			ctx, cancel := contextTimeout()
+			defer cancel()
+			info, err := cdcEtcdCli.GetChangeFeedInfo(ctx, changefeedID)
 			if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
 				return err
 			}
-			status, _, err := cdcEtcdCli.GetChangeFeedStatus(context.Background(), changefeedID)
+			status, _, err := cdcEtcdCli.GetChangeFeedStatus(ctx, changefeedID)
 			if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
 				return err
 			}
-			taskPositions, err := cdcEtcdCli.GetAllTaskPositions(context.Background(), changefeedID)
+			taskPositions, err := cdcEtcdCli.GetAllTaskPositions(ctx, changefeedID)
 			if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
 				return err
 			}
@@ -122,7 +129,7 @@ func newQueryChangefeedCommand() *cobra.Command {
 			for _, pinfo := range taskPositions {
 				count += pinfo.Count
 			}
-			processorInfos, err := cdcEtcdCli.GetAllTaskStatus(context.Background(), changefeedID)
+			processorInfos, err := cdcEtcdCli.GetAllTaskStatus(ctx, changefeedID)
 			if err != nil {
 				return err
 			}
@@ -145,7 +152,8 @@ func newCreateChangefeedCommand() *cobra.Command {
 		Short: "Create a new replication task (changefeed)",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx, cancel := contextTimeout()
+			defer cancel()
 			id := uuid.New().String()
 			if startTs == 0 {
 				ts, logical, err := pdCli.GetTS(ctx)
@@ -217,6 +225,10 @@ func newCreateChangefeedCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			err = verifySink(ctx, info.SinkURI, info.Config, info.Opts)
+			if err != nil {
+				return err
+			}
 			cmd.Printf("Create changefeed successfully!\nID: %s\nInfo: %s\n", id, d)
 			return cdcEtcdCli.SaveChangeFeedInfo(ctx, info, id)
 		},
@@ -245,6 +257,7 @@ func newStatisticsChangefeedCommand() *cobra.Command {
 				syscall.SIGTERM,
 				syscall.SIGQUIT)
 
+			ctx, cancel := context.WithCancel(context.TODO())
 			tick := time.NewTicker(time.Duration(interval) * time.Second)
 			lastTime := time.Now()
 			var lastCount uint64
@@ -253,17 +266,19 @@ func newStatisticsChangefeedCommand() *cobra.Command {
 				case sig := <-sc:
 					switch sig {
 					case syscall.SIGTERM:
+						cancel()
 						os.Exit(0)
 					default:
+						cancel()
 						os.Exit(1)
 					}
 				case <-tick.C:
 					now := time.Now()
-					status, _, err := cdcEtcdCli.GetChangeFeedStatus(context.Background(), changefeedID)
+					status, _, err := cdcEtcdCli.GetChangeFeedStatus(ctx, changefeedID)
 					if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
 						return err
 					}
-					taskPositions, err := cdcEtcdCli.GetAllTaskPositions(context.Background(), changefeedID)
+					taskPositions, err := cdcEtcdCli.GetAllTaskPositions(ctx, changefeedID)
 					if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
 						return err
 					}
@@ -271,7 +286,7 @@ func newStatisticsChangefeedCommand() *cobra.Command {
 					for _, pinfo := range taskPositions {
 						count += pinfo.Count
 					}
-					ts, _, err := pdCli.GetTS(context.Background())
+					ts, _, err := pdCli.GetTS(ctx)
 					if err != nil {
 						return err
 					}

--- a/cmd/client_meta.go
+++ b/cmd/client_meta.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +20,9 @@ func newDeleteMetaCommand() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete all meta data in etcd, confirm that you know what this command will do and use it at your own risk",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cdcEtcdCli.ClearAllCDCInfo(context.Background())
+			ctx, cancel := contextTimeout()
+			defer cancel()
+			err := cdcEtcdCli.ClearAllCDCInfo(ctx)
 			if err == nil {
 				cmd.Println("already truncate all meta in etcd!")
 			}

--- a/cmd/client_processor.go
+++ b/cmd/client_processor.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-
 	_ "github.com/go-sql-driver/mysql" // mysql driver
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/cdc/model"
@@ -26,7 +24,9 @@ func newListProcessorCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List all processors in TiCDC cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			info, err := cdcEtcdCli.GetProcessors(context.Background())
+			ctx, cancel := contextTimeout()
+			defer cancel()
+			info, err := cdcEtcdCli.GetProcessors(ctx)
 			if err != nil {
 				return err
 			}
@@ -41,11 +41,13 @@ func newQueryProcessorCommand() *cobra.Command {
 		Use:   "query",
 		Short: "Query information and status of a sub replication task (processor)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, status, err := cdcEtcdCli.GetTaskStatus(context.Background(), changefeedID, captureID)
+			ctx, cancel := contextTimeout()
+			defer cancel()
+			_, status, err := cdcEtcdCli.GetTaskStatus(ctx, changefeedID, captureID)
 			if err != nil && errors.Cause(err) != model.ErrTaskStatusNotExists {
 				return err
 			}
-			_, position, err := cdcEtcdCli.GetTaskPosition(context.Background(), changefeedID, captureID)
+			_, position, err := cdcEtcdCli.GetTaskPosition(ctx, changefeedID, captureID)
 			if err != nil && errors.Cause(err) != model.ErrTaskPositionNotExists {
 				return err
 			}

--- a/cmd/client_tso.go
+++ b/cmd/client_tso.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
 	"github.com/pingcap/tidb/store/tikv/oracle"
@@ -24,7 +23,9 @@ func newQueryTsoCommand() *cobra.Command {
 		Use:   "query",
 		Short: "Get tso from PD",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ts, logic, err := pdCli.GetTS(context.Background())
+			ctx, cancel := contextTimeout()
+			defer cancel()
+			ts, logic, err := pdCli.GetTS(ctx)
 			if err != nil {
 				return err
 			}

--- a/tests/_utils/start_tidb_cluster
+++ b/tests/_utils/start_tidb_cluster
@@ -75,21 +75,21 @@ tikv-server \
     -A ${UP_TIKV_HOST_1}:${UP_TIKV_PORT_1} \
     --log-file "$OUT_DIR/tikv1.log" \
     -C "$OUT_DIR/tikv-config.toml" \
-    -s "$OUT_DIR/tikv" &
+    -s "$OUT_DIR/tikv1" &
 
 tikv-server \
     --pd ${UP_PD_HOST}:${UP_PD_PORT} \
     -A ${UP_TIKV_HOST_2}:${UP_TIKV_PORT_2} \
     --log-file "$OUT_DIR/tikv2.log" \
     -C "$OUT_DIR/tikv-config.toml" \
-    -s "$OUT_DIR/tikv" &
+    -s "$OUT_DIR/tikv2" &
 
 tikv-server \
     --pd ${UP_PD_HOST}:${UP_PD_PORT} \
     -A ${UP_TIKV_HOST_3}:${UP_TIKV_PORT_3} \
     --log-file "$OUT_DIR/tikv3.log" \
     -C "$OUT_DIR/tikv-config.toml" \
-    -s "$OUT_DIR/tikv" &
+    -s "$OUT_DIR/tikv3" &
 
 echo "Starting Downstream TiKV..."
 tikv-server \

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $CUR/../_utils/test_prepare
 WORK_DIR=$OUT_DIR/$TEST_NAME
@@ -65,6 +63,13 @@ function run() {
     jobtype=$(cdc cli changefeed --changefeed-id $uuid query 2>&1 | grep 'admin-job-type' | grep -oE '[0-9]' | head -1)
     if [[ $jobtype != 3 ]]; then
         echo "[$(date)] <<<<< unexpect admin job type! expect 3 got ${jobtype} >>>>>"
+        exit 1
+    fi
+
+    # Make sure bad sink url fails at creating changefeed.
+    badsink=$(cdc cli changefeed create --start-ts=$start_ts --sink-uri="mysql://badsink" | grep -oE 'fail')
+    if [[ -z $badsink ]]; then
+        echo "[$(date)] <<<<< unexpect output got ${badsink} >>>>>"
         exit 1
     fi
 


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add dial timeout and verify sink connection when creating changefeed.

Cc https://github.com/pingcap/ticdc/issues/542

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->

- Add client dial timeout
- Verify sink connection when creating changefeed 
