### PR TITLE
Fix dml with database not found error in test

### DIFF
--- a/tests/multi_source/main.go
+++ b/tests/multi_source/main.go
@@ -164,6 +164,19 @@ func truncateDDL(ctx context.Context, db *sql.DB) {
 	}
 }
 
+func ignoreableError(err error) bool {
+	knownErrorList := []string{
+		"Error 1146:", // table doesn't exist
+		"Error 1049",  // database doesn't exist
+	}
+	for _, e := range knownErrorList {
+		if strings.HasPrefix(err.Error(), e) {
+			return true
+		}
+	}
+	return false
+}
+
 func dml(ctx context.Context, db *sql.DB, table string, id int) {
 	var err error
 	var i int
@@ -179,7 +192,7 @@ func dml(ctx context.Context, db *sql.DB, table string, id int) {
 				log.S().Info(id, " insert success: ", insertSuccess)
 			}
 		}
-		if err != nil && !strings.HasPrefix(err.Error(), "Error 1146:") {
+		if err != nil && !ignoreableError(err) {
 			log.Fatal("unexpected error when executing sql", zap.Error(err))
 		}
 
@@ -194,7 +207,7 @@ func dml(ctx context.Context, db *sql.DB, table string, id int) {
 					}
 				}
 			}
-			if err != nil && !strings.HasPrefix(err.Error(), "Error 1146:") {
+			if err != nil && !ignoreableError(err) {
 				log.Fatal("unexpected error when executing sql", zap.Error(err))
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a fatal met in test: https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/cdc_ghpr_integration_test/detail/cdc_ghpr_integration_test/1748/pipeline

```
[2020-07-28T09:34:15.592Z] [2020/07/28 17:34:15.247 +08:00] [FATAL] [main.go:183] ["unexpected error when executing sql"] [error="Error 1049: database doesn't exist"] [stack="github.com/pingcap/log.Fatal
        /go/pkg/mod/github.com/pingcap/log@v0.0.0-20200511115504-543df19646ad/global.go:59
main.dml
        /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/tests/multi_source/main.go:183
main.runDDLTest.func2
        /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/tests/multi_source/main.go:87"]
```

### What is changed and how it works?

Ignore this error in test client


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note