### PR TITLE
pkg: quote schema.table to avoid error in SQL syntax

### DIFF
--- a/pkg/cyclic/mark.go
+++ b/pkg/cyclic/mark.go
@@ -50,13 +50,13 @@ func CreateMarkTables(ctx context.Context, tables []model.TableName, upstreamDSN
 			return errors.Annotate(err, "fail to create mark database")
 		}
 		_, err = db.ExecContext(ctx, fmt.Sprintf(
-			`CREATE TABLE IF NOT EXISTS %s.%s
+			`CREATE TABLE IF NOT EXISTS %s
 			(
 				bucket INT NOT NULL,
 				%s BIGINT UNSIGNED NOT NULL,
 				val BIGINT DEFAULT 0,
 				PRIMARY KEY (bucket, %s)
-			);`, schema, table, CyclicReplicaIDCol, CyclicReplicaIDCol))
+			);`, model.QuoteSchema(schema, table), CyclicReplicaIDCol, CyclicReplicaIDCol))
 		if err != nil {
 			return errors.Annotatef(err, "fail to create mark table %s", table)
 		}

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -15,6 +15,8 @@ function run() {
 
     # record tso before we create tables to skip the system table DDLs
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
+    run_sql "CREATE table test.simple(id int primary key, val int);"
+    run_sql "CREATE table test.`simple-dash`(id int primary key, val int);"
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 
@@ -29,16 +31,11 @@ function run() {
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
     fi
 
-    run_sql "CREATE database tidb_cdc;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-    run_sql "CREATE table tidb_cdc.repl_mark_test_simple (
-        bucket INT NOT NULL, \
-        replica_id BIGINT UNSIGNED NOT NULL, \
-        val BIGINT DEFAULT 0, \
-        PRIMARY KEY (bucket, replica_id) \
-    );" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    $(run_cdc_cli cdc cli changefeed cyclic create-marktables --cyclic-upstream-dsn="root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/")
 
     # Make sure changefeed is created.
     check_table_exists tidb_cdc.repl_mark_test_simple ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_table_exists tidb_cdc.repl_mark_test_simple-dash ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
     uuid=$(run_cdc_cli changefeed list 2>&1 | grep -oE "[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}")
 

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -35,7 +35,7 @@ function run() {
 
     # Make sure changefeed is created.
     check_table_exists tidb_cdc.repl_mark_test_simple ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-    check_table_exists tidb_cdc.repl_mark_test_simple-dash ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_table_exists tidb_cdc."\`repl_mark_test_simple-dash\`" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
     uuid=$(run_cdc_cli changefeed list 2>&1 | grep -oE "[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}")
 

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -16,7 +16,7 @@ function run() {
     # record tso before we create tables to skip the system table DDLs
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
     run_sql "CREATE table test.simple(id int primary key, val int);"
-    run_sql "CREATE table test.`simple-dash`(id int primary key, val int);"
+    run_sql "CREATE table test.\`simple-dash\`(id int primary key, val int);"
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the error when creating mark table with invalid characters.

```
fail to create mark table repl_mark_test_dm_meta_sg-test_syncer_checkpoint: 
  Error 1064: You have an error in your SQL syntax; 
    check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 62 near "-test_syncer_checkpoint
```

### What is changed and how it works?

Should quote schema and table

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note
