### PR TITLE
docker: move kafka consumer to cdc Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ WORKDIR /go/src/github.com/pingcap/ticdc
 COPY . .
 RUN go mod download
 RUN make
+RUN make kafka_consumer
 
 FROM alpine:3.11
 COPY --from=builder  /go/src/github.com/pingcap/ticdc/bin/cdc /cdc
+COPY --from=builder  /go/src/github.com/pingcap/ticdc/bin/cdc_kafka_consumer /cdc_kafka_consumer
 EXPOSE 8300
 CMD [ "/cdc" ]

--- a/kafka_consumer/Dockerfile
+++ b/kafka_consumer/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.13 as builder
-WORKDIR /go/src/github.com/pingcap/ticdc
-COPY . .
-RUN go mod download
-RUN make kafka_consumer
-
-FROM alpine:3.11
-COPY --from=builder  /go/src/github.com/pingcap/ticdc/bin/cdc_kafka_consumer /cdc_kafka_consumer
-CMD [ "/cdc_kafka_consumer" ]


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We need to push two images to docker.io for now.

### What is changed and how it works?
Combine the Dockerfiles of ticdc and kafka-consumer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note

