### PR TITLE
processor: fix processor doesn't fully exit after `p.stop` is called

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -87,8 +87,9 @@ type processor struct {
 	globalResolvedTs      uint64
 	checkpointTs          uint64
 
-	ddlPuller     puller.Puller
-	schemaStorage *entry.SchemaStorage
+	ddlPuller       puller.Puller
+	ddlPullerCancel context.CancelFunc
+	schemaStorage   *entry.SchemaStorage
 
 	tsRWriter storage.ProcessorTsRWriter
 	output    chan *model.PolymorphicEvent
@@ -212,7 +213,8 @@ func newProcessor(
 func (p *processor) Run(ctx context.Context) {
 	wg, cctx := errgroup.WithContext(ctx)
 	p.wg = wg
-	ddlPullerCtx := util.PutTableIDInCtx(cctx, 0)
+	ddlPullerCtx, ddlPullerCancel := context.WithCancel(util.PutTableIDInCtx(cctx, 0))
+	p.ddlPullerCancel = ddlPullerCancel
 
 	wg.Go(func() error {
 		return p.positionWorker(cctx)
@@ -856,6 +858,7 @@ func (p *processor) stop(ctx context.Context) error {
 	for _, tbl := range p.tables {
 		tbl.cancel()
 	}
+	p.ddlPullerCancel()
 	// mark tables share the same context with its original table, don't need to cancel
 	p.stateMu.Unlock()
 	atomic.StoreInt32(&p.stopped, 1)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In some tests we find after changefeed is stopped via admin API, processor maybe not fully exit, and some kv client blocks at `stream.Recv`.

After some investigation we find processor doesn't cancel ddl puller when `p.stop()` is called.

### What is changed and how it works?

Cancel ddl puller when in processor stop.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- Fix processor does not fully exit when changefeed is stopped via admin API.
