### PR TITLE
util: fix local timezone parse error

### DIFF
--- a/pkg/util/tz.go
+++ b/pkg/util/tz.go
@@ -15,7 +15,7 @@ package util
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -30,6 +30,21 @@ func GetTimezone(name string) (*time.Location, error) {
 	}
 }
 
+func getTimezoneFromZonefile(zonefile string) (*time.Location, error) {
+	// the linked path of `/etc/localtime` sample:
+	// MacOS: /var/db/timezone/zoneinfo/Asia/Shanghai
+	// Linux: /usr/share/zoneinfo/Asia/Shanghai
+	region := filepath.Base(filepath.Dir(zonefile))
+	zone := filepath.Base(zonefile)
+	var tzName string
+	if region == "zoneinfo" {
+		tzName = zone
+	} else {
+		tzName = filepath.Join(region, zone)
+	}
+	return time.LoadLocation(tzName)
+}
+
 // GetLocalTimezone returns the timezone in local system
 func GetLocalTimezone() (*time.Location, error) {
 	if time.Local.String() != "Local" {
@@ -39,9 +54,5 @@ func GetLocalTimezone() (*time.Location, error) {
 	if err != nil {
 		return nil, err
 	}
-	// the linked path of `/etc/localtime`
-	// MacOS: /var/db/timezone/zoneinfo/Asia/Shanghai
-	// Linux: /etc/usr/share/zoneinfo/Asia/Shanghai
-	tzName := path.Join(path.Base(path.Dir(str)), path.Base(str))
-	return time.LoadLocation(tzName)
+	return getTimezoneFromZonefile(str)
 }

--- a/pkg/util/tz_test.go
+++ b/pkg/util/tz_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/pingcap/check"
+)
+
+type tzSuite struct{}
+
+var _ = check.Suite(&tzSuite{})
+
+func (s *tzSuite) TestGetTimezoneFromZonefile(c *check.C) {
+	var (
+		testCases = []struct {
+			hasErr   bool
+			zonefile string
+			name     string
+		}{
+			{true, "", ""},
+			{false, "UTC", "UTC"},
+			{false, "/usr/share/zoneinfo/UTC", "UTC"},
+			{false, "/usr/share/zoneinfo/Etc/UTC", "Etc/UTC"},
+			{false, "/usr/share/zoneinfo/Asia/Shanghai", "Asia/Shanghai"},
+		}
+	)
+	for _, tc := range testCases {
+		loc, err := getTimezoneFromZonefile(tc.zonefile)
+		if tc.hasErr {
+			c.Assert(err, check.NotNil)
+		} else {
+			c.Assert(err, check.IsNil)
+			c.Assert(loc.String(), check.Equals, tc.name)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #619 

### What is changed and how it works?

- if `region` information from zone file is `zoneinfo`, use the last element of zone file only.
- use `path/filepath` to instead `path`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note
