### PR TITLE
metrics: delete metrics when close the puller

### DIFF
--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -139,8 +139,17 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 	metricEventCounterKv := kvEventCounter.WithLabelValues(captureAddr, changefeedID, "kv")
 	metricEventCounterResolved := kvEventCounter.WithLabelValues(captureAddr, changefeedID, "resolved")
 	metricTxnCollectCounterKv := txnCollectCounter.WithLabelValues(captureAddr, changefeedID, tableName, "kv")
-	metricTxnCollectCounterResolved := txnCollectCounter.WithLabelValues(captureAddr, changefeedID, tableName, "kv")
-
+	metricTxnCollectCounterResolved := txnCollectCounter.WithLabelValues(captureAddr, changefeedID, tableName, "resolved")
+	defer func() {
+		outputChanSizeGauge.DeleteLabelValues(captureAddr, changefeedID, tableName)
+		eventChanSizeGauge.DeleteLabelValues(captureAddr, changefeedID, tableName)
+		memBufferSizeGauge.DeleteLabelValues(captureAddr, changefeedID, tableName)
+		pullerResolvedTsGauge.DeleteLabelValues(captureAddr, changefeedID, tableName)
+		kvEventCounter.DeleteLabelValues(captureAddr, changefeedID, "kv")
+		kvEventCounter.DeleteLabelValues(captureAddr, changefeedID, "resolved")
+		txnCollectCounter.DeleteLabelValues(captureAddr, changefeedID, tableName, "kv")
+		txnCollectCounter.DeleteLabelValues(captureAddr, changefeedID, tableName, "resolved")
+	}()
 	g.Go(func() error {
 		for {
 			select {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
delete metrics when close the puller

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
