### PR TITLE
Enable support for AutoRandom in tidb sink

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -16,7 +16,6 @@ package cdc
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"math"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/cyclic"
 	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/scheduler"
+	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"go.etcd.io/etcd/mvcc/mvccpb"
 	"go.uber.org/zap"
 )

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -16,6 +16,7 @@ package cdc
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"math"
 	"time"
 
@@ -639,6 +640,8 @@ func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.C
 		return errors.Trace(err)
 	}
 	if !c.cyclicEnabled || c.info.Config.Cyclic.SyncDDL {
+		ddlEvent.Query = binloginfo.AddSpecialComment(ddlEvent.Query)
+		log.Debug("DDL processed to make special features mysql-compatible", zap.String("query", ddlEvent.Query))
 		err = c.sink.EmitDDLEvent(ctx, ddlEvent)
 	}
 	// If DDL executing failed, pause the changefeed and print log, rather

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -134,8 +134,8 @@ func (s *mysqlSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 		return nil
 	}
 	ddl.Query = binloginfo.AddSpecialComment(ddl.Query)
-	err := s.execDDLWithMaxRetries(ctx, ddl, defaultDDLMaxRetryTime)
 	log.Debug("DDL processed to make special features mysql-compatible", zap.String("query", ddl.Query))
+	err := s.execDDLWithMaxRetries(ctx, ddl, defaultDDLMaxRetryTime)
 	return errors.Trace(err)
 }
 

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -44,7 +44,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/util"
 	tddl "github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/infoschema"
-	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"go.uber.org/zap"
 )
 
@@ -133,8 +132,6 @@ func (s *mysqlSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 		)
 		return nil
 	}
-	ddl.Query = binloginfo.AddSpecialComment(ddl.Query)
-	log.Debug("DDL processed to make special features mysql-compatible", zap.String("query", ddl.Query))
 	err := s.execDDLWithMaxRetries(ctx, ddl, defaultDDLMaxRetryTime)
 	return errors.Trace(err)
 }

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -265,7 +265,7 @@ func configureSinkURI(ctx context.Context, dsnCfg *dmysql.Config, tz *time.Locat
 
 	testDB, err := sql.Open("mysql", dsnCfg.FormatDSN())
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Annotate(err, "fail to open MySQL connection when configuring sink")
 	}
 	defer testDB.Close()
 	log.Debug("Opened connection to test whether allow_auto_random_explicit_insert is present.")
