### PR TITLE
tests: disable clustered index in all tidb in integration test

### DIFF
--- a/tests/_utils/start_tidb_cluster_impl
+++ b/tests/_utils/start_tidb_cluster_impl
@@ -191,8 +191,6 @@ while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set
     fi
     sleep 2
 done
-# TODO: remove this after TiCDC supports TiDB clustered index
-mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -e 'set @@global.tidb_enable_clustered_index=0'
 
 i=0
 while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_OTHER_PORT} --default-character-set utf8mb4 -e 'select * from mysql.tidb;'; do
@@ -203,8 +201,6 @@ while ! mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_OTHER_PORT} --default-charact
     fi
     sleep 2
 done
-# TODO: remove this after TiCDC supports TiDB clustered index
-mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_OTHER_PORT} --default-character-set utf8mb4 -e 'set @@global.tidb_enable_clustered_index=0'
 
 echo "Verifying Downstream TiDB is started..."
 i=0
@@ -219,6 +215,11 @@ done
 
 run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+
+# TODO: remove this after TiCDC supports TiDB clustered index
+run_sql "set @@global.tidb_enable_clustered_index=0" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+run_sql "set @@global.tidb_enable_clustered_index=0" ${UP_TIDB_HOST} ${UP_TIDB_OTHER_PORT}
+run_sql "set @@global.tidb_enable_clustered_index=0" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
 cat - >"$OUT_DIR/tiflash-config.toml" <<EOF
 tmp_path = "${OUT_DIR}/tiflash/tmp"

--- a/tests/_utils/start_tidb_cluster_impl
+++ b/tests/_utils/start_tidb_cluster_impl
@@ -213,13 +213,15 @@ while ! mysql -uroot -h${DOWN_TIDB_HOST} -P${DOWN_TIDB_PORT} --default-character
     sleep 2
 done
 
-run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-
 # TODO: remove this after TiCDC supports TiDB clustered index
 run_sql "set @@global.tidb_enable_clustered_index=0" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 run_sql "set @@global.tidb_enable_clustered_index=0" ${UP_TIDB_HOST} ${UP_TIDB_OTHER_PORT}
 run_sql "set @@global.tidb_enable_clustered_index=0" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+# TiDB global variables cache 2 seconds
+sleep 2
+
+run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
 cat - >"$OUT_DIR/tiflash-config.toml" <<EOF
 tmp_path = "${OUT_DIR}/tiflash/tmp"

--- a/tests/_utils/start_tls_tidb_cluster_impl
+++ b/tests/_utils/start_tls_tidb_cluster_impl
@@ -132,13 +132,15 @@ while ! mysql -uroot -h${TLS_TIDB_HOST} -P${TLS_TIDB_PORT} --default-character-s
     sleep 2
 done
 
-run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${TLS_TIDB_HOST} ${TLS_TIDB_PORT} \
+# TODO: remove this after TiCDC supports TiDB clustered index
+run_sql "set @@global.tidb_enable_clustered_index=0" ${TLS_TIDB_HOST} ${TLS_TIDB_PORT} \
     --ssl-ca=$TLS_DIR/ca.pem \
     --ssl-cert=$TLS_DIR/server.pem \
     --ssl-key=$TLS_DIR/server-key.pem
+# TiDB global variables cache 2 seconds
+sleep 2
 
-# TODO: remove this after TiCDC supports TiDB clustered index
-run_sql "set @@global.tidb_enable_clustered_index=0" ${TLS_TIDB_HOST} ${TLS_TIDB_PORT} \
+run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${TLS_TIDB_HOST} ${TLS_TIDB_PORT} \
     --ssl-ca=$TLS_DIR/ca.pem \
     --ssl-cert=$TLS_DIR/server.pem \
     --ssl-key=$TLS_DIR/server-key.pem

--- a/tests/_utils/start_tls_tidb_cluster_impl
+++ b/tests/_utils/start_tls_tidb_cluster_impl
@@ -136,3 +136,9 @@ run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc
     --ssl-ca=$TLS_DIR/ca.pem \
     --ssl-cert=$TLS_DIR/server.pem \
     --ssl-key=$TLS_DIR/server-key.pem
+
+# TODO: remove this after TiCDC supports TiDB clustered index
+run_sql "set @@global.tidb_enable_clustered_index=0" ${TLS_TIDB_HOST} ${TLS_TIDB_PORT} \
+    --ssl-ca=$TLS_DIR/ca.pem \
+    --ssl-cert=$TLS_DIR/server.pem \
+    --ssl-key=$TLS_DIR/server-key.pem


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#901 only disables clustered index in upstream tidb

### What is changed and how it works?

Disable clustered index in all TiDBs in integration test


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
