### PR TITLE
minor optimization for table number scheduler

### DIFF
--- a/pkg/scheduler/table_number.go
+++ b/pkg/scheduler/table_number.go
@@ -49,12 +49,12 @@ func (t *TableNumberScheduler) CalRebalanceOperates(targetSkewness float64) (
 	for _, captureWorkloads := range t.workloads {
 		totalTableNumber += uint64(len(captureWorkloads))
 	}
-	limitTableNumber := (totalTableNumber / uint64(len(t.workloads))) + 1
+	limitTableNumber := (float64(totalTableNumber) / float64(len(t.workloads))) + 1
 	appendTables := make(map[model.TableID]model.Ts)
 	moveTableJobs = make(map[model.TableID]*model.MoveTableJob)
 
 	for captureID, captureWorkloads := range t.workloads {
-		for uint64(len(captureWorkloads)) > limitTableNumber {
+		for float64(len(captureWorkloads)) >= limitTableNumber {
 			for tableID := range captureWorkloads {
 				// find a table in this capture
 				appendTables[tableID] = 0


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When the table count is exactly an integral multiple of capture numbers, the table number based scheduler doesn't make an absolutely even scheduling
such as 4 tables, 2 captures, the scheduling result should be 2, 2

### What is changed and how it works?

Use float64 to calculate table tableNumberLimiter

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note