### PR TITLE
Stop changefeed automatically if one of processor exits

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -58,6 +58,7 @@ type ChangeFeedInfo struct {
 
 	Config *config.ReplicaConfig `json:"config"`
 	State  FeedState             `json:"state"`
+	Error  RunningError          `json:"error"`
 }
 
 // GetStartTs returns StartTs if it's  specified or using the CreateTime of changefeed.

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -58,7 +58,7 @@ type ChangeFeedInfo struct {
 
 	Config *config.ReplicaConfig `json:"config"`
 	State  FeedState             `json:"state"`
-	Error  RunningError          `json:"error"`
+	Error  *RunningError         `json:"error"`
 }
 
 // GetStartTs returns StartTs if it's  specified or using the CreateTime of changefeed.

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -33,7 +33,7 @@ var (
 
 // RunningError represents some running error from cdc components, such as processor.
 type RunningError struct {
-	ID        string `json:"id"`
-	Error     string `json:"error"`
-	Component string `json:"component"`
+	Addr    string `json:"addr"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -30,3 +30,10 @@ var (
 	ErrCaptureNotExist       = errors.New("capture not exists")
 	ErrUnresolved            = errors.New("unresolved")
 )
+
+// RunningError represents some running error from cdc components, such as processor.
+type RunningError struct {
+	ID        string `json:"id"`
+	Error     string `json:"error"`
+	Component string `json:"component"`
+}

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -26,8 +26,9 @@ type AdminJobType int
 
 // AdminJob holds an admin job
 type AdminJob struct {
-	CfID string
-	Type AdminJobType
+	CfID  string
+	Type  AdminJobType
+	Error RunningError
 }
 
 // All AdminJob types
@@ -61,6 +62,7 @@ type TaskPosition struct {
 	ResolvedTs uint64 `json:"resolved-ts"`
 	// The count of events were synchronized. This is updated by corresponding processor.
 	Count uint64 `json:"count"`
+	Error string `json:"error"`
 }
 
 // Marshal returns the json marshal format of a TaskStatus

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -28,7 +28,7 @@ type AdminJobType int
 type AdminJob struct {
 	CfID  string
 	Type  AdminJobType
-	Error RunningError
+	Error *RunningError
 }
 
 // All AdminJob types
@@ -62,7 +62,8 @@ type TaskPosition struct {
 	ResolvedTs uint64 `json:"resolved-ts"`
 	// The count of events were synchronized. This is updated by corresponding processor.
 	Count uint64 `json:"count"`
-	Error string `json:"error"`
+	// Error code when error happens
+	Error *RunningError `json:"error"`
 }
 
 // Marshal returns the json marshal format of a TaskStatus

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -144,6 +144,10 @@ func (o *Owner) removeCapture(info *model.CaptureInfo) {
 			log.Warn("failed to delete task position",
 				zap.String("capture", info.ID), zap.String("changefeed", feed.id), zap.Error(err))
 		}
+		if err := o.etcdClient.DeleteTaskWorkload(ctx, feed.id, info.ID); err != nil {
+			log.Warn("failed to delete task workload",
+				zap.String("capture", info.ID), zap.String("changefeed", feed.id), zap.Error(err))
+		}
 	}
 }
 
@@ -339,6 +343,7 @@ func (o *Owner) loadChangeFeeds(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	errorFeeds := make(map[model.ChangeFeedID]model.RunningError)
 	for changeFeedID, cfInfoRawValue := range details {
 		taskStatus, err := o.cfRWriter.GetAllTaskStatus(ctx, changeFeedID)
 		if err != nil {
@@ -350,6 +355,18 @@ func (o *Owner) loadChangeFeeds(ctx context.Context) error {
 		}
 		if cf, exist := o.changeFeeds[changeFeedID]; exist {
 			cf.updateProcessorInfos(taskStatus, taskPositions)
+			for captureID, pos := range taskPositions {
+				// TODO: only record error of one capture,
+				// is it necessary to record all captures' error
+				if pos.Error != "" {
+					errorFeeds[changeFeedID] = model.RunningError{
+						ID:        captureID,
+						Error:     pos.Error,
+						Component: "processor",
+					}
+					break
+				}
+			}
 			continue
 		}
 
@@ -401,6 +418,16 @@ func (o *Owner) loadChangeFeeds(ctx context.Context) error {
 		}
 		o.changeFeeds[changeFeedID] = newCf
 	}
+	o.adminJobsLock.Lock()
+	for cfID, err := range errorFeeds {
+		job := model.AdminJob{
+			CfID:  cfID,
+			Type:  model.AdminStop,
+			Error: err,
+		}
+		o.adminJobs = append(o.adminJobs, job)
+	}
+	o.adminJobsLock.Unlock()
 	return nil
 }
 
@@ -543,6 +570,7 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 				continue
 			}
 			cf.info.AdminJobType = model.AdminStop
+			cf.info.Error = job.Error
 			err := o.etcdClient.SaveChangeFeedInfo(ctx, cf.info, job.CfID)
 			if err != nil {
 				return errors.Trace(err)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	pd "github.com/pingcap/pd/v4/client"
 	"github.com/pingcap/ticdc/cdc/entry"
@@ -684,6 +685,9 @@ func (p *processor) syncResolved(ctx context.Context) error {
 			if row == nil {
 				continue
 			}
+			failpoint.Inject("ProcessorSyncResolvedError", func() {
+				failpoint.Return(errors.New("processor sync resolvd injected error"))
+			})
 			if row.RawKV != nil && row.RawKV.OpType == model.OpTypeResolved {
 				err := flushRowChangedEvents()
 				if err != nil {

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -940,7 +940,12 @@ func runProcessor(
 				zap.String("processorid", processor.id),
 				zap.Error(err))
 			// record error information in etcd
-			processor.position.Error = err.Error()
+			// TODO: design error codes for TiCDC
+			processor.position.Error = &model.RunningError{
+				Addr:    captureInfo.AdvertiseAddr,
+				Code:    "CDC-processor-1000",
+				Message: err.Error(),
+			}
 			err = processor.tsRWriter.WritePosition(ctx, processor.position)
 			if err != nil {
 				log.Warn("upload processor error failed", zap.Error(err))

--- a/tests/changefeed_auto_stop/conf/diff_config.toml
+++ b/tests/changefeed_auto_stop/conf/diff_config.toml
@@ -1,0 +1,36 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "changefeed_auto_stop_1"
+    tables = ["usertable"]
+[[check-tables]]
+    schema = "changefeed_auto_stop_2"
+    tables = ["usertable"]
+[[check-tables]]
+    schema = "changefeed_auto_stop_3"
+    tables = ["usertable"]
+[[check-tables]]
+    schema = "changefeed_auto_stop_4"
+    tables = ["usertable"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/changefeed_auto_stop/conf/workload
+++ b/tests/changefeed_auto_stop/conf/workload
@@ -1,0 +1,13 @@
+threadcount=4
+recordcount=20
+operationcount=0
+workload=core
+
+readallfields=true
+
+readproportion=0
+updateproportion=0
+scanproportion=0
+insertproportion=0
+
+requestdistribution=uniform

--- a/tests/changefeed_auto_stop/run.sh
+++ b/tests/changefeed_auto_stop/run.sh
@@ -20,7 +20,7 @@ function check_changefeed_is_stopped() {
         exit 1
     fi
     changefeed_info=$(ETCDCTL_API=3 etcdctl --endpoints=$endpoints get /tidb/cdc/changefeed/info/${changefeedid}|tail -n 1)
-    if [[ ! $changefeed_info == *"error\":\"processor sync resolvd injected error"* ]]; then
+    if [[ ! $changefeed_info == *"message\":\"processor sync resolvd injected error"* ]]; then
         echo "changefeed is not marked as failed: $changefeed_info"
         exit 1
     fi

--- a/tests/changefeed_auto_stop/run.sh
+++ b/tests/changefeed_auto_stop/run.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+function check_changefeed_is_stopped() {
+    endpoints=$1
+    changefeedid=$2
+    position=$(ETCDCTL_API=3 etcdctl --endpoints=$endpoints get /tidb/cdc/task/position --prefix)
+    if [[ $position != "" ]]; then
+        exit 1
+    fi
+    status=$(ETCDCTL_API=3 etcdctl --endpoints=$endpoints get /tidb/cdc/task/status --prefix)
+    if [[ $status != "" ]]; then
+        exit 1
+    fi
+    changefeed_info=$(ETCDCTL_API=3 etcdctl --endpoints=$endpoints get /tidb/cdc/changefeed/info/${changefeedid}|tail -n 1)
+    if [[ ! $changefeed_info == *"error\":\"processor sync resolvd injected error"* ]]; then
+        echo "changefeed is not marked as failed: $changefeed_info"
+        exit 1
+    fi
+}
+
+export -f check_changefeed_is_stopped
+
+function run() {
+    DB_COUNT=4
+
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+    start_ts=$(cdc cli tso query --pd=http://$UP_PD_HOST:$UP_PD_PORT)
+
+    for i in $(seq $DB_COUNT); do
+        db="changefeed_auto_stop_$i"
+        run_sql "CREATE DATABASE $db;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+        go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=$db
+    done
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301" --pd "http://${UP_PD_HOST}:${UP_PD_PORT}"
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedError=1*return(true)'
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "2" --addr "127.0.0.1:8302" --pd "http://${UP_PD_HOST}:${UP_PD_PORT}"
+    export GO_FAILPOINTS=''
+
+    TOPIC_NAME="ticdc-changefeed-auto-stop-test-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        mysql) ;&
+        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+    esac
+    changefeedid=$(cdc cli changefeed create --pd="http://${UP_PD_HOST}:${UP_PD_PORT}" --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+
+    ensure 10 check_changefeed_is_stopped ${UP_PD_HOST}:${UP_PD_PORT} ${changefeedid}
+
+    cdc cli changefeed resume --changefeed-id=${changefeedid} --pd="http://${UP_PD_HOST}:${UP_PD_PORT}"
+    for i in $(seq $DB_COUNT); do
+        check_table_exists "changefeed_auto_stop_$i.USERTABLE" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    done
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    export GO_FAILPOINTS=''
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This is part of https://github.com/pingcap/ticdc/issues/664, and tries to release resource if one processor of a changefeed meets error

### What is changed and how it works?

- If a processor exits with error, upload the error message to `task position`.
- If owner finds error in `task position`, stop the changefeed via admin job. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- Stop changefeed automatically if one of processor exits