### PR TITLE
fix: Kafka producer error handling

### DIFF
--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -240,6 +240,12 @@ func (k *kafkaSaramaProducer) run(ctx context.Context) error {
 			atomic.StoreUint64(&k.partitionOffset[msg.Partition].flushed, flushedOffset)
 			k.flushedNotifier.Notify()
 		case err := <-k.asyncClient.Errors():
+			// We should not wrap a nil pointer if the pointer is of a subtype of `error`
+			// because Go would store the type info and the resulted `error` variable would not be nil,
+			// which will cause the pkg/error library to malfunction.
+			if err == nil {
+				return nil
+			}
 			return cerror.WrapError(cerror.ErrKafkaAsyncSendMessage, err)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- There is a possibility that Kafka producer might panic when it is being closed.

### What is changed and how it works?
- Handle the closure of error channel properly.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release note

- No release note

