### PR TITLE
tests: disable clustered index in integration test

### DIFF
--- a/tests/_utils/start_tidb_cluster_impl
+++ b/tests/_utils/start_tidb_cluster_impl
@@ -191,6 +191,8 @@ while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set
     fi
     sleep 2
 done
+# TODO: remove this after TiCDC supports TiDB clustered index
+mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -e 'set @@global.tidb_enable_clustered_index=0'
 
 i=0
 while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_OTHER_PORT} --default-character-set utf8mb4 -e 'select * from mysql.tidb;'; do
@@ -201,6 +203,8 @@ while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_OTHER_PORT} --default-charact
     fi
     sleep 2
 done
+# TODO: remove this after TiCDC supports TiDB clustered index
+mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_OTHER_PORT} --default-character-set utf8mb4 -e 'set @@global.tidb_enable_clustered_index=0'
 
 echo "Verifying Downstream TiDB is started..."
 i=0


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiDB implements `clustered index` in 5.0, ref: https://github.com/pingcap/tidb/pull/17044, TiCDC is not compatible with clustered index now

Note: this change will be reverted after TiCDC supports clustered index

### What is changed and how it works?

Set `@@global.tidb_enable_clustered_index=0` when starting TiDB in integration test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
