### PR TITLE
support force remove a changefeed, check removed/finished changefeed when creating

### DIFF
--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -233,15 +233,17 @@ func (c CDCEtcdClient) CreateChangefeedInfo(ctx context.Context, info *model.Cha
 	if err := model.ValidateChangefeedID(changeFeedID); err != nil {
 		return err
 	}
-	key := GetEtcdKeyChangeFeedInfo(changeFeedID)
+	infoKey := GetEtcdKeyChangeFeedInfo(changeFeedID)
+	jobKey := GetEtcdKeyJob(changeFeedID)
 	value, err := info.Marshal()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	resp, err := c.Client.Txn(ctx).If(
-		clientv3.Compare(clientv3.ModRevision(key), "=", 0),
+		clientv3.Compare(clientv3.ModRevision(infoKey), "=", 0),
+		clientv3.Compare(clientv3.ModRevision(jobKey), "=", 0),
 	).Then(
-		clientv3.OpPut(key, value),
+		clientv3.OpPut(infoKey, value),
 	).Commit()
 	if err != nil {
 		return errors.Trace(err)
@@ -249,7 +251,7 @@ func (c CDCEtcdClient) CreateChangefeedInfo(ctx context.Context, info *model.Cha
 	if !resp.Succeeded {
 		log.Warn("changefeed already exists, ignore create changefeed",
 			zap.String("changefeedid", changeFeedID))
-		return errors.Annotatef(model.ErrChangeFeedAlreadyExists, "key: %s", key)
+		return errors.Trace(model.ErrChangeFeedAlreadyExists)
 	}
 	return errors.Trace(err)
 }
@@ -657,6 +659,16 @@ func (c CDCEtcdClient) PutTaskPosition(
 // DeleteTaskPosition remove task position from etcd
 func (c CDCEtcdClient) DeleteTaskPosition(ctx context.Context, changefeedID string, captureID string) error {
 	key := GetEtcdKeyTaskPosition(changefeedID, captureID)
+	_, err := c.Client.Delete(ctx, key)
+	return errors.Trace(err)
+}
+
+// RemoveChangeFeedStatus removes changefeed job status from etcd
+func (c CDCEtcdClient) RemoveChangeFeedStatus(
+	ctx context.Context,
+	changefeedID string,
+) error {
+	key := GetEtcdKeyJob(changefeedID)
 	_, err := c.Client.Delete(ctx, key)
 	return errors.Trace(err)
 }

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -254,6 +254,23 @@ func (s *etcdSuite) TestPutAllChangeFeedStatus(c *check.C) {
 	}
 }
 
+func (s *etcdSuite) TestRemoveChangeFeedStatus(c *check.C) {
+	ctx := context.Background()
+	changefeedID := "test-remove-changefeed-status"
+	status := &model.ChangeFeedStatus{
+		ResolvedTs: 1,
+	}
+	err := s.client.PutChangeFeedStatus(ctx, changefeedID, status)
+	c.Assert(err, check.IsNil)
+	status, _, err = s.client.GetChangeFeedStatus(ctx, changefeedID)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.DeepEquals, status)
+	err = s.client.RemoveChangeFeedStatus(ctx, changefeedID)
+	c.Assert(err, check.IsNil)
+	_, _, err = s.client.GetChangeFeedStatus(ctx, changefeedID)
+	c.Assert(errors.Cause(err), check.Equals, model.ErrChangeFeedNotExists)
+}
+
 func (s *etcdSuite) TestSetChangeFeedStatusTTL(c *check.C) {
 	ctx := context.Background()
 	err := s.client.PutChangeFeedStatus(ctx, "test1", &model.ChangeFeedStatus{

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -24,10 +24,16 @@ import (
 // AdminJobType represents for admin job type, both used in owner and processor
 type AdminJobType int
 
+// AdminJobOption records addition options of an admin job
+type AdminJobOption struct {
+	ForceRemove bool
+}
+
 // AdminJob holds an admin job
 type AdminJob struct {
 	CfID  string
 	Type  AdminJobType
+	Opts  *AdminJobOption
 	Error *RunningError
 }
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -72,6 +72,8 @@ var (
 	captureID    string
 	interval     uint
 
+	optForceRemove bool
+
 	defaultContext context.Context
 )
 

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -90,6 +90,9 @@ func newAdminChangefeedCommand() []*cobra.Command {
 				job := model.AdminJob{
 					CfID: changefeedID,
 					Type: model.AdminRemove,
+					Opts: &model.AdminJobOption{
+						ForceRemove: optForceRemove,
+					},
 				}
 				return applyAdminChangefeed(ctx, job, getCredential())
 			},
@@ -99,6 +102,9 @@ func newAdminChangefeedCommand() []*cobra.Command {
 	for _, cmd := range cmds {
 		cmd.PersistentFlags().StringVarP(&changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
 		_ = cmd.MarkPersistentFlagRequired("changefeed-id")
+		if cmd.Use == "remove" {
+			cmd.PersistentFlags().BoolVarP(&optForceRemove, "force", "f", false, "remove all information of the changefeed")
+		}
 	}
 	return cmds
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -147,9 +147,14 @@ func applyAdminChangefeed(ctx context.Context, job model.AdminJob, credential *s
 	if err != nil {
 		return err
 	}
+	forceRemoveOpt := "false"
+	if job.Opts != nil && job.Opts.ForceRemove {
+		forceRemoveOpt = "true"
+	}
 	resp, err := cli.PostForm(addr, url.Values(map[string][]string{
-		cdc.APIOpVarAdminJob:     {fmt.Sprint(int(job.Type))},
-		cdc.APIOpVarChangefeedID: {job.CfID},
+		cdc.APIOpVarAdminJob:           {fmt.Sprint(int(job.Type))},
+		cdc.APIOpVarChangefeedID:       {job.CfID},
+		cdc.APIOpForceRemoveChangefeed: {forceRemoveOpt},
 	}))
 	if err != nil {
 		return err

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -126,6 +126,19 @@ EOF
     fi
     check_changefeed_state $uuid "removed"
 
+    # Make sure changefeed can not be created if a removed changefeed with the same name exists
+    create_log=$(run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --changefeed-id="$uuid" 2>&1)
+    exists=$(echo $create_log | grep -oE 'already exists')
+    if [[ -z $exists ]]; then
+        echo "[$(date)] <<<<< unexpect output got ${create_log} >>>>>"
+        exit 1
+    fi
+
+    # force remove the changefeed, and re create a new one with the same name
+    run_cdc_cli changefeed --changefeed-id $uuid remove --force && sleep 3
+    run_cdc_cli changefeed create --sink-uri="$SINK_URI" --tz="Asia/Shanghai" -c="$uuid" && sleep 3
+    check_changefeed_state $uuid "normal"
+
     # Make sure bad sink url fails at creating changefeed.
     badsink=$(run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="mysql://badsink" 2>&1 | grep -oE 'fail')
     if [[ -z $badsink ]]; then


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/858

### What is changed and how it works?

- add a force option in cdc cli changefeed remove, if `--force` is provided, remove the remaining task position after the changefeed is fully stopped, or if the changefeed is already removed or finished, clear the remaining task position.
- refuse to create a changefeed, if changefeedInfo or job status is remaining in PD

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
- Integration test

Related changes

- Need to update the documentation

### Release note

- No release note
