### PR TITLE
process sorted RowChangedEvent in batch to increase throughput

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -663,18 +663,19 @@ func waitPrepareWorkers(ctx context.Context, ch chan *model.PolymorphicEvent, er
 		}
 	}
 	for {
+		var ev *model.PolymorphicEvent
 		select {
 		case <-ctx.Done():
 			return
-		case ev := <-ch:
-			err := ev.WaitPrepare(ctx)
-			if err != nil {
-				sendNoneBlock(err)
-				wg.Done()
-				return
-			}
-			wg.Done()
+		case ev = <-ch:
 		}
+		err := ev.WaitPrepare(ctx)
+		if err != nil {
+			sendNoneBlock(err)
+			wg.Done()
+			return
+		}
+		wg.Done()
 	}
 }
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -708,6 +708,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 				return errors.Trace(err)
 			}
 		}
+		events = events[:0]
 		return nil
 	}
 
@@ -727,7 +728,6 @@ func (p *processor) syncResolved(ctx context.Context) error {
 				return errors.Trace(err)
 			}
 		}
-		events = events[:0]
 		return nil
 	}
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -668,7 +668,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 	events := make([]*model.PolymorphicEvent, 0, defaultSyncResolvedBatch)
 
 	flushRowChangedEvents := func() error {
-		emitEvs := make([]*model.PolymorphicEvent, 0, len(events))
+		emitEvs := make([]*model.RowChangedEvent, 0, len(events))
 		for _, ev := range events {
 			err := ev.WaitPrepare(ctx)
 			if err != nil {
@@ -677,7 +677,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 			if ev.Row == nil {
 				continue
 			}
-			emitEvs = append(emitEvs, ev)
+			emitEvs = append(emitEvs, ev.Row)
 		}
 		err := p.sink.EmitRowChangedEvents(ctx, emitEvs...)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

optimization for https://github.com/pingcap/ticdc/issues/571

### What is changed and how it works?

- Emit RowChangedEvents in batch
- cache RowChangedEvent and flush them when reaching batch limit or receiving a ResolvedEvent

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note

