### PR TITLE
Decrease data size and increase wait time in file sort test

### DIFF
--- a/tests/file_sort/conf/workload
+++ b/tests/file_sort/conf/workload
@@ -1,5 +1,5 @@
 threadcount=10
-recordcount=20000
+recordcount=15000
 operationcount=0
 workload=core
 

--- a/tests/file_sort/run.sh
+++ b/tests/file_sort/run.sh
@@ -40,12 +40,12 @@ function run() {
     # directly, there maybe a lot of diff data at first because of the incremental scan
     run_sql "CREATE table file_sort.check1(id int primary key);"
     check_table_exists "file_sort.USERTABLE" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-    check_table_exists "file_sort.check1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 60
+    check_table_exists "file_sort.check1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 90
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
     go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=file_sort
     run_sql "CREATE table file_sort.check2(id int primary key);"
-    check_table_exists "file_sort.check2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 60
+    check_table_exists "file_sort.check2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 90
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
     cleanup_process $CDC_BINARY


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`file_sort` test often runs timeout now.

### What is changed and how it works?

- Decrease data size
-  Increase wait time

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note
