### PR TITLE
*/: add pd write frequency control from cdc server parameter

### DIFF
--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -54,7 +54,7 @@ func (s *etcdSuite) SetUpTest(c *check.C) {
 		DialTimeout: 3 * time.Second,
 	})
 	c.Assert(err, check.IsNil)
-	s.client = NewCDCEtcdClient(client)
+	s.client = NewCDCEtcdClient(context.TODO(), client)
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.errg = util.HandleErrWithErrGroup(s.ctx, s.e.Err(), func(e error) { c.Log(e) })
 }

--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -67,6 +67,13 @@ var (
 			Name:      "channel_size",
 			Help:      "size of each channel in kv client",
 		}, []string{"id", "channel"})
+	etcdRequestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "etcd",
+			Name:      "request_count",
+			Help:      "request counter of etcd operation",
+		}, []string{"type", "capture"})
 )
 
 // InitMetrics registers all metrics in the kv package
@@ -78,4 +85,5 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(pullEventCounter)
 	registry.MustRegister(sendEventCounter)
 	registry.MustRegister(clientChannelSize)
+	registry.MustRegister(etcdRequestCounter)
 }

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -80,6 +80,9 @@ type Owner struct {
 	gcTTL int64
 	// last update gc safepoint time. zero time means has not updated or cleared
 	gcSafepointLastUpdate time.Time
+	// record last time that flushes all changefeeds' replication status
+	lastFlushChangefeeds    time.Time
+	flushChangefeedInterval time.Duration
 }
 
 const (
@@ -90,25 +93,33 @@ const (
 )
 
 // NewOwner creates a new Owner instance
-func NewOwner(pdClient pd.Client, credential *security.Credential, sess *concurrency.Session, gcTTL int64) (*Owner, error) {
-	cli := kv.NewCDCEtcdClient(sess.Client())
+func NewOwner(
+	ctx context.Context,
+	pdClient pd.Client,
+	credential *security.Credential,
+	sess *concurrency.Session,
+	gcTTL int64,
+	flushChangefeedInterval time.Duration,
+) (*Owner, error) {
+	cli := kv.NewCDCEtcdClient(ctx, sess.Client())
 	endpoints := sess.Client().Endpoints()
 
 	owner := &Owner{
-		done:                  make(chan struct{}),
-		session:               sess,
-		pdClient:              pdClient,
-		credential:            credential,
-		changeFeeds:           make(map[model.ChangeFeedID]*changeFeed),
-		failInitFeeds:         make(map[model.ChangeFeedID]struct{}),
-		stoppedFeeds:          make(map[model.ChangeFeedID]*model.ChangeFeedStatus),
-		captures:              make(map[model.CaptureID]*model.CaptureInfo),
-		rebalanceTigger:       make(map[model.ChangeFeedID]bool),
-		manualScheduleCommand: make(map[model.ChangeFeedID][]*model.MoveTableJob),
-		pdEndpoints:           endpoints,
-		cfRWriter:             cli,
-		etcdClient:            cli,
-		gcTTL:                 gcTTL,
+		done:                    make(chan struct{}),
+		session:                 sess,
+		pdClient:                pdClient,
+		credential:              credential,
+		changeFeeds:             make(map[model.ChangeFeedID]*changeFeed),
+		failInitFeeds:           make(map[model.ChangeFeedID]struct{}),
+		stoppedFeeds:            make(map[model.ChangeFeedID]*model.ChangeFeedStatus),
+		captures:                make(map[model.CaptureID]*model.CaptureInfo),
+		rebalanceTigger:         make(map[model.ChangeFeedID]bool),
+		manualScheduleCommand:   make(map[model.ChangeFeedID][]*model.MoveTableJob),
+		pdEndpoints:             endpoints,
+		cfRWriter:               cli,
+		etcdClient:              cli,
+		gcTTL:                   gcTTL,
+		flushChangefeedInterval: flushChangefeedInterval,
 	}
 
 	return owner, nil
@@ -569,9 +580,12 @@ func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 				minCheckpointTs = changefeed.status.CheckpointTs
 			}
 		}
-		err := o.cfRWriter.PutAllChangeFeedStatus(ctx, snapshot)
-		if err != nil {
-			return errors.Trace(err)
+		if time.Since(o.lastFlushChangefeeds) > o.flushChangefeedInterval {
+			err := o.cfRWriter.PutAllChangeFeedStatus(ctx, snapshot)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			o.lastFlushChangefeeds = time.Now()
 		}
 	}
 	for _, status := range o.stoppedFeeds {

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -411,9 +411,6 @@ func (p *processor) positionWorker(ctx context.Context) error {
 			// deployed NTP service, a little bias is acceptable here.
 			metricCheckpointTsLagGauge.Set(float64(oracle.GetPhysical(time.Now())-phyTs) / 1e3)
 
-			if p.position.CheckPointTs >= checkpointTs {
-				continue
-			}
 			if time.Since(lastFlushTime) < p.flushCheckpointInterval {
 				continue
 			}

--- a/cdc/task_test.go
+++ b/cdc/task_test.go
@@ -49,7 +49,7 @@ func (s *taskSuite) SetUpTest(c *check.C) {
 
 	// Create a task watcher
 	capture := &Capture{
-		etcdClient: kv.NewCDCEtcdClient(client),
+		etcdClient: kv.NewCDCEtcdClient(context.TODO(), client),
 		processors: make(map[string]*processor),
 		info:       &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
 	}
@@ -75,7 +75,7 @@ func (s *taskSuite) TestNewTaskWatcher(c *check.C) {
 	// initialize the PD service witch does not support to
 	// be embeded.
 	capture := &Capture{
-		etcdClient: kv.NewCDCEtcdClient(s.c),
+		etcdClient: kv.NewCDCEtcdClient(context.TODO(), s.c),
 		processors: make(map[string]*processor),
 		info:       &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
 	}
@@ -87,7 +87,7 @@ func (s *taskSuite) TestNewTaskWatcher(c *check.C) {
 }
 
 func (s *taskSuite) setupFeedInfo(c *check.C, changeFeedID string) {
-	client := kv.NewCDCEtcdClient(s.c)
+	client := kv.NewCDCEtcdClient(context.TODO(), s.c)
 	// Create the change feed
 	c.Assert(client.SaveChangeFeedInfo(s.c.Ctx(), &model.ChangeFeedInfo{
 		SinkURI:    "mysql://fake",
@@ -152,7 +152,7 @@ func (s *taskSuite) TestWatch(c *check.C) {
 	s.setupFeedInfo(c, "changefeed-1")
 	defer s.teardownFeedInfo(c, "changefeed-1")
 
-	client := kv.NewCDCEtcdClient(s.c)
+	client := kv.NewCDCEtcdClient(context.TODO(), s.c)
 	// Watch with a canceled context
 	failedCtx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -165,7 +165,7 @@ func newCliCommand() *cobra.Command {
 				// PD embeds an etcd server.
 				return errors.Annotate(err, "fail to open PD etcd client")
 			}
-			cdcEtcdCli = kv.NewCDCEtcdClient(etcdCli)
+			cdcEtcdCli = kv.NewCDCEtcdClient(defaultContext, etcdCli)
 			pdCli, err = pd.NewClientWithContext(
 				defaultContext, pdEndpoints, credential.PDSecurityOption(),
 				pd.WithGRPCDialOptions(

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,7 +56,7 @@ func init() {
 	serverCmd.Flags().StringVar(&logFile, "log-file", "", "log file path")
 	serverCmd.Flags().StringVar(&logLevel, "log-level", "info", "log level (etc: debug|info|warn|error)")
 	serverCmd.Flags().DurationVar(&ownerFlushInterval, "owner-flush-interval", time.Millisecond*200, "owner flushes changefeed status interval")
-	serverCmd.Flags().DurationVar(&processorFlushInterval, "processor-flush-interval", time.Millisecond*200, "processor flushes task status interval")
+	serverCmd.Flags().DurationVar(&processorFlushInterval, "processor-flush-interval", time.Millisecond*100, "processor flushes task status interval")
 	addSecurityFlags(serverCmd.Flags(), true /* isServer */)
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -34,6 +35,9 @@ var (
 	logFile       string
 	logLevel      string
 
+	ownerFlushInterval     time.Duration
+	processorFlushInterval time.Duration
+
 	serverCmd = &cobra.Command{
 		Use:   "server",
 		Short: "Start a TiCDC capture server",
@@ -51,6 +55,8 @@ func init() {
 	serverCmd.Flags().Int64Var(&gcTTL, "gc-ttl", cdc.DefaultCDCGCSafePointTTL, "CDC GC safepoint TTL duration, specified in seconds")
 	serverCmd.Flags().StringVar(&logFile, "log-file", "", "log file path")
 	serverCmd.Flags().StringVar(&logLevel, "log-level", "info", "log level (etc: debug|info|warn|error)")
+	serverCmd.Flags().DurationVar(&ownerFlushInterval, "owner-flush-interval", time.Millisecond*200, "owner flushes changefeed status interval")
+	serverCmd.Flags().DurationVar(&processorFlushInterval, "processor-flush-interval", time.Millisecond*200, "processor flushes task status interval")
 	addSecurityFlags(serverCmd.Flags(), true /* isServer */)
 }
 
@@ -72,7 +78,10 @@ func runEServer(cmd *cobra.Command, args []string) error {
 		cdc.AdvertiseAddress(advertiseAddr),
 		cdc.GCTTL(gcTTL),
 		cdc.Timezone(tz),
-		cdc.Credential(getCredential())}
+		cdc.Credential(getCredential()),
+		cdc.OwnerFlushInterval(ownerFlushInterval),
+		cdc.ProcessorFlushInterval(processorFlushInterval),
+	}
 	server, err := cdc.NewServer(opts...)
 	if err != nil {
 		return errors.Annotate(err, "new server")

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -4956,6 +4956,105 @@
       ],
       "title": "Events",
       "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_TEST-CLUSTER}",
+      "description": "request count of etcd operation",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 121
+      },
+      "hiddenSeries": false,
+      "id": 97,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(ticdc_etcd_request_count{capture=~\"$capture\"}[1m])) by (instance, type)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}-{{type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Etcd Request Count By Instance",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:381",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:382",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "1m",

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -4952,109 +4952,107 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "request count of etcd operation",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 121
+          },
+          "hiddenSeries": false,
+          "id": 97,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(ticdc_etcd_request_count{capture=~\"$capture\"}[1m])) by (instance, type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}-{{type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Etcd Request Count By Instance",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Events",
       "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_TEST-CLUSTER}",
-      "description": "request count of etcd operation",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 121
-      },
-      "hiddenSeries": false,
-      "id": 97,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": true,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(rate(ticdc_etcd_request_count{capture=~\"$capture\"}[1m])) by (instance, type)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{instance}}-{{type}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Etcd Request Count By Instance",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:381",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:382",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
     }
   ],
   "refresh": "1m",

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -20,18 +20,30 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/retry"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 )
 
+// etcd operation names
+const (
+	EtcdPut    = "Put"
+	EtcdGet    = "Get"
+	EtcdTxn    = "Txn"
+	EtcdDel    = "Del"
+	EtcdGrant  = "Grant"
+	EtcdRevoke = "Revoke"
+)
+
 // Client is a simple wrapper that adds retry to etcd RPC
 type Client struct {
-	cli *clientv3.Client
+	cli     *clientv3.Client
+	metrics map[string]prometheus.Counter
 }
 
 // Wrap warps a clientv3.Client that provides etcd APIs required by TiCDC.
-func Wrap(cli *clientv3.Client) *Client {
-	return &Client{cli: cli}
+func Wrap(cli *clientv3.Client, metrics map[string]prometheus.Counter) *Client {
+	return &Client{cli: cli, metrics: metrics}
 }
 
 // Unwrap returns a clientv3.Client
@@ -39,7 +51,7 @@ func (c *Client) Unwrap() *clientv3.Client {
 	return c.cli
 }
 
-func retryRPC(rpcName string, etcdRPC func() error) error {
+func retryRPC(rpcName string, metric prometheus.Counter, etcdRPC func() error) error {
 	// By default, PD etcd sets [3s, 6s) for election timeout.
 	// Some rpc could fail due to etcd errors, like "proposal dropped".
 	// Retry at least two election timeout to handle the case that two PDs restarted
@@ -51,13 +63,16 @@ func retryRPC(rpcName string, etcdRPC func() error) error {
 			if err != nil && errors.Cause(err) != context.Canceled {
 				log.Warn("etcd RPC failed", zap.String("RPC", rpcName), zap.Error(err))
 			}
+			if metric != nil {
+				metric.Inc()
+			}
 			return err
 		})
 }
 
 // Put delegates request to clientv3.KV.Put
 func (c *Client) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (resp *clientv3.PutResponse, err error) {
-	err = retryRPC("Put", func() error {
+	err = retryRPC(EtcdPut, c.metrics[EtcdPut], func() error {
 		var inErr error
 		resp, inErr = c.cli.Put(ctx, key, val, opts...)
 		return inErr
@@ -67,7 +82,7 @@ func (c *Client) Put(ctx context.Context, key, val string, opts ...clientv3.OpOp
 
 // Get delegates request to clientv3.KV.Get
 func (c *Client) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (resp *clientv3.GetResponse, err error) {
-	err = retryRPC("Get", func() error {
+	err = retryRPC(EtcdGet, c.metrics[EtcdGet], func() error {
 		var inErr error
 		resp, inErr = c.cli.Get(ctx, key, opts...)
 		return inErr
@@ -77,18 +92,24 @@ func (c *Client) Get(ctx context.Context, key string, opts ...clientv3.OpOption)
 
 // Delete delegates request to clientv3.KV.Delete
 func (c *Client) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (resp *clientv3.DeleteResponse, err error) {
+	if metric, ok := c.metrics[EtcdTxn]; ok {
+		metric.Inc()
+	}
 	// We don't retry on delete operatoin. It's dangerous.
 	return c.cli.Delete(ctx, key, opts...)
 }
 
 // Txn delegates request to clientv3.KV.Txn
 func (c *Client) Txn(ctx context.Context) clientv3.Txn {
+	if metric, ok := c.metrics[EtcdTxn]; ok {
+		metric.Inc()
+	}
 	return c.cli.Txn(ctx)
 }
 
 // Grant delegates request to clientv3.Lease.Grant
 func (c *Client) Grant(ctx context.Context, ttl int64) (resp *clientv3.LeaseGrantResponse, err error) {
-	err = retryRPC("Grant", func() error {
+	err = retryRPC(EtcdGrant, c.metrics[EtcdGrant], func() error {
 		var inErr error
 		resp, inErr = c.cli.Grant(ctx, ttl)
 		return inErr
@@ -98,7 +119,7 @@ func (c *Client) Grant(ctx context.Context, ttl int64) (resp *clientv3.LeaseGran
 
 // Revoke delegates request to clientv3.Lease.Revoke
 func (c *Client) Revoke(ctx context.Context, id clientv3.LeaseID) (resp *clientv3.LeaseRevokeResponse, err error) {
-	err = retryRPC("Revoke", func() error {
+	err = retryRPC(EtcdRevoke, c.metrics[EtcdRevoke], func() error {
 		var inErr error
 		resp, inErr = c.cli.Revoke(ctx, id)
 		return inErr

--- a/pkg/etcd/client_test.go
+++ b/pkg/etcd/client_test.go
@@ -46,7 +46,7 @@ func (m *mockClient) Put(ctx context.Context, key, val string, opts ...clientv3.
 func (s *clientSuite) TestRetry(c *check.C) {
 	cli := clientv3.NewCtxClient(context.TODO())
 	cli.KV = &mockClient{}
-	retrycli := Wrap(cli)
+	retrycli := Wrap(cli, nil)
 	get, err := retrycli.Get(context.TODO(), "")
 	c.Assert(err, check.IsNil)
 	c.Assert(get, check.NotNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, we use a watch mechanism to update processor/changefeed checkpoint, the update frequency could be 20+/s, which may be too frequent in most scenarios.

### What is changed and how it works?

Add parameters in cdc server to control owner/processor flush checkpoint interval

Before, with 200ms interval and 500ms interval

![微信截图_20200909163819](https://user-images.githubusercontent.com/1527315/92575456-ecdd8200-f2ba-11ea-8e36-b589c4bcd14c.png)

After resolved ts check, processor flush interval=100ms, owner flush interval=200ms. **But this has a bug, if both checkpoint ts and resolved ts are not forwarded and new table is dispatched to this processor, replication will be blocked!**. We should fix this.

![image](https://user-images.githubusercontent.com/1527315/92575501-fd8df800-f2ba-11ea-9a13-03d2991d1353.png)

Current status

![image](https://user-images.githubusercontent.com/1527315/92581318-1bab2680-f2c2-11ea-8b30-4088e473c96d.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to update the documentation

### Release note

- Support to control the write frequency of checkpoint flush from cdc server parameter
