### PR TITLE
remove incorrect kafka parameter

### DIFF
--- a/cdc/sink/mqProducer/kafka.go
+++ b/cdc/sink/mqProducer/kafka.go
@@ -310,7 +310,6 @@ func newSaramaConfig(ctx context.Context, c KafkaConfig) (*sarama.Config, error)
 		return nil, errors.Trace(err)
 	}
 	config.Version = version
-	config.Producer.Flush.MaxMessages = c.MaxMessageBytes
 	config.Metadata.Retry.Max = 20
 	config.Metadata.Retry.Backoff = 500 * time.Millisecond
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Since the values of `Producer.Flush.Frequency`, `Producer.Flush.Bytes` and `Producer.Flush.Messages` are 0, sarama always flushes message as-fast-as-possible 
https://github.com/Shopify/sarama/blob/5933302b8bc4b51c43f1bc2531146d59dc88a91d/produce_set.go#L258-L259
In most cases `Producer.Flush.MaxMessages` will be not used. Besides we can control message size via `Producer.MaxMessageBytes` (https://github.com/Shopify/sarama/blob/master/produce_set.go#L230-L250)

### What is changed and how it works?

Remove this config

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


### Release note

- No release note
