### PR TITLE
owner: ignore the invalid admin jobs

### DIFF
--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -261,14 +261,14 @@ func (s *etcdSuite) TestSetChangeFeedStatusTTL(c *check.C) {
 	c.Assert(status, check.DeepEquals, &model.ChangeFeedStatus{
 		ResolvedTs: 1,
 	})
-	err = s.client.SetChangeFeedStatusTTL(ctx, "test1", 2 /* seconds */)
+	err = s.client.SetChangeFeedStatusTTL(ctx, "test1", 1 /* seconds */)
 	c.Assert(err, check.IsNil)
 	status, _, err = s.client.GetChangeFeedStatus(ctx, "test1")
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.DeepEquals, &model.ChangeFeedStatus{
 		ResolvedTs: 1,
 	})
-	time.Sleep(3 * time.Second)
+	time.Sleep(1.5 * time.Second)
 	_, _, err = s.client.GetChangeFeedStatus(ctx, "test1")
 	c.Assert(errors.Cause(err), check.Equals, model.ErrChangeFeedNotExists)
 }

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -19,6 +19,9 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/cdc/model"
@@ -261,14 +264,25 @@ func (s *etcdSuite) TestSetChangeFeedStatusTTL(c *check.C) {
 	c.Assert(status, check.DeepEquals, &model.ChangeFeedStatus{
 		ResolvedTs: 1,
 	})
-	err = s.client.SetChangeFeedStatusTTL(ctx, "test1", 1 /* seconds */)
+	err = s.client.SetChangeFeedStatusTTL(ctx, "test1", 1 /* second */)
 	c.Assert(err, check.IsNil)
 	status, _, err = s.client.GetChangeFeedStatus(ctx, "test1")
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.DeepEquals, &model.ChangeFeedStatus{
 		ResolvedTs: 1,
 	})
-	time.Sleep(1.5 * time.Second)
-	_, _, err = s.client.GetChangeFeedStatus(ctx, "test1")
-	c.Assert(errors.Cause(err), check.Equals, model.ErrChangeFeedNotExists)
+	for i := 0; i < 50; i++ {
+		_, _, err = s.client.GetChangeFeedStatus(ctx, "test1")
+		log.Warn("nil", zap.Error(err))
+		switch errors.Cause(err) {
+		case model.ErrChangeFeedNotExists:
+			return
+		case nil:
+			time.Sleep(100 * time.Millisecond)
+			continue
+		default:
+			c.Fatal("got unexpected error", err)
+		}
+	}
+	c.Fatal("the change feed status is still exists after 5 seconds")
 }

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -249,3 +249,26 @@ func (s *etcdSuite) TestPutAllChangeFeedStatus(c *check.C) {
 		}
 	}
 }
+
+func (s *etcdSuite) TestSetChangeFeedStatusTTL(c *check.C) {
+	ctx := context.Background()
+	err := s.client.PutChangeFeedStatus(ctx, "test1", &model.ChangeFeedStatus{
+		ResolvedTs: 1,
+	})
+	c.Assert(err, check.IsNil)
+	status, _, err := s.client.GetChangeFeedStatus(ctx, "test1")
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.DeepEquals, &model.ChangeFeedStatus{
+		ResolvedTs: 1,
+	})
+	err = s.client.SetChangeFeedStatusTTL(ctx, "test1", 2 /* seconds */)
+	c.Assert(err, check.IsNil)
+	status, _, err = s.client.GetChangeFeedStatus(ctx, "test1")
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.DeepEquals, &model.ChangeFeedStatus{
+		ResolvedTs: 1,
+	})
+	time.Sleep(3 * time.Second)
+	_, _, err = s.client.GetChangeFeedStatus(ctx, "test1")
+	c.Assert(errors.Cause(err), check.Equals, model.ErrChangeFeedNotExists)
+}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -443,8 +443,10 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 		o.adminJobs = o.adminJobs[removeIdx:]
 		o.adminJobsLock.Unlock()
 	}()
