### PR TITLE
Fix mysql sink may be blocked by network io wait

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -706,6 +706,9 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 }
 
 func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent, replicaID uint64, bucket int) error {
+	failpoint.Inject("MySQLSinkExecDMLError", func() {
+		failpoint.Return(errors.Trace(dmysql.ErrInvalidConn))
+	})
 	dmls, err := s.prepareDMLs(rows, replicaID, bucket)
 	if err != nil {
 		return errors.Trace(err)

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -621,6 +621,9 @@ func (s *mysqlSink) execDMLWithMaxRetries(
 			failpoint.Inject("MySQLSinkTxnRandomError", func() {
 				failpoint.Return(checkTxnErr(errors.Trace(dmysql.ErrInvalidConn)))
 			})
+			failpoint.Inject("MySQLSinkHangLongTime", func() {
+				time.Sleep(time.Hour)
+			})
 			err := s.statistics.RecordBatchExecution(func() (int, error) {
 				tx, err := s.db.BeginTx(ctx, nil)
 				if err != nil {

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -422,12 +422,12 @@ func (s *mysqlSink) createSinkWorkers(ctx context.Context) {
 
 func (s *mysqlSink) notifyAndWaitExec(ctx context.Context) {
 	s.notifier.Notify()
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		for _, w := range s.workers {
 			w.waitAllTxnsExecuted()
 		}
-		done <- struct{}{}
+		close(done)
 	}()
 	// This is a hack code to avoid io wait in some routine blocks others to exit.
 	// As the network io wait is blocked in kernel code, the goroutine is in a

--- a/tests/sink_hang/conf/diff_config.toml
+++ b/tests/sink_hang/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "sink_hang"
+    tables = ["usertable"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/sink_hang/conf/diff_config.toml
+++ b/tests/sink_hang/conf/diff_config.toml
@@ -11,7 +11,7 @@ fix-sql-file = "fix.sql"
 # tables need to check.
 [[check-tables]]
     schema = "sink_hang"
-    tables = ["usertable"]
+    tables = ["~t.*"]
 
 [[source-db]]
     host = "127.0.0.1"

--- a/tests/sink_hang/run.sh
+++ b/tests/sink_hang/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+CDC_COUNT=3
+DB_COUNT=4
+MAX_RETRIES=10
+
+function check_changefeed_state() {
+    pd_addr=$1
+    changefeed_id=$2
+    expected=$3
+    state=$(cdc cli --pd=$pd_addr changefeed query -s -c $changefeed_id|jq -r ".state")
+    if [[ "$state" != "$expected" ]];then
+        echo "unexpected state $state, expected $expected"
+        exit 1
+    fi
+}
+
+export -f check_changefeed_state
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    pd_addr="http://$UP_PD_HOST:$UP_PD_PORT"
+    TOPIC_NAME="ticdc-sink-hang-test-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sink/MySQLSinkHangLongTime=1*return(true)'
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
+    changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+
+    run_sql "CREATE DATABASE sink_hang;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table sink_hang.simple(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO sink_hang.simple VALUES (),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "failed"
+    cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr
+    ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "normal"
+
+    check_table_exists "sink_hang.simple" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/sink_hang/run.sh
+++ b/tests/sink_hang/run.sh
@@ -47,9 +47,9 @@ function run() {
     run_sql "CREATE DATABASE sink_hang;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     run_sql "CREATE table sink_hang.t1(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     run_sql "CREATE table sink_hang.t2(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-    run_sql "BEGIN; INSERT INTO sink_hang.t1 VALUES (),(),();INSERT INTO sink_hang.t2 VALUES (),(),();COMMIT" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "BEGIN; INSERT INTO sink_hang.t1 VALUES (),(),(); INSERT INTO sink_hang.t2 VALUES (),(),(); COMMIT" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
-    ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "failed"
+    ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "stopped"
     cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr
     ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "normal"
 

--- a/tests/sink_hang/run.sh
+++ b/tests/sink_hang/run.sh
@@ -26,6 +26,11 @@ function check_changefeed_state() {
 export -f check_changefeed_state
 
 function run() {
+    # kafka is not supported yet.
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      return
+    fi
+
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
     start_tidb_cluster --workdir $WORK_DIR
     cd $WORK_DIR

--- a/tests/sink_hang/run.sh
+++ b/tests/sink_hang/run.sh
@@ -40,14 +40,14 @@ function run() {
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
     fi
 
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sink/MySQLSinkHangLongTime=1*return(true);github.com/pingcap/ticdc/cdc/sink/MySQLSinkTxnRandomError=1*return(true)'
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sink/MySQLSinkHangLongTime=1*return(true);github.com/pingcap/ticdc/cdc/sink/MySQLSinkExecDMLError=1*return(true)'
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
 
     run_sql "CREATE DATABASE sink_hang;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     run_sql "CREATE table sink_hang.t1(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     run_sql "CREATE table sink_hang.t2(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-    run_sql "INSERT INTO sink_hang.t1.VALUES (),(),();INSERT INTO sink_hang.t2.VALUES (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "BEGIN; INSERT INTO sink_hang.t1 VALUES (),(),();INSERT INTO sink_hang.t2 VALUES (),(),();COMMIT" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
     ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "failed"
     cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In a test when TiDB cluster is abnormal, ticdc executes DMLs with some errors, but one of goroutine is hang up and blocks the whole sink

```
goroutine 1560236 [IO wait, 205 minutes]:
internal/poll.runtime_pollWait(0x7fa0f1b689c8, 0x72, 0xffffffffffffffff)
        runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc010079618, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
        internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc010079600, 0xc0113cc000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        internal/poll/fd_unix.go:169 +0x1cf
net.(*netFD).Read(0xc010079600, 0xc0113cc000, 0x1000, 0x1000, 0xc0254cad80, 0xc010079600, 0xc010079618)
        net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc00ddea000, 0xc0113cc000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        net/net.go:184 +0x68
github.com/go-sql-driver/mysql.(*buffer).fill(0xc013bf2360, 0x4, 0xc0254cabd0, 0x69d3b3)
        github.com/go-sql-driver/mysql@v1.5.0/buffer.go:90 +0x13c
github.com/go-sql-driver/mysql.(*buffer).readNext(0xc013bf2360, 0x4, 0x22b5, 0x0, 0x0, 0x22b1, 0xc0001b4000)
        github.com/go-sql-driver/mysql@v1.5.0/buffer.go:119 +0x9c
github.com/go-sql-driver/mysql.(*mysqlConn).readPacket(0xc013bf2360, 0x22b5, 0x22b5, 0x22b5, 0x4051d9, 0xc017504a00)
        github.com/go-sql-driver/mysql@v1.5.0/packets.go:31 +0x91
github.com/go-sql-driver/mysql.(*mysqlConn).readResultSetHeaderPacket(0xc013bf2360, 0xc01734c003, 0xc017502500, 0x22b0)
        github.com/go-sql-driver/mysql@v1.5.0/packets.go:537 +0x2f
github.com/go-sql-driver/mysql.(*mysqlConn).exec(0xc013bf2360, 0xc017502500, 0x22b0, 0xc017330000, 0x64)
        github.com/go-sql-driver/mysql@v1.5.0/connection.go:345 +0xd3
github.com/go-sql-driver/mysql.(*mysqlConn).Exec(0xc013bf2360, 0xc0156bd900, 0x340, 0xc017330000, 0x64, 0x64, 0x0, 0x0, 0x3, 0xc0254cad98)
        github.com/go-sql-driver/mysql@v1.5.0/connection.go:327 +0x1a8
github.com/go-sql-driver/mysql.(*mysqlConn).ExecContext(0xc013bf2360, 0x2de6440, 0xc002706480, 0xc0156bd900, 0x340, 0xc017302000, 0x64, 0x64, 0x0, 0x0, ...)
        github.com/go-sql-driver/mysql@v1.5.0/connection.go:532 +0x165
database/sql.ctxDriverExec(0x2de6440, 0xc002706480, 0x7fa0f11a9408, 0xc013bf2360, 0x0, 0x0, 0xc0156bd900, 0x340, 0xc017302000, 0x64, ...)
        database/sql/ctxutil.go:31 +0x227
database/sql.(*DB).execDC.func2()
        database/sql/sql.go:1519 +0x1db
database/sql.withLock(0x2daad80, 0xc015746280, 0xc0254cb158)
        database/sql/sql.go:3184 +0x6d
database/sql.(*DB).execDC(0xc001de0000, 0x2de6440, 0xc002706480, 0xc015746280, 0xc02446cd60, 0xc0156bd900, 0x340, 0xc01722c700, 0x64, 0x64, ...)
        database/sql/sql.go:1514 +0x4b2
database/sql.(*Tx).ExecContext(0xc028b72280, 0x2de6440, 0xc002706480, 0xc0156bd900, 0x340, 0xc01722c700, 0x64, 0x64, 0x2db0a40, 0xc02c54c480, ...)
        database/sql/sql.go:2275 +0xef
github.com/pingcap/ticdc/cdc/sink.(*mysqlSink).execDMLWithMaxRetries.func2.2(0xbfc2b352a76b1ac5, 0x46ebd2c39e57, 0x48c0660)
        github.com/pingcap/ticdc@/cdc/sink/mysql.go:619 +0x17c
github.com/pingcap/ticdc/cdc/sink.(*Statistics).RecordBatchExecution(0xc000ce83f0, 0xc0254cb538, 0x4e3a7a, 0xc000c0a1e0)
        github.com/pingcap/ticdc@/cdc/sink/statistics.go:86 +0x50
github.com/pingcap/ticdc/cdc/sink.(*mysqlSink).execDMLWithMaxRetries.func2(0xfadd0b, 0x48e1358)
        github.com/pingcap/ticdc@/cdc/sink/mysql.go:612 +0xa7
github.com/pingcap/ticdc/pkg/retry.Run.func1(0xc029496260, 0xc029496280)
        github.com/pingcap/ticdc@/pkg/retry/retry.go:31 +0x2a
github.com/cenkalti/backoff.RetryNotify(0xc0254cb858, 0x2dab6c0, 0xc029496260, 0x0, 0x0, 0x0)
        github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0xb8
github.com/cenkalti/backoff.Retry(...)
        github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:24
github.com/pingcap/ticdc/pkg/retry.Run(0x1dcd6500, 0x8, 0xc0254cb8e0, 0x58, 0x2663c80)
        github.com/pingcap/ticdc@/pkg/retry/retry.go:30 +0xb8
github.com/pingcap/ticdc/cdc/sink.(*mysqlSink).execDMLWithMaxRetries(0xc026f2a500, 0x2de6440, 0xc002706480, 0xc0238a9480, 0x8, 0x1a, 0x17, 0x0)
```

### What is changed and how it works?

Use a hack code to avoid io wait in some routine blocks others to exit.
As the network io wait is blocked in kernel code, the goroutine is in a
D-state that we could not even stop it by canceling the context. So if this
scenario happens, the blocked goroutine will be leak.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix network io wait will block task exits