### PR TITLE
Fix auto random enable detect

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -313,7 +313,7 @@ func configureSinkURI(ctx context.Context, dsnCfg *dmysql.Config, tz *time.Locat
 	if err != nil && err != sql.ErrNoRows {
 		return "", errors.Annotate(err, "fail to query sink for support of auto-random")
 	}
-	if err == nil && autoRandomInsertEnabled == "off" {
+	if err == nil && (autoRandomInsertEnabled == "off" || autoRandomInsertEnabled == "0") {
 		dsnCfg.Params["allow_auto_random_explicit_insert"] = "1"
 		log.Debug("Set allow_auto_random_explicit_insert to 1")
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `allow_auto_random_explicit_insert` option detect in TiCDC fails after https://github.com/pingcap/tidb/pull/18896 merged, because 

```
mysql> show global variables like 'allow_auto_random_explicit_insert';
+-----------------------------------+-------+
| Variable_name                     | Value |
+-----------------------------------+-------+
| allow_auto_random_explicit_insert | off   |
+-----------------------------------+-------+
1 row in set (0.01 sec)

mysql> show session variables like 'allow_auto_random_explicit_insert';
+-----------------------------------+-------+
| Variable_name                     | Value |
+-----------------------------------+-------+
| allow_auto_random_explicit_insert | 0     |
+-----------------------------------+-------+
1 row in set (0.01 sec)
```

### What is changed and how it works?

To make it compatible with TiDB (also with TiDB of old version), treat both `off` and `0` as the turned off of the `allow_auto_random_explicit_insert` option.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
