### PR TITLE
pkg/util: fix check version in git describe format

### DIFF
--- a/pkg/util/check.go
+++ b/pkg/util/check.go
@@ -30,9 +30,13 @@ import (
 var minPDVersion *semver.Version = semver.New("4.0.0-rc.1")
 var minTiKVVersion *semver.Version = semver.New("4.0.0-rc.1")
 
-func removeV(v string) string {
+func removeVAndHash(v string) string {
 	if v == "" {
 		return v
+	}
+	hash := regexp.MustCompile("-[0-9]+-g[0-9a-f]{8,}")
+	if hash.Match([]byte(v)) {
+		v = hash.ReplaceAllLiteralString(v, "")
 	}
 	return strings.TrimPrefix(v, "v")
 }
@@ -44,14 +48,14 @@ func CheckClusterVersion(ctx context.Context, client pd.Client, pdHTTP string) e
 		return err
 	}
 	for _, s := range stores {
-		ver, err := semver.NewVersion(removeV(s.Version))
+		ver, err := semver.NewVersion(removeVAndHash(s.Version))
 		if err != nil {
 			return err
 		}
 		ord := ver.Compare(*minTiKVVersion)
 		if ord < 0 {
 			return errors.NotSupportedf("TiKV %s is not supported, require minimal version %s",
-				removeV(s.Version), minTiKVVersion)
+				removeVAndHash(s.Version), minTiKVVersion)
 		}
 	}
 	// See more: https://github.com/pingcap/pd/blob/v4.0.0-rc.1/server/api/version.go
@@ -82,14 +86,14 @@ func CheckClusterVersion(ctx context.Context, client pd.Client, pdHTTP string) e
 	if err != nil {
 		return errors.Annotate(err, "fail to request PD")
 	}
-	ver, err := semver.NewVersion(removeV(pdVer.Version))
+	ver, err := semver.NewVersion(removeVAndHash(pdVer.Version))
 	if err != nil {
 		return err
 	}
 	ord := ver.Compare(*minPDVersion)
 	if ord < 0 {
 		return errors.NotSupportedf("PD %s is not supported, require minimal version %s",
-			removeV(pdVer.Version), minPDVersion)
+			removeVAndHash(pdVer.Version), minPDVersion)
 	}
 	return nil
 }

--- a/pkg/util/check_test.go
+++ b/pkg/util/check_test.go
@@ -111,8 +111,8 @@ func (s *checkSuite) TestCheckClusterVersion(c *check.C) {
 func (s *checkSuite) TestCompareVersion(c *check.C) {
 	c.Assert(semver.New("4.0.0-rc").Compare(*semver.New("4.0.0-rc.2")), check.Equals, -1)
 	c.Assert(semver.New("4.0.0-rc.1").Compare(*semver.New("4.0.0-rc.2")), check.Equals, -1)
-	// BUG it should be "<" instead of ">".
-	// c.Assert(semver.New("4.0.0-rc-35-g31dae220").Compare(*semver.New("4.0.0-rc.2")), check.Equals, -1)
+	c.Assert(semver.New(removeVAndHash("4.0.0-rc-35-g31dae220")).Compare(*semver.New("4.0.0-rc.2")), check.Equals, -1)
+	c.Assert(semver.New(removeVAndHash("4.0.0-9-g30f0b014")).Compare(*semver.New("4.0.0-rc.1")), check.Equals, 1)
 }
 
 func (s *checkSuite) TestIsValidUUIDv4(c *check.C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

PD uses version in git describe format which has a string `-[0-9]+-g[0-9a-f]{8,}`. It breaks semver comparison.

### What is changed and how it works?

Remove the string `-[0-9]+-g[0-9a-f]{8,}`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Related changes

 - Need to cherry-pick to the release branch

### Release note

- Fix check version in git describe format.
 
<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
