### PR TITLE
sink: support config tidb txn mode in mysql sink

### DIFF
--- a/tests/resolve_lock/run.sh
+++ b/tests/resolve_lock/run.sh
@@ -25,7 +25,7 @@ function prepare() {
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
         mysql) ;&
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/tidb-txn-mode=pessimistic";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

support config tidb txn mode in mysql sink, and use `optimistic` as default mode. ref: https://github.com/pingcap/ticdc/issues/668

### What is changed and how it works?

Pass this parameter from `sink-uri` (If user use MySQL dsn as sink-uri, this parameter is passed from dsn parameter)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- Support config tidb txn mode in MySQL sink, and use optimistic as default
