### PR TITLE
kv-client: fix entry variable wrong usage

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1219,7 +1219,7 @@ func (s *eventFeedSession) singleEventFeed(
 							continue
 						}
 
-						revent, err := assembleCommitEvent(regionID, entry, value)
+						revent, err := assembleCommitEvent(regionID, cacheEntry, value)
 						if err != nil {
 							return checkpointTs, errors.Trace(err)
 						}
@@ -1240,7 +1240,7 @@ func (s *eventFeedSession) singleEventFeed(
 					case cdcpb.Event_Row_PUT:
 						opType = model.OpTypePut
 					default:
-						return checkpointTs, errors.Errorf("unknown tp: %v", entry.GetOpType())
+						return checkpointTs, errors.Errorf("unknown tp: %v, entry: %v", entry.GetOpType(), entry)
 					}
 
 					revent := &model.RegionFeedEvent{
@@ -1435,7 +1435,7 @@ func assembleCommitEvent(regionID uint64, entry *cdcpb.Event_Row, value *pending
 	case cdcpb.Event_Row_PUT:
 		opType = model.OpTypePut
 	default:
-		return nil, errors.Errorf("unknow tp: %v", entry.GetOpType())
+		return nil, errors.Errorf("unknown tp: %v, entry: %v", entry.GetOpType(), entry)
 	}
 
 	revent := &model.RegionFeedEvent{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix event entry wrong usage during code refactor

### What is changed and how it works?

Use correct cacheEntry

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
