### PR TITLE
fix: sync vendor directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apk add --no-cache git make bash
 WORKDIR /go/src/github.com/pingcap/ticdc
 COPY . .
 ENV CDC_ENABLE_VENDOR=1
+RUN go mod vendor
 RUN make
 
 FROM alpine:3.12


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
- Failure to build docker image when a local `vendor` directory does not exist or is not up-to-date.

### What is changed and how it works?
- Added `RUN go mod vendor` to Dockerfile.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)

### Release note
- No release note

