### PR TITLE
Add log-level to cli command, replace sarama logger

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -38,6 +38,7 @@ func init() {
 	cliCmd := newCliCommand()
 	cliCmd.PersistentFlags().StringVar(&cliPdAddr, "pd", "http://127.0.0.1:2379", "PD address")
 	cliCmd.PersistentFlags().BoolVarP(&interact, "interact", "i", false, "Run cdc cli with readline")
+	cliCmd.PersistentFlags().StringVar(&cliLogLevel, "log-level", "warn", "log level (etc: debug|info|warn|error)")
 	rootCmd.AddCommand(cliCmd)
 }
 
@@ -60,8 +61,9 @@ var (
 	cdcEtcdCli kv.CDCEtcdClient
 	pdCli      pd.Client
 
-	interact   bool
-	simplified bool
+	interact    bool
+	simplified  bool
+	cliLogLevel string
 
 	changefeedID string
 	captureID    string
@@ -112,7 +114,7 @@ func newCliCommand() *cobra.Command {
 		Use:   "cli",
 		Short: "Manage replication task and TiCDC cluster",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			initCmd(cmd, &util.Config{Level: "warn"})
+			initCmd(cmd, &util.Config{Level: cliLogLevel})
 
 			etcdCli, err := clientv3.New(clientv3.Config{
 				Endpoints:   []string{cliPdAddr},

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -14,9 +14,11 @@
 package util
 
 import (
+	"github.com/Shopify/sarama"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // _globalP is the global ZapProperties in log
@@ -83,6 +85,11 @@ func InitLogger(cfg *Config) error {
 
 	log.ReplaceGlobals(lg, _globalP)
 
+	err = initSaramaLogger(cfg.Level)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -95,4 +102,22 @@ func ZapErrorFilter(err error, filterErrors ...error) zap.Field {
 		}
 	}
 	return zap.Error(err)
+}
+
+// InitSaramaLogger hacks logger used in sarama lib
+func initSaramaLogger(logLevel string) error {
+	var level zapcore.Level
+	err := level.UnmarshalText([]byte(logLevel))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// only available less than info level
+	if !zapcore.InfoLevel.Enabled(level) {
+		logger, err := zap.NewStdLogAt(log.L().With(zap.String("name", "sarama")), level)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		sarama.Logger = logger
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

cdc cli forces to use `warn` log level, when some operation blocks, we need verbose logs for debug.

### What is changed and how it works?

- Add log-level option to cli command, default use warn
- Enable sarama logger when log level less than `info`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note
