### PR TITLE
Add some backward compatibility to cdc cli

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -206,6 +206,10 @@ func (c *Capture) assignTask(ctx context.Context, task *Task) (*processor, error
 			zap.String("captureid", c.info.ID),
 			zap.Error(err))
 	}
+	err = cf.VerifyAndFix()
+	if err != nil {
+		return nil, err
+	}
 	log.Info("run processor", zap.String("captureid", c.info.ID),
 		zap.String("changefeedid", task.ChangeFeedID))
 

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -103,6 +103,9 @@ func (info *ChangeFeedInfo) Unmarshal(data []byte) error {
 // If some necessary filed is missing but can use a default value, fillin it.
 func (info *ChangeFeedInfo) VerifyAndFix() error {
 	defaultConfig := config.GetDefaultReplicaConfig()
+	if info.Engine == "" {
+		info.Engine = SortInMemory
+	}
 	if info.Config.Filter == nil {
 		info.Config.Filter = defaultConfig.Filter
 	}

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -97,3 +97,26 @@ func (info *ChangeFeedInfo) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+
+// VerifyAndFix verifies changefeed info and may fillin some fields.
+// If a must field is not provided, return an error.
+// If some necessary filed is missing but can use a default value, fillin it.
+func (info *ChangeFeedInfo) VerifyAndFix() error {
+	defaultConfig := config.GetDefaultReplicaConfig()
+	if info.Config.Filter == nil {
+		info.Config.Filter = defaultConfig.Filter
+	}
+	if info.Config.Mounter == nil {
+		info.Config.Mounter = defaultConfig.Mounter
+	}
+	if info.Config.Sink == nil {
+		info.Config.Sink = defaultConfig.Sink
+	}
+	if info.Config.Cyclic == nil {
+		info.Config.Cyclic = defaultConfig.Cyclic
+	}
+	if info.Config.Scheduler == nil {
+		info.Config.Scheduler = defaultConfig.Scheduler
+	}
+	return nil
+}

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -154,3 +154,24 @@ func (s *configSuite) TestFillV1(c *check.C) {
 		},
 	})
 }
+
+func (s *configSuite) TestVerifyAndFix(c *check.C) {
+	info := &ChangeFeedInfo{
+		SinkURI: "blackhole://",
+		Opts:    map[string]string{},
+		StartTs: 417257993615179777,
+		Config:  &config.ReplicaConfig{},
+	}
+
+	err := info.VerifyAndFix()
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Engine, check.Equals, SortInMemory)
+
+	marshalConfig1, err := info.Config.Marshal()
+	c.Assert(err, check.IsNil)
+	defaultConfig := config.GetDefaultReplicaConfig()
+	defaultConfig.CaseSensitive = false
+	marshalConfig2, err := defaultConfig.Marshal()
+	c.Assert(err, check.IsNil)
+	c.Assert(marshalConfig1, check.Equals, marshalConfig2)
+}

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -22,10 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/ticdc/pkg/cyclic"
-
-	"github.com/pingcap/ticdc/pkg/scheduler"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
@@ -34,7 +30,9 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/cyclic"
 	"github.com/pingcap/ticdc/pkg/filter"
+	"github.com/pingcap/ticdc/pkg/scheduler"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
@@ -353,6 +351,10 @@ func (o *Owner) loadChangeFeeds(ctx context.Context) error {
 
 		cfInfo := &model.ChangeFeedInfo{}
 		err = cfInfo.Unmarshal(cfInfoRawValue.Value)
+		if err != nil {
+			return err
+		}
+		err = cfInfo.VerifyAndFix()
 		if err != nil {
 			return err
 		}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -16,6 +16,7 @@ package filter
 import (
 	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/ticdc/pkg/config"
 	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
@@ -46,7 +47,7 @@ func NewFilter(cfg *config.ReplicaConfig) (*Filter, error) {
 		f, err = filter.Parse(rules)
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if !cfg.CaseSensitive {
 		f = filter.CaseInsensitive(f)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This is a part of https://github.com/pingcap/ticdc/issues/629, make cdc server can be compatible with changefeed created by cdc cli version (4.0.0-rc to 4.0.0) (no panic from old style changefeedinfo)

### What is changed and how it works?

- Fill in default changefeed info if needed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
    - start cdc server with this PR
    - create a cdc changefeed with cdc cli v4.0.0
    - the changefeed can run normally

### Release note

- No release note
