### PR TITLE
file-sorter: fix fake resolved ts event breaks CRTs restraint

### DIFF
--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -415,7 +415,7 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 			// file sorter outputs all events in this rotate round.
 			rowCount += 1
 			if rowCount%defaultAutoResolvedRows == 0 {
-				fs.output(ctx, model.NewResolvedPolymorphicEvent(item.entry.CRTs))
+				fs.output(ctx, model.NewResolvedPolymorphicEvent(item.entry.CRTs-1))
 			}
 		} else {
 			lastSortedFileUpdated = true

--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -413,6 +413,9 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 			// If we don't output a resovled ts event, the processor will still
 			// cache all events in memory until it receives the resolved ts when
 			// file sorter outputs all events in this rotate round.
+			// The previous event is guaranteed to be sent to output chan, and
+			// `item.entry.CRTs-1` >= `presvious_item.entry.CRTs`, which means
+			// it is safe to output a resolved event with `item.entry.CRTs-1`
 			rowCount += 1
 			if rowCount%defaultAutoResolvedRows == 0 {
 				fs.output(ctx, model.NewResolvedPolymorphicEvent(item.entry.CRTs-1))

--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -413,9 +413,9 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 			// If we don't output a resovled ts event, the processor will still
 			// cache all events in memory until it receives the resolved ts when
 			// file sorter outputs all events in this rotate round.
-			// The previous event is guaranteed to be sent to output chan, and
-			// `item.entry.CRTs-1` >= `presvious_item.entry.CRTs`, which means
-			// it is safe to output a resolved event with `item.entry.CRTs-1`
+			// The following events could have the same commit ts with
+			// `item.entry.CRTs`, so we can't output a resolved event with
+			// `item.entry.CRTs`. But it is safe to output with `item.entry.CRTs-1`.
 			rowCount += 1
 			if rowCount%defaultAutoResolvedRows == 0 {
 				fs.output(ctx, model.NewResolvedPolymorphicEvent(item.entry.CRTs-1))

--- a/cdc/puller/file_sorter.go
+++ b/cdc/puller/file_sorter.go
@@ -413,7 +413,7 @@ func (fs *FileSorter) rotate(ctx context.Context, resolvedTs uint64) error {
 			// If we don't output a resovled ts event, the processor will still
 			// cache all events in memory until it receives the resolved ts when
 			// file sorter outputs all events in this rotate round.
-			// The following events could have the same commit ts with
+			// Events after this one could have the same commit ts with
 			// `item.entry.CRTs`, so we can't output a resolved event with
 			// `item.entry.CRTs`. But it is safe to output with `item.entry.CRTs-1`.
 			rowCount += 1

--- a/tests/file_sort/conf/diff_config.toml
+++ b/tests/file_sort/conf/diff_config.toml
@@ -11,7 +11,7 @@ fix-sql-file = "fix.sql"
 # tables need to check.
 [[check-tables]]
     schema = "file_sort"
-    tables = ["usertable"]
+    tables = ["~usertable.*"]
 
 [[source-db]]
     host = "127.0.0.1"

--- a/tests/file_sort/run.sh
+++ b/tests/file_sort/run.sh
@@ -47,6 +47,11 @@ function run() {
     check_table_exists "file_sort.check2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 90
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
+    run_sql "CREATE table file_sort.USERTABLE2 like file_sort.USERTABLE"
+    run_sql "insert into file_sort.USERTABLE2 select * from file_sort.USERTABLE"
+    check_table_exists "file_sort.USERTABLE2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
     cleanup_process $CDC_BINARY
 }
 

--- a/tests/file_sort/run.sh
+++ b/tests/file_sort/run.sh
@@ -47,9 +47,12 @@ function run() {
     check_table_exists "file_sort.check2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 90
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
-    run_sql "CREATE table file_sort.USERTABLE2 like file_sort.USERTABLE"
+    run_sql "create table file_sort.USERTABLE2 like file_sort.USERTABLE"
     run_sql "insert into file_sort.USERTABLE2 select * from file_sort.USERTABLE"
+    run_sql "create table file_sort.check3(id int primary key);"
     check_table_exists "file_sort.USERTABLE2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_table_exists "file_sort.check3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 90
+
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
     cleanup_process $CDC_BINARY


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix bug found in https://github.com/pingcap/ticdc/issues/754


### What is changed and how it works?

Use `CRTs-1` as fake resolved ts, where `CRTs` is commit ts of a real event. The root cause is sorted events could have the same commit ts, use `CRTs-1` as resolved ts is safe and eliminates this problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
