### PR TITLE
tests: turn log level to debug

### DIFF
--- a/tests/_utils/run_cdc_server
+++ b/tests/_utils/run_cdc_server
@@ -14,6 +14,7 @@ logsuffix=
 addr=
 pd_addr=
 pwd=$pwd
+log_level=debug
 
 while [[ ${1} ]]; do
     case "${1}" in
@@ -37,6 +38,10 @@ while [[ ${1} ]]; do
             pd_addr="--pd ${2}"
             shift
             ;;
+        --loglevel)
+            log_level=${2}
+            shift
+            ;;
         *)
             echo "Unknown parameter: ${1}" >&2
             exit 1
@@ -51,5 +56,5 @@ done
 echo "[$(date)] <<<<<< START cdc server in $TEST_NAME case >>>>>>"
 cd $workdir
 pid=$(ps -C run_cdc_server -o pid=|tr -d '[:space:]')
-$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME.$pid.out" server --log-file $workdir/cdc$logsuffix.log --log-level info $addr $pd_addr >> $workdir/stdout$log_suffix.log 2>&1 &
+$binary -test.coverprofile="$OUT_DIR/cov.$TEST_NAME.$pid.out" server --log-file $workdir/cdc$logsuffix.log --log-level $log_level $addr $pd_addr >> $workdir/stdout$log_suffix.log 2>&1 &
 cd $pwd

--- a/tests/_utils/start_tidb_cluster
+++ b/tests/_utils/start_tidb_cluster
@@ -87,6 +87,7 @@ for idx in $(seq 1 3); do
         -A ${!host}:${!port} \
         --status-addr ${!host}:${!status_port} \
         --log-file "$OUT_DIR/tikv$idx.log" \
+        --log-level debug \
         -C "$OUT_DIR/tikv-config.toml" \
         -s "$OUT_DIR/tikv$idx" &
 done
@@ -97,6 +98,7 @@ tikv-server \
     -A ${DOWN_TIKV_HOST}:${DOWN_TIKV_PORT} \
     --status-addr ${DOWN_TIKV_HOST}:${DOWN_TIKV_STATUS_PORT} \
     --log-file "$OUT_DIR/tikv_down.log" \
+    --log-level debug \
     -C "$OUT_DIR/tikv-config.toml" \
     -s "$OUT_DIR/tikv_down" &
 

--- a/tests/file_sort/run.sh
+++ b/tests/file_sort/run.sh
@@ -21,7 +21,7 @@ function run() {
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
     run_sql "CREATE DATABASE file_sort;"
     go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=file_sort
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --loglevel "info"
 
     TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"
     case $SINK_TYPE in


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

For now, we use info level to run CI, it is not enough for debugging some CI failure like #644.

This PR set level to debug by default. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note.
<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
