### PR TITLE
upgrade go.etcd.io/etcd to fix panic in unit test with go1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
-	go.etcd.io/etcd v0.5.0-alpha.5.0.20191211224106-0dc78a144b31
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200425165423-262c93980547
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
+github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -239,6 +241,7 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-graphviz v0.0.5/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -733,10 +736,12 @@ github.com/zhangjinpeng1987/raft v0.0.0-20190624145930-deeb32d6553d/go.mod h1:1K
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
+go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
-go.etcd.io/etcd v0.5.0-alpha.5.0.20191211224106-0dc78a144b31 h1:eyYvL5Nw6qK5WqiO4hBoxn0jtmbSANxqmezYGp0vuC0=
-go.etcd.io/etcd v0.5.0-alpha.5.0.20191211224106-0dc78a144b31/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+go.etcd.io/etcd v0.5.0-alpha.5.0.20200425165423-262c93980547 h1:s71VGheLtWmCYsnNjf+s7XE8HsrZnd3EYGrLGWVm7nY=
+go.etcd.io/etcd v0.5.0-alpha.5.0.20200425165423-262c93980547/go.mod h1:YoUyTScD3Vcv2RBm3eGVOq7i1ULiz3OuXoQFWOirmAM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
@@ -779,6 +784,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -886,6 +892,7 @@ golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix panic in unit test with go >= 1.14. ref: https://github.com/etcd-io/bbolt/pull/201

```
fatal error: checkptr: unsafe pointer conversion

goroutine 124 [running]:
runtime.throw(0x1dee7a4, 0x23)
        /home/tidb/.gvm/gos/go1.14.4/src/runtime/panic.go:1116 +0x72 fp=0xc0001c97a0 sp=0xc0001c9770 pc=0x4678e2
runtime.checkptrAlignment(0xc000116a90, 0x1cd75c0, 0x1)
        /home/tidb/.gvm/gos/go1.14.4/src/runtime/checkptr.go:20 +0xc9 fp=0xc0001c97d0 sp=0xc0001c97a0 pc=0x438b99
go.etcd.io/bbolt.(*Bucket).write(0xc0001c9948, 0x0, 0x0, 0x0)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/bbolt@v1.3.3/bucket.go:624 +0x15c fp=0xc0001c9838 sp=0xc0001c97d0 pc=0x161b4dc
go.etcd.io/bbolt.(*Bucket).CreateBucket(0xc0001280f8, 0x2c836b0, 0x7, 0x7, 0xc0001c9ba8, 0x16d7096, 0xc000156748)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/bbolt@v1.3.3/bucket.go:181 +0x465 fp=0xc0001c99f8 sp=0xc0001c9838 pc=0x1617925
go.etcd.io/bbolt.(*Tx).CreateBucket(...)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/bbolt@v1.3.3/tx.go:108
go.etcd.io/etcd/mvcc/backend.(*batchTx).UnsafeCreateBucket(0xc000125a10, 0x2c836b0, 0x7, 0x7)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191211224106-0dc78a144b31/mvcc/backend/batch_tx.go:72 +0x9c fp=0xc0001c9c28 sp=0xc0001c99f8 pc=0x16487ac
go.etcd.io/etcd/mvcc/backend.(*batchTxBuffered).UnsafeCreateBucket(0xc000125a10, 0x2c836b0, 0x7, 0x7)
        <autogenerated>:1 +0x62 fp=0xc0001c9c58 sp=0xc0001c9c28 pc=0x16547a2
go.etcd.io/etcd/etcdserver/api/membership.mustCreateBackendBuckets(0x20fdf80, 0xc000154d00)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191211224106-0dc78a144b31/etcdserver/api/membership/store.go:166 +0x109 fp=0xc0001c9cf0 sp=0xc0001c9c58 pc=0x16ea779
go.etcd.io/etcd/etcdserver/api/membership.(*RaftCluster).SetBackend(...)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191211224106-0dc78a144b31/etcdserver/api/membership/cluster.go:242
go.etcd.io/etcd/etcdserver.NewServer(0x1dbd3be, 0x7, 0x0, 0x0, 0x0, 0x0, 0xc000154400, 0x1, 0x1, 0xc000154380, ...)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191211224106-0dc78a144b31/etcdserver/server.go:406 +0x6493 fp=0xc0001cb6a0 sp=0xc0001c9cf0 pc=0x1852303
go.etcd.io/etcd/embed.StartEtcd(0xc00014ea00, 0xc00030cb00, 0x0, 0x0)
        /home/tidb/.gvm/pkgsets/go1.14.4/global/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191211224106-0dc78a144b31/embed/etcd.go:211 +0x11d3 fp=0xc0001cd780 sp=0xc0001cb6a0 pc=0x19fd123
github.com/pingcap/ticdc/pkg/etcd.SetupEmbedEtcd(0xc000116500, 0x20, 0x20, 0x7f9f776dde20, 0xc00006a990, 0x43eb6c)
        /home/tidb/code/ticdc/pkg/etcd/etcd.go:60 +0x33d fp=0xc0001cd8c0 sp=0xc0001cd780 pc=0x1a8f2bd
github.com/pingcap/ticdc/cdc/roles/storage.(*etcdSuite).SetUpTest(0xc000398dc0, 0xc0003e00f0)
        /home/tidb/code/ticdc/cdc/roles/storage/etcd_test.go:48 +0x6c fp=0xc0001cdb18 sp=0xc0001cd8c0 pc=0x1a9154c
runtime.call32(0xc000124ae0, 0xc00013a038, 0xc0001127e0, 0x1000000010)
```

### What is changed and how it works?

upgrade `go.etcd.io/etcd` to latest

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Code changes

### Release note

- No release note
