### PR TITLE
Refine some state transition when handling admin job

### DIFF
--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/cdc/model"
@@ -216,8 +215,7 @@ func (s *Server) handleChangefeedQuery(w http.ResponseWriter, req *http.Request)
 	}
 	if status != nil {
 		resp.TSO = status.CheckpointTs
-		physical := oracle.ExtractPhysical(status.CheckpointTs)
-		tm := time.Unix(int64(physical/1000), int64(physical)%1000*time.Millisecond.Nanoseconds())
+		tm := oracle.GetTimeFromTS(status.CheckpointTs)
 		resp.Checkpoint = tm.Format("2006-01-02 15:04:05.000")
 	}
 	writeData(w, resp)

--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -47,6 +47,7 @@ func (s *Server) startStatusHTTP() error {
 	serverMux.HandleFunc("/capture/owner/admin", s.handleChangefeedAdmin)
 	serverMux.HandleFunc("/capture/owner/rebalance_trigger", s.handleRebalanceTrigger)
 	serverMux.HandleFunc("/capture/owner/move_table", s.handleMoveTable)
+	serverMux.HandleFunc("/capture/owner/changefeed/query", s.handleChangefeedQuery)
 
 	prometheus.DefaultGatherer = registry
 	serverMux.Handle("/metrics", promhttp.Handler())

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -38,8 +38,10 @@ type FeedState string
 
 // All FeedStates
 const (
-	StateNormal FeedState = "normal"
-	StateFailed FeedState = "failed"
+	StateNormal  FeedState = "normal"
+	StateFailed  FeedState = "failed"
+	StateStopped FeedState = "stopped"
+	StateRemoved FeedState = "removed"
 )
 
 // ChangeFeedInfo describes the detail of a ChangeFeed

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -60,7 +60,8 @@ var (
 	cdcEtcdCli kv.CDCEtcdClient
 	pdCli      pd.Client
 
-	interact bool
+	interact   bool
+	simplified bool
 
 	changefeedID string
 	captureID    string

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -122,6 +122,16 @@ func newQueryChangefeedCommand() *cobra.Command {
 		Short: "Query information and status of a replicaiton task (changefeed)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := defaultContext
+
+			if simplified {
+				resp, err := applyOwnerChangefeedQuery(ctx, changefeedID)
+				if err != nil {
+					return err
+				}
+				cmd.Println(resp)
+				return nil
+			}
+
 			info, err := cdcEtcdCli.GetChangeFeedInfo(ctx, changefeedID)
 			if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
 				return err
@@ -153,6 +163,7 @@ func newQueryChangefeedCommand() *cobra.Command {
 			return jsonPrint(cmd, meta)
 		},
 	}
+	command.PersistentFlags().BoolVar(&simplified, "simple", false, "Output simplified replication status")
 	command.PersistentFlags().StringVar(&changefeedID, "changefeed-id", "", "Replication task (changefeed) ID")
 	_ = command.MarkPersistentFlagRequired("changefeed-id")
 	return command

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -92,6 +92,28 @@ func applyAdminChangefeed(ctx context.Context, job model.AdminJob) error {
 	return nil
 }
 
+func applyOwnerChangefeedQuery(ctx context.Context, cid model.ChangeFeedID) (string, error) {
+	owner, err := getOwnerCapture(ctx)
+	if err != nil {
+		return "", err
+	}
+	addr := fmt.Sprintf("http://%s/capture/owner/changefeed/query", owner.AdvertiseAddr)
+	resp, err := http.PostForm(addr, url.Values(map[string][]string{
+		cdc.APIOpVarChangefeedID: {cid},
+	}))
+	if err != nil {
+		return "", err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.BadRequestf("query changefeed simplified status")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", errors.BadRequestf("%s", string(body))
+	}
+	return string(body), nil
+}
+
 func jsonPrint(cmd *cobra.Command, v interface{}) error {
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -10,7 +10,7 @@ function check_changefeed_state() {
     changefeedid=$1
     expected=$2
     state=$(cdc cli changefeed query --changefeed-id $changefeedid --pd=http://$UP_PD_HOST:$UP_PD_PORT 2>&1|grep -oE "\"state\": \"[a-z]+\""|tr -d '" '|awk -F':' '{print $(NF)}')
-    if [ "state" != "$expected" ]; then
+    if [ "$state" != "$expected" ]; then
         echo "unexpected state $state, expected $expected"
         exit 1
     fi

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -9,7 +9,7 @@ SINK_TYPE=$1
 function check_changefeed_state() {
     changefeedid=$1
     expected=$2
-    state=$(cdc cli changefeed query --changefeed-id $changefeedid --pd=http://$UP_PD_HOST:$UP_PD_PORT 2>&1|grep -oE "\"state\": \"[a-z]+\""|tr -d '" '|awk -F':' '{print $(NF)}')
+    state=$(cdc cli changefeed query --simple --changefeed-id $changefeedid --pd=http://$UP_PD_HOST:$UP_PD_PORT 2>&1|grep -oE "\"state\": \"[a-z]+\""|tr -d '" '|awk -F':' '{print $(NF)}')
     if [ "$state" != "$expected" ]; then
         echo "unexpected state $state, expected $expected"
         exit 1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Fix bug that a paused changefeed can't be removed. item-5 in https://github.com/pingcap/ticdc/issues/542
- Add a `--simple` option in changefeed query command, and output the most common used replication status to users, with more user-friendly output format. part of item-11 in https://github.com/pingcap/ticdc/issues/542
- Make state transition of a changefeed more clearly.

### What is changed and how it works?

- Expand the feed state, to `normal`, `stopped`, `removed` and `failed`
   - `failed` is an internal state, only exists when the owner creates chagnefeed meets error, in this case, the changefeed can't be resumed, users can re-create a new changefeed.
   - `normal`, `stopped`, `removed` are published to users, and these states can be transformed as follows. 


        | state in column title -> state in row | normal | paused | removed |
        | ---------------------------------- | ------ | ------ | ------- |
        | normal                             | resume | resume | ❌       |
        | paused                             | pause  | pause  | ❌       |
        | removed                            | remove | remove | remove  |

- Minor change to admin job execution model, and don't check whether the job can be executed before job enqueue. Because we can't determine whether the job is valid until the whole jobs before it have been finished.

- sample output of simplified changefeed status query:


      ➜  ./cdc cli changefeed query --simple --changefeed-id=19bdbd27-370e-4022-adc6-b0fb2f838f77
      {
       "state": "normal",
       "tso": 417728968103821313,
       "checkpoint": "2020-06-30 17:32:32.398",
       "error": null
      }

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

- No release note
