### PR TITLE
kv-client: remove useless retry in scan regions if ctx is canceled

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -780,6 +780,11 @@ func (s *eventFeedSession) divideAndSendEventFeedToRegions(
 		)
 		retryErr := retry.Run(50*time.Millisecond, maxRetry,
 			func() error {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+				}
 				scanT0 := time.Now()
 				bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
 				regions, err = s.regionCache.BatchLoadRegionsWithKeyRange(bo, nextSpan.Start, nextSpan.End, limit)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If we want to cancel a running processor, but a scan region just starts at the same time, `BatchLoadRegionsWithKeyRange` returns a cause error like `scanRegion from PD failed, startKey: \"mDDLJobAd\\xffdIdxList\\xff\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xf7\\x00\\x00\\x00\\x00\\x00\\x00\\x
00l\", limit: '\\x14', err: rpc error: code = Canceled desc = context canceled"`, which will be retried many times in our retry moudle.

### What is changed and how it works?

check `context.Done` before each round of retry

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note
