### PR TITLE
kvclient: advance the max receive msg size of GRPC

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -53,6 +53,7 @@ const (
 	tikvRequestMaxBackoff     = 20000 // Maximum total sleep time(in ms)
 	grpcInitialWindowSize     = 1 << 30
 	grpcInitialConnWindowSize = 1 << 30
+	grpcInitialMaxRecvMsgSize = 1 << 30
 	grpcConnCount             = 10
 )
 
@@ -181,6 +182,7 @@ func (a *connArray) Init(ctx context.Context) error {
 			a.target,
 			grpc.WithInitialWindowSize(grpcInitialWindowSize),
 			grpc.WithInitialConnWindowSize(grpcInitialConnWindowSize),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcInitialMaxRecvMsgSize)),
 			grpc.WithInsecure(),
 			grpc.WithConnectParams(grpc.ConnectParams{
 				Backoff: gbackoff.Config{

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -50,10 +50,10 @@ import (
 const (
 	dialTimeout               = 10 * time.Second
 	maxRetry                  = 100
-	tikvRequestMaxBackoff     = 20000 // Maximum total sleep time(in ms)
-	grpcInitialWindowSize     = 1 << 30
-	grpcInitialConnWindowSize = 1 << 30
-	grpcInitialMaxRecvMsgSize = 1 << 30
+	tikvRequestMaxBackoff     = 20000   // Maximum total sleep time(in ms)
+	grpcInitialWindowSize     = 1 << 30 // The value for initial window size on a stream
+	grpcInitialConnWindowSize = 1 << 30 // The value for initial window size on a connection
+	grpcInitialMaxRecvMsgSize = 1 << 30 // The maximum message size the client can receive
 	grpcConnCount             = 10
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
advance the max receive msg size of GRPC

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