@@ -275,7 +275,7 @@ func configureSinkURI(ctx context.Context, dsnCfg *dmysql.Config, tz *time.Locat
 	queryStr := "show session variables like 'allow_auto_random_explicit_insert';"
 	err = testDB.QueryRowContext(ctx, queryStr).Scan(&variableName, &autoRandomInsertEnabled)
 	if err != nil && err != sql.ErrNoRows {
-		return "", errors.Trace(err)
+		return "", errors.Annotate(err, "fail to query sink for support of auto-random")
 	}
 
 	if err == nil && autoRandomInsertEnabled == "off" {

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -254,7 +254,7 @@ var defaultParams = params{
 	maxTxnRow:   defaultMaxTxnRow,
 }
 
-func configureSinkURI(dsnCfg *dmysql.Config, tz *time.Location, ctx context.Context) (string, error) {
+func configureSinkURI(ctx context.Context, dsnCfg *dmysql.Config, tz *time.Location) (string, error) {
 	if dsnCfg.Params == nil {
 		dsnCfg.Params = make(map[string]string, 1)
 	}
@@ -341,13 +341,13 @@ func newMySQLSink(ctx context.Context, sinkURI *url.URL, dsn *dmysql.Config, fil
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		dsnStr, err = configureSinkURI(dsn, tz, ctx)
+		dsnStr, err = configureSinkURI(ctx, dsn, tz)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	case dsn != nil:
 		var err error
-		dsnStr, err = configureSinkURI(dsn, tz, ctx)
+		dsnStr, err = configureSinkURI(ctx, dsn, tz)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -135,6 +135,7 @@ func (s *mysqlSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 	}
 	ddl.Query = binloginfo.AddSpecialComment(ddl.Query)
 	err := s.execDDLWithMaxRetries(ctx, ddl, defaultDDLMaxRetryTime)
+	log.Debug("DDL processed to make special features mysql-compatible", zap.String("query", ddl.Query))
 	return errors.Trace(err)
 }
 

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -283,7 +283,6 @@ func configureSinkURI(ctx context.Context, dsnCfg *dmysql.Config, tz *time.Locat
 		log.Debug("Set allow_auto_random_explicit_insert to 1")
 	}
 
-	log.Info("Connection string:", zap.String("dsnStr", dsnCfg.FormatDSN()))
 	return dsnCfg.FormatDSN(), nil
 }
 
@@ -301,10 +300,9 @@ func newMySQLSink(ctx context.Context, sinkURI *url.URL, dsn *dmysql.Config, fil
 	tz := util.TimezoneFromCtx(ctx)
 
 	var dsnStr string
-	var scheme string
 	switch {
 	case sinkURI != nil:
-		scheme = strings.ToLower(sinkURI.Scheme)
+		scheme := strings.ToLower(sinkURI.Scheme)
 		if scheme != "mysql" && scheme != "tidb" {
 			return nil, errors.New("can create mysql sink with unsupported scheme")
 		}

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/util"
 	tddl "github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"go.uber.org/zap"
 )
 
@@ -132,6 +133,7 @@ func (s *mysqlSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 		)
 		return nil
 	}
+	ddl.Query = binloginfo.AddSpecialComment(ddl.Query)
 	err := s.execDDLWithMaxRetries(ctx, ddl, defaultDDLMaxRetryTime)
 	return errors.Trace(err)
 }

--- a/tests/_utils/start_tidb_cluster
+++ b/tests/_utils/start_tidb_cluster
@@ -75,6 +75,8 @@ EOF
 # tidb server config file
 cat - >"$OUT_DIR/tidb-config.toml" <<EOF
 split-table = true
+[experimental]
+allow-auto-random = true
 EOF
 
 echo "Starting Upstream TiKV..."

--- a/tests/autorandom/conf/diff_config.toml
+++ b/tests/autorandom/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "autorandom_test"
+    tables = ["~.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/autorandom/data/test.sql
+++ b/tests/autorandom/data/test.sql
@@ -1,0 +1,15 @@
+drop database if exists `autorandom_test`;
+create database `autorandom_test`;
+use `autorandom_test`;
+
+CREATE TABLE table_a (
+	id BIGINT AUTO_RANDOM,
+	data int,
+	PRIMARY KEY(id)
+);
+
+INSERT INTO table_a (data) value (1);
+INSERT INTO table_a (data) value (2);
+INSERT INTO table_a (data) value (3);
+INSERT INTO table_a (data) value (4);
+INSERT INTO table_a (data) value (5);

--- a/tests/autorandom/run.sh
+++ b/tests/autorandom/run.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+    start_tidb_cluster $WORK_DIR
+
+    cd $WORK_DIR
+
+    # record tso before we create tables to skip the system table DDLs
+    start_ts=$(cdc cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+
+    TOPIC_NAME="ticdc-autorandom-test-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        mysql) ;&
+        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+    esac
+    cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+    run_sql_file $CUR/data/test.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    # sync_diff can't check non-exist table, so we check expected tables are created in downstream first
+    check_table_exists autorandom_test.table_a ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -67,7 +67,7 @@ function run() {
     fi
 
     # Make sure bad sink url fails at creating changefeed.
-    badsink=$(run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="mysql://badsink" | grep -oE 'fail')
+    badsink=$(run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="mysql://badsink" 2>&1 | grep -oE 'fail')
     if [[ -z $badsink ]]; then
         echo "[$(date)] <<<<< unexpect output got ${badsink} >>>>>"
         exit 1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When syncing data from tidb to tidb, if the primary key is AutoRandom, insert operations will fail because by default the db session to the sink does not allow writing to the AutoRandom key.

### What is changed and how it works?
Adding code to set the session veriable allow_auto_random_explicit_insert to true when creating a mysqlSink.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
