### PR TITLE
fix: use latest instead of nightly versions of docker images for Avro integration

### DIFF
--- a/docker-compose-avro.yml
+++ b/docker-compose-avro.yml
@@ -92,7 +92,7 @@ services:
     restart: on-failure
 
   upstream-pd:
-    image: pingcap/pd:nightly
+    image: pingcap/pd:latest
     ports:
       - "2379:2379"
     volumes:
@@ -113,7 +113,7 @@ services:
     restart: on-failure
 
   upstream-tikv0:
-    image: pingcap/tikv:nightly
+    image: pingcap/tikv:latest
     volumes:
       - ./docker/config/tikv.toml:/tikv.toml:ro
       - /data
@@ -131,7 +131,7 @@ services:
     restart: on-failure
 
   upstream-tikv1:
-    image: pingcap/tikv:nightly
+    image: pingcap/tikv:latest
     volumes:
       - ./docker/config/tikv.toml:/tikv.toml:ro
       - ./docker/data:/data
@@ -149,7 +149,7 @@ services:
     restart: on-failure
 
   upstream-tikv2:
-    image: pingcap/tikv:nightly
+    image: pingcap/tikv:latest
     volumes:
       - ./docker/config/tikv.toml:/tikv.toml:ro
       - /data
@@ -167,7 +167,7 @@ services:
     restart: on-failure
 
   upstream-tidb:
-    image: pingcap/tidb:nightly
+    image: pingcap/tidb:latest
     ports:
       - "4000:4000"
       - "10080:10080"
@@ -188,7 +188,7 @@ services:
     restart: on-failure
 
   downstream-pd:
-    image: pingcap/pd:nightly
+    image: pingcap/pd:latest
     ports:
       - "3379:2379"
     volumes:
@@ -209,7 +209,7 @@ services:
     restart: on-failure
 
   downstream-tikv0:
-    image: pingcap/tikv:nightly
+    image: pingcap/tikv:latest
     volumes:
       - ./docker/config/tikv.toml:/tikv.toml:ro
       - /data
@@ -227,7 +227,7 @@ services:
     restart: on-failure
 
   downstream-tikv1:
-    image: pingcap/tikv:nightly
+    image: pingcap/tikv:latest
     volumes:
       - ./docker/config/tikv.toml:/tikv.toml:ro
       - /data
@@ -245,7 +245,7 @@ services:
     restart: on-failure
 
   downstream-tikv2:
-    image: pingcap/tikv:nightly
+    image: pingcap/tikv:latest
     volumes:
       - ./docker/config/tikv.toml:/tikv.toml:ro
       - /data
@@ -263,7 +263,7 @@ services:
     restart: on-failure
 
   downstream-tidb:
-    image: pingcap/tidb:nightly
+    image: pingcap/tidb:latest
     ports:
       - "5000:4000"
       - "20080:10080"


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
- Avro integration fails because of TiKV nightly features.

### What is changed and how it works?
- Pull the latest instead of the nightly version of docker images.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note

