### PR TITLE
*: fix cyclic replication issues with filter and ineligible tables

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -158,6 +158,11 @@ func (c *changeFeed) addTable(sid model.SchemaID, tid model.TableID, startTs mod
 		return
 	}
 
+	if !entry.WrapTableInfo(sid, table.Schema, tblInfo).IsEligible() {
+		log.Warn("skip ineligible table", zap.Int64("tid", tid), zap.Stringer("table", table))
+		return
+	}
+
 	if _, ok := c.schemas[sid]; !ok {
 		c.schemas[sid] = make(tableIDMap)
 	}

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
-	"github.com/pingcap/ticdc/pkg/cyclic"
+	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/scheduler"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
@@ -149,7 +149,7 @@ func (c *changeFeed) addTable(sid model.SchemaID, tid model.TableID, startTs mod
 	if c.filter.ShouldIgnoreTable(table.Schema, table.Table) {
 		return
 	}
-	if c.cyclicEnabled && cyclic.IsMarkTable(table.Schema, table.Table) {
+	if c.cyclicEnabled && mark.IsMarkTable(table.Schema, table.Table) {
 		return
 	}
 
@@ -326,7 +326,7 @@ func (c *changeFeed) balanceOrphanTables(ctx context.Context, captures map[model
 				if !found {
 					continue
 				}
-				markTableSchameName, markTableTableName := cyclic.MarkTableName(tableName.Schema, tableName.Table)
+				markTableSchameName, markTableTableName := mark.GetMarkTableName(tableName.Schema, tableName.Table)
 				orphanMarkTableID, found = schemaSnapshot.GetTableIDByName(markTableSchameName, markTableTableName)
 				if !found {
 					// Mark table is not created yet, skip and wait.

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -29,6 +29,7 @@ import (
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/quotes"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
@@ -416,7 +417,7 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *TableInfo, row *rowKVEntry) (*m
 	}
 	event.Delete = row.Delete
 	event.Columns = values
-	event.Keys = genMultipleKeys(tableInfo.TableInfo, values, model.QuoteSchema(event.Table.Schema, event.Table.Table))
+	event.Keys = genMultipleKeys(tableInfo.TableInfo, values, quotes.QuoteSchema(event.Table.Schema, event.Table.Table))
 	return event, nil
 }
 
@@ -464,7 +465,7 @@ func (m *mounterImpl) mountIndexKVEntry(tableInfo *TableInfo, idx *indexKVEntry)
 		IndieMarkCol: tableInfo.IndieMarkCol,
 		Delete:       true,
 		Columns:      values,
-		Keys:         genMultipleKeys(tableInfo.TableInfo, values, model.QuoteSchema(tableInfo.TableName.Schema, tableInfo.TableName.Table)),
+		Keys:         genMultipleKeys(tableInfo.TableInfo, values, quotes.QuoteSchema(tableInfo.TableName.Schema, tableInfo.TableName.Table)),
 	}, nil
 }
 

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/pkg/config"
-	"github.com/pingcap/ticdc/pkg/filter"
+	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 )
 
@@ -103,7 +103,7 @@ func (info *ChangeFeedInfo) Unmarshal(data []byte) error {
 		if err != nil {
 			return errors.Annotatef(err, "Marshal data: %v", data)
 		}
-		info.Opts[filter.OptCyclicConfig] = string(cyclicCfg)
+		info.Opts[mark.OptCyclicConfig] = string(cyclicCfg)
 	}
 	return nil
 }

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -47,6 +47,16 @@ func (t TableName) String() string {
 	return fmt.Sprintf("%s.%s", t.Schema, t.Table)
 }
 
