### PR TITLE
fix some tiny bugs in canal test cases

### DIFF
--- a/cdc/sink/codec/canal_test.go
+++ b/cdc/sink/codec/canal_test.go
@@ -121,7 +121,7 @@ func (s *canalBatchSuite) TestCanalEventBatchEncoder(c *check.C) {
 
 type canalEntrySuite struct{}
 
-var _ = check.Suite(canalEntrySuite{})
+var _ = check.Suite(&canalEntrySuite{})
 
 func (s *canalEntrySuite) TestConvertEntry(c *check.C) {
 	trueVar := true
@@ -164,7 +164,7 @@ func (s *canalEntrySuite) TestConvertEntry(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(entry.GetEntryType(), check.Equals, canal.EntryType_ROWDATA)
 	header := entry.GetHeader()
-	c.Assert(header.GetExecuteTime(), check.Equals, 1591943372224)
+	c.Assert(header.GetExecuteTime(), check.Equals, int64(1591943372224))
 	c.Assert(header.GetSourceType(), check.Equals, canal.Type_MYSQL)
 	c.Assert(header.GetSchemaName(), check.Equals, testCaseUpdate.Table.Schema)
 	c.Assert(header.GetTableName(), check.Equals, testCaseUpdate.Table.Table)
@@ -183,22 +183,22 @@ func (s *canalEntrySuite) TestConvertEntry(c *check.C) {
 		c.Assert(col.GetUpdated(), check.IsTrue)
 		switch col.GetName() {
 		case "id":
-			c.Assert(col.GetSqlType(), check.Equals, JavaSQLTypeBIGINT)
+			c.Assert(col.GetSqlType(), check.Equals, int32(JavaSQLTypeBIGINT))
 			c.Assert(col.GetIsKey(), check.IsTrue)
 			c.Assert(col.GetIsNull(), check.IsFalse)
 			c.Assert(col.GetValue(), check.Equals, "1")
 		case "name":
-			c.Assert(col.GetSqlType(), check.Equals, JavaSQLTypeVARCHAR)
+			c.Assert(col.GetSqlType(), check.Equals, int32(JavaSQLTypeVARCHAR))
 			c.Assert(col.GetIsKey(), check.IsFalse)
 			c.Assert(col.GetIsNull(), check.IsFalse)
 			c.Assert(col.GetValue(), check.Equals, "Bob")
 		case "tiny":
-			c.Assert(col.GetSqlType(), check.Equals, JavaSQLTypeSMALLINT)
+			c.Assert(col.GetSqlType(), check.Equals, int32(JavaSQLTypeSMALLINT))
 			c.Assert(col.GetIsKey(), check.IsFalse)
 			c.Assert(col.GetIsNull(), check.IsFalse)
 			c.Assert(col.GetValue(), check.Equals, "255")
 		case "comment":
-			c.Assert(col.GetSqlType(), check.Equals, JavaSQLTypeBLOB)
+			c.Assert(col.GetSqlType(), check.Equals, int32(JavaSQLTypeBLOB))
 			c.Assert(col.GetIsKey(), check.IsFalse)
 			c.Assert(col.GetIsNull(), check.IsFalse)
 			s, err := charmap.ISO8859_1.NewEncoder().String(col.GetValue())
@@ -229,7 +229,7 @@ func (s *canalEntrySuite) TestConvertEntry(c *check.C) {
 		c.Assert(col.GetUpdated(), check.IsFalse)
 		switch col.GetName() {
 		case "id":
-			c.Assert(col.GetSqlType(), check.Equals, JavaSQLTypeBIGINT)
+			c.Assert(col.GetSqlType(), check.Equals, int32(JavaSQLTypeBIGINT))
 			c.Assert(col.GetIsKey(), check.IsTrue)
 			c.Assert(col.GetIsNull(), check.IsFalse)
 			c.Assert(col.GetValue(), check.Equals, "1")

--- a/cdc/sink/codec/json_test.go
+++ b/cdc/sink/codec/json_test.go
@@ -160,7 +160,7 @@ func (s *batchSuite) TestDefaultEventBatchCodec(c *check.C) {
 	s.testBatchCodec(c, NewJSONEventBatchEncoder, NewJSONEventBatchDecoder)
 }
 
-var _ = check.Suite(columnSuite{})
+var _ = check.Suite(&columnSuite{})
 
 type columnSuite struct{}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#709 and fix some tiny bugs which are ignored for this issue.

### What is changed and how it works?
```go
package main

import (
	`reflect`
)

type A struct{}

func (a *A) Foo() {
	println("Foo")
}

func main() {
	a := &A{}
	println(reflect.TypeOf(a).NumMethod()) // 1
	a_ := A{}
	println(reflect.TypeOf(a_).NumMethod()) // 0
}
```
### Check List <!--REMOVE the items that are not applicable-->

 - Unit test


### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
