### PR TITLE
Add timezone data in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN go mod download
 RUN make
 
 FROM alpine:3.11
-COPY --from=builder  /go/src/github.com/pingcap/ticdc/bin/cdc /cdc
+RUN apk add --no-cache tzdata
+COPY --from=builder /go/src/github.com/pingcap/ticdc/bin/cdc /cdc
 EXPOSE 8300
 CMD [ "/cdc" ]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

timezone info is not shipped in `alpine` container, so the CDC will fail to start if `timezone` is configured.

### What is changed and how it works?

add `tzdata` package

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manually test, build docker image from new Dockerfile

Related changes

 - Need to cherry-pick to the release branch
 - Need to republish v4.0.x docker images.

### Release note

- No release note
