### PR TITLE
support to balance subtasks to new captures

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -429,9 +429,10 @@ func (c *changeFeed) rebanlanceTables(ctx context.Context, captures map[model.Ca
 			return nil
 		}
 	}
+	timeToRebanlance := time.Since(c.lastRebanlanceTime) > time.Duration(c.info.Config.Scheduler.PollingTime)*time.Minute
+	timeToRebanlance = timeToRebanlance && c.info.Config.Scheduler.PollingTime > 0
 
-	if !c.rebanlanceNextTick &&
-		time.Since(c.lastRebanlanceTime) < time.Duration(c.info.Config.Scheduler.PollingTime)*time.Minute {
+	if !c.rebanlanceNextTick && !timeToRebanlance {
 		return nil
 	}
 	c.lastRebanlanceTime = time.Now()

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -397,7 +397,7 @@ func (p *processor) ddlPullWorker(ctx context.Context) error {
 }
 
 func (p *processor) workloadWorker(ctx context.Context) error {
-	t := time.NewTicker(1 * time.Minute)
+	t := time.NewTicker(10 * time.Second)
 	err := p.etcdCli.PutTaskWorkload(ctx, p.changefeedID, p.captureID, nil)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,8 +39,8 @@ var defaultReplicaConfig = &ReplicaConfig{
 		Enable: false,
 	},
 	Scheduler: &SchedulerConfig{
-		Tp:          "manual",
-		PollingTime: 5,
+		Tp:          "table-number",
+		PollingTime: -1,
 	},
 }
 

--- a/pkg/scheduler/interface.go
+++ b/pkg/scheduler/interface.go
@@ -40,11 +40,9 @@ type Scheduler interface {
 func NewScheduler(tp string) Scheduler {
 	switch tp {
 	case "table-number":
-		return newTableNumberScheduler(false)
-	case "manual":
-		return newTableNumberScheduler(true)
+		return newTableNumberScheduler()
 	default:
 		log.Info("invalid scheduler type, using default scheduler")
-		return newTableNumberScheduler(true)
+		return newTableNumberScheduler()
 	}
 }

--- a/pkg/scheduler/table_number.go
+++ b/pkg/scheduler/table_number.go
@@ -17,15 +17,13 @@ import "github.com/pingcap/ticdc/cdc/model"
 
 // TableNumberScheduler provides a feature that scheduling by the table number
 type TableNumberScheduler struct {
-	workloads      workloads
-	distributeOnly bool
+	workloads workloads
 }
 
 // newTableNumberScheduler creates a new table number scheduler
-func newTableNumberScheduler(distributeOnly bool) *TableNumberScheduler {
+func newTableNumberScheduler() *TableNumberScheduler {
 	return &TableNumberScheduler{
-		workloads:      make(workloads),
-		distributeOnly: distributeOnly,
+		workloads: make(workloads),
 	}
 }
 
@@ -47,9 +45,6 @@ func (t *TableNumberScheduler) Skewness() float64 {
 // CalRebalanceOperates implements the Scheduler interface
 func (t *TableNumberScheduler) CalRebalanceOperates(targetSkewness float64) (
 	skewness float64, moveTableJobs map[model.TableID]*model.MoveTableJob) {
-	if t.distributeOnly {
-		return 0, nil
-	}
 	var totalTableNumber uint64
 	for _, captureWorkloads := range t.workloads {
 		totalTableNumber += uint64(len(captureWorkloads))

--- a/pkg/scheduler/table_number_test.go
+++ b/pkg/scheduler/table_number_test.go
@@ -26,7 +26,7 @@ type tableNumberSuite struct{}
 var _ = check.Suite(&tableNumberSuite{})
 
 func (s *tableNumberSuite) TestDistributeTables(c *check.C) {
-	scheduler := newTableNumberScheduler(false)
+	scheduler := newTableNumberScheduler()
 	scheduler.ResetWorkloads("capture1", model.TaskWorkload{
 		1: model.WorkloadInfo{Workload: 1},
 		2: model.WorkloadInfo{Workload: 1}})
@@ -58,7 +58,7 @@ func (s *tableNumberSuite) TestDistributeTables(c *check.C) {
 }
 
 func (s *tableNumberSuite) TestCalRebalanceOperates(c *check.C) {
-	scheduler := newTableNumberScheduler(false)
+	scheduler := newTableNumberScheduler()
 	scheduler.ResetWorkloads("capture1", model.TaskWorkload{
 		1: model.WorkloadInfo{Workload: 1},
 		2: model.WorkloadInfo{Workload: 1}})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
support to balance subtasks to new captures ,fix #638

### What is changed and how it works?
- Adjust the default value of `Scheduler.PollingTime` to `-1`
- If `Scheduler.PollingTime` is less than 0, the rebanlance process will not be call by time trigger.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- support to balance subtasks to new captures 