### PR TITLE
make filter support filter column types

### DIFF
--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -107,6 +107,15 @@ type RowChangedEvent struct {
 	Keys         []string           `json:"keys"`
 }
 
+//GetColumnTypes get column types from dml query
+func (e *RowChangedEvent) GetColumnTypes() []byte {
+	res := make([]byte, 0, len(e.Columns))
+	for _, col := range e.Columns {
+		res = append(res, col.Type)
+	}
+	return res
+}
+
 // Column represents a column value in row changed event
 type Column struct {
 	Type        byte           `json:"t"`
@@ -145,6 +154,18 @@ type DDLEvent struct {
 	TableInfo *TableInfo
 	Query     string
 	Type      model.ActionType
+}
+
+//GetColumnTypes get column types from ddl query
+func (e *DDLEvent) GetColumnTypes() []byte {
+	if e.TableInfo == nil || len(e.TableInfo.ColumnInfo) == 0 {
+		return nil
+	}
+	typs := make([]byte, len(e.TableInfo.ColumnInfo))
+	for i := 0; i < len(typs); i++ {
+		typs[i] = e.TableInfo.ColumnInfo[i].Type
+	}
+	return typs
 }
 
 // FromJob fills the values of DDLEvent from DDL job

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -129,7 +129,7 @@ func newMqSink(
 
 func (k *mqSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowChangedEvent) error {
 	for _, row := range rows {
-		if k.filter.ShouldIgnoreDMLEvent(row.StartTs, row.Table.Schema, row.Table.Table) {
+		if k.filter.ShouldIgnoreDMLEvent(row.StartTs, row.Table.Schema, row.Table.Table, row.GetColumnTypes()) {
 			log.Info("Row changed event ignored", zap.Uint64("start-ts", row.StartTs))
 			continue
 		}
@@ -208,7 +208,7 @@ func (k *mqSink) EmitCheckpointTs(ctx context.Context, ts uint64) error {
 }
 
 func (k *mqSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
-	if k.filter.ShouldIgnoreDDLEvent(ddl.StartTs, ddl.Schema, ddl.Table) {
+	if k.filter.ShouldIgnoreDDLEvent(ddl.StartTs, ddl.Schema, ddl.Table, ddl.GetColumnTypes()) {
 		log.Info(
 			"DDL event ignored",
 			zap.String("query", ddl.Query),

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -81,7 +81,7 @@ func (s *mysqlSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.Row
 	s.unresolvedTxnsMu.Lock()
 	defer s.unresolvedTxnsMu.Unlock()
 	for _, row := range rows {
-		if s.filter.ShouldIgnoreDMLEvent(row.StartTs, row.Table.Schema, row.Table.Table) {
+		if s.filter.ShouldIgnoreDMLEvent(row.StartTs, row.Table.Schema, row.Table.Table, row.GetColumnTypes()) {
 			log.Info("Row changed event ignored", zap.Uint64("start-ts", row.StartTs))
 			continue
 		}
@@ -148,7 +148,7 @@ func (s *mysqlSink) EmitCheckpointTs(ctx context.Context, ts uint64) error {
 }
 
 func (s *mysqlSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
-	if s.filter.ShouldIgnoreDDLEvent(ddl.StartTs, ddl.Schema, ddl.Table) {
+	if s.filter.ShouldIgnoreDDLEvent(ddl.StartTs, ddl.Schema, ddl.Table, ddl.GetColumnTypes()) {
 		log.Info(
 			"DDL event ignored",
 			zap.String("query", ddl.Query),

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -23,5 +23,6 @@ type FilterConfig struct {
 	Rules []string `toml:"rules" json:"rules"`
 	*filter.MySQLReplicationRules
 	IgnoreTxnStartTs []uint64           `toml:"ignore-txn-start-ts" json:"ignore-txn-start-ts"`
+	IgnoreColumnType []string           `toml:"ignore-column-type" json:"ignore-column-type"`
 	DDLAllowlist     []model.ActionType `toml:"ddl-allow-list" json:"ddl-allow-list"`
 }

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -18,15 +18,21 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
+
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
-	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
 )
+
+//errNoSuchMySQLType means the input mysql type is invalid
+var errNoSuchMySQLType = errors.New("No such mysql type")
 
 // Filter is a event filter implementation
 type Filter struct {
 	filter           filter.Filter
 	ignoreTxnStartTs []uint64
+	ignoreColumnType map[byte]struct{}
 	ddlAllowlist     []model.ActionType
 	isCyclicEnabled  bool
 }
@@ -35,6 +41,7 @@ type Filter struct {
 func NewFilter(cfg *config.ReplicaConfig) (*Filter, error) {
 	var f filter.Filter
 	var err error
+	var ignoreColumnType map[byte]struct{}
 	if len(cfg.Filter.Rules) == 0 && cfg.Filter.MySQLReplicationRules != nil {
 		f, err = filter.ParseMySQLReplicationRules(cfg.Filter.MySQLReplicationRules)
 	} else {
@@ -47,12 +54,17 @@ func NewFilter(cfg *config.ReplicaConfig) (*Filter, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	ignoreColumnType, err = strsToColumnTypes(cfg.Filter.IgnoreColumnType)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	if !cfg.CaseSensitive {
 		f = filter.CaseInsensitive(f)
 	}
 	return &Filter{
 		filter:           f,
 		ignoreTxnStartTs: cfg.Filter.IgnoreTxnStartTs,
+		ignoreColumnType: ignoreColumnType,
 		ddlAllowlist:     cfg.Filter.DDLAllowlist,
 		isCyclicEnabled:  cfg.Cyclic.IsEnabled(),
 	}, nil
@@ -82,14 +94,14 @@ func (f *Filter) ShouldIgnoreTable(db, tbl string) bool {
 
 // ShouldIgnoreDMLEvent removes DMLs that's not wanted by this change feed.
 // CDC only supports filtering by database/table now.
-func (f *Filter) ShouldIgnoreDMLEvent(ts uint64, schema, table string) bool {
-	return f.shouldIgnoreStartTs(ts) || f.ShouldIgnoreTable(schema, table)
+func (f *Filter) ShouldIgnoreDMLEvent(ts uint64, schema, table string, columnTypes []byte) bool {
+	return f.shouldIgnoreStartTs(ts) || f.ShouldIgnoreTable(schema, table) || f.shouldIgnoreColumnTypes(columnTypes)
 }
 
 // ShouldIgnoreDDLEvent removes DDLs that's not wanted by this change feed.
 // CDC only supports filtering by database/table now.
-func (f *Filter) ShouldIgnoreDDLEvent(ts uint64, schema, table string) bool {
-	return f.shouldIgnoreStartTs(ts) || f.ShouldIgnoreTable(schema, table)
+func (f *Filter) ShouldIgnoreDDLEvent(ts uint64, schema, table string, columnTypes []byte) bool {
+	return f.shouldIgnoreStartTs(ts) || f.ShouldIgnoreTable(schema, table) || f.shouldIgnoreColumnTypes(columnTypes)
 }
 
 // ShouldDiscardDDL returns true if this DDL should be discarded
@@ -103,6 +115,15 @@ func (f *Filter) ShouldDiscardDDL(ddlType model.ActionType) bool {
 		}
 	}
 	return true
+}
+
+func (f *Filter) shouldIgnoreColumnTypes(columnTypes []byte) bool {
+	for _, typ := range columnTypes {
+		if _, exist := f.ignoreColumnType[typ]; exist {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *Filter) shouldDiscardByBuiltInDDLAllowlist(ddlType model.ActionType) bool {
@@ -148,6 +169,63 @@ func (f *Filter) shouldDiscardByBuiltInDDLAllowlist(ddlType model.ActionType) bo
 		return false
 	}
 	return true
+}
+
+var str2Type = map[string]byte{
+	"bit":         mysql.TypeBit,
+	"text":        mysql.TypeBlob,
+	"date":        mysql.TypeDate,
+	"datetime":    mysql.TypeDatetime,
+	"unspecified": mysql.TypeDecimal,
+	"decimal":     mysql.TypeNewDecimal,
+	"double":      mysql.TypeDouble,
+	"enum":        mysql.TypeEnum,
+	"float":       mysql.TypeFloat,
+	"geometry":    mysql.TypeGeometry,
+	"mediumint":   mysql.TypeInt24,
+	"json":        mysql.TypeJSON,
+	"int":         mysql.TypeLong,
+	"bigint":      mysql.TypeLonglong,
+	"longtext":    mysql.TypeLongBlob,
+	"mediumtext":  mysql.TypeMediumBlob,
+	"null":        mysql.TypeNull,
+	"set":         mysql.TypeSet,
+	"smallint":    mysql.TypeShort,
+	"char":        mysql.TypeString,
+	"time":        mysql.TypeDuration,
+	"timestamp":   mysql.TypeTimestamp,
+	"tinyint":     mysql.TypeTiny,
+	"tinytext":    mysql.TypeTinyBlob,
+	"varchar":     mysql.TypeVarchar,
+	"var_string":  mysql.TypeVarString,
+	"year":        mysql.TypeYear,
+}
+
+// StrType converts string to a type.
+func StrType(str string) (r byte, err error) {
+	typStr := strings.ToLower(str)
+	if strings.Contains(typStr, "blob") {
+		typStr = strings.ReplaceAll(typStr, "blob", "text")
+	}
+	if strings.Contains(typStr, "binary") {
+		typStr = strings.ReplaceAll(typStr, "binary", "char")
+	}
+	if typ, exist := str2Type[typStr]; exist {
+		return typ, nil
+	}
+	return 0, errNoSuchMySQLType
+}
+
+func strsToColumnTypes(columnTypeStr []string) (map[byte]struct{}, error) {
+	columnTypeByte := make(map[byte]struct{}, len(columnTypeStr))
+	for i := range columnTypeStr {
+		typ, err := StrType(columnTypeStr[i])
+		if err != nil {
+			return nil, err
+		}
+		columnTypeByte[typ] = struct{}{}
+	}
+	return columnTypeByte, nil
 }
 
 // IsSysSchema returns true if the given schema is a system schema

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -16,6 +16,8 @@ package filter
 import (
 	"testing"
 
+	"github.com/pingcap/parser/mysql"
+
 	"github.com/pingcap/ticdc/pkg/config"
 
 	"github.com/pingcap/check"
@@ -66,27 +68,32 @@ func (s *filterSuite) TestShouldIgnoreTxn(c *check.C) {
 		Filter: &config.FilterConfig{
 			IgnoreTxnStartTs: []uint64{1, 3},
 			Rules:            []string{"sns.*", "ecom.*", "!sns.log", "!ecom.test"},
+			IgnoreColumnType: []string{"blob", "bit", "int", "binary"},
 		},
 	})
 	c.Assert(err, check.IsNil)
 	testCases := []struct {
-		schema string
-		table  string
-		ts     uint64
-		ignore bool
+		schema      string
+		table       string
+		ts          uint64
+		columnTypes []byte
+		ignore      bool
 	}{
-		{"sns", "ttta", 1, true},
-		{"ecom", "aabb", 2, false},
-		{"sns", "log", 3, true},
-		{"sns", "log", 4, true},
-		{"ecom", "test", 5, true},
-		{"test", "test", 6, true},
-		{"ecom", "log", 6, false},
+		{"sns", "ttta", 1, nil, true},
+		{"ecom", "aabb", 2, nil, false},
+		{"sns", "log", 3, nil, true},
+		{"sns", "log", 4, nil, true},
+		{"ecom", "test", 5, nil, true},
+		{"test", "test", 6, nil, true},
+		{"ecom", "log", 6, nil, false},
+		{"ecom", "log", 6, []byte{mysql.TypeBit, mysql.TypeTinyBlob}, true},
+		{"ecom", "log", 6, []byte{mysql.TypeJSON, mysql.TypeTinyBlob}, false},
+		{"ecom", "log", 6, []byte{mysql.TypeString}, true},
 	}
 
 	for _, tc := range testCases {
-		c.Assert(filter.ShouldIgnoreDMLEvent(tc.ts, tc.schema, tc.table), check.Equals, tc.ignore)
-		c.Assert(filter.ShouldIgnoreDDLEvent(tc.ts, tc.schema, tc.table), check.Equals, tc.ignore)
+		c.Assert(filter.ShouldIgnoreDMLEvent(tc.ts, tc.schema, tc.table, tc.columnTypes), check.Equals, tc.ignore)
+		c.Assert(filter.ShouldIgnoreDDLEvent(tc.ts, tc.schema, tc.table, tc.columnTypes), check.Equals, tc.ignore)
 	}
 
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
There are some column types at cdc which are not compatible with alibaba consumer, such as `year, bit`, we can use column typs in ddl and dml to filter the queries.

### What is changed and how it works?
Add `ignoreColumnType` at `config.filter`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Possible performance regression

