### PR TITLE
remove events count check in cyclic test

### DIFF
--- a/tests/cyclic_ab/run.sh
+++ b/tests/cyclic_ab/run.sh
@@ -85,18 +85,6 @@ function run() {
 
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
-    # Sleep a while to make sure no more events will be created in cyclic.
-    sleep 5
-
-    # Why 30? 20 insert + 10 mark table insert.
-    expect=30
-    uuid=$(run_cdc_cli changefeed list --pd=http://$UP_PD_HOST:$UP_PD_PORT 2>&1 | grep -oE "[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}")
-    count=$(curl -sSf 127.0.0.1:8300/metrics | grep txn_batch_size_sum | grep ${uuid} | awk -F ' ' '{print $2}')
-    if [[ $count != $expect ]]; then
-        echo "[$(date)] <<<<< found extra mysql events! expect to ${expect} got ${count} >>>>>"
-        exit 1
-    fi
-
     cleanup_process $CDC_BINARY
 }
 

--- a/tests/cyclic_abc/run.sh
+++ b/tests/cyclic_abc/run.sh
@@ -112,18 +112,6 @@ function run() {
     check_sync_diff $WORK_DIR $CUR/conf/diff_config_up_down.toml
     check_sync_diff $WORK_DIR $CUR/conf/diff_config_down_third.toml
 
-    # Sleep a while to make sure no more events will be created in cyclic.
-    sleep 5
-
-    # Why 50? 10 insert from 1 + 20 insert from 3 + 10 mark table insert from 1 + 10 mark table insert from 3.
-    expect=50
-    uuid=$(run_cdc_cli changefeed list --pd=http://$UP_PD_HOST:$UP_PD_PORT 2>&1 | grep -oE "[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}")
-    count=$(curl -sSf 127.0.0.1:8300/metrics | grep txn_batch_size_sum | grep ${uuid} | awk -F ' ' '{print $2}')
-    if [[ $count != $expect ]]; then
-        echo "[$(date)] <<<<< found extra mysql events! expect to ${expect} got ${count} >>>>>"
-        exit 1
-    fi
-
     cleanup_process $CDC_BINARY
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Row changed events could be duplicated in CDC, so the number of DML events is nondeterministic 

### What is changed and how it works?

Remove the event count check in test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note
