### PR TITLE
Fix start-ts in row changed event emitted from kafka consumer

### DIFF
--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -112,7 +112,7 @@ func (t *Txn) Append(row *RowChangedEvent) {
 			zap.Uint64("startTs of txn", t.StartTs),
 			zap.Uint64("commitTs of txn", t.CommitTs),
 			zap.Uint64("startTs of row", row.StartTs),
-			zap.Uint64("startTs of row", row.CommitTs))
+			zap.Uint64("commitTs of row", row.CommitTs))
 	}
 	t.Rows = append(t.Rows, row)
 	if len(row.Keys) == 0 {

--- a/kafka_consumer/main.go
+++ b/kafka_consumer/main.go
@@ -378,6 +378,9 @@ ClaimMessages:
 						zap.Int32("partition", partition))
 					break ClaimMessages
 				}
+				// FIXME: hack to set start-ts in row changed event, as start-ts
+				// is not contained in TiCDC open protocol
+				row.StartTs = row.CommitTs
 				err = sink.EmitRowChangedEvents(ctx, row)
 				if err != nil {
 					log.Fatal("emit row changed event failed", zap.Error(err))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Kafka consumer used in integration test reuses the MySQL sink of TiCDC, MySQL sink groups transaction by `start-ts` of row changed events, but `start-ts` is not contained in TiCDC open protocol.

### What is changed and how it works?

Just hack to set `start-ts` equals to `commit-ts` of row changed events emitted from Kafka consumer. (We don't change TiCDC open protocol in this PR)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note

