### PR TITLE
cmd: add a command to delete CDC GC TTL

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -69,7 +69,8 @@ type Owner struct {
 	gcTTL int64
 }
 
-const cdcServiceSafePointID = "ticdc"
+// CDCServiceSafePointID is the ID of CDC service in pd.UpdateServiceGCSafePoint.
+const CDCServiceSafePointID = "ticdc"
 
 // NewOwner creates a new Owner instance
 func NewOwner(pdClient pd.Client, sess *concurrency.Session, gcTTL int64) (*Owner, error) {
@@ -417,7 +418,7 @@ func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = o.pdClient.UpdateServiceGCSafePoint(ctx, cdcServiceSafePointID, o.gcTTL, minCheckpointTs)
+	_, err = o.pdClient.UpdateServiceGCSafePoint(ctx, CDCServiceSafePointID, o.gcTTL, minCheckpointTs)
 	if err != nil {
 		log.Info("failed to update service safe point", zap.Error(err))
 		return errors.Trace(err)

--- a/cmd/client_meta.go
+++ b/cmd/client_meta.go
@@ -14,6 +14,11 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +29,9 @@ func newMetadataCommand() *cobra.Command {
 	}
 	command.AddCommand(
 		newDeleteMetaCommand(),
+		newDeleteGCTTLCommand(),
 	)
+	command.PersistentFlags().BoolVar(&noConfirm, "no-confirm", false, "Don't ask user whether to confirm executing meta command")
 	return command
 }
 
@@ -33,13 +40,55 @@ func newDeleteMetaCommand() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete all meta data in etcd, confirm that you know what this command will do and use it at your own risk",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmMetaDelete(cmd); err != nil {
+				return err
+			}
 			ctx := defaultContext
 			err := cdcEtcdCli.ClearAllCDCInfo(ctx)
-			if err == nil {
-				cmd.Println("already truncate all meta in etcd!")
+			if err != nil {
+				return errors.Trace(err)
 			}
-			return err
+			_, err = pdCli.UpdateServiceGCSafePoint(ctx, cdc.CDCServiceSafePointID, 0, 0)
+			if err == nil {
+				cmd.Println("all metadata truncated in PD!")
+			}
+			return errors.Trace(err)
 		},
 	}
 	return command
+}
+
+func newDeleteGCTTLCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "delete-gc-ttl",
+		Short: "Delete CDC GC TTL in PD, confirm that you know what this command will do and use it at your own risk",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmMetaDelete(cmd); err != nil {
+				return err
+			}
+			ctx := defaultContext
+			_, err := pdCli.UpdateServiceGCSafePoint(ctx, cdc.CDCServiceSafePointID, 0, 0)
+			if err == nil {
+				cmd.Println("CDC GC TTL truncated in PD!")
+			}
+			return errors.Trace(err)
+		},
+	}
+	return command
+}
+
+func confirmMetaDelete(cmd *cobra.Command) error {
+	if noConfirm {
+		return nil
+	}
+	cmd.Printf("Confirm that you know what this command will do and use it at your own risk [Y/N]\n")
+	var yOrN string
+	_, err := fmt.Scan(&yOrN)
+	if err != nil {
+		return err
+	}
+	if strings.ToLower(strings.TrimSpace(yOrN)) != "y" {
+		return errors.NewNoStackError("abort meta command")
+	}
+	return nil
 }

--- a/tests/_utils/run_cdc_cli
+++ b/tests/_utils/run_cdc_cli
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -eux
 
 cdc.test -test.coverprofile="$OUT_DIR/cov.$TEST_NAME.cli.$$.out" cli "$@"
+
+set +x

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -73,6 +73,10 @@ function run() {
         exit 1
     fi
 
+    # Smoke test meta delete-gc-ttl and delete
+    echo "y" | run_cdc_cli meta delete-gc-ttl
+    run_cdc_cli meta delete --no-confirm
+
     cleanup_process $CDC_BINARY
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Add a command to delete CDC GC TTL, the item 13 in #542 .

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

- Add a command to delete CDC GC TTL

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
