### PR TITLE
ci: extend the timeout of changefeed_pause_resume test

### DIFF
--- a/tests/changefeed_pause_resume/run.sh
+++ b/tests/changefeed_pause_resume/run.sh
@@ -57,7 +57,7 @@ function run() {
 
         cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr
 
-        check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+        check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 120
     done
 
     cleanup_process $CDC_BINARY


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
extend the timeout of changefeed_pause_resume test

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
