### PR TITLE
owner: increase gc safepoint update frequency to 2s

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -82,7 +82,8 @@ type Owner struct {
 
 const (
 	// CDCServiceSafePointID is the ID of CDC service in pd.UpdateServiceGCSafePoint.
-	CDCServiceSafePointID     = "ticdc"
+	CDCServiceSafePointID = "ticdc"
+	// GCSafepointUpdateInterval is the minimual interval that CDC can update gc safepoint
 	GCSafepointUpdateInterval = time.Duration(2 * time.Second)
 )
 

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -76,12 +76,15 @@ type Owner struct {
 
 	// gcTTL is the ttl of cdc gc safepoint ttl.
 	gcTTL int64
-	// whether gc safepoint is set in pd
-	gcSafePointSet bool
+	// last update gc safepoint time. zero time means has not updated or cleared
+	gcSafepointLastUpdate time.Time
 }
 
-// CDCServiceSafePointID is the ID of CDC service in pd.UpdateServiceGCSafePoint.
-const CDCServiceSafePointID = "ticdc"
+const (
+	// CDCServiceSafePointID is the ID of CDC service in pd.UpdateServiceGCSafePoint.
+	CDCServiceSafePointID     = "ticdc"
+	GCSafepointUpdateInterval = time.Duration(2 * time.Second)
+)
 
 // NewOwner creates a new Owner instance
 func NewOwner(pdClient pd.Client, credential *security.Credential, sess *concurrency.Session, gcTTL int64) (*Owner, error) {
@@ -545,12 +548,12 @@ func (o *Owner) balanceTables(ctx context.Context) error {
 func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 	// no running or stopped changefeed, clear gc safepoint.
 	if len(o.changeFeeds) == 0 && len(o.stoppedFeeds) == 0 {
-		if o.gcSafePointSet {
+		if !o.gcSafepointLastUpdate.IsZero() {
 			_, err := o.pdClient.UpdateServiceGCSafePoint(ctx, CDCServiceSafePointID, 0, 0)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			o.gcSafePointSet = false
+			o.gcSafepointLastUpdate = *new(time.Time)
 		}
 		return nil
 	}
@@ -574,12 +577,14 @@ func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 			minCheckpointTs = status.CheckpointTs
 		}
 	}
-	_, err := o.pdClient.UpdateServiceGCSafePoint(ctx, CDCServiceSafePointID, o.gcTTL, minCheckpointTs)
-	if err != nil {
-		log.Info("failed to update service safe point", zap.Error(err))
-		return errors.Trace(err)
+	if time.Since(o.gcSafepointLastUpdate) > GCSafepointUpdateInterval {
+		_, err := o.pdClient.UpdateServiceGCSafePoint(ctx, CDCServiceSafePointID, o.gcTTL, minCheckpointTs)
+		if err != nil {
+			log.Info("failed to update service safe point", zap.Error(err))
+			return errors.Trace(err)
+		}
+		o.gcSafepointLastUpdate = time.Now()
 	}
-	o.gcSafePointSet = true
 	return nil
 }
 

--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -7,19 +7,19 @@ source $CUR/../_utils/test_prepare
 WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
-MAX_RETRIES=5
+MAX_RETRIES=10
 
 function get_safepoint() {
     pd_addr=$1
     pd_cluster_id=$2
-    safe_point=$(etcdctl get --endpoints=$pd_addr /pd/$pd_cluster_id/gc/safe_point/service/ticdc|grep -oE "safe_point\":[0-9]+"|grep -oE "[0-9]+")
+    safe_point=$(ETCDCTL_API=3 etcdctl --endpoints=$pd_addr get /pd/$pd_cluster_id/gc/safe_point/service/ticdc|grep -oE "safe_point\":[0-9]+"|grep -oE "[0-9]+")
     echo $safe_point
 }
 
 function check_safepoint_cleared() {
     pd_addr=$1
     pd_cluster_id=$2
-    query=$(etcdctl get --endpoints=$pd_addr /pd/$pd_cluster_id/gc/safe_point/service/ticdc)
+    query=$(ETCDCTL_API=3 etcdctl --endpoints=$pd_addr get /pd/$pd_cluster_id/gc/safe_point/service/ticdc)
     if [ ! -z "$query" ]; then
         echo "gc safepoint is not cleared: $query"
     fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiCDC updates service gc safepoint too frequent now, nearly every 10ms

```
[2020/08/23 22:12:43.902 +08:00] [INFO] [grpc_service.go:796] ["update service GC safe point"] [service-id=ticdc] [expire-at=1598278363] [safepoint=418956433904893954]
[2020/08/23 22:12:43.917 +08:00] [INFO] [grpc_service.go:796] ["update service GC safe point"] [service-id=ticdc] [expire-at=1598278363] [safepoint=418956433904893954]
[2020/08/23 22:12:43.927 +08:00] [INFO] [grpc_service.go:796] ["update service GC safe point"] [service-id=ticdc] [expire-at=1598278363] [safepoint=418956433904893954]
[2020/08/23 22:12:43.934 +08:00] [INFO] [grpc_service.go:796] ["update service GC safe point"] [service-id=ticdc] [expire-at=1598278363] [safepoint=418956433904893954]
```

### What is changed and how it works?

increase gc safepoint update internal to 2s, it is safe to update gc safepoint less frequent

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
### Release note

- No release note