### PR TITLE
Add changefeed summary in list command, add some shortcut

### DIFF
--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -41,7 +41,8 @@ type commonResp struct {
 	Message string `json:"message"`
 }
 
-type changefeedResp struct {
+// ChangefeedResp holds the most common usage information for a changefeed
+type ChangefeedResp struct {
 	FeedState    string              `json:"state"`
 	TSO          uint64              `json:"tso"`
 	Checkpoint   string              `json:"checkpoint"`
@@ -205,7 +206,7 @@ func (s *Server) handleChangefeedQuery(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	resp := &changefeedResp{
+	resp := &ChangefeedResp{
 		FeedState: string(feedState),
 	}
 	if cf != nil {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mattn/go-shellwords"
 	"github.com/pingcap/errors"
 	pd "github.com/pingcap/pd/v4/client"
+	"github.com/pingcap/ticdc/cdc"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -72,9 +73,10 @@ var (
 	defaultContext context.Context
 )
 
-// cf holds changefeed id, which is used for output only
-type cf struct {
-	ID string `json:"id"`
+// changefeedCommonInfo holds some common used information of a changefeed
+type changefeedCommonInfo struct {
+	ID      string              `json:"id"`
+	Summary *cdc.ChangefeedResp `json:"summary"`
 }
 
 // capture holds capture information

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/cyclic"
@@ -30,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/r3labs/diff"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 func newChangefeedCommand() *cobra.Command {
@@ -93,7 +96,7 @@ func newAdminChangefeedCommand() []*cobra.Command {
 	}
 
 	for _, cmd := range cmds {
-		cmd.PersistentFlags().StringVar(&changefeedID, "changefeed-id", "", "Replication task (changefeed) ID")
+		cmd.PersistentFlags().StringVarP(&changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
 		_ = cmd.MarkPersistentFlagRequired("changefeed-id")
 	}
 	return cmds
@@ -109,9 +112,22 @@ func newListChangefeedCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cfs := make([]*cf, 0, len(raw))
+			cfs := make([]*changefeedCommonInfo, 0, len(raw))
 			for id := range raw {
-				cfs = append(cfs, &cf{ID: id})
+				cfci := &changefeedCommonInfo{ID: id}
+				resp, err := applyOwnerChangefeedQuery(ctx, id)
+				if err != nil {
+					// if no capture is available, the query will fail, just add a warning here
+					log.Warn("query changefeed info failed", zap.String("error", err.Error()))
+				} else {
+					info := &cdc.ChangefeedResp{}
+					err = json.Unmarshal([]byte(resp), info)
+					if err != nil {
+						return err
+					}
+					cfci.Summary = info
+				}
+				cfs = append(cfs, cfci)
 			}
 			return jsonPrint(cmd, cfs)
 		},
@@ -166,8 +182,8 @@ func newQueryChangefeedCommand() *cobra.Command {
 			return jsonPrint(cmd, meta)
 		},
 	}
-	command.PersistentFlags().BoolVar(&simplified, "simple", false, "Output simplified replication status")
-	command.PersistentFlags().StringVar(&changefeedID, "changefeed-id", "", "Replication task (changefeed) ID")
+	command.PersistentFlags().BoolVarP(&simplified, "simple", "s", false, "Output simplified replication status")
+	command.PersistentFlags().StringVarP(&changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
 	_ = command.MarkPersistentFlagRequired("changefeed-id")
 	return command
 }
@@ -388,7 +404,7 @@ func newUpdateChangefeedCommand() *cobra.Command {
 		},
 	}
 	changefeedConfigVariables(command)
-	command.PersistentFlags().StringVar(&changefeedID, "changefeed-id", "", "Replication task (changefeed) ID")
+	command.PersistentFlags().StringVarP(&changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
 	command.PersistentFlags().BoolVar(&noConfirm, "no-confirm", false, "Don't ask user whether to confirm update changefeed config")
 	_ = command.MarkPersistentFlagRequired("changefeed-id")
 
@@ -443,8 +459,8 @@ func newStatisticsChangefeedCommand() *cobra.Command {
 			}
 		},
 	}
-	command.PersistentFlags().StringVar(&changefeedID, "changefeed-id", "", "Replication task (changefeed) ID")
-	command.PersistentFlags().UintVar(&interval, "interval", 10, "Interval for outputing the latest statistics")
+	command.PersistentFlags().StringVarP(&changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
+	command.PersistentFlags().UintVarP(&interval, "interval", "I", 10, "Interval for outputing the latest statistics")
 	_ = command.MarkPersistentFlagRequired("changefeed-id")
 	return command
 }

--- a/cmd/client_processor.go
+++ b/cmd/client_processor.go
@@ -66,8 +66,8 @@ func newQueryProcessorCommand() *cobra.Command {
 			return jsonPrint(cmd, meta)
 		},
 	}
-	command.PersistentFlags().StringVar(&changefeedID, "changefeed-id", "", "Replication task (changefeed) ID")
-	command.PersistentFlags().StringVar(&captureID, "capture-id", "", "Capture ID")
+	command.PersistentFlags().StringVarP(&changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
+	command.PersistentFlags().StringVarP(&captureID, "capture-id", "p", "", "Capture ID")
 	_ = command.MarkPersistentFlagRequired("changefeed-id")
 	_ = command.MarkPersistentFlagRequired("capture-id")
 	return command


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix item-12 in https://github.com/pingcap/ticdc/issues/542

### What is changed and how it works?

- Add a summary filed in changefeed list
- Accepts a shorthand letter for some variable name, including `c` is short for `changefeed-id`, `p` is short for `capture-id

Sample output

```
➜  ./cdc cli changefeed list
[
  {
    "id": "4e24dde6-53c1-40b6-badf-63620e4940dc",
    "summary": {
      "state": "normal",
      "tso": 417886179132964865,
      "checkpoint": "2020-07-07 16:07:44.881",
      "error": null
    }
  },
  {
    "id": "8f0bd661-e3ab-4e25-a8eb-d835c0348a58",
    "summary": {
      "state": "stopped",
      "tso": 417885338318929921,
      "checkpoint": "2020-07-07 15:14:17.430",
      "error": null
    }
  }
]
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to update the documentation

### Release note

- No release note