+// GetSchema returns schema name.
+func (t *TableName) GetSchema() string {
+	return t.Schema
+}
+
+// GetTable returns table name.
+func (t *TableName) GetTable() string {
+	return t.Table
+}
+
 // RowChangedEvent represents a row changed event
 type RowChangedEvent struct {
 	StartTs  uint64 `json:"start-ts"`

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -240,6 +240,10 @@ func (o *Owner) newChangeFeed(
 			log.Warn("table not found for table ID", zap.Int64("tid", tid))
 			continue
 		}
+		if !tblInfo.IsEligible() {
+			log.Warn("skip ineligible table", zap.Int64("tid", tid), zap.Stringer("table", table))
+			continue
+		}
 		if pi := tblInfo.GetPartitionInfo(); pi != nil {
 			delete(partitions, tid)
 			for _, partition := range pi.Definitions {

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
-	"github.com/pingcap/ticdc/pkg/cyclic"
+	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/scheduler"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -215,7 +215,7 @@ func (o *Owner) newChangeFeed(
 		if filter.ShouldIgnoreTable(table.Schema, table.Table) {
 			continue
 		}
-		if info.Config.Cyclic.IsEnabled() && cyclic.IsMarkTable(table.Schema, table.Table) {
+		if info.Config.Cyclic.IsEnabled() && mark.IsMarkTable(table.Schema, table.Table) {
 			// skip the mark table if cyclic is enabled
 			continue
 		}

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -37,8 +37,10 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/cyclic"
+	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	"github.com/pingcap/ticdc/pkg/filter"
 	tifilter "github.com/pingcap/ticdc/pkg/filter"
+	"github.com/pingcap/ticdc/pkg/quotes"
 	"github.com/pingcap/ticdc/pkg/retry"
 	"github.com/pingcap/ticdc/pkg/util"
 	tddl "github.com/pingcap/tidb/ddl"
@@ -180,7 +182,7 @@ func (s *mysqlSink) execDDL(ctx context.Context, ddl *model.DDLEvent) error {
 	}
 
 	if shouldSwitchDB {
-		_, err = tx.ExecContext(ctx, "USE "+model.QuoteName(ddl.Schema)+";")
+		_, err = tx.ExecContext(ctx, "USE "+quotes.QuoteName(ddl.Schema)+";")
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
 				log.Error("Failed to rollback", zap.Error(err))
@@ -411,7 +413,7 @@ func newMySQLSink(ctx context.Context, sinkURI *url.URL, dsn *dmysql.Config, fil
 		statistics:     NewStatistics("mysql", opts),
 	}
 
-	if val, ok := opts[cyclic.OptCyclicConfig]; ok {
+	if val, ok := opts[mark.OptCyclicConfig]; ok {
 		cfg := new(config.CyclicConfig)
 		err := cfg.Unmarshal([]byte(val))
 		if err != nil {
@@ -682,7 +684,7 @@ func prepareReplace(schema, table string, cols map[string]*model.Column) (string
 	}
 
 	colList := "(" + buildColumnList(columnNames) + ")"
-	tblName := model.QuoteSchema(schema, table)
+	tblName := quotes.QuoteSchema(schema, table)
 	builder.WriteString("REPLACE INTO " + tblName + colList + " VALUES ")
 	builder.WriteString("(" + model.HolderString(len(columnNames)) + ");")
 
@@ -691,7 +693,7 @@ func prepareReplace(schema, table string, cols map[string]*model.Column) (string
 
 func prepareDelete(schema, table string, cols map[string]*model.Column) (string, []interface{}, error) {
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("DELETE FROM %s WHERE ", model.QuoteSchema(schema, table)))
+	builder.WriteString(fmt.Sprintf("DELETE FROM %s WHERE ", quotes.QuoteSchema(schema, table)))
 
 	colNames, wargs := whereSlice(cols)
 	args := make([]interface{}, 0, len(wargs))
@@ -700,9 +702,9 @@ func prepareDelete(schema, table string, cols map[string]*model.Column) (string,
 			builder.WriteString(" AND ")
 		}
 		if wargs[i] == nil {
-			builder.WriteString(model.QuoteName(colNames[i]) + " IS NULL")
+			builder.WriteString(quotes.QuoteName(colNames[i]) + " IS NULL")
 		} else {
-			builder.WriteString(model.QuoteName(colNames[i]) + " = ?")
+			builder.WriteString(quotes.QuoteName(colNames[i]) + " = ?")
 			args = append(args, wargs[i])
 		}
 	}
@@ -759,7 +761,7 @@ func buildColumnList(names []string) string {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString(model.QuoteName(name))
+		b.WriteString(quotes.QuoteName(name))
 
 	}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -147,7 +147,7 @@ func verifyTables(ctx context.Context, cfg *config.ReplicaConfig, startTs uint64
 		if filter.ShouldIgnoreTable(tableName.Schema, tableName.Table) {
 			continue
 		}
-		if !tableInfo.ExistTableUniqueColumn() {
+		if !tableInfo. IsEligible() {
 			ineligibleTables = append(ineligibleTables, tableName)
 		} else {
 			eligibleTables = append(eligibleTables, tableName)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -119,7 +119,7 @@ func verifyStartTs(ctx context.Context, startTs uint64, cli kv.CDCEtcdClient) er
 	return nil
 }
 
-func verifyTables(ctx context.Context, cfg *config.ReplicaConfig, startTs uint64) (ineligibleTables, fullTables []model.TableName, err error) {
+func verifyTables(ctx context.Context, cfg *config.ReplicaConfig, startTs uint64) (ineligibleTables, eligibleTables []model.TableName, err error) {
 	kvStore, err := kv.CreateTiStore(cliPdAddr)
 	if err != nil {
 		return nil, nil, err
@@ -147,9 +147,10 @@ func verifyTables(ctx context.Context, cfg *config.ReplicaConfig, startTs uint64
 		if filter.ShouldIgnoreTable(tableName.Schema, tableName.Table) {
 			continue
 		}
-		fullTables = append(fullTables, tableName)
 		if !tableInfo.ExistTableUniqueColumn() {
 			ineligibleTables = append(ineligibleTables, tableName)
+		} else {
+			eligibleTables = append(eligibleTables, tableName)
 		}
 	}
 	return

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -147,7 +147,7 @@ func verifyTables(ctx context.Context, cfg *config.ReplicaConfig, startTs uint64
 		if filter.ShouldIgnoreTable(tableName.Schema, tableName.Table) {
 			continue
 		}
-		if !tableInfo. IsEligible() {
+		if !tableInfo.IsEligible() {
 			ineligibleTables = append(ineligibleTables, tableName)
 		} else {
 			eligibleTables = append(eligibleTables, tableName)

--- a/pkg/cyclic/filter_test.go
+++ b/pkg/cyclic/filter_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 )
 
 type markSuit struct{}
@@ -28,7 +29,7 @@ var _ = check.Suite(&markSuit{})
 func TestCyclic(t *testing.T) { check.TestingT(t) }
 
 func (s *markSuit) TestFilterAndReduceTxns(c *check.C) {
-	rID := CyclicReplicaIDCol
+	rID := mark.CyclicReplicaIDCol
 	testCases := []struct {
 		input     map[model.TableName][]*model.Txn
 		output    map[model.TableName][]*model.Txn

--- a/pkg/cyclic/mark/mark.go
+++ b/pkg/cyclic/mark/mark.go
@@ -1,0 +1,109 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mark
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/pkg/quotes"
+	"go.uber.org/zap"
+)
+
+const (
+	// SchemaName is the name of schema where all mark tables are created
+	SchemaName string = "tidb_cdc"
+	tableName  string = "repl_mark"
+
+	// CyclicReplicaIDCol is the name of replica ID in mark tables
+	CyclicReplicaIDCol string = "replica_id"
+
+	// OptCyclicConfig is the key that adds to changefeed options
+	// automatically is cyclic replication is on.
+	OptCyclicConfig string = "_cyclic_relax_sql_mode"
+)
+
+// GetMarkTableName returns mark table name regards to the tableID
+func GetMarkTableName(sourceSchema, sourceTable string) (schema, table string) { // nolint:exported
+	// TODO(neil) better unquote or just crc32 the name.
+	table = strings.Join([]string{tableName, sourceSchema, sourceTable}, "_")
+	schema = SchemaName
+	return
+}
+
+// IsMarkTable tells whether the table is a mark table or not.
+func IsMarkTable(schema, table string) bool {
+	const quoteSchemaName = "`" + SchemaName + "`"
+	const quotetableName = "`" + tableName
+
+	if schema == SchemaName || schema == quoteSchemaName {
+		return true
+	}
+	if strings.HasPrefix(table, quotetableName) {
+		return true
+	}
+	return strings.HasPrefix(table, tableName)
+}
+
+// TableName is an interface gets schema and table name.
+// Note it is only used for avoiding import model.TableName.
+type TableName interface {
+	GetSchema() string
+	GetTable() string
+}
+
+// CreateMarkTables creates mark table regard to the table name.
+//
+// Note table name is only for avoid write hotspot there is *NO* guarantee
+// normal tables and mark tables are one:one map.
+func CreateMarkTables(ctx context.Context, upstreamDSN string, tables ...TableName) error {
+	db, err := sql.Open("mysql", upstreamDSN)
+	if err != nil {
+		return errors.Annotate(err, "Open upsteam database connection failed")
+	}
+	err = db.PingContext(ctx)
+	if err != nil {
+		return errors.Annotate(err, "fail to open upstream TiDB connection")
+	}
+
+	userTableCount := 0
+	for _, name := range tables {
+		if IsMarkTable(name.GetSchema(), name.GetTable()) {
+			continue
+		}
+		userTableCount++
+		schema, table := GetMarkTableName(name.GetSchema(), name.GetTable())
+		_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s;", schema))
+		if err != nil {
+			return errors.Annotate(err, "fail to create mark database")
+		}
+		_, err = db.ExecContext(ctx, fmt.Sprintf(
+			`CREATE TABLE IF NOT EXISTS %s
+			(
+				bucket INT NOT NULL,
+				%s BIGINT UNSIGNED NOT NULL,
+				val BIGINT DEFAULT 0,
+				PRIMARY KEY (bucket, %s)
+			);`, quotes.QuoteSchema(schema, table), CyclicReplicaIDCol, CyclicReplicaIDCol))
+		if err != nil {
+			return errors.Annotatef(err, "fail to create mark table %s", table)
+		}
+	}
+	log.Info("create upstream mark done", zap.Int("count", userTableCount))
+	return nil
+}

--- a/pkg/cyclic/mark/mark_test.go
+++ b/pkg/cyclic/mark/mark_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mark
+
+import (
+	"testing"
+
+	"github.com/pingcap/check"
+)
+
+type markSuit struct{}
+
+var _ = check.Suite(&markSuit{})
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+func (s *markSuit) TestIsMarkTable(c *check.C) {
+	tests := []struct {
+		schema, table string
+		isMarkTable   bool
+	}{
+		{"", "", false},
+		{"a", "a", false},
+		{"a", "", false},
+		{"", "a", false},
+		{SchemaName, "", true},
+		{"", tableName, true},
+		{"`" + SchemaName + "`", "", true},
+		{"`" + SchemaName + "`", "repl_mark_1", true},
+		{SchemaName, tableName, true},
+		{SchemaName, "`repl_mark_1`", true},
+	}
+
+	for _, test := range tests {
+		c.Assert(IsMarkTable(test.schema, test.table), check.Equals, test.isMarkTable,
+			check.Commentf("%v", test))
+	}
+}

--- a/pkg/cyclic/replication_test.go
+++ b/pkg/cyclic/replication_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 )
 
 type cyclicSuit struct{}
@@ -49,16 +50,16 @@ func (s *cyclicSuit) TestIsTablePaired(c *check.C) {
 		isParied bool
 	}{
 		{[]model.TableName{}, true},
-		{[]model.TableName{{Schema: SchemaName, Table: "repl_mark_1"}},
+		{[]model.TableName{{Schema: mark.SchemaName, Table: "repl_mark_1"}},
 			true},
 		{[]model.TableName{{Schema: "a", Table: "a"}},
 			false},
-		{[]model.TableName{{Schema: SchemaName, Table: "repl_mark_a_a"},
+		{[]model.TableName{{Schema: mark.SchemaName, Table: "repl_mark_a_a"},
 			{Schema: "a", Table: "a"}},
 			true},
 		{[]model.TableName{
-			{Schema: SchemaName, Table: "repl_mark_a_a"},
-			{Schema: SchemaName, Table: "repl_mark_a_b"},
+			{Schema: mark.SchemaName, Table: "repl_mark_a_a"},
+			{Schema: mark.SchemaName, Table: "repl_mark_a_b"},
 			{Schema: "a", Table: "a"},
 			{Schema: "a", Table: "b"}},
 			true},
@@ -66,29 +67,6 @@ func (s *cyclicSuit) TestIsTablePaired(c *check.C) {
 
 	for _, test := range tests {
 		c.Assert(IsTablesPaired(test.tables), check.Equals, test.isParied,
-			check.Commentf("%v", test))
-	}
-}
-
-func (s *cyclicSuit) TestIsMarkTable(c *check.C) {
-	tests := []struct {
-		schema, table string
-		isMarkTable   bool
-	}{
-		{"", "", false},
-		{"a", "a", false},
-		{"a", "", false},
-		{"", "a", false},
-		{SchemaName, "", true},
-		{"", tableName, true},
-		{"`" + SchemaName + "`", "", true},
-		{"`" + SchemaName + "`", "repl_mark_1", true},
-		{SchemaName, tableName, true},
-		{SchemaName, "`repl_mark_1`", true},
-	}
-
-	for _, test := range tests {
-		c.Assert(IsMarkTable(test.schema, test.table), check.Equals, test.isMarkTable,
 			check.Commentf("%v", test))
 	}
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -36,6 +36,7 @@ func (s *filterSuite) TestShouldUseDefaultRules(c *check.C) {
 	c.Assert(filter.ShouldIgnoreTable("performance_schema", ""), check.IsTrue)
 	c.Assert(filter.ShouldIgnoreTable("metric_schema", "query_duration"), check.IsTrue)
 	c.Assert(filter.ShouldIgnoreTable("sns", "user"), check.IsFalse)
+	c.Assert(filter.ShouldIgnoreTable("tidb_cdc", "repl_mark_a_a"), check.IsFalse)
 }
 
 func (s *filterSuite) TestShouldUseCustomRules(c *check.C) {
@@ -43,6 +44,7 @@ func (s *filterSuite) TestShouldUseCustomRules(c *check.C) {
 		Filter: &config.FilterConfig{
 			Rules: []string{"sns.*", "ecom.*", "!sns.log", "!ecom.test"},
 		},
+		Cyclic: &config.CyclicConfig{Enable: true},
 	})
 	c.Assert(err, check.IsNil)
 	assertIgnore := func(db, tbl string, boolCheck check.Checker) {
@@ -56,6 +58,7 @@ func (s *filterSuite) TestShouldUseCustomRules(c *check.C) {
 	assertIgnore("ecom", "test", check.IsTrue)
 	assertIgnore("sns", "log", check.IsTrue)
 	assertIgnore("information_schema", "", check.IsTrue)
+	assertIgnore("tidb_cdc", "repl_mark_a_a", check.IsFalse)
 }
 
 func (s *filterSuite) TestShouldIgnoreTxn(c *check.C) {

--- a/pkg/quotes/quotes.go
+++ b/pkg/quotes/quotes.go
@@ -1,0 +1,34 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quotes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// QuoteSchema quotes a full table name
+func QuoteSchema(schema string, table string) string {
+	return fmt.Sprintf("`%s`.`%s`", EscapeName(schema), EscapeName(table))
+}
+
+// QuoteName wraps a name with "`"
+func QuoteName(name string) string {
+	return "`" + EscapeName(name) + "`"
+}
+
+// EscapeName replaces all "`" in name with "``"
+func EscapeName(name string) string {
+	return strings.Replace(name, "`", "``", -1)
+}

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -31,7 +31,8 @@ function run() {
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
     fi
 
-    $(run_cdc_cli cdc cli changefeed cyclic create-marktables --cyclic-upstream-dsn="root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/")
+    run_cdc_cli changefeed cyclic create-marktables \
+        --cyclic-upstream-dsn="root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/"
 
     # Make sure changefeed is created.
     check_table_exists tidb_cdc.repl_mark_test_simple ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}

--- a/tests/cyclic_ab/conf/only_test_simple.toml
+++ b/tests/cyclic_ab/conf/only_test_simple.toml
@@ -1,0 +1,2 @@
+[filter]
+rules = ['test.simple']

--- a/tests/cyclic_ab/run.sh
+++ b/tests/cyclic_ab/run.sh
@@ -23,6 +23,8 @@ function run() {
 
     # create table to upstream.
     run_sql "CREATE table test.simple(id1 int, id2 int, source int, primary key (id1, id2));" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    # create an ineligible table to make sure cyclic replication works fine even with some ineligible tables.
+    # run_sql "CREATE table test.ineligible(id int, val int);"
 
     # create table to downsteam.
     run_sql "CREATE table test.simple(id1 int, id2 int, source int, primary key (id1, id2));" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
@@ -50,6 +52,8 @@ function run() {
         --pd "http://${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
         --addr "127.0.0.1:8301"
 
+    # Echo y to ignore ineligible tables
+    # echo "y" | run_cdc_cli changefeed create --start-ts=$start_ts \
     run_cdc_cli changefeed create --start-ts=$start_ts \
         --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/" \
         --pd "http://${UP_PD_HOST}:${UP_PD_PORT}" \
@@ -62,7 +66,8 @@ function run() {
         --pd "http://${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
         --cyclic-replica-id 2 \
         --cyclic-filter-replica-ids 1 \
-        --cyclic-sync-ddl false
+        --cyclic-sync-ddl false \
+        --config $CUR/conf/only_test_simple.toml
 
     for i in $(seq 11 20); do {
         sqlup="START TRANSACTION;"

--- a/tests/cyclic_ab/run.sh
+++ b/tests/cyclic_ab/run.sh
@@ -24,7 +24,7 @@ function run() {
     # create table to upstream.
     run_sql "CREATE table test.simple(id1 int, id2 int, source int, primary key (id1, id2));" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     # create an ineligible table to make sure cyclic replication works fine even with some ineligible tables.
-    # run_sql "CREATE table test.ineligible(id int, val int);"
+    run_sql "CREATE table test.ineligible(id int, val int);"
 
     # create table to downsteam.
     run_sql "CREATE table test.simple(id1 int, id2 int, source int, primary key (id1, id2));" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
@@ -53,8 +53,7 @@ function run() {
         --addr "127.0.0.1:8301"
 
     # Echo y to ignore ineligible tables
-    # echo "y" | run_cdc_cli changefeed create --start-ts=$start_ts \
-    run_cdc_cli changefeed create --start-ts=$start_ts \
+    echo "y" | run_cdc_cli changefeed create --start-ts=$start_ts \
         --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/" \
         --pd "http://${UP_PD_HOST}:${UP_PD_PORT}" \
         --cyclic-replica-id 1 \


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR tries to:

- Fix #679 CDC stops replication due to ineligible tables are not ignored.
- Fix #678 If mark table not in allow list, create cyclic changefeed will fail

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

### Release note

- Fix the issue that fail to create cyclic changefeed if mark table not in allow list.
- Fix the issue that cyclic changefeed does works if there are some ineligible tables.

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
