### PR TITLE
Fix statistics command panic

### DIFF
--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -438,7 +438,7 @@ func newStatisticsChangefeedCommand() *cobra.Command {
 						return err
 					}
 					taskPositions, err := cdcEtcdCli.GetAllTaskPositions(ctx, changefeedID)
-					if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
+					if err != nil {
 						return err
 					}
 					var count uint64

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -434,7 +434,7 @@ func newStatisticsChangefeedCommand() *cobra.Command {
 				case <-tick.C:
 					now := time.Now()
 					status, _, err := cdcEtcdCli.GetChangeFeedStatus(ctx, changefeedID)
-					if err != nil && errors.Cause(err) != model.ErrChangeFeedNotExists {
+					if err != nil {
 						return err
 					}
 					taskPositions, err := cdcEtcdCli.GetAllTaskPositions(ctx, changefeedID)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
statistics command will panic if changefeed doesn't exist #767 

### What is changed and how it works?
Handle the not-exist error.

### Release note
- No release note
