### PR TITLE
Fix crts maybe less than emit resolved ts in processor

### DIFF
--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -25,6 +25,7 @@ type PolymorphicEvent struct {
 
 	RawKV    *RawKVEntry
 	Row      *RowChangedEvent
+	Table    int64
 	finished chan struct{}
 }
 

--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -25,7 +25,6 @@ type PolymorphicEvent struct {
 
 	RawKV    *RawKVEntry
 	Row      *RowChangedEvent
-	Table    int64
 	finished chan struct{}
 }
 

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -128,10 +128,6 @@ func (t *tableInfo) loadResolvedTs() uint64 {
 	return tableRts
 }
 
-func (t *tableInfo) storeResolvedTs(ts uint64, rts *uint64) {
-	atomic.StoreUint64(rts, ts)
-}
-
 // newProcessor creates and returns a processor for the specified change feed
 func newProcessor(
 	ctx context.Context,
@@ -815,7 +811,7 @@ func (p *processor) addTable(ctx context.Context, tableID int64, replicaInfo *mo
 						continue
 					}
 					if pEvent.RawKV != nil && pEvent.RawKV.OpType == model.OpTypeResolved {
-						table.storeResolvedTs(pEvent.CRTs, pResolvedTs)
+						atomic.StoreUint64(pResolvedTs, pEvent.CRTs)
 						p.localResolvedNotifier.Notify()
 						resolvedTsGauge.Set(float64(oracle.ExtractPhysical(pEvent.CRTs)))
 						continue

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -99,7 +99,6 @@ type processor struct {
 	status   *model.TaskStatus
 	position *model.TaskPosition
 	tables   map[int64]*tableInfo
-	tableRts map[int64]uint64
 
 	sinkEmittedResolvedNotifier *notify.Notifier
 	sinkEmittedResolvedReceiver *notify.Receiver

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -111,7 +111,7 @@ type processor struct {
 type tableInfo struct {
 	id          int64
 	resolvedTs  uint64
-	mid         int64
+	markTableID int64
 	mResolvedTs uint64
 	workload    model.WorkloadInfo
 	cancel      context.CancelFunc
@@ -119,7 +119,7 @@ type tableInfo struct {
 
 func (t *tableInfo) loadResolvedTs() uint64 {
 	tableRts := atomic.LoadUint64(&t.resolvedTs)
-	if t.mid != 0 {
+	if t.markTableID != 0 {
 		mTableRts := atomic.LoadUint64(&t.mResolvedTs)
 		if mTableRts < tableRts {
 			return mTableRts
@@ -844,7 +844,7 @@ func (p *processor) addTable(ctx context.Context, tableID int64, replicaInfo *mo
 
 		startPuller(mTableID, true)
 
-		table.mid = mTableID
+		table.markTableID = mTableID
 		table.mResolvedTs = replicaInfo.StartTs
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #644 

Found two bugs:

~1. sinkEmittedResolvedTs and real emitted row changed events
    - each sorter sends row changed events to the output channel of a processor.
    - but resolved ts of each table is updated asynchronously, which means if the resolved ts of a table is updated, some row changed events before this resolved ts may be not consumed by processor yet.~ as `processor.output` chan is sequence, when resolved ts event is fetched, row changed events must have been consumed.
2. processor local resolved ts calculation and mark table (Then why the cyclic test often meets this bug makes sense )
    - processor receives and emits row changed events of mark table, but mark table is not maintained in processor table list, and when calculating processor local resolved ts, the mark table is not taken into consideration. https://github.com/pingcap/ticdc/blob/master/cdc/processor.go#L827-L833

### What is changed and how it works?

~- Update table's resolved ts and consume row changed events in the same routine in processor.~
- Maintain both normal tables and mark tables in processor.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch


### Release note

- No release note
