### PR TITLE
fix service gc safepoint key name

### DIFF
--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -12,7 +12,7 @@ MAX_RETRIES=5
 function get_safepoint() {
     pd_addr=$1
     pd_cluster_id=$2
-    safe_point=$(etcdctl get --endpoints=$pd_addr /pd/$pd_cluster_id/gc/safe_point/service/ticdc|grep -oE "SafePoint\":[0-9]+"|grep -oE "[0-9]+")
+    safe_point=$(etcdctl get --endpoints=$pd_addr /pd/$pd_cluster_id/gc/safe_point/service/ticdc|grep -oE "safe_point\":[0-9]+"|grep -oE "[0-9]+")
     echo $safe_point
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix gc safepoint name, still use query etcd way for gc safepoint, because I found `pd-ctl` doesn't work well in CI. (doesn't known why, the request will be blocked)

### What is changed and how it works?

use correct gc safepoint key name

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
