### PR TITLE
sink: close the sink and release the db connect

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -843,11 +843,13 @@ func (p *processor) stop(ctx context.Context) error {
 	}
 	p.stateMu.Unlock()
 	atomic.StoreInt32(&p.stopped, 1)
-
 	if err := p.etcdCli.DeleteTaskPosition(ctx, p.changefeedID, p.captureID); err != nil {
 		return err
 	}
-	return p.etcdCli.DeleteTaskStatus(ctx, p.changefeedID, p.captureID)
+	if err := p.etcdCli.DeleteTaskStatus(ctx, p.changefeedID, p.captureID); err != nil {
+		return err
+	}
+	return p.sink.Close()
 }
 
 func (p *processor) isStopped() bool {

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -528,7 +528,7 @@ func (w *mysqlSinkWorker) fetchAllPendingEvents(
 }
 
 func (s *mysqlSink) Close() error {
-	return nil
+	return s.db.Close()
 }
 
 func (s *mysqlSink) execDMLWithMaxRetries(


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close the sink and release the db connect after processor is stoped and changefeed is closed

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->

fix the issue about the db content leak