### PR TITLE
tests: add ddl reentrant test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ check_third_party_binary:
 	@which bin/sync_diff_inspector
 	@which bin/go-ycsb
 	@which bin/etcdctl
+	@which bin/jq
 
 integration_test_build: check_failpoint_ctl
 	$(FAILPOINT_ENABLE)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -554,7 +554,7 @@ func (p *processor) globalStatusWorker(ctx context.Context) error {
 	retryCfg := backoff.WithMaxRetries(
 		backoff.WithContext(
 			backoff.NewExponentialBackOff(), ctx),
-		3,
+		5,
 	)
 	for {
 		select {

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -715,7 +715,8 @@ func isIgnorableDDLError(err error) bool {
 	case infoschema.ErrDatabaseExists.Code(), infoschema.ErrDatabaseNotExists.Code(), infoschema.ErrDatabaseDropExists.Code(),
 		infoschema.ErrTableExists.Code(), infoschema.ErrTableNotExists.Code(), infoschema.ErrTableDropExists.Code(),
 		infoschema.ErrColumnExists.Code(), infoschema.ErrColumnNotExists.Code(), infoschema.ErrIndexExists.Code(),
-		infoschema.ErrKeyNotExists.Code(), tddl.ErrCantDropFieldOrKey.Code(), mysql.ErrDupKeyName:
+		infoschema.ErrKeyNotExists.Code(), tddl.ErrCantDropFieldOrKey.Code(), mysql.ErrDupKeyName, mysql.ErrSameNamePartition,
+		mysql.ErrDropPartitionNonExistent:
 		return true
 	default:
 		return false

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -716,7 +716,7 @@ func isIgnorableDDLError(err error) bool {
 		infoschema.ErrTableExists.Code(), infoschema.ErrTableNotExists.Code(), infoschema.ErrTableDropExists.Code(),
 		infoschema.ErrColumnExists.Code(), infoschema.ErrColumnNotExists.Code(), infoschema.ErrIndexExists.Code(),
 		infoschema.ErrKeyNotExists.Code(), tddl.ErrCantDropFieldOrKey.Code(), mysql.ErrDupKeyName, mysql.ErrSameNamePartition,
-		mysql.ErrDropPartitionNonExistent:
+		mysql.ErrDropPartitionNonExistent, mysql.ErrMultiplePriKey:
 		return true
 	default:
 		return false

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -56,6 +56,8 @@ def prepare_binaries() {
                         mv tmp/etcd-v3.4.7-linux-amd64/etcdctl third_bin
                         curl https://download.pingcap.org/tidb-tools-v2.1.6-linux-amd64.tar.gz | tar xz -C ./tmp tidb-tools-v2.1.6-linux-amd64/bin/sync_diff_inspector
                         mv tmp/tidb-tools-v2.1.6-linux-amd64/bin/* third_bin
+                        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq
+                        mv jq third_bin
                         chmod a+x third_bin/*
                         rm -rf tmp
                     """

--- a/tests/_utils/start_tidb_cluster
+++ b/tests/_utils/start_tidb_cluster
@@ -1,16 +1,36 @@
 #!/bin/bash
-# parameter 1: full path of output directory
+
+# --workdir: work directory
+# --tidb-config: path to tidb config file
 
 set -e
 
+OUT_DIR=
+tidb_config=
+
+while [[ ${1} ]]; do
+    case "${1}" in
+        --workdir)
+            OUT_DIR=${2}
+            shift
+            ;;
+        --tidb-config)
+            tidb_config=${2}
+            shift
+            ;;
+        *)
+            echo "Unknown parameter: ${1}" >&2
+            exit 1
+    esac
+
+    if ! shift; then
+        echo 'Missing parameter argument.' >&2
+        exit 1
+    fi
+done
+
 CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source $CUR/../_utils/test_prepare
-
-OUT_DIR=$1
-if [[ -z $OUT_DIR ]]; then
-    echo "wrong out_dir value: $1"
-    exit 1
-fi
 
 stop_tidb_cluster
 
@@ -73,11 +93,13 @@ sync-log = false
 EOF
 
 # tidb server config file
-cat - >"$OUT_DIR/tidb-config.toml" <<EOF
+if [[ "$tidb_config" != "" ]]; then
+    cat $tidb_config > $OUT_DIR/tidb-config.toml
+else
+    cat - >"$OUT_DIR/tidb-config.toml" <<EOF
 split-table = true
-[experimental]
-allow-auto-random = true
 EOF
+fi
 
 echo "Starting Upstream TiKV..."
 for idx in $(seq 1 3); do

--- a/tests/autorandom/conf/tidb_config.toml
+++ b/tests/autorandom/conf/tidb_config.toml
@@ -1,0 +1,3 @@
+split-table = true
+[experimental]
+allow-auto-random = true

--- a/tests/autorandom/run.sh
+++ b/tests/autorandom/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR --tidb-config $CUR/conf/tidb_config.toml
 
     cd $WORK_DIR
 

--- a/tests/availability/run.sh
+++ b/tests/availability/run.sh
@@ -16,7 +16,7 @@ export DOWN_TIDB_PORT
 function prepare() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/batch_add_table/run.sh
+++ b/tests/batch_add_table/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/cdc/run.sh
+++ b/tests/cdc/run.sh
@@ -12,7 +12,7 @@ function prepare() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
     stop_tidb_cluster
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -9,7 +9,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/common_1/run.sh
+++ b/tests/common_1/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/cyclic_ab/run.sh
+++ b/tests/cyclic_ab/run.sh
@@ -16,7 +16,7 @@ function run() {
 
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/cyclic_loopback/run.sh
+++ b/tests/cyclic_loopback/run.sh
@@ -16,7 +16,7 @@ function run() {
 
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/ddl_reentrant/conf/diff_config.toml
+++ b/tests/ddl_reentrant/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "ddl_reentrant"
+    tables = ["~.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/ddl_reentrant/conf/tidb_config.toml
+++ b/tests/ddl_reentrant/conf/tidb_config.toml
@@ -1,0 +1,2 @@
+split-table = true
+alter-primary-key = true

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -9,7 +9,7 @@ CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
 ddls=("create database ddl_reentrant" false
-      "create table ddl_reentrant.t1 (id int primary key, a varchar(10) not null, unique a(a))" false
+      "create table ddl_reentrant.t1 (id int primary key, id2 int not null, a varchar(10) not null, unique a(a), unique id2(id2))" false
       "alter table ddl_reentrant.t1 add column b int" false
       "alter table ddl_reentrant.t1 drop column b" false
       "alter table ddl_reentrant.t1 add key index_a(a)" false
@@ -29,13 +29,10 @@ ddls=("create database ddl_reentrant" false
       "alter table ddl_reentrant.t3 default character set utf8mb4 default collate utf8mb4_unicode_ci" true
       "alter schema ddl_reentrant default character set utf8mb4 default collate utf8mb4_unicode_ci" true
       "alter table ddl_reentrant.t2 drop primary key" false
+      "alter table ddl_reentrant.t2 add primary key pk(id)" false
       "drop table ddl_reentrant.t2" false
       "drop database ddl_reentrant" false
 )
-
-# TODO: we should retry on DDL error only with specific errors
-# re execute `alter table add primary key` raises error "Error 1068: Multiple primary key defined"
-reentrant_not_support_ddls=("alter table ddl_reentrant.t2 add primary key pk(id)")
 
 changefeedid=""
 SINK_URI="mysql://root@127.0.0.1:3306/"

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+ddls=("create database ddl_reentrant" false
+      "create table ddl_reentrant.t1 (id int primary key, a varchar(10) not null, unique a(a))" false
+      "alter table ddl_reentrant.t1 add column b int" false
+      "alter table ddl_reentrant.t1 drop column b" false
+      "alter table ddl_reentrant.t1 add key index_a(a)" false
+      "alter table ddl_reentrant.t1 drop index index_a" false
+      "truncate table ddl_reentrant.t1" true
+      "alter table ddl_reentrant.t1 modify a varchar(20)" true
+      "rename table ddl_reentrant.t1 to ddl_reentrant.t2" false
+      "alter table ddl_reentrant.t2 alter a set default 'hello'" true
+      "alter table ddl_reentrant.t2 comment='modify comment'" true
+      "alter table ddl_reentrant.t2 rename index a to idx_a" false
+      "create table ddl_reentrant.t3 (a int primary key, b int) partition by range(a) (partition p0 values less than (1000), partition p1 values less than (2000))" false
+      "alter table ddl_reentrant.t3 add partition (partition p2 values less than (3000))" false
+      "alter table ddl_reentrant.t3 drop partition p2" false
+      "alter table ddl_reentrant.t3 truncate partition p0" true
+      "create view ddl_reentrant.t3_view as select a, b from ddl_reentrant.t3" false
+      "drop view ddl_reentrant.t3_view" false
+      "alter table ddl_reentrant.t3 default character set utf8mb4 default collate utf8mb4_unicode_ci" true
+      "alter schema ddl_reentrant default character set utf8mb4 default collate utf8mb4_unicode_ci" true
+      "alter table ddl_reentrant.t2 drop primary key" false
+      "drop table ddl_reentrant.t2" false
+      "drop database ddl_reentrant" false
+)
+
+# TODO: we should retry on DDL error only with specific errors
+# re execute `alter table add primary key` raises error "Error 1068: Multiple primary key defined"
+reentrant_not_support_ddls=("alter table ddl_reentrant.t2 add primary key pk(id)")
+
+changefeedid=""
+SINK_URI="mysql://root@127.0.0.1:3306/"
+
+function check_ts_forward() {
+    i=0
+    check_time=10
+    while [ $i -lt 10 ]; do
+        rts1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."resolved-ts"')
+        checkpoint1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."checkpoint-ts"')
+        sleep 1
+        rts2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."resolved-ts"')
+        checkpoint2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."checkpoint-ts"')
+        if [[ "$rts1" != "null" ]] && [[ "$rts1" != "0" ]]; then
+            if [[  "$rts1" -ne "$rts2" ]] || [[ "$checkpoint1" -ne "$checkpoint2" ]]; then
+                echo "changefeed is working normally rts: ${rts1}->${rts2} checkpoint: ${checkpoint1}->${checkpoint2}"
+                break
+            fi
+        fi
+        i=$((i+1))
+        echo "changefeed ts doesn't forward $i-th time, retry later"
+    done
+    if [ $i -ge $check_time ]; then
+        echo "changefeed is not working"
+        exit 1
+    fi
+}
+
+function check_ddl_executed() {
+    log_file="$1"
+    ddl=$(cat $2)
+    success="$3"
+    if [[ $success == "true" ]]; then
+        key_word="Exec DDL succeeded"
+    else
+        key_word="execute DDL failed, but error can be ignored"
+    fi
+    log=$(grep "${key_word}" ${log_file}|tail -n 1)
+    if [[ $log == *"${ddl}"* ]]; then
+        echo $log
+        return
+    else
+        exit 1
+    fi
+}
+export -f check_ddl_executed
+
+function ddl_test() {
+    ddl=$1
+    is_reentrant=$2
+
+    echo "------------------------------------------"
+    echo "test ddl $ddl, is_reentrant: $is_reentrant"
+
+    run_sql $ddl ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_ts_forward
+
+    echo $ddl > ${WORK_DIR}/ddl_temp.sql
+    ensure 10 check_ddl_executed "${WORK_DIR}/cdc.log" "${WORK_DIR}/ddl_temp.sql" true
+    ddl_start_ts=$(grep "Execute DDL succeeded" ${WORK_DIR}/cdc.log|tail -n 1|grep -oE '"start_ts\\":[0-9]{18}'|awk -F: '{print $(NF)}')
+    cdc cli changefeed remove --changefeed-id=${changefeedid}
+    changefeedid=$(cdc cli changefeed create --no-confirm --start-ts=${ddl_start_ts} --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+    echo "create new changefeed ${changefeedid} from ${ddl_start_ts}"
+    check_ts_forward
+    ensure 10 check_ddl_executed "${WORK_DIR}/cdc.log" "${WORK_DIR}/ddl_temp.sql" $is_reentrant
+}
+
+function run() {
+    # don't test kafka in this case
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      return
+    fi
+
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+    start_tidb_cluster --workdir $WORK_DIR --tidb-config $CUR/conf/tidb_config.toml
+
+    cd $WORK_DIR
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    changefeedid=$(cdc cli changefeed create --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+
+    OLDIFS=$IFS
+    IFS=""
+    idx=0
+    while [ $idx -lt ${#ddls[*]} ]; do
+        ddl=${ddls[$idx]}
+        idx=$((idx+1))
+        idxs_reentrant=${ddls[$idx]}
+        idx=$((idx+1))
+        ddl_test $ddl $idxs_reentrant
+    done
+    IFS=$OLDIFS
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -31,6 +31,7 @@ ddls=("create database ddl_reentrant" false
       "alter table ddl_reentrant.t2 drop primary key" false
       "alter table ddl_reentrant.t2 add primary key pk(id)" false
       "drop table ddl_reentrant.t2" false
+      "recover table ddl_reentrant.t2" false
       "drop database ddl_reentrant" false
 )
 

--- a/tests/ddl_sequence/run.sh
+++ b/tests/ddl_sequence/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/drop_many_tables/run.sh
+++ b/tests/drop_many_tables/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/file_sort/run.sh
+++ b/tests/file_sort/run.sh
@@ -14,7 +14,7 @@ DB_COUNT=4
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/generate_column/run.sh
+++ b/tests/generate_column/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/many_pk_or_uk/run.sh
+++ b/tests/many_pk_or_uk/run.sh
@@ -12,7 +12,7 @@ function prepare() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
     stop_tidb_cluster
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/multi_capture/run.sh
+++ b/tests/multi_capture/run.sh
@@ -14,7 +14,7 @@ DB_COUNT=4
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/multi_source/run.sh
+++ b/tests/multi_source/run.sh
@@ -12,7 +12,7 @@ function prepare() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
     stop_tidb_cluster
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/partition_table/run.sh
+++ b/tests/partition_table/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/resolve_lock/run.sh
+++ b/tests/resolve_lock/run.sh
@@ -12,7 +12,7 @@ function prepare() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
     stop_tidb_cluster
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/row_format/run.sh
+++ b/tests/row_format/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,7 +18,7 @@ if [ "${1-}" = '--debug' ]; then
     LD_LIBRARY_PATH="$CUR/../bin:$CUR/_utils:$PATH" \
     OUT_DIR=$OUT_DIR \
     TEST_NAME="debug" \
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cdc server --log-file $WORK_DIR/cdc.log --log-level debug --addr 0.0.0.0:8300 > $WORK_DIR/stdout.log 2>&1 &
     sleep 1

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function prepare() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/sink_retry/run.sh
+++ b/tests/sink_retry/run.sh
@@ -14,7 +14,7 @@ DB_COUNT=4
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/split_region/run.sh
+++ b/tests/split_region/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 

--- a/tests/tiflash/run.sh
+++ b/tests/tiflash/run.sh
@@ -11,7 +11,7 @@ SINK_TYPE=$1
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-    start_tidb_cluster $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
 
     cd $WORK_DIR
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This is the first part of https://github.com/pingcap/ticdc/issues/625

### What is changed and how it works?

- Add an integration test, `ddl_reentrant`, which test each kind of DDL as following
  1. start a changefeed, run this DDL, test DDL is replicated and record the `start-ts` of DDL
  2. remove the changefeed in step 1, re-create a changefeed with start-ts equals to the `start-ts` of DDL in step 1.
  3. then the DDL will be re-executed by the new changefeed (which simulates a DDL reentrant in the same changefeed), we can check the execute result and replication status.
      - DDL executed, replication continues
      - DDL failed, but error can be ignored and replication continues
      - DDL failed, and error can't be ignore, the replciation stops
- Add three more DDL errors that can be ignored, because these DDLs can't be reentrant 
 executed in TiDB
    - `mysql.ErrSameNamePartition`, which means repeated execution of `alter table add partition`.
    - `mysql.ErrDropPartitionNonExistent`, which means repeated execution of `drop partition`. 
    - `mysql.ErrMultiplePriKey`, which means repeated execution of `add primary key`.
- Increase query changefeed job status retry time from 3 to 5, in the test then continuous DDL may lead to some latency of PD information update.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


### Release note

- No release note
