### PR TITLE
cyclic: add start_timestamp to mark tables

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -687,8 +687,9 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 	}
 	if s.cyclic != nil && len(rows) > 0 {
 		// Write mark table with the current replica ID.
+		row := rows[0]
 		updateMark := s.cyclic.UdpateSourceTableCyclicMark(
-			rows[0].Table.Schema, rows[0].Table.Table, uint64(bucket), replicaID)
+			row.Table.Schema, row.Table.Table, uint64(bucket), replicaID, row.StartTs)
 		sqls = append(sqls, updateMark)
 		values = append(values, nil)
 	}

--- a/pkg/cyclic/mark/mark.go
+++ b/pkg/cyclic/mark/mark.go
@@ -116,6 +116,7 @@ func CreateMarkTables(ctx context.Context, upstreamDSN string, upstreamCred *sec
 				bucket INT NOT NULL,
 				%s BIGINT UNSIGNED NOT NULL,
 				val BIGINT DEFAULT 0,
+				start_timestamp BIGINT DEFAULT 0,
 				PRIMARY KEY (bucket, %s)
 			);`, quotes.QuoteSchema(schema, table), CyclicReplicaIDCol, CyclicReplicaIDCol))
 		if err != nil {

--- a/pkg/cyclic/replication.go
+++ b/pkg/cyclic/replication.go
@@ -61,11 +61,11 @@ type Cyclic struct {
 
 // UdpateSourceTableCyclicMark return a DML to update mark table regrad to
 // the source table name, bucket and replicaID.
-func (*Cyclic) UdpateSourceTableCyclicMark(sourceSchema, sourceTable string, bucket, replicaID uint64) string {
+func (*Cyclic) UdpateSourceTableCyclicMark(sourceSchema, sourceTable string, bucket, replicaID uint64, startTs uint64) string {
 	schema, table := mark.GetMarkTableName(sourceSchema, sourceTable)
 	return fmt.Sprintf(
-		`INSERT INTO %s VALUES (%d, %d, 0) ON DUPLICATE KEY UPDATE val = val + 1;`,
-		model.QuoteSchema(schema, table), bucket, replicaID)
+		`INSERT INTO %s VALUES (%d, %d, 0, %d) ON DUPLICATE KEY UPDATE val = val + 1;`,
+		model.QuoteSchema(schema, table), bucket, replicaID, startTs)
 }
 
 // FilterReplicaID return a slice of replica IDs needs to be filtered.

--- a/tests/_utils/check_contains
+++ b/tests/_utils/check_contains
@@ -3,7 +3,7 @@
 set -eu
 OUT_DIR=/tmp/tidb_cdc_test
 
-if ! grep -Fq "$1" "$OUT_DIR/sql_res.$TEST_NAME.txt"; then
+if ! grep -Eq "$1" "$OUT_DIR/sql_res.$TEST_NAME.txt"; then
     echo "TEST FAILED: OUTPUT DOES NOT CONTAIN '$1'"
     echo "____________________________________"
     cat "$OUT_DIR/sql_res.$TEST_NAME.txt"

--- a/tests/cyclic_ab/run.sh
+++ b/tests/cyclic_ab/run.sh
@@ -100,6 +100,13 @@ function run() {
 
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
+    # At the time of writing, tso is at least 18 digits long in decimal format.
+    # $ pd-ctl tso 418252158551982113
+    # system:  2020-07-23 19:56:05.57 +0800 CST
+    # logic:  33
+    run_sql "SELECT start_timestamp FROM tidb_cdc.repl_mark_test_simple LIMIT 1;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} && \
+    check_contains "start_timestamp: [0-9]{18,}"
+
     cleanup_process $CDC_BINARY
 }
 


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add start_timestamp column to mark table to facilitate debugging.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
 - Has persistent data change

Side effects

 - **Breaking backward compatibility**

Related changes

 - Need to cherry-pick to the release branch

### Release note

- Add start_timestamp column to mark table to facilitate debugging.
<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
