### PR TITLE
fix unstable test in sink hang

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -716,6 +716,9 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 
 func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent, replicaID uint64, bucket int) error {
 	failpoint.Inject("MySQLSinkExecDMLError", func() {
+		// Add a delay to ensure the sink worker with `MySQLSinkHangLongTime`
+		// failpoint injected is executed first.
+		time.Sleep(time.Second * 2)
 		failpoint.Return(errors.Trace(dmysql.ErrInvalidConn))
 	})
 	dmls, err := s.prepareDMLs(rows, replicaID, bucket)

--- a/tests/sink_hang/run.sh
+++ b/tests/sink_hang/run.sh
@@ -10,7 +10,7 @@ SINK_TYPE=$1
 
 CDC_COUNT=3
 DB_COUNT=4
-MAX_RETRIES=10
+MAX_RETRIES=20
 
 function check_changefeed_state() {
     pd_addr=$1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix case-3 in https://github.com/pingcap/ticdc/issues/838

The transactions are sent to two sink workers, we must ensure the sink worker with `MySQLSinkHangLongTime` injected is executed before the sink worker with `MySQLSinkExecDMLError` injected returns.

### What is changed and how it works?

Add a delay in sink worker before injected `MySQLSinkExecDMLError` returns.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note