### PR TITLE
sink: support to configure kafka-client-id in mq sink-uri

### DIFF
--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -326,6 +326,8 @@ func newKafkaSaramaSink(ctx context.Context, sinkURI *url.URL, filter *filter.Fi
 		config.Compression = s
 	}
 
+	config.ClientID = sinkURI.Query().Get("kafka-client-id")
+
 	s = sinkURI.Query().Get("protocol")
 	if s != "" {
 		replicaConfig.Sink.Protocol = s

--- a/cdc/sink/mqProducer/kafka.go
+++ b/cdc/sink/mqProducer/kafka.go
@@ -305,7 +305,7 @@ func newSaramaConfig(ctx context.Context, c KafkaConfig) (*sarama.Config, error)
 	captureAddr := util.CaptureAddrFromCtx(ctx)
 	changefeedID := util.ChangefeedIDFromCtx(ctx)
 
-	config.ClientID, err = kafkaClientID(role, captureAddr, changefeedID, config.ClientID)
+	config.ClientID, err = kafkaClientID(role, captureAddr, changefeedID, c.ClientID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/sink/mqProducer/kafka.go
+++ b/cdc/sink/mqProducer/kafka.go
@@ -37,6 +37,7 @@ type KafkaConfig struct {
 	Version         string
 	MaxMessageBytes int
 	Compression     string
+	ClientID        string
 }
 
 // DefaultKafkaConfig is the default Kafka configuration
@@ -274,13 +275,17 @@ var (
 	commonInvalidChar *regexp.Regexp = regexp.MustCompile(`[\?:,"]`)
 )
 
-func kafkaClientID(role, captureAddr, changefeedID string) (string, error) {
-	clientID := fmt.Sprintf("TiCDC_sarama_producer_%s_%s_%s", role, captureAddr, changefeedID)
-	clientID = commonInvalidChar.ReplaceAllString(clientID, "_")
+func kafkaClientID(role, captureAddr, changefeedID, configuredClientID string) (clientID string, err error) {
+	if configuredClientID != "" {
+		clientID = configuredClientID
+	} else {
+		clientID = fmt.Sprintf("TiCDC_sarama_producer_%s_%s_%s", role, captureAddr, changefeedID)
+		clientID = commonInvalidChar.ReplaceAllString(clientID, "_")
+	}
 	if !validClienID.MatchString(clientID) {
 		return "", errors.Errorf("invalid kafka client ID '%s'", clientID)
 	}
-	return clientID, nil
+	return
 }
 
 // NewSaramaConfig return the default config and set the according version and metrics
@@ -300,7 +305,7 @@ func newSaramaConfig(ctx context.Context, c KafkaConfig) (*sarama.Config, error)
 	captureAddr := util.CaptureAddrFromCtx(ctx)
 	changefeedID := util.ChangefeedIDFromCtx(ctx)
 
-	config.ClientID, err = kafkaClientID(role, captureAddr, changefeedID)
+	config.ClientID, err = kafkaClientID(role, captureAddr, changefeedID, config.ClientID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -25,7 +25,7 @@ function prepare() {
 
     TOPIC_NAME="ticdc-simple-test-$RANDOM"
     case $SINK_TYPE in
-        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-client-id=cdc_test_simple";;
         mysql) ;&
         *) SINK_URI="mysql://root@127.0.0.1:3306/";;
     esac


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Support user to configure `kafka-client-id` in sink-uri

### What is changed and how it works?

Extract `kafka-client-id` from sink-uri and pass it to KafkaConfig

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to update the documentation

### Release note

- Support to configure `kafka-client-id` in the mq sink-uri