+	var deletedIdx int
 	for i, job := range o.adminJobs {
 		log.Info("handle admin job", zap.String("changefeed", job.CfID), zap.Stringer("type", job.Type))
+		deletedIdx = i
 		switch job.Type {
 		case model.AdminStop:
 			// update ChangeFeedDetail to tell capture ChangeFeedDetail watcher to cleanup
@@ -506,8 +508,8 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 				return errors.Trace(err)
 			}
 		}
-		removeIdx = i + 1
 	}
+	removeIdx = deletedIdx + 1
 	return nil
 }
 

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -443,7 +443,7 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 		o.adminJobs = o.adminJobs[removeIdx:]
 		o.adminJobsLock.Unlock()
 	}()
-	var deletedIdx int
+	deletedIdx := -1
 	for i, job := range o.adminJobs {
 		log.Info("handle admin job", zap.String("changefeed", job.CfID), zap.Stringer("type", job.Type))
 		deletedIdx = i

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -443,10 +443,9 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 		o.adminJobs = o.adminJobs[removeIdx:]
 		o.adminJobsLock.Unlock()
 	}()
-	deletedIdx := -1
 	for i, job := range o.adminJobs {
 		log.Info("handle admin job", zap.String("changefeed", job.CfID), zap.Stringer("type", job.Type))
-		deletedIdx = i
+		removeIdx = i + 1
 		switch job.Type {
 		case model.AdminStop:
 			// update ChangeFeedDetail to tell capture ChangeFeedDetail watcher to cleanup
@@ -509,7 +508,6 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 			}
 		}
 	}
-	removeIdx = deletedIdx + 1
 	return nil
 }
 

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -477,7 +477,7 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 			}
 		case model.AdminResume:
 			cfStatus, _, err := o.etcdClient.GetChangeFeedStatus(ctx, job.CfID)
-			if errors.Cause(err) != model.ErrChangeFeedNotExists {
+			if errors.Cause(err) == model.ErrChangeFeedNotExists {
 				log.Warn("invalid admin job, changefeed not found", zap.String("changefeed", job.CfID))
 				continue
 			}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -485,7 +485,7 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 				return errors.Trace(err)
 			}
 			cfInfo, err := o.etcdClient.GetChangeFeedInfo(ctx, job.CfID)
-			if errors.Cause(err) != model.ErrChangeFeedNotExists {
+			if errors.Cause(err) == model.ErrChangeFeedNotExists {
 				log.Warn("invalid admin job, changefeed not found", zap.String("changefeed", job.CfID))
 				continue
 			}

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/log"
+
 	"github.com/pingcap/ticdc/pkg/config"
 
 	"github.com/google/uuid"
@@ -143,6 +145,9 @@ func newQueryChangefeedCommand() *cobra.Command {
 				taskStatus = append(taskStatus, captureTaskStatus{CaptureID: captureID, TaskStatus: status})
 			}
 			meta := &cfMeta{Info: info, Status: status, Count: count, TaskStatus: taskStatus}
+			if info == nil {
+				log.Warn("this changefeed has been deleted, the residual meta data will be completely deleted within 24 hours.")
+			}
 			return jsonPrint(cmd, meta)
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #541 #542.(3)
ignore and warn the invalid admin jobs.

if users remove the changefeed, the owner will delete the changefeed info immediately and set 24h TTL to the changefeed status.

the CDC CLI will report a warning to tall users the changefeed has been deleted.

```
./cdc cli changefeed remove --changefeed-id 04dac05c-484d-49e2-8163-1cca0d7f2

./cdc cli changefeed query --changefeed-id 04dac05c-484d-49e2-8163-1cca0d7f2fb5
[2020/06/01 09:07:24.984 +00:00] [WARN] [client_changefeed.go:149] ["this changefeed has been deleted, the residual meta data will be completely deleted within 24 hours."]
{
  "info": null,
  "status": {
    "resolved-ts": 417071719969980417,
    "checkpoint-ts": 417071719707836417,
    "admin-job-type": 3
  },
  "count": 0,
  "task-status": []
}                                                             
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
