### PR TITLE
Use batch replace in mysql sink to increase performance

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -368,7 +368,7 @@ func UnmarshalDDL(raw *model.RawKVEntry) (*timodel.Job, error) {
 func datum2Column(tableInfo *model.TableInfo, datums map[int64]types.Datum, fillWithDefaultValue bool) ([]*model.Column, error) {
 	cols := make([]*model.Column, len(tableInfo.RowColumnsOffset))
 	for _, colInfo := range tableInfo.Columns {
-		if !tableInfo.IsColCDCVisible(colInfo) {
+		if !model.IsColCDCVisible(colInfo) {
 			continue
 		}
 		colName := colInfo.Name.O

--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -86,7 +86,7 @@ func WrapTableInfo(schemaID int64, schemaName string, version uint64, info *mode
 	for i, col := range ti.Columns {
 		ti.columnsOffset[col.ID] = i
 		isPK := false
-		if ti.IsColCDCVisible(col) {
+		if IsColCDCVisible(col) {
 			ti.RowColumnsOffset[col.ID] = rowColumnsCurrentOffset
 			rowColumnsCurrentOffset++
 			isPK = (ti.PKIsHandle && mysql.HasPriKeyFlag(col.Flag)) || col.ID == model.ExtraHandleID
@@ -117,7 +117,7 @@ func WrapTableInfo(schemaID int64, schemaName string, version uint64, info *mode
 			indexColOffset := make([]int, 0, len(idx.Columns))
 			for _, idxCol := range idx.Columns {
 				colInfo := ti.Columns[idxCol.Offset]
-				if ti.IsColCDCVisible(colInfo) {
+				if IsColCDCVisible(colInfo) {
 					indexColOffset = append(indexColOffset, ti.RowColumnsOffset[colInfo.ID])
 				}
 			}
@@ -255,7 +255,7 @@ func (ti *TableInfo) GetRowColInfos() (int64, []rowcodec.ColInfo) {
 }
 
 // IsColCDCVisible returns whether the col is visible for CDC
-func (ti *TableInfo) IsColCDCVisible(col *model.ColumnInfo) bool {
+func IsColCDCVisible(col *model.ColumnInfo) bool {
 	// this column is a virtual generated column
 	if col.IsGenerated() && !col.GeneratedStored {
 		return false

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -718,8 +718,6 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 				replaces = make(map[string][][]interface{})
 			}
 			query, args = prepareDelete(quoteTable, row.PreColumns)
-			sqls = append(sqls, query)
-			values = append(values, args)
 			if query != "" {
 				sqls = append(sqls, query)
 				values = append(values, args)

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -52,12 +52,14 @@ import (
 )
 
 const (
-	defaultWorkerCount     = 16
-	defaultMaxTxnRow       = 256
-	defaultDMLMaxRetryTime = 8
-	defaultDDLMaxRetryTime = 20
-	defaultTiDBTxnMode     = "optimistic"
-	defaultFlushInterval   = time.Millisecond * 50
+	defaultWorkerCount         = 16
+	defaultMaxTxnRow           = 256
+	defaultDMLMaxRetryTime     = 8
+	defaultDDLMaxRetryTime     = 20
+	defaultTiDBTxnMode         = "optimistic"
+	defaultFlushInterval       = time.Millisecond * 50
+	defaultBatchReplaceEnabled = true
+	defaultBatchReplaceSize    = 20
 )
 
 type mysqlSink struct {
@@ -214,17 +216,21 @@ func (s *mysqlSink) adjustSQLMode(ctx context.Context) error {
 var _ Sink = &mysqlSink{}
 
 type sinkParams struct {
-	workerCount  int
-	maxTxnRow    int
-	tidbTxnMode  string
-	changefeedID string
-	captureAddr  string
+	workerCount         int
+	maxTxnRow           int
+	tidbTxnMode         string
+	changefeedID        string
+	captureAddr         string
+	batchReplaceEnabled bool
+	batchReplaceSize    int
 }
 
 var defaultParams = &sinkParams{
-	workerCount: defaultWorkerCount,
-	maxTxnRow:   defaultMaxTxnRow,
-	tidbTxnMode: defaultTiDBTxnMode,
+	workerCount:         defaultWorkerCount,
+	maxTxnRow:           defaultMaxTxnRow,
+	tidbTxnMode:         defaultTiDBTxnMode,
+	batchReplaceEnabled: defaultBatchReplaceEnabled,
+	batchReplaceSize:    defaultBatchReplaceSize,
 }
 
 func configureSinkURI(ctx context.Context, dsnCfg *dmysql.Config, tz *time.Location, params *sinkParams) (string, error) {
@@ -336,6 +342,23 @@ func newMySQLSink(ctx context.Context, changefeedID model.ChangeFeedID, sinkURI 
 		}
 		tlsParam = "?tls=" + name
 	}
+
+	s = sinkURI.Query().Get("batch-replace-enable")
+	if s != "" {
+		enable, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		params.batchReplaceEnabled = enable
+	}
+	if params.batchReplaceEnabled && sinkURI.Query().Get("batch-replace-size") != "" {
+		size, err := strconv.Atoi(sinkURI.Query().Get("batch-replace-size"))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		params.batchReplaceSize = size
+	}
+
 	// dsn format of the driver:
 	// [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
 	username := sinkURI.User.Username()
@@ -654,14 +677,14 @@ func (s *mysqlSink) execDMLWithMaxRetries(
 				if err = tx.Commit(); err != nil {
 					return 0, checkTxnErr(errors.Trace(err))
 				}
-				return len(dmls.sqls), nil
+				return dmls.rowCount, nil
 			})
 			if err != nil {
 				return errors.Trace(err)
 			}
 			log.Debug("Exec Rows succeeded",
 				zap.String("changefeed", s.params.changefeedID),
-				zap.Int("num of Rows", len(dmls.sqls)),
+				zap.Int("num of Rows", dmls.rowCount),
 				zap.Int("bucket", bucket))
 			return nil
 		},
@@ -669,40 +692,66 @@ func (s *mysqlSink) execDMLWithMaxRetries(
 }
 
 type preparedDMLs struct {
-	sqls    []string
-	values  [][]interface{}
-	markSQL string
+	sqls     []string
+	values   [][]interface{}
+	markSQL  string
+	rowCount int
 }
 
 // prepareDMLs converts model.RowChangedEvent list to query string list and args list
-func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64, bucket int) (*preparedDMLs, error) {
+func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64, bucket int) *preparedDMLs {
 	sqls := make([]string, 0, len(rows))
 	values := make([][]interface{}, 0, len(rows))
+	replaces := make(map[string][][]interface{})
+	rowCount := 0
 	for _, row := range rows {
 		var query string
 		var args []interface{}
-		var err error
+		quoteTable := quotes.QuoteSchema(row.Table.Schema, row.Table.Table)
 		// TODO(leoppro): using `UPDATE` instead of `REPLACE` if the old value is enabled
 		if len(row.PreColumns) != 0 {
-			query, args, err = prepareDelete(row.Table.Schema, row.Table.Table, row.PreColumns)
-			if err != nil {
-				return nil, errors.Trace(err)
+			// flush cached batch replace, we must keep the sequence of DMLs
+			if s.params.batchReplaceEnabled && len(replaces) > 0 {
+				replaceSqls, replaceValues := reduceReplace(replaces, s.params.batchReplaceSize)
+				sqls = append(sqls, replaceSqls...)
+				values = append(values, replaceValues...)
+				replaces = make(map[string][][]interface{})
 			}
+			query, args = prepareDelete(quoteTable, row.PreColumns)
+			sqls = append(sqls, query)
+			values = append(values, args)
 			if query != "" {
 				sqls = append(sqls, query)
 				values = append(values, args)
+				rowCount++
 			}
 		}
 		if len(row.Columns) != 0 {
-			query, args, err = prepareReplace(row.Table.Schema, row.Table.Table, row.Columns)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if query != "" {
+			if s.params.batchReplaceEnabled {
+				query, args = prepareReplace(quoteTable, row.Columns, false /* appendPlaceHolder */)
+				if query != "" {
+					if _, ok := replaces[query]; !ok {
+						replaces[query] = make([][]interface{}, 0)
+					}
+					replaces[query] = append(replaces[query], args)
+					rowCount++
+				}
+			} else {
+				query, args = prepareReplace(quoteTable, row.Columns, true /* appendPlaceHolder */)
 				sqls = append(sqls, query)
 				values = append(values, args)
+				if query != "" {
+					sqls = append(sqls, query)
+					values = append(values, args)
+					rowCount++
+				}
 			}
 		}
+	}
+	if s.params.batchReplaceEnabled {
+		replaceSqls, replaceValues := reduceReplace(replaces, s.params.batchReplaceSize)
+		sqls = append(sqls, replaceSqls...)
+		values = append(values, replaceValues...)
 	}
 	dmls := &preparedDMLs{
 		sqls:   sqls,
@@ -714,18 +763,17 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 		updateMark := s.cyclic.UdpateSourceTableCyclicMark(
 			row.Table.Schema, row.Table.Table, uint64(bucket), replicaID, row.StartTs)
 		dmls.markSQL = updateMark
+		rowCount++
 	}
-	return dmls, nil
+	dmls.rowCount = rowCount
+	return dmls
 }
 
 func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent, replicaID uint64, bucket int) error {
 	failpoint.Inject("MySQLSinkExecDMLError", func() {
 		failpoint.Return(errors.Trace(dmysql.ErrInvalidConn))
 	})
-	dmls, err := s.prepareDMLs(rows, replicaID, bucket)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	dmls := s.prepareDMLs(rows, replicaID, bucket)
 	log.Debug("prepare DMLs", zap.Any("rows", rows), zap.Strings("sqls", dmls.sqls), zap.Any("values", dmls.values))
 	if err := s.execDMLWithMaxRetries(ctx, dmls, defaultDMLMaxRetryTime, bucket); err != nil {
 		ts := make([]uint64, 0, len(rows))
@@ -740,7 +788,7 @@ func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent,
 	return nil
 }
 
-func prepareReplace(schema, table string, cols []*model.Column) (string, []interface{}, error) {
+func prepareReplace(quoteTable string, cols []*model.Column, appendPlaceHolder bool) (string, []interface{}) {
 	var builder strings.Builder
 	columnNames := make([]string, 0, len(cols))
 	args := make([]interface{}, 0, len(cols))
@@ -752,24 +800,63 @@ func prepareReplace(schema, table string, cols []*model.Column) (string, []inter
 		args = append(args, col.Value)
 	}
 	if len(args) == 0 {
-		return "", nil, nil
+		return "", nil
 	}
 
 	colList := "(" + buildColumnList(columnNames) + ")"
-	tblName := quotes.QuoteSchema(schema, table)
-	builder.WriteString("REPLACE INTO " + tblName + colList + " VALUES ")
-	builder.WriteString("(" + model.HolderString(len(columnNames)) + ");")
+	builder.WriteString("REPLACE INTO " + quoteTable + colList + " VALUES ")
+	if appendPlaceHolder {
+		builder.WriteString("(" + model.HolderString(len(columnNames)) + ");")
+	}
 
-	return builder.String(), args, nil
+	return builder.String(), args
 }
 
-func prepareDelete(schema, table string, cols []*model.Column) (string, []interface{}, error) {
+// reduceReplace groups SQLs with the same replace statement format, as following
+// sql: `REPLACE INTO `test`.`t` (`a`,`b`) VALUES (?,?,?,?,?,?)`
+// args: (1,"",2,"2",3,"")
+func reduceReplace(replaces map[string][][]interface{}, batchSize int) ([]string, [][]interface{}) {
+	nextHolderString := func(query string, valueNum int, last bool) string {
+		query += "(" + model.HolderString(valueNum) + ")"
+		if !last {
+			query += ","
+		}
+		return query
+	}
+	sqls := make([]string, 0)
+	args := make([][]interface{}, 0)
+	for replace, vals := range replaces {
+		query := replace
+		cacheCount := 0
+		cacheArgs := make([]interface{}, 0)
+		last := false
+		for i, val := range vals {
+			cacheCount += 1
+			if i == len(vals)-1 || cacheCount >= batchSize {
+				last = true
+			}
+			query = nextHolderString(query, len(val), last)
+			cacheArgs = append(cacheArgs, val...)
+			if last {
+				sqls = append(sqls, query)
+				args = append(args, cacheArgs)
+				query = replace
+				cacheCount = 0
+				cacheArgs = make([]interface{}, 0, len(cacheArgs))
+				last = false
+			}
+		}
+	}
+	return sqls, args
+}
+
+func prepareDelete(quoteTable string, cols []*model.Column) (string, []interface{}) {
 	var builder strings.Builder
-	builder.WriteString("DELETE FROM " + quotes.QuoteSchema(schema, table) + " WHERE ")
+	builder.WriteString("DELETE FROM " + quoteTable + " WHERE ")
 
 	colNames, wargs := whereSlice(cols)
 	if len(wargs) == 0 {
-		return "", nil, nil
+		return "", nil
 	}
 	args := make([]interface{}, 0, len(wargs))
 	for i := 0; i < len(colNames); i++ {
@@ -785,7 +872,7 @@ func prepareDelete(schema, table string, cols []*model.Column) (string, []interf
 	}
 	builder.WriteString(" LIMIT 1;")
 	sql := builder.String()
-	return sql, args, nil
+	return sql, args
 }
 
 func whereSlice(cols []*model.Column) (colNames []string, args []interface{}) {

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -15,13 +15,14 @@ package sink
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 	"time"
 
-	"github.com/pingcap/parser/mysql"
-
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink/common"
 	"github.com/pingcap/ticdc/pkg/config"
@@ -439,9 +440,164 @@ func (s MySQLSinkSuite) TestPrepareDML(c *check.C) {
 	}}
 	ms := newMySQLSink4Test(c)
 	for i, tc := range testCases {
-		dmls, err := ms.prepareDMLs(tc.input, 0, 0)
-		c.Assert(err, check.IsNil)
+		dmls := ms.prepareDMLs(tc.input, 0, 0)
 		c.Assert(dmls, check.DeepEquals, tc.expected, check.Commentf("%d", i))
+	}
+}
+
+func (s MySQLSinkSuite) TestMapReplace(c *check.C) {
+	testCases := []struct {
+		quoteTable    string
+		cols          []*model.Column
+		expectedQuery string
+		expectedArgs  []interface{}
+	}{
+		{
+			quoteTable: "`test`.`t1`",
+			cols: []*model.Column{
+				{Name: "a", Type: mysql.TypeLong, Value: 1},
+				{Name: "b", Type: mysql.TypeVarchar, Value: "varchar"},
+				{Name: "c", Type: mysql.TypeLong, Value: 1, Flag: model.GeneratedColumnFlag},
+				{Name: "d", Type: mysql.TypeTiny, Value: uint8(255)},
+			},
+			expectedQuery: "REPLACE INTO `test`.`t1`(`a`,`b`,`d`) VALUES ",
+			expectedArgs:  []interface{}{1, "varchar", uint8(255)},
+		},
+		{
+			quoteTable: "`test`.`t1`",
+			cols: []*model.Column{
+				{Name: "a", Type: mysql.TypeLong, Value: 1},
+				{Name: "b", Type: mysql.TypeVarchar, Value: "varchar"},
+				{Name: "c", Type: mysql.TypeLong, Value: 1},
+				{Name: "d", Type: mysql.TypeTiny, Value: uint8(255)},
+			},
+			expectedQuery: "REPLACE INTO `test`.`t1`(`a`,`b`,`c`,`d`) VALUES ",
+			expectedArgs:  []interface{}{1, "varchar", 1, uint8(255)},
+		},
+	}
+	for _, tc := range testCases {
+		// multiple times to verify the stability of column sequence in query string
+		for i := 0; i < 10; i++ {
+			query, args := prepareReplace(tc.quoteTable, tc.cols, false)
+			c.Assert(query, check.Equals, tc.expectedQuery)
+			c.Assert(args, check.DeepEquals, tc.expectedArgs)
+		}
+	}
+}
+
+type sqlArgs [][]interface{}
+
+func (a sqlArgs) Len() int           { return len(a) }
+func (a sqlArgs) Less(i, j int) bool { return fmt.Sprintf("%s", a[i]) < fmt.Sprintf("%s", a[j]) }
+func (a sqlArgs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func (s MySQLSinkSuite) TestReduceReplace(c *check.C) {
+	testCases := []struct {
+		replaces   map[string][][]interface{}
+		batchSize  int
+		sort       bool
+		expectSQLs []string
+		expectArgs [][]interface{}
+	}{
+		{
+			replaces: map[string][][]interface{}{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES ": {
+					[]interface{}{1, "1"},
+					[]interface{}{2, "2"},
+					[]interface{}{3, "3"},
+				},
+			},
+			batchSize: 1,
+			sort:      false,
+			expectSQLs: []string{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?)",
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?)",
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?)",
+			},
+			expectArgs: [][]interface{}{
+				{1, "1"},
+				{2, "2"},
+				{3, "3"},
+			},
+		},
+		{
+			replaces: map[string][][]interface{}{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES ": {
+					[]interface{}{1, "1"},
+					[]interface{}{2, "2"},
+					[]interface{}{3, "3"},
+					[]interface{}{4, "3"},
+					[]interface{}{5, "5"},
+				},
+			},
+			batchSize: 3,
+			sort:      false,
+			expectSQLs: []string{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?),(?,?),(?,?)",
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?),(?,?)",
+			},
+			expectArgs: [][]interface{}{
+				{1, "1", 2, "2", 3, "3"},
+				{4, "3", 5, "5"},
+			},
+		},
+		{
+			replaces: map[string][][]interface{}{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES ": {
+					[]interface{}{1, "1"},
+					[]interface{}{2, "2"},
+					[]interface{}{3, "3"},
+					[]interface{}{4, "3"},
+					[]interface{}{5, "5"},
+				},
+			},
+			batchSize: 10,
+			sort:      false,
+			expectSQLs: []string{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?),(?,?),(?,?),(?,?),(?,?)",
+			},
+			expectArgs: [][]interface{}{
+				{1, "1", 2, "2", 3, "3", 4, "3", 5, "5"},
+			},
+		},
+		{
+			replaces: map[string][][]interface{}{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES ": {
+					[]interface{}{1, "1"},
+					[]interface{}{2, "2"},
+					[]interface{}{3, "3"},
+					[]interface{}{4, "3"},
+					[]interface{}{5, "5"},
+					[]interface{}{6, "6"},
+				},
+				"REPLACE INTO `test`.`t2`(`a`,`b`) VALUES ": {
+					[]interface{}{7, ""},
+					[]interface{}{8, ""},
+					[]interface{}{9, ""},
+				},
+			},
+			batchSize: 3,
+			sort:      true,
+			expectSQLs: []string{
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?),(?,?),(?,?)",
+				"REPLACE INTO `test`.`t1`(`a`,`b`) VALUES (?,?),(?,?),(?,?)",
+				"REPLACE INTO `test`.`t2`(`a`,`b`) VALUES (?,?),(?,?),(?,?)",
+			},
+			expectArgs: [][]interface{}{
+				{1, "1", 2, "2", 3, "3"},
+				{4, "3", 5, "5", 6, "6"},
+				{7, "", 8, "", 9, ""},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		sqls, args := reduceReplace(tc.replaces, tc.batchSize)
+		if tc.sort {
+			sort.Strings(sqls)
+			sort.Sort(sqlArgs(args))
+		}
+		c.Assert(sqls, check.DeepEquals, tc.expectSQLs)
+		c.Assert(args, check.DeepEquals, tc.expectArgs)
 	}
 }
 

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -40,10 +40,13 @@ var _ = check.Suite(&MySQLSinkSuite{})
 func newMySQLSink4Test(c *check.C) *mysqlSink {
 	f, err := filter.NewFilter(config.GetDefaultReplicaConfig())
 	c.Assert(err, check.IsNil)
+	params := defaultParams
+	params.batchReplaceEnabled = false
 	return &mysqlSink{
 		txnCache:   common.NewUnresolvedTxnCache(),
 		filter:     f,
 		statistics: NewStatistics(context.TODO(), "test", make(map[string]string)),
+		params:     params,
 	}
 }
 
@@ -434,8 +437,9 @@ func (s MySQLSinkSuite) TestPrepareDML(c *check.C) {
 			},
 		},
 		expected: &preparedDMLs{
-			sqls:   []string{"DELETE FROM `common_1`.`uk_without_pk` WHERE `a1` = ? AND `a3` = ? LIMIT 1;"},
-			values: [][]interface{}{{1, 1}},
+			sqls:     []string{"DELETE FROM `common_1`.`uk_without_pk` WHERE `a1` = ? AND `a3` = ? LIMIT 1;"},
+			values:   [][]interface{}{{1, 1}},
+			rowCount: 1,
 		},
 	}}
 	ms := newMySQLSink4Test(c)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Implement https://github.com/pingcap/ticdc/issues/807

### What is changed and how it works?

- [x] Add a batchReplace option, if enabled, group replace SQLs by `` `schema`.`table` ``
- [x] Add unit test about map/reduce replace
- [x] Make the batchReplace option configurable
- [ ] Benchmark for this optimization
- [x] ~~Pass necessary information to sink to avoid column name sorting, has the following solutions, choose 3 now.~~ Column sequence is stable now
     1. pass `SchemaStorage` from processor
     2. pass table info in each RowChangedEvent
     3. pass a stable coumn name list in each RowChangedEvent

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Add a batch replace way to optimize download write throughput in MySQL sink.
