### PR TITLE
cmd: fix cmd TLS usage

### DIFF
--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -67,7 +67,7 @@ func newAdminChangefeedCommand() []*cobra.Command {
 					CfID: changefeedID,
 					Type: model.AdminStop,
 				}
-				return applyAdminChangefeed(ctx, job)
+				return applyAdminChangefeed(ctx, job, getCredential())
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func newAdminChangefeedCommand() []*cobra.Command {
 					CfID: changefeedID,
 					Type: model.AdminResume,
 				}
-				return applyAdminChangefeed(ctx, job)
+				return applyAdminChangefeed(ctx, job, getCredential())
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func newAdminChangefeedCommand() []*cobra.Command {
 					CfID: changefeedID,
 					Type: model.AdminRemove,
 				}
-				return applyAdminChangefeed(ctx, job)
+				return applyAdminChangefeed(ctx, job, getCredential())
 			},
 		},
 	}
@@ -116,7 +116,7 @@ func newListChangefeedCommand() *cobra.Command {
 			cfs := make([]*changefeedCommonInfo, 0, len(raw))
 			for id := range raw {
 				cfci := &changefeedCommonInfo{ID: id}
-				resp, err := applyOwnerChangefeedQuery(ctx, id)
+				resp, err := applyOwnerChangefeedQuery(ctx, id, getCredential())
 				if err != nil {
 					// if no capture is available, the query will fail, just add a warning here
 					log.Warn("query changefeed info failed", zap.String("error", err.Error()))
@@ -144,7 +144,7 @@ func newQueryChangefeedCommand() *cobra.Command {
 			ctx := defaultContext
 
 			if simplified {
-				resp, err := applyOwnerChangefeedQuery(ctx, changefeedID)
+				resp, err := applyOwnerChangefeedQuery(ctx, changefeedID, getCredential())
 				if err != nil {
 					return err
 				}

--- a/pkg/security/credential.go
+++ b/pkg/security/credential.go
@@ -31,6 +31,11 @@ type Credential struct {
 	CertAllowedCN []string `toml:"cert-allowed-cn" json:"cert-allowed-cn"`
 }
 
+// IsTLSEnabled checks whether TLS is enabled or not.
+func (s *Credential) IsTLSEnabled() bool {
+	return len(s.CAPath) != 0
+}
+
 // PDSecurityOption creates a new pd SecurityOption from Security
 func (s *Credential) PDSecurityOption() pd.SecurityOption {
 	return pd.SecurityOption{

--- a/tests/cyclic_abc/run.sh
+++ b/tests/cyclic_abc/run.sh
@@ -106,6 +106,7 @@ function run() {
     run_cdc_cli changefeed create --start-ts=$start_ts \
         --sink-uri="mysql://root@${UP_TIDB_HOST}:${UP_TIDB_PORT}/" \
         --pd "https://${TLS_PD_HOST}:${TLS_PD_PORT}" \
+        --changefeed-id "tls-changefeed" \
         --ca=$TLS_DIR/ca.pem \
         --cert=$TLS_DIR/client.pem \
         --key=$TLS_DIR/client-key.pem \
@@ -162,6 +163,20 @@ function run() {
         echo "must not connect successfully"
         exit 1
     fi
+
+    # Check cli TLS
+    run_cdc_cli changefeed list \
+        --pd "https://${TLS_PD_HOST}:${TLS_PD_PORT}" \
+        --ca=$TLS_DIR/ca.pem \
+        --cert=$TLS_DIR/client.pem \
+        --key=$TLS_DIR/client-key.pem
+
+    run_cdc_cli changefeed query \
+        --changefeed-id "tls-changefeed" \
+        --pd "https://${TLS_PD_HOST}:${TLS_PD_PORT}" \
+        --ca=$TLS_DIR/ca.pem \
+        --cert=$TLS_DIR/client.pem \
+        --key=$TLS_DIR/client-key.pem
 
     cleanup_process $CDC_BINARY
 }


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix `changefeed list` and `changefeed query` do not work when TLS is enabled.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note

- Fix `changefeed list` and `changefeed query` do not work when TLS is enabled.


<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
