### PR TITLE
fix DDL may be lost if owner exits

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -789,7 +789,7 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 	for len(c.ddlJobHistory) > 0 && c.ddlJobHistory[0].BinlogInfo.FinishedTS <= c.ddlExecutedTs {
 		c.ddlJobHistory = c.ddlJobHistory[1:]
 	}
-	if len(c.ddlJobHistory) > 0 && minResolvedTs > c.ddlJobHistory[0].BinlogInfo.FinishedTS {
+	if len(c.ddlJobHistory) > 0 && minResolvedTs >= c.ddlJobHistory[0].BinlogInfo.FinishedTS {
 		minResolvedTs = c.ddlJobHistory[0].BinlogInfo.FinishedTS
 		c.ddlState = model.ChangeFeedWaitToExecDDL
 	}

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -471,6 +471,9 @@ func (p *processor) flushTaskPosition(ctx context.Context) error {
 	failpoint.Inject("ProcessorUpdatePositionDelaying", func() {
 		time.Sleep(1 * time.Second)
 	})
+	if p.isStopped() {
+		return errors.Trace(model.ErrAdminStopProcessor)
+	}
 	//p.position.Count = p.sink.Count()
 	err := p.etcdCli.PutTaskPosition(ctx, p.changefeedID, p.captureInfo.ID, p.position)
 	if err != nil {

--- a/tests/kill_owner_with_ddl/conf/diff_config.toml
+++ b/tests/kill_owner_with_ddl/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "kill_owner_with_ddl"
+    tables = ["~t.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/kill_owner_with_ddl/run.sh
+++ b/tests/kill_owner_with_ddl/run.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+MAX_RETRIES=10
+
+function check_capture_count() {
+    pd=$1
+    expected=$2
+    count=$(cdc cli capture list --pd=$pd 2>&1|jq '.|length')
+    if [[ ! "$count" -eq "$expected" ]]; then
+        echo "count: $count expected: $expected"
+        exit 1
+    fi
+}
+
+function kill_cdc_and_restart() {
+    pd_addr=$1
+    work_dir=$2
+    cdc_binary=$3
+    MAX_RETRIES=10
+    cdc_pid=$(curl -s http://127.0.0.1:8300/status|jq '.pid')
+    kill $cdc_pid
+    ensure $MAX_RETRIES check_capture_count $pd_addr 0
+    run_cdc_server --workdir $work_dir --binary $cdc_binary --addr "127.0.0.1:8300" --pd $pd_addr
+    ensure $MAX_RETRIES check_capture_count $pd_addr 1
+}
+
+export -f check_capture_count
+export -f kill_cdc_and_restart
+
+function run() {
+    # kafka is not supported yet.
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      return
+    fi
+
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    pd_addr="http://$UP_PD_HOST:$UP_PD_PORT"
+    SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1"
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
+    cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI"
+    run_sql "CREATE DATABASE kill_owner_with_ddl;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table kill_owner_with_ddl.t1 (id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_table_exists "kill_owner_with_ddl.t1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sink/MySQLSinkExecDDLDelay=return(true)'
+    kill_cdc_and_restart $pd_addr $WORK_DIR $CDC_BINARY
+
+    for i in $(seq 2 3); do
+        run_sql "CREATE table kill_owner_with_ddl.t$i (id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    done
+    for i in $(seq 1 3); do
+        run_sql "INSERT INTO kill_owner_with_ddl.t$i VALUES (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    done
+
+    # sleep to ensure processor has consumed the DDL and flushed checkpoint
+    sleep 5
+
+    for i in $(seq 1 3); do
+        kill_cdc_and_restart $pd_addr $WORK_DIR $CDC_BINARY
+        sleep 2
+    done
+
+    export GO_FAILPOINTS=''
+    kill_cdc_and_restart $pd_addr $WORK_DIR $CDC_BINARY
+
+    for i in $(seq 1 3); do
+        check_table_exists "kill_owner_with_ddl.t$i" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    done
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the bug found in https://github.com/pingcap/ticdc/issues/838

For the case-1:

- task position could be updated after processor is stopped.

For the case-2:
- Owner exits before a DDL is executed, and checkpoint ts of all processors have reached DDL FinishedTs
- When owner restarts, the resolved ts equals to the unfinished DDL and the replication state is not correctly updated to `ChangeFeedWaitToExecDDL`
- The global checkpoint ts will be forwarded, and this DDL will be lost.

### What is changed and how it works?

- check whether processor is stopped before flushing task position, to fix case-1
- change the condition to `minResolvedTs >= c.ddlJobHistory[0].BinlogInfo.FinishedTS` to fix case-2

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note