### PR TITLE
dispatcher: refine table operation log, add status field in table operation

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -743,7 +743,7 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 			minResolvedTs = appliedTs
 		}
 		if appliedTs != math.MaxUint64 {
-			log.Info("some operation is still unapplied",
+			log.Debug("some operation is still unapplied",
 				zap.String("captureID", captureID),
 				zap.Uint64("appliedTs", appliedTs),
 				zap.Stringer("status", status))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The following logs are too many when a table is dispatched to processor

```
[2020/09/14 16:25:52.338 +08:00] [INFO] [changefeed.go:746] ["some operation is still unapplied"] [captureID=158cb6fd-e023-4e90-862f-d5af82324a37] [appliedTs=419449261358317578] [status="{\"tables\":{\"45\":{\"start-ts\":419449209232556033,\"mark-table-id\":0},\"47\":{\"start-ts\":419449260481183754,\"mark-table-id\":0},\"49\":{\"start-ts\":419449261358317578,\"mark-table-id\":0}},\"operation\":{\"49\":{\"delete\":false,\"boundary_ts\":419449261358317578,\"done\":false}},\"admin-job-type\":0}"]
```

```
[2020/09/14 17:40:38.656 +08:00] [INFO] [owner.go:306] ["ignore known table"] [tid=49] [table=test.t3] [ts=419450436785274881]
```

### What is changed and how it works?

- For the `some operation is still unapplied` log, we can extract all logged information from etcd key-values, so we change this log level to `debug` simply.
- For the `ignore known table` log, when a table is dispatched to processor, the `opt.Done` is set to true after the table's resovled ts catchup with global resolved ts, so the operation should have three states (1. dispatched to processor; 2. accepted and processed by processor; 3. table resovled ts reaches global resovled ts), so we add a `Status` field in the `TableOperation`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note