### PR TITLE
sink: when context is done, send to chan will be block

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -399,7 +399,11 @@ func concurrentExec(
 	sendFn := func(rows []*model.RowChangedEvent, keys []string, idx int) {
 		causality.add(keys, idx)
 		jobWg.Add(1)
-		rowsChs[idx] <- rows
+		select {
+		case <-ctx.Done():
+			jobWg.Done()
+		case rowsChs[idx] <- rows:
+		}
 	}
 	for groupKey, multiRows := range rowGroups {
 		for _, rows := range multiRows {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix bug in https://github.com/pingcap/ticdc/issues/573

### What is changed and how it works?

send to channel in select mode, with `ctx.Done()` check


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
