### PR TITLE
Fix compatibility of libzstd with different gcc version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ check_third_party_binary:
 	@which bin/jq
 
 integration_test_build: check_failpoint_ctl
+	./scripts/fix_lib_zstd.sh
 	$(FAILPOINT_ENABLE)
 	$(GOTEST) -c -cover -covemode=atomic \
 		-coverpkg=github.com/pingcap/ticdc/... \

--- a/scripts/fix_lib_zstd.sh
+++ b/scripts/fix_lib_zstd.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+user=$(whoami)
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+module="github.com/valyala/gozstd@v1.7.0"
+
+GO111MODULE=on go mod download ${module}
+# In CI environment, the gopath contains multiple dirs, choose the first one
+cd $(echo $GOPATH|awk -F':' '{print $1}')/pkg/mod/${module}
+sudo MOREFLAGS=-fPIC make clean libzstd.a
+
+sudo which go
+if [[ $? != 0 ]]; then
+    lib_name=libzstd_${GOOS}_${GOARCH}.a
+    echo "mv libzstd__.a ${lib_name}"
+    sudo mv libzstd__.a ${lib_name}
+    sudo chown ${user}:${user} ${lib_name}
+fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Fix CI warning `cdc.test: Symbol 'stderr' causes overflow in R_X86_64_PC32 relocation`

- Fix build failure with some GCC version, such as with `gcc version 9.3.0 (on Ubuntu 20.04.1 LTS)·

```
/home/apple/.gvm/gos/go1.14.6/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /home/apple/.gvm/pkgsets/go1.14.6/global/pkg/mod/github.com/valyala/gozstd@v1.7.0/libzstd_linux_amd64.a(zdict.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a PDE object; recompile with -fPIE
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

NOTE: this fix can be removed after we upgrade https://github.com/apache/pulsar-client-go to latest version

### What is changed and how it works?

Compile `libzstd.a` based on https://github.com/valyala/gozstd#faq

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
