### PR TITLE
*: refine cdc server log and sink statistics log

### DIFF
--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -148,6 +148,7 @@ flushLoop:
 		return errors.Trace(err)
 	}
 	k.checkpointTs = resolvedTs
+	k.statistics.PrintStatus()
 	return nil
 }
 

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -87,6 +87,8 @@ func (s *mysqlSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64
 		return nil
 	}
 
+	defer s.statistics.PrintStatus()
+
 	s.unresolvedRowsMu.Lock()
 	if len(s.unresolvedRows) == 0 {
 		atomic.StoreUint64(&s.checkpointTs, resolvedTs)
@@ -112,7 +114,6 @@ func (s *mysqlSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64
 		return errors.Trace(err)
 	}
 	atomic.StoreUint64(&s.checkpointTs, resolvedTs)
-	s.statistics.PrintStatus()
 	return nil
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -36,10 +36,9 @@ var (
 	logLevel      string
 
 	serverCmd = &cobra.Command{
-		Use:              "server",
-		Short:            "Start a TiCDC capture server",
-		PersistentPreRun: preRunLogInfo,
-		RunE:             runEServer,
+		Use:   "server",
+		Short: "Start a TiCDC capture server",
+		RunE:  runEServer,
 	}
 )
 
@@ -51,13 +50,9 @@ func init() {
 	serverCmd.Flags().StringVar(&advertiseAddr, "advertise-addr", "", "Set the advertise listening address for client communication")
 	serverCmd.Flags().StringVar(&timezone, "tz", "System", "Specify time zone of TiCDC cluster")
 	serverCmd.Flags().Int64Var(&gcTTL, "gc-ttl", cdc.DefaultCDCGCSafePointTTL, "CDC GC safepoint TTL duration, specified in seconds")
-	serverCmd.Flags().StringVar(&logFile, "log-file", "cdc.log", "log file path")
+	serverCmd.Flags().StringVar(&logFile, "log-file", "", "log file path")
 	serverCmd.Flags().StringVar(&logLevel, "log-level", "info", "log level (etc: debug|info|warn|error)")
 
-}
-
-func preRunLogInfo(cmd *cobra.Command, args []string) {
-	util.LogVersionInfo()
 }
 
 func runEServer(cmd *cobra.Command, args []string) error {
@@ -70,13 +65,13 @@ func runEServer(cmd *cobra.Command, args []string) error {
 		return errors.Annotate(err, "can not load timezone, Please specify the time zone through environment variable `TZ` or command line parameters `--tz`")
 	}
 
+	util.LogVersionInfo()
 	opts := []cdc.ServerOption{
 		cdc.PDEndpoints(serverPdAddr),
 		cdc.Address(address),
 		cdc.AdvertiseAddress(advertiseAddr),
 		cdc.GCTTL(gcTTL),
 		cdc.Timezone(tz)}
-
 	server, err := cdc.NewServer(opts...)
 	if err != nil {
 		return errors.Annotate(err, "new server")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Currently cdc servers logs version info (a.k.a welcome information `"Welcome to Change Data Capture (CDC)"`) to stdout, and other logs log to `cdc.log` by default.
- Fix https://github.com/pingcap/ticdc/issues/575
- Fix statistics is not print periodically in some cases.

### What is changed and how it works?

- Default log to stdout in cdc server
- Log welcome information after log handler is initialized

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch


### Release note

- No release note
