### PR TITLE
sink: fix wait group is not updated when exec with error

### DIFF
--- a/cdc/server.go
+++ b/cdc/server.go
@@ -239,13 +239,6 @@ func (s *Server) run(ctx context.Context) (err error) {
 
 // Close closes the server.
 func (s *Server) Close() {
-	if s.statusServer != nil {
-		err := s.statusServer.Close()
-		if err != nil {
-			log.Error("close status server", zap.Error(err))
-		}
-		s.statusServer = nil
-	}
 	if s.capture != nil {
 		s.capture.Cleanup()
 
@@ -255,5 +248,12 @@ func (s *Server) Close() {
 			log.Error("close capture", zap.Error(err))
 		}
 		closeCancel()
+	}
+	if s.statusServer != nil {
+		err := s.statusServer.Close()
+		if err != nil {
+			log.Error("close status server", zap.Error(err))
+		}
+		s.statusServer = nil
 	}
 }

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -535,14 +535,15 @@ func (w *mysqlSinkWorker) run(ctx context.Context) (err error) {
 		if len(toExecRows) == 0 {
 			return nil
 		}
-		defer w.txnWg.Add(-1 * txnNum)
 		rows := make([]*model.RowChangedEvent, len(toExecRows))
 		copy(rows, toExecRows)
 		err := w.execDMLs(ctx, rows, replicaID, w.bucket)
 		if err != nil {
+			w.txnWg.Add(-1 * txnNum)
 			return err
 		}
 		toExecRows = toExecRows[:0]
+		w.txnWg.Add(-1 * txnNum)
 		txnNum = 0
 		lastExecTime = time.Now()
 		return nil

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -535,6 +535,7 @@ func (w *mysqlSinkWorker) run(ctx context.Context) (err error) {
 		if len(toExecRows) == 0 {
 			return nil
 		}
+		defer w.txnWg.Add(-1 * txnNum)
 		rows := make([]*model.RowChangedEvent, len(toExecRows))
 		copy(rows, toExecRows)
 		err := w.execDMLs(ctx, rows, replicaID, w.bucket)
@@ -542,7 +543,6 @@ func (w *mysqlSinkWorker) run(ctx context.Context) (err error) {
 			return err
 		}
 		toExecRows = toExecRows[:0]
-		w.txnWg.Add(-1 * txnNum)
 		txnNum = 0
 		lastExecTime = time.Now()
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix goroutine hangs when executing dmls with error

```
goroutine 446 [semacquire, 2 minutes]:
sync.runtime_Semacquire(0xc005850730)
    runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc005850728)
    sync/waitgroup.go:130 +0x64
github.com/pingcap/ticdc/cdc/sink.(*mysqlSinkWorker).waitAllTxnsExecuted(...)
    github.com/pingcap/ticdc/cdc/sink/mysql.go:499
github.com/pingcap/ticdc/cdc/sink.(*mysqlSinkWorker).waitAndClose(...)
    github.com/pingcap/ticdc/cdc/sink/mysql.go:503
github.com/pingcap/ticdc/cdc/sink.concurrentExec(0x2a97bc0, 0xc000d14840, 0xc0058506c0, 0x10, 0x100, 0xc00575dda0, 0x0, 0xffffffffffffffff)
    github.com/pingcap/ticdc/cdc/sink/mysql.go:476 +0x601
github.com/pingcap/ticdc/cdc/sink.(*mysqlSink).concurrentExec(0xc000d6e7c0, 0x2a97bc0, 0xc000d14840, 0xc0058506c0, 0x0, 0x0)
    github.com/pingcap/ticdc/cdc/sink/mysql.go:432 +0x8e
github.com/pingcap/ticdc/cdc/sink.(*mysqlSink).FlushRowChangedEvents(0xc000d6e7c0, 0x2a97bc0, 0xc000d14840, 0x5cb6b2c67540001, 0x0, 0x0)
    github.com/pingcap/ticdc/cdc/sink/mysql.go:130 +0x164
github.com/pingcap/ticdc/cdc.(*processor).sinkDriver(0xc000760700, 0x2a97bc0, 0xc000d14840, 0x0, 0x0)
    github.com/pingcap/ticdc/cdc/processor.go:624 +0x13b
github.com/pingcap/ticdc/cdc.(*processor).Run.func3(0x0, 0x0)
    github.com/pingcap/ticdc/cdc/processor.go:226 +0x3c
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc00076fb90, 0xc0008dac00)
    golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
    golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:54 +0x66
```

### What is changed and how it works?

- update counter of txn wait group when exec DMLs with error
- change the close sequence of `capture` and `statusServer`, after this change, we could access the status server if the close of `capture` is blocked.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note
