### PR TITLE
notify: fix data race and send on close chan in receiveCh

### DIFF
--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -42,3 +42,18 @@ func (s *notifySuite) TestNotifyHub(c *check.C) {
 	<-r5.C
 	r5.Stop()
 }
+
+func (s *notifySuite) TestContinusStop(c *check.C) {
+	notifier := new(Notifier)
+	n := 20000
+	receivers := make([]*Receiver, n)
+	for i := 0; i < n; i++ {
+		receivers[i] = notifier.NewReceiver(10 * time.Millisecond)
+	}
+	for i := 0; i < n; i++ {
+		<-receivers[i].C
+	}
+	for i := 0; i < n; i++ {
+		receivers[i].Stop()
+	}
+}

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -45,7 +45,7 @@ func (s *notifySuite) TestNotifyHub(c *check.C) {
 
 func (s *notifySuite) TestContinusStop(c *check.C) {
 	notifier := new(Notifier)
-	n := 20000
+	n := 5000
 	receivers := make([]*Receiver, n)
 	for i := 0; i < n; i++ {
 		receivers[i] = notifier.NewReceiver(10 * time.Millisecond)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `receiverCh` is not closed from the sender routine.

```
➜  GO111MODULE=on go test -check.f TestContinusStop
panic: send on closed channel

goroutine 3445 [running]:
github.com/pingcap/ticdc/pkg/notify.signalNonBlocking(0xc000b510e0)
        /home/tidb/code/ticdc/pkg/notify/notify.go:29 +0x35
github.com/pingcap/ticdc/pkg/notify.(*Notifier).NewReceiver.func1(0xc000b3b720, 0xc000b510e0)
        /home/tidb/code/ticdc/pkg/notify/notify.go:55 +0x5c
created by github.com/pingcap/ticdc/pkg/notify.(*Notifier).NewReceiver
        /home/tidb/code/ticdc/pkg/notify/notify.go:53 +0x30b
exit status 2
FAIL    github.com/pingcap/ticdc/pkg/notify     0.126s
```
This error also happens in integration test: https://internal.pingcap.net/idc-jenkins/blue/rest/organizations/jenkins/pipelines/cdc_ghpr_kafka_integration_test/runs/216/nodes/113/steps/541/log/?start=0

### What is changed and how it works?

Add a `closeCh` to be used as the close barrier, only close `receiveCh` in the ticker loop.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note

