### PR TITLE
*: a new table migration mechanism

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/pingcap/ticdc/pkg/cyclic"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	timodel "github.com/pingcap/parser/model"
@@ -27,6 +25,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/cyclic"
 	"github.com/pingcap/ticdc/pkg/filter"
 	"go.etcd.io/etcd/mvcc/mvccpb"
 	"go.uber.org/zap"

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -18,20 +18,21 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/pingcap/ticdc/pkg/cyclic"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/ticdc/cdc/entry"
+	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/cdc/roles/storage"
 	"github.com/pingcap/ticdc/cdc/sink"
-	"github.com/pingcap/ticdc/pkg/cyclic"
 	"github.com/pingcap/ticdc/pkg/filter"
 	"go.etcd.io/etcd/mvcc/mvccpb"
 	"go.uber.org/zap"
 )
 
-type tableIDMap = map[uint64]struct{}
+type tableIDMap = map[model.TableID]struct{}
 
 // OwnerDDLHandler defines the ddl handler for Owner
 // which can pull ddl jobs and execute ddl jobs
@@ -72,7 +73,7 @@ type changeFeed struct {
 	ddlState      model.ChangeFeedDDLState
 	targetTs      uint64
 	taskStatus    model.ProcessorsInfos
-	taskPositions map[string]*model.TaskPosition
+	taskPositions map[model.CaptureID]*model.TaskPosition
 	filter        *filter.Filter
 	sink          sink.Sink
 
@@ -83,16 +84,13 @@ type changeFeed struct {
 	ddlJobHistory []*timodel.Job
 	ddlExecutedTs uint64
 
-	schemas    map[uint64]tableIDMap
-	tables     map[uint64]entry.TableName
-	partitions map[uint64][]int64 // key is table ID, value is the slice of partitions ID.
-	// The key is table ID or the partition ID.
-	orphanTables map[uint64]model.ProcessTableInfo
-	// The key is table ID or the partition ID.
-	waitingConfirmTables map[uint64]string
-	// The key is table ID or the partition ID.
-	toCleanTables map[uint64]struct{}
-	infoWriter    *storage.OwnerTaskStatusEtcdWriter
+	schemas map[model.SchemaID]tableIDMap
+	tables  map[model.TableID]entry.TableName
+	// value of partitions is the slice of partitions ID.
+	partitions    map[model.TableID][]int64
+	orphanTables  map[model.TableID]model.Ts
+	toCleanTables map[model.TableID]model.Ts
+	etcdCli       kv.CDCEtcdClient
 }
 
 // String implements fmt.Stringer interface.
@@ -115,30 +113,30 @@ func (c *changeFeed) updateProcessorInfos(processInfos model.ProcessorsInfos, po
 	c.taskPositions = positions
 }
 
-func (c *changeFeed) addSchema(schemaID uint64) {
+func (c *changeFeed) addSchema(schemaID model.SchemaID) {
 	if _, ok := c.schemas[schemaID]; ok {
-		log.Warn("add schema already exists", zap.Uint64("schemaID", schemaID))
+		log.Warn("add schema already exists", zap.Int64("schemaID", schemaID))
 		return
 	}
-	c.schemas[schemaID] = make(map[uint64]struct{})
+	c.schemas[schemaID] = make(map[model.TableID]struct{})
 }
 
-func (c *changeFeed) dropSchema(schemaID uint64) {
+func (c *changeFeed) dropSchema(schemaID model.SchemaID, targetTs model.Ts) {
 	if schema, ok := c.schemas[schemaID]; ok {
 		for tid := range schema {
-			c.removeTable(schemaID, tid)
+			c.removeTable(schemaID, tid, targetTs)
 		}
 	}
 	delete(c.schemas, schemaID)
 }
 
-func (c *changeFeed) addTable(sid, tid, startTs uint64, table entry.TableName, tblInfo *timodel.TableInfo) {
+func (c *changeFeed) addTable(sid model.SchemaID, tid model.TableID, startTs model.Ts, table entry.TableName, tblInfo *timodel.TableInfo) {
 	if c.filter.ShouldIgnoreTable(table.Schema, table.Table) {
 		return
 	}
 
 	if _, ok := c.tables[tid]; ok {
-		log.Warn("add table already exists", zap.Uint64("tableID", tid), zap.Stringer("table", table))
+		log.Warn("add table already exists", zap.Int64("tableID", tid), zap.Stringer("table", table))
 		return
 	}
 
@@ -151,37 +149,30 @@ func (c *changeFeed) addTable(sid, tid, startTs uint64, table entry.TableName, t
 		delete(c.partitions, tid)
 		for _, partition := range pi.Definitions {
 			c.partitions[tid] = append(c.partitions[tid], partition.ID)
-			id := uint64(partition.ID)
-			c.orphanTables[id] = model.ProcessTableInfo{
-				ID:      id,
-				StartTs: startTs,
-			}
+			c.orphanTables[partition.ID] = startTs
 		}
 	} else {
-		c.orphanTables[tid] = model.ProcessTableInfo{
-			ID:      tid,
-			StartTs: startTs,
-		}
+		c.orphanTables[tid] = startTs
 	}
 }
 
-func (c *changeFeed) removeTable(sid, tid uint64) {
+func (c *changeFeed) removeTable(sid model.SchemaID, tid model.TableID, targetTs model.Ts) {
 	if _, ok := c.schemas[sid]; ok {
 		delete(c.schemas[sid], tid)
 	}
 	delete(c.tables, tid)
 
-	removeFunc := func(id uint64) {
+	removeFunc := func(id int64) {
 		if _, ok := c.orphanTables[id]; ok {
 			delete(c.orphanTables, id)
 		} else {
-			c.toCleanTables[id] = struct{}{}
+			c.toCleanTables[id] = targetTs
 		}
 	}
 
 	if pids, ok := c.partitions[tid]; ok {
 		for _, id := range pids {
-			removeFunc(uint64(id))
+			removeFunc(id)
 		}
 		delete(c.partitions, tid)
 	} else {
@@ -189,11 +180,11 @@ func (c *changeFeed) removeTable(sid, tid uint64) {
 	}
 }
 
-func (c *changeFeed) selectCapture(captures map[string]*model.CaptureInfo, toAppend map[string][]*model.ProcessTableInfo) string {
-	return c.minimumTablesCapture(captures, toAppend)
+func (c *changeFeed) selectCapture(captures map[string]*model.CaptureInfo, newTaskStatus map[model.CaptureID]*model.TaskStatus) string {
+	return c.minimumTablesCapture(captures, newTaskStatus)
 }
 
-func (c *changeFeed) minimumTablesCapture(captures map[string]*model.CaptureInfo, toAppend map[string][]*model.ProcessTableInfo) string {
+func (c *changeFeed) minimumTablesCapture(captures map[string]*model.CaptureInfo, newTaskStatus map[model.CaptureID]*model.TaskStatus) string {
 	if len(captures) == 0 {
 		return ""
 	}
@@ -202,11 +193,11 @@ func (c *changeFeed) minimumTablesCapture(captures map[string]*model.CaptureInfo
 	minCount := math.MaxInt64
 	for id := range captures {
 		var tableCount int
-		if pinfo, ok := c.taskStatus[id]; ok {
-			tableCount += len(pinfo.TableInfos)
+		if status, ok := c.taskStatus[id]; ok {
+			tableCount = len(status.Tables)
 		}
-		if append, ok := toAppend[id]; ok {
-			tableCount += len(append)
+		if newStatus, ok := newTaskStatus[id]; ok {
+			tableCount = len(newStatus.Tables)
 		}
 		if tableCount < minCount {
 			minID = id
@@ -218,66 +209,14 @@ func (c *changeFeed) minimumTablesCapture(captures map[string]*model.CaptureInfo
 }
 
 func (c *changeFeed) tryBalance(ctx context.Context, captures map[string]*model.CaptureInfo) error {
-	c.cleanTables(ctx)
 	return c.balanceOrphanTables(ctx, captures)
 }
 
-func (c *changeFeed) restoreTableInfos(infoSnapshot *model.TaskStatus, captureID string) {
-	// the capture information maybe deleted during table cleaning
-	if _, ok := c.taskStatus[captureID]; !ok {
-		log.Warn("ignore restore table info, task status for capture not found", zap.String("captureID", captureID))
-	}
-	c.taskStatus[captureID].TableInfos = infoSnapshot.TableInfos
-}
-
-func (c *changeFeed) cleanTables(ctx context.Context) {
-	var cleanIDs []uint64
-
-cleanLoop:
-	for id := range c.toCleanTables {
-		captureID, taskStatus, ok := findTaskStatusWithTable(c.taskStatus, id)
-		if !ok {
-			log.Warn("ignore clean table id", zap.Uint64("id", id))
-			cleanIDs = append(cleanIDs, id)
-			continue
-		}
-
-		infoClone := taskStatus.Clone()
-		taskStatus.RemoveTable(id)
-
-		newInfo, err := c.infoWriter.Write(ctx, c.id, captureID, taskStatus, true)
-		if err == nil {
-			c.taskStatus[captureID] = newInfo
-		}
-		switch errors.Cause(err) {
-		case model.ErrFindPLockNotCommit:
-			c.restoreTableInfos(infoClone, captureID)
-			log.Info("write table info delay, wait plock resolve",
-				zap.String("changefeed", c.id),
-				zap.String("capture", captureID))
-		case nil:
-			log.Info("cleanup table success",
-				zap.Uint64("table id", id),
-				zap.String("capture id", captureID))
-			log.Debug("after remove", zap.Stringer("task status", taskStatus))
-			cleanIDs = append(cleanIDs, id)
-		default:
-			c.restoreTableInfos(infoClone, captureID)
-			log.Error("fail to put sub changefeed info", zap.Error(err))
-			break cleanLoop
-		}
-	}
-
-	for _, id := range cleanIDs {
-		delete(c.toCleanTables, id)
-	}
-}
-
-func findTaskStatusWithTable(infos model.ProcessorsInfos, tableID uint64) (captureID string, info *model.TaskStatus, ok bool) {
-	for id, info := range infos {
-		for _, table := range info.TableInfos {
-			if table.ID == tableID {
-				return id, info, true
+func findTaskStatusWithTable(infos model.ProcessorsInfos, tableID model.TableID) (captureID model.CaptureID, info *model.TaskStatus, ok bool) {
+	for cid, info := range infos {
+		for tid := range info.Tables {
+			if tid == tableID {
+				return cid, info, true
 			}
 		}
 	}
@@ -285,34 +224,45 @@ func findTaskStatusWithTable(infos model.ProcessorsInfos, tableID uint64) (captu
 	return "", nil, false
 }
 
-func (c *changeFeed) balanceOrphanTables(ctx context.Context, captures map[string]*model.CaptureInfo) error {
+func (c *changeFeed) balanceOrphanTables(ctx context.Context, captures map[model.CaptureID]*model.CaptureInfo) error {
 	if len(captures) == 0 {
 		return nil
 	}
-
-	for tableID, captureID := range c.waitingConfirmTables {
-		lockStatus, err := c.infoWriter.CheckLock(ctx, c.id, captureID)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		switch lockStatus {
-		case model.TableNoLock:
-			log.Debug("no c-lock", zap.Uint64("tableID", tableID), zap.String("captureID", captureID))
-			delete(c.waitingConfirmTables, tableID)
-		case model.TablePLock:
-			log.Debug("waiting the c-lock", zap.Uint64("tableID", tableID), zap.String("captureID", captureID))
-		case model.TablePLockCommited:
-			log.Debug("delete the c-lock", zap.Uint64("tableID", tableID), zap.String("captureID", captureID))
-			delete(c.waitingConfirmTables, tableID)
+	for _, status := range c.taskStatus {
+		if status.SomeOperationsUnapplied() {
+			return nil
 		}
 	}
 
-	appendTableInfos := make(map[string][]*model.ProcessTableInfo, len(captures))
+	newTaskStatus := make(map[model.CaptureID]*model.TaskStatus, len(captures))
+	cleanedTables := make(map[model.TableID]struct{})
+	addedTables := make(map[model.TableID]struct{})
+
+	for id, targetTs := range c.toCleanTables {
+		captureID, taskStatus, ok := findTaskStatusWithTable(c.taskStatus, id)
+		if !ok {
+			log.Warn("ignore clean table id", zap.Int64("id", id))
+			delete(c.toCleanTables, id)
+			continue
+		}
+		status, exist := newTaskStatus[captureID]
+		if !exist {
+			status = taskStatus.Clone()
+		}
+		status.RemoveTable(id)
+		status.Operation = append(status.Operation, &model.TableOperation{
+			TableID:    id,
+			Delete:     true,
+			BoundaryTs: targetTs,
+		})
+		newTaskStatus[captureID] = status
+		cleanedTables[id] = struct{}{}
+	}
 	schemaSnapshot := c.schema
-	for tableID, orphan := range c.orphanTables {
-		var orphanMarkTable *model.ProcessTableInfo
+	for tableID, startTs := range c.orphanTables {
+		var orphanMarkTableID int64
 		if c.cyclicEnabled {
-			tableName, found := schemaSnapshot.GetTableNameByID(int64(tableID))
+			tableName, found := schemaSnapshot.GetTableNameByID(tableID)
 			if !found || cyclic.IsMarkTable(tableName.Schema, tableName.Table) {
 				// Skip, mark tables should not be balanced alone.
 				continue
@@ -324,73 +274,73 @@ func (c *changeFeed) balanceOrphanTables(ctx context.Context, captures map[strin
 				// Mark table is not created yet, skip and wait.
 				log.Info("balance table info delay, wait mark table",
 					zap.String("changefeed", c.id),
-					zap.Uint64("tableID", tableID),
+					zap.Int64("tableID", tableID),
 					zap.String("markTableName", markTableTableName))
 				continue
 			}
-			orphanMarkTable = &model.ProcessTableInfo{
-				ID:      uint64(id),
-				StartTs: orphan.StartTs,
-			}
+			orphanMarkTableID = id
 		}
-
-		captureID := c.selectCapture(captures, appendTableInfos)
+		captureID := c.selectCapture(captures, newTaskStatus)
 		if len(captureID) == 0 {
 			return nil
 		}
-		info := appendTableInfos[captureID]
-		info = append(info, &model.ProcessTableInfo{
-			ID:      tableID,
-			StartTs: orphan.StartTs,
-		})
-		// Table and mark table must be balanced to the same capture.
-		if orphanMarkTable != nil {
-			info = append(info, orphanMarkTable)
+		taskStatus := c.taskStatus[captureID]
+		if taskStatus == nil {
+			taskStatus = new(model.TaskStatus)
 		}
-		appendTableInfos[captureID] = info
+		status, exist := newTaskStatus[captureID]
+		if !exist {
+			status = taskStatus.Clone()
+		}
+		status.Tables[tableID] = startTs
+		status.Operation = append(status.Operation, &model.TableOperation{
+			TableID:    tableID,
+			BoundaryTs: startTs,
+		})
+		if orphanMarkTableID != 0 {
+			status.Tables[orphanMarkTableID] = startTs
+			addedTables[orphanMarkTableID] = struct{}{}
+			status.Operation = append(status.Operation, &model.TableOperation{
+				TableID:    orphanMarkTableID,
+				BoundaryTs: startTs,
+			})
+		}
+		newTaskStatus[captureID] = status
+		addedTables[tableID] = struct{}{}
 	}
 
-	for captureID, tableInfos := range appendTableInfos {
-		status := c.taskStatus[captureID]
-		if status == nil {
-			status = new(model.TaskStatus)
-		}
-		statusClone := status.Clone()
-		status.TableInfos = append(status.TableInfos, tableInfos...)
-
-		newInfo, err := c.infoWriter.Write(ctx, c.id, captureID, status, true)
-		if err == nil {
-			c.taskStatus[captureID] = newInfo
-		}
-		switch errors.Cause(err) {
-		case model.ErrFindPLockNotCommit:
-			c.restoreTableInfos(statusClone, captureID)
-			log.Info("write table info delay, wait plock resolve",
-				zap.String("changefeed", c.id),
-				zap.String("capture", captureID))
-		case nil:
-			log.Info("dispatch table success",
-				zap.Reflect("tableInfos", tableInfos),
-				zap.String("capture", captureID))
-			for _, tableInfo := range tableInfos {
-				delete(c.orphanTables, tableInfo.ID)
-				c.waitingConfirmTables[tableInfo.ID] = captureID
+	for captureID, status := range newTaskStatus {
+		newStatus, err := c.etcdCli.AtomicPutTaskStatus(ctx, c.id, captureID, func(taskStatus *model.TaskStatus) error {
+			if taskStatus.SomeOperationsUnapplied() {
+				return errors.Errorf("waiting to processor handle the operation finished time out")
 			}
-		default:
-			c.restoreTableInfos(statusClone, captureID)
-			log.Error("fail to put sub changefeed info", zap.Error(err))
+			taskStatus.Tables = status.Tables
+			taskStatus.Operation = status.Operation
+			return nil
+		})
+		if err != nil {
 			return errors.Trace(err)
 		}
+		c.taskStatus[captureID] = newStatus.Clone()
+		log.Info("dispatch table success", zap.String("captureID", captureID), zap.Stringer("status", status))
 	}
+
+	for tableID := range cleanedTables {
+		delete(c.toCleanTables, tableID)
+	}
+	for tableID := range addedTables {
+		delete(c.orphanTables, tableID)
+	}
+
 	return nil
 }
 
 func (c *changeFeed) applyJob(ctx context.Context, job *timodel.Job) (skip bool, err error) {
-	schemaID := uint64(job.SchemaID)
+	schemaID := job.SchemaID
 	if job.BinlogInfo != nil && job.BinlogInfo.TableInfo != nil && c.schema.IsIneligibleTableID(job.BinlogInfo.TableInfo.ID) {
-		tableID := uint64(job.BinlogInfo.TableInfo.ID)
+		tableID := job.BinlogInfo.TableInfo.ID
 		if _, exist := c.tables[tableID]; exist {
-			c.removeTable(schemaID, tableID)
+			c.removeTable(schemaID, tableID, job.BinlogInfo.FinishedTS)
 		}
 		return true, nil
 	}
@@ -401,33 +351,33 @@ func (c *changeFeed) applyJob(ctx context.Context, job *timodel.Job) (skip bool,
 		case timodel.ActionCreateSchema:
 			c.addSchema(schemaID)
 		case timodel.ActionDropSchema:
-			c.dropSchema(schemaID)
+			c.dropSchema(schemaID, job.BinlogInfo.FinishedTS)
 		case timodel.ActionCreateTable, timodel.ActionRecoverTable:
-			addID := uint64(job.BinlogInfo.TableInfo.ID)
+			addID := job.BinlogInfo.TableInfo.ID
 			tableName, exist := c.schema.GetTableNameByID(job.BinlogInfo.TableInfo.ID)
 			if !exist {
 				return errors.NotFoundf("table(%d)", addID)
 			}
 			c.addTable(schemaID, addID, job.BinlogInfo.FinishedTS, tableName, job.BinlogInfo.TableInfo)
 		case timodel.ActionDropTable:
-			dropID := uint64(job.TableID)
-			c.removeTable(schemaID, dropID)
+			dropID := job.TableID
+			c.removeTable(schemaID, dropID, job.BinlogInfo.FinishedTS)
 		case timodel.ActionRenameTable:
 			tableName, exist := c.schema.GetTableNameByID(job.TableID)
 			if !exist {
 				return errors.NotFoundf("table(%d)", job.TableID)
 			}
 			// no id change just update name
-			c.tables[uint64(job.TableID)] = tableName
+			c.tables[job.TableID] = tableName
 		case timodel.ActionTruncateTable:
-			dropID := uint64(job.TableID)
-			c.removeTable(schemaID, dropID)
+			dropID := job.TableID
+			c.removeTable(schemaID, dropID, job.BinlogInfo.FinishedTS)
 
 			tableName, exist := c.schema.GetTableNameByID(job.BinlogInfo.TableInfo.ID)
 			if !exist {
 				return errors.NotFoundf("table(%d)", job.BinlogInfo.TableInfo.ID)
 			}
-			addID := uint64(job.BinlogInfo.TableInfo.ID)
+			addID := job.BinlogInfo.TableInfo.ID
 			c.addTable(schemaID, addID, job.BinlogInfo.FinishedTS, tableName, job.BinlogInfo.TableInfo)
 		}
 		return nil
@@ -533,13 +483,6 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 		return nil
 	}
 
-	// ProcessorInfos don't contains the whole set table id now.
-	if len(c.waitingConfirmTables) > 0 {
-		log.Debug("skip calcResolvedTs",
-			zap.Reflect("waitingConfirmTables", c.orphanTables))
-		return nil
-	}
-
 	minResolvedTs := c.targetTs
 	minCheckpointTs := c.targetTs
 
@@ -561,12 +504,34 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 		}
 	}
 
-	for _, orphanTable := range c.orphanTables {
-		if minCheckpointTs > orphanTable.StartTs {
-			minCheckpointTs = orphanTable.StartTs
+	for captureID, status := range c.taskStatus {
+		appliedTs := status.AppliedTs()
+		if minCheckpointTs > appliedTs {
+			minCheckpointTs = appliedTs
 		}
-		if minResolvedTs > orphanTable.StartTs {
-			minResolvedTs = orphanTable.StartTs
+		if minResolvedTs > appliedTs {
+			minResolvedTs = appliedTs
+		}
+		if appliedTs != math.MaxUint64 {
+			log.Info("some operation is still unapplied", zap.String("captureID", captureID), zap.Uint64("appliedTs", appliedTs), zap.Stringer("status", status))
+		}
+	}
+
+	for _, startTs := range c.orphanTables {
+		if minCheckpointTs > startTs {
+			minCheckpointTs = startTs
+		}
+		if minResolvedTs > startTs {
+			minResolvedTs = startTs
+		}
+	}
+
+	for _, targetTs := range c.toCleanTables {
+		if minCheckpointTs > targetTs {
+			minCheckpointTs = targetTs
+		}
+		if minResolvedTs > targetTs {
+			minResolvedTs = targetTs
 		}
 	}
 

--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -664,11 +664,11 @@ func (s *schemaSnapshot) handleDDL(job *timodel.Job) error {
 }
 
 // CloneTables return a clone of the existing tables.
-func (s *schemaSnapshot) CloneTables() map[uint64]TableName {
-	mp := make(map[uint64]TableName, len(s.tables))
+func (s *schemaSnapshot) CloneTables() map[model.TableID]TableName {
+	mp := make(map[model.TableID]TableName, len(s.tables))
 
 	for id, table := range s.tables {
-		mp[uint64(id)] = table.TableName
+		mp[id] = table.TableName
 	}
 
 	return mp

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -102,8 +102,8 @@ func (s *etcdSuite) TestGetChangeFeeds(c *check.C) {
 func (s *etcdSuite) TestGetPutTaskStatus(c *check.C) {
 	ctx := context.Background()
 	info := &model.TaskStatus{
-		TableInfos: []*model.ProcessTableInfo{
-			{ID: 1, StartTs: 100},
+		Tables: map[model.TableID]model.Ts{
+			1: 100,
 		},
 	}
 
@@ -126,8 +126,8 @@ func (s *etcdSuite) TestGetPutTaskStatus(c *check.C) {
 func (s *etcdSuite) TestDeleteTaskStatus(c *check.C) {
 	ctx := context.Background()
 	info := &model.TaskStatus{
-		TableInfos: []*model.ProcessTableInfo{
-			{ID: 1, StartTs: 100},
+		Tables: map[model.TableID]model.Ts{
+			1: 100,
 		},
 	}
 	feedID := "feedid"

--- a/cdc/model/capture.go
+++ b/cdc/model/capture.go
@@ -21,8 +21,8 @@ import (
 
 // CaptureInfo store in etcd.
 type CaptureInfo struct {
-	ID            string `json:"id"`
-	AdvertiseAddr string `json:"address"`
+	ID            CaptureID `json:"id"`
+	AdvertiseAddr string    `json:"address"`
 }
 
 // Marshal using json.Marshal.

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -190,8 +189,8 @@ func newProcessor(
 		tables: make(map[int64]*tableInfo),
 	}
 
-	for _, table := range p.status.TableInfos {
-		p.addTable(ctx, int64(table.ID), table.StartTs)
+	for tableID, startTs := range p.status.Tables {
+		p.addTable(ctx, tableID, startTs)
 	}
 	return p, nil
 }
@@ -380,17 +379,16 @@ func (p *processor) updateInfo(ctx context.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		log.Debug("update task position", zap.Stringer("status", p.position))
+		log.Debug("update task position", zap.Stringer("position", p.position))
 		return nil
 	}
-	statusChanged, locked, err := p.tsRWriter.UpdateInfo(ctx)
+	statusChanged, err := p.tsRWriter.UpdateInfo(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if !statusChanged && !locked {
+	if !statusChanged && !p.tsRWriter.GetTaskStatus().SomeOperationsUnapplied() {
 		return updatePosition()
 	}
-	oldStatus := p.status
 	p.status = p.tsRWriter.GetTaskStatus()
 	if p.status.AdminJobType == model.AdminStop || p.status.AdminJobType == model.AdminRemove {
 		err = p.stop(ctx)
@@ -399,11 +397,11 @@ func (p *processor) updateInfo(ctx context.Context) error {
 		}
 		return errors.Trace(model.ErrAdminStopProcessor)
 	}
-	err = p.handleTables(ctx, oldStatus, p.status, p.position.CheckPointTs)
+	err = p.handleTables(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(len(p.status.TableInfos)))
+	syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureID).Set(float64(len(p.status.Tables)))
 	err = updatePosition()
 	if err != nil {
 		return errors.Trace(err)
@@ -424,46 +422,6 @@ func (p *processor) updateInfo(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 	return nil
-}
-
-func diffProcessTableInfos(oldInfo, newInfo []*model.ProcessTableInfo) (removed, added []*model.ProcessTableInfo) {
-	sort.Slice(oldInfo, func(i, j int) bool {
-		return oldInfo[i].ID < oldInfo[j].ID
-	})
-
-	sort.Slice(newInfo, func(i, j int) bool {
-		return newInfo[i].ID < newInfo[j].ID
-	})
-
-	i, j := 0, 0
-	for i < len(oldInfo) && j < len(newInfo) {
-		if oldInfo[i].ID == newInfo[j].ID {
-			i++
-			j++
-		} else if oldInfo[i].ID < newInfo[j].ID {
-			removed = append(removed, oldInfo[i])
-			i++
-		} else {
-			added = append(added, newInfo[j])
-			j++
-		}
-	}
-	for ; i < len(oldInfo); i++ {
-		removed = append(removed, oldInfo[i])
-	}
-	for ; j < len(newInfo); j++ {
-		added = append(added, newInfo[j])
-	}
-
-	if len(removed) > 0 || len(added) > 0 {
-		log.Debug("table diff", zap.Reflect("old", oldInfo),
-			zap.Reflect("new", newInfo),
-			zap.Reflect("add", added),
-			zap.Reflect("remove", removed),
-		)
-	}
-
-	return
 }
 
 func (p *processor) removeTable(tableID int64) {
@@ -488,18 +446,16 @@ func (p *processor) removeTable(tableID int64) {
 }
 
 // handleTables handles table scheduler on this processor, add or remove table puller
-func (p *processor) handleTables(
-	ctx context.Context, oldInfo, newInfo *model.TaskStatus, checkpointTs uint64,
-) error {
-	checkPairedMarkTable := func(tables []*model.ProcessTableInfo, hint string) error {
+func (p *processor) handleTables(ctx context.Context) error {
+	checkPairedMarkTable := func(tables map[model.TableID]model.Ts) error {
 		if p.changefeed.Config != nil && p.changefeed.Config.Cyclic.IsEnabled() {
 			// Make sure all normal tables and mark tables are paired.
 			schemaSnapshot := p.schemaStorage.GetLastSnapshot()
 			tableNames := make([]model.TableName, 0, len(tables))
-			for _, table := range tables {
-				name, ok := schemaSnapshot.GetTableNameByID(int64(table.ID))
+			for tableID := range tables {
+				name, ok := schemaSnapshot.GetTableNameByID(tableID)
 				if !ok {
-					return errors.NotFoundf("table(%d)", table.ID)
+					return errors.NotFoundf("table(%d)", tableID)
 				}
 				tableNames = append(tableNames, model.TableName{
 					Schema: name.Schema,
@@ -507,36 +463,29 @@ func (p *processor) handleTables(
 				})
 			}
 			if !cyclic.IsTablesPaired(tableNames) {
-				return errors.NotValidf(
-					"%s normal table and mark table not match %v", hint, tableNames)
+				return errors.NotValidf("normal table and mark table not match %v", tableNames)
 			}
 		}
 		return nil
 	}
 
-	removedTables, addedTables := diffProcessTableInfos(oldInfo.TableInfos, newInfo.TableInfos)
-	// remove tables
-	if err := checkPairedMarkTable(removedTables, "remove table"); err != nil {
+	if err := checkPairedMarkTable(p.status.Tables); err != nil {
 		return err
 	}
-	for _, pinfo := range removedTables {
-		p.removeTable(int64(pinfo.ID))
-	}
 
-	// add tables
-	if err := checkPairedMarkTable(removedTables, "add table"); err != nil {
-		return err
-	}
-	for _, pinfo := range addedTables {
-		p.addTable(ctx, int64(pinfo.ID), pinfo.StartTs)
-	}
-
-	// write clock if need
-	if newInfo.TablePLock != nil && newInfo.TableCLock == nil {
-		newInfo.TableCLock = &model.TableLock{
-			Ts:           newInfo.TablePLock.Ts,
-			CheckpointTs: checkpointTs,
+	for _, opt := range p.status.Operation {
+		if opt.Delete {
+			if opt.BoundaryTs <= p.position.CheckPointTs {
+				p.removeTable(opt.TableID)
+				opt.Done = true
+			}
+		} else {
+			p.addTable(ctx, opt.TableID, opt.BoundaryTs)
+			opt.Done = true
 		}
+	}
+	if !p.status.SomeOperationsUnapplied() {
+		p.status.Operation = nil
 	}
 	return nil
 }

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -1,13 +1,17 @@
 package notify
 
 import (
+	"context"
+	_ "net/http/pprof"
 	"testing"
 	"time"
 
 	"github.com/pingcap/check"
 )
 
-func Test(t *testing.T) { check.TestingT(t) }
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
 
 type notifySuite struct{}
 
@@ -44,16 +48,38 @@ func (s *notifySuite) TestNotifyHub(c *check.C) {
 }
 
 func (s *notifySuite) TestContinusStop(c *check.C) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	notifier := new(Notifier)
-	n := 5000
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			notifier.Notify()
+		}
+	}()
+	n := 50
 	receivers := make([]*Receiver, n)
 	for i := 0; i < n; i++ {
 		receivers[i] = notifier.NewReceiver(10 * time.Millisecond)
 	}
 	for i := 0; i < n; i++ {
-		<-receivers[i].C
+		i := i
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-receivers[i].C:
+				}
+			}
+		}()
 	}
 	for i := 0; i < n; i++ {
 		receivers[i].Stop()
 	}
+	<-ctx.Done()
 }

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -2,7 +2,6 @@ package notify
 
 import (
 	"context"
-	_ "net/http/pprof"
 	"testing"
 	"time"
 

--- a/tests/_utils/run_cdc_server
+++ b/tests/_utils/run_cdc_server
@@ -51,5 +51,5 @@ done
 echo "[$(date)] <<<<<< START cdc server in $TEST_NAME case >>>>>>"
 cd $workdir
 pid=$(ps -C run_cdc_server -o pid=|tr -d '[:space:]')
-$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME.$pid.out" server --log-file $workdir/cdc$logsuffix.log --log-level debug $addr $pd_addr >> $workdir/stdout$log_suffix.log 2>&1 &
+$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME.$pid.out" server --log-file $workdir/cdc$logsuffix.log --log-level info $addr $pd_addr >> $workdir/stdout$log_suffix.log 2>&1 &
 cd $pwd

--- a/tests/_utils/start_tidb_cluster
+++ b/tests/_utils/start_tidb_cluster
@@ -131,28 +131,28 @@ echo "Verifying Upstream TiDB is started..."
 i=0
 while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -e 'select * from mysql.tidb;'; do
     i=$((i + 1))
-    if [ "$i" -gt 40 ]; then
+    if [ "$i" -gt 60 ]; then
         echo 'Failed to start upstream TiDB'
         exit 2
     fi
-    sleep 1
+    sleep 2
 done
 
 i=0
 while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_OTHER_PORT} --default-character-set utf8mb4 -e 'select * from mysql.tidb;'; do
     i=$((i + 1))
-    if [ "$i" -gt 40 ]; then
+    if [ "$i" -gt 60 ]; then
         echo 'Failed to start upstream TiDB'
         exit 2
     fi
-    sleep 1
+    sleep 2
 done
 
 echo "Verifying Downstream TiDB is started..."
 i=0
 while ! mysql -uroot -h${DOWN_TIDB_HOST} -P${DOWN_TIDB_PORT} --default-character-set utf8mb4 -e 'select * from mysql.tidb;'; do
     i=$((i + 1))
-    if [ "$i" -gt 10 ]; then
+    if [ "$i" -gt 60 ]; then
         echo 'Failed to start downstream TiDB'
         exit 1
     fi

--- a/tests/availability/owner.sh
+++ b/tests/availability/owner.sh
@@ -25,7 +25,7 @@ function test_owner_ha() {
 function test_kill_owner() {
     echo "run test case test_kill_owner"
     # start a capture server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_kill_owner.server1
     # ensure the server become the owner
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
     owner_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}')
@@ -34,7 +34,7 @@ function test_kill_owner() {
     echo "owner id" $owner_id
 
     # run another server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301"
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301" --logsuffix test_kill_owner.server2
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep id"
     capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
     echo "capture_id:" $capture_id
@@ -55,7 +55,7 @@ function test_kill_owner() {
 function test_hang_up_owner() {
     echo "run test case test_hang_up_owner"
 
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_hang_up_owner.server1
     # ensure the server become the owner
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
 
@@ -65,7 +65,7 @@ function test_hang_up_owner() {
     echo "owner id" $owner_id
 
     # run another server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301"
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301" --logsuffix test_hang_up_owner.server2
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep id"
     capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
     echo "capture_id:" $capture_id
@@ -91,7 +91,7 @@ function test_hang_up_owner() {
 function test_expire_owner() {
     echo "run test case test_expire_owner"
 
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_expire_owner.server1
     # ensure the server become the owner
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
 
@@ -121,7 +121,7 @@ function test_owner_cleanup_stale_tasks() {
     echo "run test case test_owner_cleanup_stale_tasks"
 
     # start a capture server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_owner_cleanup_stale_tasks.server1
     # ensure the server become the owner
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
     owner_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}')
@@ -130,7 +130,7 @@ function test_owner_cleanup_stale_tasks() {
     echo "owner id" $owner_id
 
     # run another server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301"
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301" --logsuffix test_owner_cleanup_stale_tasks.server2
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep id"
     capture_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}' | grep -v "$owner_pid")
     capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
@@ -143,7 +143,7 @@ function test_owner_cleanup_stale_tasks() {
 
     # simulate task status is deleted but task position stales
     etcdctl del /tidb/cdc/task/status --prefix
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8302"
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8302" --logsuffix test_owner_cleanup_stale_tasks.server3
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
 
     run_sql "INSERT INTO test.availability1(id, val) VALUES (1, 1);"
@@ -164,7 +164,7 @@ function test_owner_retryable_error() {
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/capture-campaign-compacted-error=1*return(true)'
 
     # start a capture server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix server1
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_owner_retryable_error.server1
 
     # ensure the server become the owner
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
@@ -176,7 +176,7 @@ function test_owner_retryable_error() {
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/owner-run-with-error=1*return(true);github.com/pingcap/ticdc/cdc/capture-resign-failed=1*return(true)'
 
     # run another server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix server2 --addr "0.0.0.0:8301"
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_owner_retryable_error.server2 --addr "0.0.0.0:8301"
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep id"
     capture_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}' | grep -v "$owner_pid")
     capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
@@ -201,7 +201,7 @@ function test_gap_between_watch_capture() {
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sleep-before-watch-capture=1*sleep(6000)'
 
     # start a capture server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_gap_between_watch_capture.server1
     # ensure the server become the owner
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep '\"is-owner\": true'"
     owner_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}')
@@ -210,7 +210,7 @@ function test_gap_between_watch_capture() {
     echo "owner id" $owner_id
 
     # run another server
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301"
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "0.0.0.0:8301" --logsuffix test_gap_between_watch_capture.server2
     ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep id"
     capture_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}' | grep -v "$owner_pid")
     capture_id=$($CDC_BINARY cli capture list 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")

--- a/tests/cyclic_ab/conf/diff_config.toml
+++ b/tests/cyclic_ab/conf/diff_config.toml
@@ -5,7 +5,7 @@ chunk-size = 10
 check-thread-count = 4
 sample-percent = 100
 use-rowid = false
-use-checksum = true
+use-checksum = false
 fix-sql-file = "fix.sql"
 
 # tables need to check.

--- a/tests/resolve_lock/main.go
+++ b/tests/resolve_lock/main.go
@@ -52,7 +52,7 @@ func main() {
 	if err := prepare(sourceDB); err != nil {
 		log.S().Fatal(err)
 	}
-	if err := addLock(cfg); err != nil {
+	if err := addLock(cfg); err != nil && errors.Cause(err) != context.Canceled && errors.Cause(err) != context.DeadlineExceeded {
 		log.S().Fatal(err)
 	}
 	time.Sleep(5 * time.Second)
@@ -99,10 +99,11 @@ func addLock(cfg *util.Config) error {
 	}
 
 	pdcli, err := pd.NewClientWithContext(
-		ctx, strings.Split(cfg.PDAddr, ","), pd.SecurityOption{})
+		context.Background(), strings.Split(cfg.PDAddr, ","), pd.SecurityOption{})
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer pdcli.Close()
 
 	driver := tikv.Driver{}
 	store, err := driver.Open(fmt.Sprintf("tikv://%s?disableGC=true", cfg.PDAddr))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Unify the variable types of tableID
- Deprecated the table lock and using undo list(Operation in TaskStatus) to maintain table migration
- support to add or remove more than one tables in one tick

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note
