### PR TITLE
cdc: add metrics about pending rows and txn execution duration

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -406,7 +406,7 @@ func (s *eventFeedSession) eventFeed(ctx context.Context, ts uint64) error {
 	eventFeedGauge.Inc()
 	defer eventFeedGauge.Dec()
 
-	log.Debug("event feed started", zap.Reflect("span", s.totalSpan), zap.Uint64("ts", ts))
+	log.Debug("event feed started", zap.Stringer("span", s.totalSpan), zap.Uint64("ts", ts))
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -491,7 +491,7 @@ func (s *eventFeedSession) scheduleRegionRequest(ctx context.Context, sri single
 		case regionspan.LockRangeStatusStale:
 			log.Info("request expired",
 				zap.Uint64("regionID", sri.verID.GetID()),
-				zap.Reflect("span", sri.span),
+				zap.Stringer("span", sri.span),
 				zap.Reflect("retrySpans", res.RetryRanges))
 			for _, r := range res.RetryRanges {
 				// This call can be always blocking because if `blocking` is set to false, this will in a new goroutine,
@@ -591,7 +591,7 @@ MainLoop:
 				// The region info is invalid. Retry the span.
 				log.Info("cannot get rpcCtx, retry span",
 					zap.Uint64("regionID", sri.verID.GetID()),
-					zap.Reflect("span", sri.span))
+					zap.Stringer("span", sri.span))
 				err = s.onRegionFail(ctx, regionErrorInfo{
 					singleRegionInfo: sri,
 					err: &rpcCtxUnavailableErr{
@@ -781,7 +781,7 @@ func (s *eventFeedSession) partialRegionFeed(
 
 	log.Info("EventFeed disconnected",
 		zap.Reflect("regionID", state.sri.verID.GetID()),
-		zap.Reflect("span", state.sri.span),
+		zap.Stringer("span", state.sri.span),
 		zap.Uint64("checkpoint", ts),
 		zap.String("error", err.Error()))
 
@@ -829,17 +829,17 @@ func (s *eventFeedSession) divideAndSendEventFeedToRegions(
 				for _, region := range regions {
 					if region.GetMeta() == nil {
 						err = errors.New("meta not exists in region")
-						log.Warn("batch load region", zap.Reflect("span", nextSpan), zap.Error(err))
+						log.Warn("batch load region", zap.Stringer("span", nextSpan), zap.Error(err))
 						return err
 					}
 					metas = append(metas, region.GetMeta())
 				}
 				if !regionspan.CheckRegionsLeftCover(metas, nextSpan) {
 					err = errors.Errorf("regions not completely left cover span, span %v regions: %v", nextSpan, metas)
-					log.Warn("ScanRegions", zap.Reflect("span", nextSpan), zap.Reflect("regions", metas), zap.Error(err))
+					log.Warn("ScanRegions", zap.Stringer("span", nextSpan), zap.Reflect("regions", metas), zap.Error(err))
 					return err
 				}
-				log.Debug("ScanRegions", zap.Reflect("span", nextSpan), zap.Reflect("regions", metas))
+				log.Debug("ScanRegions", zap.Stringer("span", nextSpan), zap.Reflect("regions", metas))
 				return nil
 			})
 
@@ -853,13 +853,13 @@ func (s *eventFeedSession) divideAndSendEventFeedToRegions(
 			if err != nil {
 				return errors.Trace(err)
 			}
-			log.Debug("get partialSpan", zap.Reflect("span", partialSpan), zap.Uint64("regionID", region.Id))
+			log.Debug("get partialSpan", zap.Stringer("span", partialSpan), zap.Uint64("regionID", region.Id))
 
 			nextSpan.Start = region.EndKey
 
 			sri := newSingleRegionInfo(tiRegion.VerID(), partialSpan, ts, nil)
 			s.scheduleRegionRequest(ctx, sri, true)
-			log.Debug("partialSpan scheduled", zap.Reflect("span", partialSpan), zap.Uint64("regionID", region.Id))
+			log.Debug("partialSpan scheduled", zap.Stringer("span", partialSpan), zap.Uint64("regionID", region.Id))
 
 			// return if no more regions
 			if regionspan.EndCompare(nextSpan.Start, span.End) >= 0 {
@@ -1109,7 +1109,7 @@ func (s *eventFeedSession) singleEventFeed(
 			sinceLastEvent := time.Since(lastReceivedEventTime)
 			if sinceLastEvent > time.Second*20 {
 				log.Warn("region not receiving event from tikv for too long time",
-					zap.Uint64("regionID", regionID), zap.Reflect("span", span), zap.Duration("duration", sinceLastEvent))
+					zap.Uint64("regionID", regionID), zap.Stringer("span", span), zap.Duration("duration", sinceLastEvent))
 			}
 			version, err := s.kvStorage.(*StorageWithCurVersionCache).GetCachedCurrentVersion()
 			if err != nil {
@@ -1120,7 +1120,7 @@ func (s *eventFeedSession) singleEventFeed(
 			sinceLastResolvedTs := currentTimeFromPD.Sub(oracle.GetTimeFromTS(checkpointTs))
 			if sinceLastResolvedTs > time.Second*20 && initialized {
 				log.Warn("region not receiving resolved event from tikv or resolved ts is not pushing for too long time, try to resolve lock",
-					zap.Uint64("regionID", regionID), zap.Reflect("span", span),
+					zap.Uint64("regionID", regionID), zap.Stringer("span", span),
 					zap.Duration("duration", sinceLastResolvedTs),
 					zap.Uint64("checkpointTs", checkpointTs))
 				maxVersion := oracle.ComposeTS(oracle.GetPhysical(currentTimeFromPD.Add(-10*time.Second)), 0)

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -159,7 +159,7 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 					// we can make tikv only return the events about the keys in the specified range.
 					comparableKey := regionspan.ToComparableKey(val.Key)
 					if !regionspan.KeyInSpans(comparableKey, p.spans) {
-						// log.Warn("key not in spans range", zap.Binary("key", val.Key), zap.Reflect("span", p.spans))
+						// log.Warn("key not in spans range", zap.Binary("key", val.Key), zap.Stringer("span", p.spans))
 						continue
 					}
 

--- a/cdc/sink/black_hole.go
+++ b/cdc/sink/black_hole.go
@@ -23,9 +23,9 @@ import (
 )
 
 // newBlackHoleSink creates a block hole sink
-func newBlackHoleSink(opts map[string]string) *blackHoleSink {
+func newBlackHoleSink(ctx context.Context, opts map[string]string) *blackHoleSink {
 	return &blackHoleSink{
-		statistics: NewStatistics("blackhole", opts),
+		statistics: NewStatistics(ctx, "blackhole", opts),
 	}
 }
 
@@ -46,7 +46,9 @@ func (b *blackHoleSink) EmitRowChangedEvents(ctx context.Context, rows ...*model
 		}
 		log.Debug("BlockHoleSink: EmitRowChangedEvents", zap.Any("row", row))
 	}
-	atomic.AddUint64(&b.accumulated, uint64(len(rows)))
+	rowsCount := len(rows)
+	atomic.AddUint64(&b.accumulated, uint64(rowsCount))
+	b.statistics.AddRowsCount(rowsCount)
 	return nil
 }
 

--- a/cdc/sink/common/common.go
+++ b/cdc/sink/common/common.go
@@ -39,9 +39,10 @@ func NewUnresolvedTxnCache() *UnresolvedTxnCache {
 }
 
 // Append adds unresolved rows to cache
-func (c *UnresolvedTxnCache) Append(filter *filter.Filter, rows ...*model.RowChangedEvent) {
+func (c *UnresolvedTxnCache) Append(filter *filter.Filter, rows ...*model.RowChangedEvent) int {
 	c.unresolvedTxnsMu.Lock()
 	defer c.unresolvedTxnsMu.Unlock()
+	appendRows := 0
 	for _, row := range rows {
 		if filter.ShouldIgnoreDMLEvent(row.StartTs, row.Table.Schema, row.Table.Table) {
 			log.Info("Row changed event ignored", zap.Uint64("start-ts", row.StartTs))
@@ -66,7 +67,9 @@ func (c *UnresolvedTxnCache) Append(filter *filter.Filter, rows ...*model.RowCha
 			c.unresolvedTxns[key] = txns
 		}
 		txns[len(txns)-1].Append(row)
+		appendRows++
 	}
+	return appendRows
 }
 
 // Resolved returns resolved txns according to resolvedTs

--- a/cdc/sink/metrics.go
+++ b/cdc/sink/metrics.go
@@ -56,6 +56,20 @@ var (
 			Name:      "bucket_size",
 			Help:      "size of the DML bucket",
 		}, []string{"capture", "changefeed", "bucket"})
+	totalRowsCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "total_rows_count",
+			Help:      "totla count of rows",
+		}, []string{"capture", "changefeed"})
+	totalFlushedRowsCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "total_flushed_rows_count",
+			Help:      "totla count of flushed rows",
+		}, []string{"capture", "changefeed"})
 )
 
 // InitMetrics registers all metrics in this file
@@ -65,4 +79,6 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(executionErrorCounter)
 	registry.MustRegister(conflictDetectDurationHis)
 	registry.MustRegister(bucketSizeCounter)
+	registry.MustRegister(totalRowsCountGauge)
+	registry.MustRegister(totalFlushedRowsCountGauge)
 }

--- a/cdc/sink/metrics.go
+++ b/cdc/sink/metrics.go
@@ -32,7 +32,7 @@ var (
 			Subsystem: "sink",
 			Name:      "txn_exec_duration",
 			Help:      "Bucketed histogram of processing time (s) of a txn.",
-			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 18),
+			Buckets:   prometheus.ExponentialBuckets(0.002 /* 2 ms */, 2, 18),
 		}, []string{"capture", "changefeed"})
 	executionErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -80,7 +80,8 @@ type mysqlSink struct {
 }
 
 func (s *mysqlSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowChangedEvent) error {
-	s.txnCache.Append(s.filter, rows...)
+	count := s.txnCache.Append(s.filter, rows...)
+	s.statistics.AddRowsCount(count)
 	return nil
 }
 
@@ -374,7 +375,7 @@ func newMySQLSink(ctx context.Context, changefeedID model.ChangeFeedID, sinkURI 
 		params:                          params,
 		filter:                          filter,
 		txnCache:                        common.NewUnresolvedTxnCache(),
-		statistics:                      NewStatistics("mysql", opts),
+		statistics:                      NewStatistics(ctx, "mysql", opts),
 		metricConflictDetectDurationHis: metricConflictDetectDurationHis,
 		metricBucketSizeCounters:        metricBucketSizeCounters,
 		errCh:                           make(chan error, 1),
@@ -589,10 +590,12 @@ func (s *mysqlSink) Close() error {
 }
 
 func (s *mysqlSink) execDMLWithMaxRetries(
-	ctx context.Context, sqls []string, values [][]interface{}, maxRetries uint64, bucket int,
+	ctx context.Context, dmls *preparedDMLs, maxRetries uint64, bucket int,
 ) error {
-	if len(sqls) != len(values) {
-		log.Fatal("unexpected number of sqls and values", zap.Strings("sqls", sqls), zap.Any("values", values))
+	if len(dmls.sqls) != len(dmls.values) {
+		log.Fatal("unexpected number of sqls and values",
+			zap.Strings("sqls", dmls.sqls),
+			zap.Any("values", dmls.values))
 	}
 	checkTxnErr := func(err error) error {
 		if errors.Cause(err) == context.Canceled {
@@ -611,32 +614,44 @@ func (s *mysqlSink) execDMLWithMaxRetries(
 				if err != nil {
 					return 0, checkTxnErr(errors.Trace(err))
 				}
-				for i, query := range sqls {
-					args := values[i]
+				for i, query := range dmls.sqls {
+					args := dmls.values[i]
 					log.Debug("exec row", zap.String("sql", query), zap.Any("args", args))
 					if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+						return 0, checkTxnErr(errors.Trace(err))
+					}
+				}
+				if len(dmls.markSQL) != 0 {
+					log.Debug("exec row", zap.String("sql", dmls.markSQL))
+					if _, err := tx.ExecContext(ctx, dmls.markSQL); err != nil {
 						return 0, checkTxnErr(errors.Trace(err))
 					}
 				}
 				if err = tx.Commit(); err != nil {
 					return 0, checkTxnErr(errors.Trace(err))
 				}
-				return len(sqls), nil
+				return len(dmls.sqls), nil
 			})
 			if err != nil {
 				return errors.Trace(err)
 			}
 			log.Debug("Exec Rows succeeded",
 				zap.String("changefeed", s.params.changefeedID),
-				zap.Int("num of Rows", len(sqls)),
+				zap.Int("num of Rows", len(dmls.sqls)),
 				zap.Int("bucket", bucket))
 			return nil
 		},
 	)
 }
 
+type preparedDMLs struct {
+	sqls    []string
+	values  [][]interface{}
+	markSQL string
+}
+
 // prepareDMLs converts model.RowChangedEvent list to query string list and args list
-func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64, bucket int) ([]string, [][]interface{}, error) {
+func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64, bucket int) (*preparedDMLs, error) {
 	sqls := make([]string, 0, len(rows))
 	values := make([][]interface{}, 0, len(rows))
 	for _, row := range rows {
@@ -647,7 +662,7 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 		if len(row.PreColumns) != 0 {
 			query, args, err = prepareDelete(row.Table.Schema, row.Table.Table, row.PreColumns)
 			if err != nil {
-				return nil, nil, errors.Trace(err)
+				return nil, errors.Trace(err)
 			}
 			sqls = append(sqls, query)
 			values = append(values, args)
@@ -655,30 +670,33 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 		if len(row.Columns) != 0 {
 			query, args, err = prepareReplace(row.Table.Schema, row.Table.Table, row.Columns)
 			if err != nil {
-				return nil, nil, errors.Trace(err)
+				return nil, errors.Trace(err)
 			}
 			sqls = append(sqls, query)
 			values = append(values, args)
 		}
+	}
+	dmls := &preparedDMLs{
+		sqls:   sqls,
+		values: values,
 	}
 	if s.cyclic != nil && len(rows) > 0 {
 		// Write mark table with the current replica ID.
 		row := rows[0]
 		updateMark := s.cyclic.UdpateSourceTableCyclicMark(
 			row.Table.Schema, row.Table.Table, uint64(bucket), replicaID, row.StartTs)
-		sqls = append(sqls, updateMark)
-		values = append(values, nil)
+		dmls.markSQL = updateMark
 	}
-	return sqls, values, nil
+	return dmls, nil
 }
 
 func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent, replicaID uint64, bucket int) error {
-	sqls, values, err := s.prepareDMLs(rows, replicaID, bucket)
+	dmls, err := s.prepareDMLs(rows, replicaID, bucket)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	log.Debug("prepare DMLs", zap.Any("rows", rows), zap.Strings("sqls", sqls), zap.Any("values", values))
-	if err := s.execDMLWithMaxRetries(ctx, sqls, values, defaultDMLMaxRetryTime, bucket); err != nil {
+	log.Debug("prepare DMLs", zap.Any("rows", rows), zap.Strings("sqls", dmls.sqls), zap.Any("values", dmls.values))
+	if err := s.execDMLWithMaxRetries(ctx, dmls, defaultDMLMaxRetryTime, bucket); err != nil {
 		ts := make([]uint64, 0, len(rows))
 		for _, row := range rows {
 			if len(ts) == 0 || ts[len(ts)-1] != row.CommitTs {

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -38,8 +38,9 @@ func newMySQLSink4Test(c *check.C) *mysqlSink {
 	f, err := filter.NewFilter(config.GetDefaultReplicaConfig())
 	c.Assert(err, check.IsNil)
 	return &mysqlSink{
-		txnCache: common.NewUnresolvedTxnCache(),
-		filter:   f,
+		txnCache:   common.NewUnresolvedTxnCache(),
+		filter:     f,
+		statistics: NewStatistics(context.TODO(), "test", make(map[string]string)),
 	}
 }
 

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -63,7 +63,7 @@ func NewSink(ctx context.Context, changefeedID model.ChangeFeedID, sinkURIStr st
 	}
 	switch strings.ToLower(sinkURI.Scheme) {
 	case "blackhole":
-		return newBlackHoleSink(opts), nil
+		return newBlackHoleSink(ctx, opts), nil
 	case "mysql", "tidb", "mysql+ssl", "tidb+ssl":
 		return newMySQLSink(ctx, changefeedID, sinkURI, filter, opts)
 	case "kafka":

--- a/cdc/sink/statistics.go
+++ b/cdc/sink/statistics.go
@@ -14,6 +14,7 @@
 package sink
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -23,9 +24,10 @@ import (
 )
 
 const printStatusInterval = 30 * time.Second
+const flushMetricsInterval = 5 * time.Second
 
 // NewStatistics creates a statistics
-func NewStatistics(name string, opts map[string]string) *Statistics {
+func NewStatistics(ctx context.Context, name string, opts map[string]string) *Statistics {
 	statistics := &Statistics{name: name, lastPrintStatusTime: time.Now()}
 	if cid, ok := opts[OptChangefeedID]; ok {
 		statistics.changefeedID = cid
@@ -36,22 +38,46 @@ func NewStatistics(name string, opts map[string]string) *Statistics {
 	statistics.metricExecTxnHis = execTxnHistogram.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
 	statistics.metricExecBatchHis = execBatchHistogram.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
 	statistics.metricExecErrCnt = executionErrorCounter.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
+
+	// Flush metrics in background for better accurate and efficiency.
+	ticker := time.NewTicker(flushMetricsInterval)
+	metricTotalRows := totalRowsCountGauge.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
+	metricTotalFlushedRows := totalFlushedRowsCountGauge.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				metricTotalRows.Set(float64(statistics.totalRows))
+				metricTotalFlushedRows.Set(float64(statistics.totalFlushedRows))
+			}
+		}
+	}()
+
 	return statistics
 }
 
 // Statistics maintains some status and metrics of the Sink
 type Statistics struct {
-	name         string
-	captureAddr  string
-	changefeedID string
-	accumulated  uint64
+	name             string
+	captureAddr      string
+	changefeedID     string
+	totalRows        uint64
+	totalFlushedRows uint64
 
-	lastPrintStatusAccumulated uint64
-	lastPrintStatusTime        time.Time
+	lastPrintStatusTotalRows uint64
+	lastPrintStatusTime      time.Time
 
 	metricExecTxnHis   prometheus.Observer
 	metricExecBatchHis prometheus.Observer
 	metricExecErrCnt   prometheus.Counter
+}
+
+// AddRowsCount records total number of rows needs to flush
+func (b *Statistics) AddRowsCount(count int) {
+	atomic.AddUint64(&b.totalRows, uint64(count))
 }
 
 // RecordBatchExecution records the cost time of batch execution and batch size
@@ -65,7 +91,7 @@ func (b *Statistics) RecordBatchExecution(executer func() (int, error)) error {
 	castTime := time.Since(startTime).Seconds()
 	b.metricExecTxnHis.Observe(castTime)
 	b.metricExecBatchHis.Observe(float64(batchSize))
-	atomic.AddUint64(&b.accumulated, uint64(batchSize))
+	atomic.AddUint64(&b.totalFlushedRows, uint64(batchSize))
 	return nil
 }
 
@@ -75,15 +101,15 @@ func (b *Statistics) PrintStatus() {
 	if since < printStatusInterval {
 		return
 	}
-	accumulated := atomic.LoadUint64(&b.accumulated)
-	count := accumulated - b.lastPrintStatusAccumulated
+	totalRows := atomic.LoadUint64(&b.totalRows)
+	count := totalRows - b.lastPrintStatusTotalRows
 	seconds := since.Seconds()
 	var qps uint64
 	if seconds > 0 {
 		qps = count / uint64(seconds)
 	}
 	b.lastPrintStatusTime = time.Now()
-	b.lastPrintStatusAccumulated = accumulated
+	b.lastPrintStatusTotalRows = totalRows
 	log.Info("sink replication status",
 		zap.String("name", b.name),
 		zap.String("changefeed", b.changefeedID),

--- a/cdc/sink/statistics.go
+++ b/cdc/sink/statistics.go
@@ -39,7 +39,7 @@ func NewStatistics(ctx context.Context, name string, opts map[string]string) *St
 	statistics.metricExecBatchHis = execBatchHistogram.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
 	statistics.metricExecErrCnt = executionErrorCounter.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
 
-	// Flush metrics in background for better accurate and efficiency.
+	// Flush metrics in background for better accuracy and efficiency.
 	ticker := time.NewTicker(flushMetricsInterval)
 	metricTotalRows := totalRowsCountGauge.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
 	metricTotalFlushedRows := totalFlushedRowsCountGauge.WithLabelValues(statistics.captureAddr, statistics.changefeedID)

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -60,7 +60,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1592842019456,
+  "iteration": 1596457144174,
   "links": [],
   "panels": [
     {
@@ -2502,7 +2502,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 32,
@@ -2596,7 +2596,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 5,
@@ -2690,7 +2690,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 33,
@@ -2783,7 +2783,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 31
           },
           "id": 82,
           "legend": {
@@ -2872,7 +2872,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 35,
@@ -2980,7 +2980,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 34,
@@ -3082,7 +3082,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 45
           },
           "hiddenSeries": false,
           "id": 37,
@@ -3178,7 +3178,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 45
           },
           "hiddenSeries": false,
           "id": 36,
@@ -3287,7 +3287,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 55,
@@ -3399,7 +3399,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 38,
@@ -3495,7 +3495,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 48,
@@ -3591,7 +3591,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 56,
@@ -3693,7 +3693,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 66
           },
           "id": 81,
           "legend": {
@@ -3782,7 +3782,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 83,
@@ -3884,7 +3884,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 66
+            "y": 73
           },
           "hiddenSeries": false,
           "id": 84,
@@ -3966,6 +3966,178 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "size of pending flush rows",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 73
+          },
+          "hiddenSeries": false,
+          "id": 88,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(ticdc_sink_total_rows_count{changefeed=~\"$changefeed\",capture=~\"$capture\"}) by (capture) - sum(ticdc_sink_total_flushed_rows_count{changefeed=~\"$changefeed\",capture=~\"$capture\"}) by (capture)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{capture}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Pending flush rows",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": 0,
+            "cardRound": 0
+          },
+          "color": {
+            "cardColor": "#FF9830",
+            "colorScale": "linear",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "min": 0,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 80
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 87,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(rate(ticdc_sink_txn_exec_duration_bucket{capture=~\"$capture\"}[1m])) by (le)",
+              "format": "heatmap",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Sink txn execution duration",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "tooltipDecimals": 1,
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": 1,
+            "format": "s",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "upper",
+          "yBucketNumber": null,
+          "yBucketSize": null
         }
       ],
       "title": "Changefeed",
@@ -4882,7 +5054,7 @@
       "type": "row"
     }
   ],
-  "refresh": "5s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -4957,7 +5129,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/pkg/regionspan/span.go
+++ b/pkg/regionspan/span.go
@@ -15,6 +15,8 @@ package regionspan
 
 import (
 	"bytes"
+	"encoding/hex"
+	"fmt"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -30,11 +32,21 @@ type Span struct {
 	End   []byte
 }
 
+// String returns a string that encodes Span in hex format.
+func (s Span) String() string {
+	return fmt.Sprintf("[%s, %s)", hex.EncodeToString(s.Start), hex.EncodeToString(s.End))
+}
+
 // UpperBoundKey represents the maximum value.
 var UpperBoundKey = []byte{255, 255, 255, 255, 255}
 
 // ComparableSpan represents a arbitrary kv range which is comparable
 type ComparableSpan Span
+
+// String returns a string that encodes ComparableSpan in hex format.
+func (s ComparableSpan) String() string {
+	return Span(s).String()
+}
 
 // Hack will set End as UpperBoundKey if End is Nil.
 func (s ComparableSpan) Hack() ComparableSpan {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

* Add a metrics about pending flush rows.
* Add a metrics about MySQL sink txn execution duration.
* Pretty print Span.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

![image](https://user-images.githubusercontent.com/2150711/89185003-204a3400-d5cc-11ea-8968-5a0d6a097cee.png)

![image](https://user-images.githubusercontent.com/2150711/89184964-158f9f00-d5cc-11ea-83ea-d52ab01e7042.png)

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch

### Release note

* No release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
