### PR TITLE
test: kill the process to avoid port occupancy issues

### DIFF
--- a/tests/_utils/stop_tidb_cluster
+++ b/tests/_utils/stop_tidb_cluster
@@ -6,3 +6,24 @@ killall -w -s 9 tidb-server || true
 killall -w -s 9 cdc || true
 killall -w -s 9 cdc.test || true
 killall -w -s 9 tiflash || true
+
+kill -9 $(lsof -i tcp:4000 -t) || true
+kill -9 $(lsof -i tcp:4001 -t) || true
+kill -9 $(lsof -i tcp:10080 -t) || true
+kill -9 $(lsof -i tcp:10081 -t) || true
+kill -9 $(lsof -i tcp:3306 -t) || true
+kill -9 $(lsof -i tcp:20080 -t) || true
+kill -9 $(lsof -i tcp:2379 -t) || true
+kill -9 $(lsof -i tcp:2380 -t) || true
+kill -9 $(lsof -i tcp:2479 -t) || true
+kill -9 $(lsof -i tcp:2480 -t) || true
+kill -9 $(lsof -i tcp:20160 -t) || true
+kill -9 $(lsof -i tcp:20181 -t) || true
+kill -9 $(lsof -i tcp:20161 -t) || true
+kill -9 $(lsof -i tcp:20182 -t) || true
+kill -9 $(lsof -i tcp:20162 -t) || true
+kill -9 $(lsof -i tcp:20183 -t) || true
+kill -9 $(lsof -i tcp:21160 -t) || true
+kill -9 $(lsof -i tcp:21180 -t) || true
+kill -9 $(lsof -i tcp:9500 -t) || true
+kill -9 $(lsof -i tcp:17000 -t) || true

--- a/tests/_utils/stop_tidb_cluster
+++ b/tests/_utils/stop_tidb_cluster
@@ -7,23 +7,23 @@ killall -w -s 9 cdc || true
 killall -w -s 9 cdc.test || true
 killall -w -s 9 tiflash || true
 
-kill -9 $(lsof -i tcp:4000 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:4001 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:10080 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:10081 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:3306 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:20080 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:2379 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:2380 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:2479 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:2480 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:20160 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:20181 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:20161 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:20182 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:20162 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:20183 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:21160 -t) &>/dev/null || true
-kill -9 $(lsof -i tcp:21180 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIDB_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIDB_OTHER_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIDB_STATUS} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIDB_OTHER_STATUS} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${DOWN_TIDB_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${DOWN_TIDB_STATUS} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_PD_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_PD_PEER_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${DOWN_PD_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${DOWN_PD_PEER_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIKV_PORT_1} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIKV_STATUS_PORT_1} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIKV_PORT_2} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIKV_STATUS_PORT_2} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIKV_PORT_3} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${UP_TIKV_STATUS_PORT_3} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${DOWN_TIKV_PORT} -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:${DOWN_TIKV_STATUS_PORT} -t) &>/dev/null || true
 kill -9 $(lsof -i tcp:9500 -t) &>/dev/null || true
 kill -9 $(lsof -i tcp:17000 -t) &>/dev/null || true

--- a/tests/_utils/stop_tidb_cluster
+++ b/tests/_utils/stop_tidb_cluster
@@ -7,23 +7,23 @@ killall -w -s 9 cdc || true
 killall -w -s 9 cdc.test || true
 killall -w -s 9 tiflash || true
 
-kill -9 $(lsof -i tcp:4000 -t) || true
-kill -9 $(lsof -i tcp:4001 -t) || true
-kill -9 $(lsof -i tcp:10080 -t) || true
-kill -9 $(lsof -i tcp:10081 -t) || true
-kill -9 $(lsof -i tcp:3306 -t) || true
-kill -9 $(lsof -i tcp:20080 -t) || true
-kill -9 $(lsof -i tcp:2379 -t) || true
-kill -9 $(lsof -i tcp:2380 -t) || true
-kill -9 $(lsof -i tcp:2479 -t) || true
-kill -9 $(lsof -i tcp:2480 -t) || true
-kill -9 $(lsof -i tcp:20160 -t) || true
-kill -9 $(lsof -i tcp:20181 -t) || true
-kill -9 $(lsof -i tcp:20161 -t) || true
-kill -9 $(lsof -i tcp:20182 -t) || true
-kill -9 $(lsof -i tcp:20162 -t) || true
-kill -9 $(lsof -i tcp:20183 -t) || true
-kill -9 $(lsof -i tcp:21160 -t) || true
-kill -9 $(lsof -i tcp:21180 -t) || true
-kill -9 $(lsof -i tcp:9500 -t) || true
-kill -9 $(lsof -i tcp:17000 -t) || true
+kill -9 $(lsof -i tcp:4000 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:4001 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:10080 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:10081 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:3306 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:20080 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:2379 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:2380 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:2479 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:2480 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:20160 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:20181 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:20161 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:20182 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:20162 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:20183 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:21160 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:21180 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:9500 -t) &>/dev/null || true
+kill -9 $(lsof -i tcp:17000 -t) &>/dev/null || true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

kill the process to avoid port occupancy issues

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
