### PR TITLE
api: return immediately when meeting non leader error

### DIFF
--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -102,6 +102,7 @@ func (s *Server) handleChangefeedAdmin(w http.ResponseWriter, req *http.Request)
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
 		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		return
 	}
 
 	err := req.ParseForm()
@@ -144,6 +145,7 @@ func (s *Server) handleRebalanceTrigger(w http.ResponseWriter, req *http.Request
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
 		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		return
 	}
 
 	err := req.ParseForm()
@@ -170,6 +172,7 @@ func (s *Server) handleMoveTable(w http.ResponseWriter, req *http.Request) {
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
 		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		return
 	}
 
 	err := req.ParseForm()
@@ -206,6 +209,7 @@ func (s *Server) handleChangefeedQuery(w http.ResponseWriter, req *http.Request)
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
 		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		return
 	}
 
 	err := req.ParseForm()

--- a/cdc/http_handler.go
+++ b/cdc/http_handler.go
@@ -69,7 +69,7 @@ func (s *Server) handleResignOwner(w http.ResponseWriter, req *http.Request) {
 	}
 	s.ownerLock.RLock()
 	if s.owner == nil {
-		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		handleOwnerResp(w, concurrency.ErrElectionNotLeader)
 		s.ownerLock.RUnlock()
 		return
 	}
@@ -101,7 +101,7 @@ func (s *Server) handleChangefeedAdmin(w http.ResponseWriter, req *http.Request)
 	s.ownerLock.RLock()
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
-		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		handleOwnerResp(w, concurrency.ErrElectionNotLeader)
 		return
 	}
 
@@ -144,7 +144,7 @@ func (s *Server) handleRebalanceTrigger(w http.ResponseWriter, req *http.Request
 	s.ownerLock.RLock()
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
-		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		handleOwnerResp(w, concurrency.ErrElectionNotLeader)
 		return
 	}
 
@@ -171,7 +171,7 @@ func (s *Server) handleMoveTable(w http.ResponseWriter, req *http.Request) {
 	s.ownerLock.RLock()
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
-		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		handleOwnerResp(w, concurrency.ErrElectionNotLeader)
 		return
 	}
 
@@ -208,7 +208,7 @@ func (s *Server) handleChangefeedQuery(w http.ResponseWriter, req *http.Request)
 	s.ownerLock.RLock()
 	defer s.ownerLock.RUnlock()
 	if s.owner == nil {
-		handleOwnerResp(w, concurrency.ErrElectionNoLeader)
+		handleOwnerResp(w, concurrency.ErrElectionNotLeader)
 		return
 	}
 

--- a/cdc/http_status_test.go
+++ b/cdc/http_status_test.go
@@ -123,5 +123,6 @@ func testRequestNonOwnerFailed(c *check.C, uri string) {
 	data, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, check.IsNil)
 	defer resp.Body.Close()
-	c.Assert(string(data), check.Equals, concurrency.ErrElectionNoLeader.Error())
+	c.Assert(resp.StatusCode, check.Equals, http.StatusBadRequest)
+	c.Assert(string(data), check.Equals, concurrency.ErrElectionNotLeader.Error())
 }

--- a/cdc/http_status_test.go
+++ b/cdc/http_status_test.go
@@ -17,9 +17,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/pingcap/check"
+	"go.etcd.io/etcd/clientv3/concurrency"
 )
 
 type httpStatusSuite struct{}
@@ -63,6 +65,10 @@ func (s *httpStatusSuite) TestHTTPStatus(c *check.C) {
 
 	testPprof(c)
 	testReisgnOwner(c)
+	testHandleChangefeedAdmin(c)
+	testHandleRebalance(c)
+	testHandleMoveTable(c)
+	testHandleChangefeedQuery(c)
 }
 
 func testPprof(c *check.C) {
@@ -76,8 +82,46 @@ func testPprof(c *check.C) {
 
 func testReisgnOwner(c *check.C) {
 	uri := fmt.Sprintf("http://%s/capture/owner/resign", testingServerOptions.advertiseAddr)
+	testHTTPPostOnly(c, uri)
+	testRequestNonOwnerFailed(c, uri)
+}
+
+func testHandleChangefeedAdmin(c *check.C) {
+	uri := fmt.Sprintf("http://%s/capture/owner/admin", testingServerOptions.advertiseAddr)
+	testHTTPPostOnly(c, uri)
+	testRequestNonOwnerFailed(c, uri)
+}
+
+func testHandleRebalance(c *check.C) {
+	uri := fmt.Sprintf("http://%s/capture/owner/rebalance_trigger", testingServerOptions.advertiseAddr)
+	testHTTPPostOnly(c, uri)
+	testRequestNonOwnerFailed(c, uri)
+}
+
+func testHandleMoveTable(c *check.C) {
+	uri := fmt.Sprintf("http://%s/capture/owner/move_table", testingServerOptions.advertiseAddr)
+	testHTTPPostOnly(c, uri)
+	testRequestNonOwnerFailed(c, uri)
+}
+
+func testHandleChangefeedQuery(c *check.C) {
+	uri := fmt.Sprintf("http://%s/capture/owner/changefeed/query", testingServerOptions.advertiseAddr)
+	testHTTPPostOnly(c, uri)
+	testRequestNonOwnerFailed(c, uri)
+}
+
+func testHTTPPostOnly(c *check.C, uri string) {
 	resp, err := http.Get(uri)
 	c.Assert(err, check.IsNil)
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, check.Equals, http.StatusBadRequest)
+}
+
+func testRequestNonOwnerFailed(c *check.C, uri string) {
+	resp, err := http.PostForm(uri, url.Values{})
+	c.Assert(err, check.IsNil)
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, check.IsNil)
+	defer resp.Body.Close()
+	c.Assert(string(data), check.Equals, concurrency.ErrElectionNoLeader.Error())
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Some http API can be served by CDC owner only, fix https://github.com/pingcap/ticdc/issues/891

### What is changed and how it works?

Return immediately when meeting non leader error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note