### PR TITLE
Remove fmt.Sprintf when assembling SQLs

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -694,7 +694,7 @@ func prepareReplace(schema, table string, cols map[string]*model.Column) (string
 
 func prepareDelete(schema, table string, cols map[string]*model.Column) (string, []interface{}, error) {
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("DELETE FROM %s WHERE ", quotes.QuoteSchema(schema, table)))
+	builder.WriteString("DELETE FROM " + quotes.QuoteSchema(schema, table) + " WHERE")
 
 	colNames, wargs := whereSlice(cols)
 	args := make([]interface{}, 0, len(wargs))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
minor performance optimization

### What is changed and how it works?
use string operator `+` instead of `fmt.Spritnf`

In fact TiDB has schema/table name size limit of 64 (https://github.com/pingcap/parser/blob/master/mysql/const.go#L71-L74), and in most cases, table name tends to be shorter.

simple benchmark

```
package main

import (
        "fmt"
        "strings"
        "testing"
)

func BenchmarkBuild(b *testing.B) {
        funcs := []struct {
                name string
                f    func(table string)
        }{
                {
                        "fmt.Sprintf", func(table string) {
                                var builder strings.Builder
                                builder.WriteString(fmt.Sprintf("DELETE FROM %s WHERE", table))
                        },
                }, {
                        "builder", func(table string) {
                                var builder strings.Builder
                                builder.WriteString("DELETE FROM ")
                                builder.WriteString(table)
                                builder.WriteString(" WHERE")
                        },
                }, {
                        "operator", func(table string) {
                                var builder strings.Builder
                                builder.WriteString("DELETE FROM " + table + " WHERE")
                        },
                },
        }
        tests := []struct {
                name string
                n    int
        }{
                {name: "8", n: 8},
                {name: "16", n: 16},
                {name: "32", n: 32},
                {name: "64", n: 64},
                {name: "128", n: 128},
                {name: "256", n: 256},
                {name: "512", n: 512},
        }

        for _, f := range funcs {
                for _, t := range tests {
                        bs := make([]byte, t.n)
                        for i := range bs {
                                bs[i] = 't'
                        }
                        table := string(bs)

                        b.Run(f.name+t.name, func(b *testing.B) {
                                b.ResetTimer()
                                for i := 0; i < b.N; i++ {
                                        f.f(table)
                                }
                        })
                }
        }
}
```

```
goos: linux
goarch: amd64
BenchmarkBuild/fmt.Sprintf8-2            5339469               226 ns/op
BenchmarkBuild/fmt.Sprintf16-2           5070963               234 ns/op
BenchmarkBuild/fmt.Sprintf32-2           4791955               246 ns/op
BenchmarkBuild/fmt.Sprintf64-2           4618758               265 ns/op
BenchmarkBuild/fmt.Sprintf128-2          3850172               311 ns/op
BenchmarkBuild/fmt.Sprintf256-2          2816152               625 ns/op
BenchmarkBuild/fmt.Sprintf512-2          1650277               608 ns/op
BenchmarkBuild/builder8-2               13306366               104 ns/op
BenchmarkBuild/builder16-2               8331376               140 ns/op
BenchmarkBuild/builder32-2               7783357               167 ns/op
BenchmarkBuild/builder64-2               5785912               229 ns/op
BenchmarkBuild/builder128-2              3927531               324 ns/op
BenchmarkBuild/builder256-2              4684329               235 ns/op
BenchmarkBuild/builder512-2              3805598               322 ns/op
BenchmarkBuild/operator8-2              13016476                90.8 ns/op
BenchmarkBuild/operator16-2              9745203               125 ns/op
BenchmarkBuild/operator32-2              8271038               137 ns/op
BenchmarkBuild/operator64-2              7600426               150 ns/op
BenchmarkBuild/operator128-2             5875749               192 ns/op
BenchmarkBuild/operator256-2             4437096               284 ns/op
BenchmarkBuild/operator512-2             2311954               552 ns/op
PASS
ok      command-line-arguments  33.651s
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Related changes

 - Need to cherry-pick to the release branch


### Release note

- No release note

