### PR TITLE
changefeed: simplify debug log, put task position only value changes

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -695,6 +695,7 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 	minResolvedTs := c.targetTs
 	minCheckpointTs := c.targetTs
 
+	// prevMinResolvedTs and prevMinCheckpointTs are used for debug
 	prevMinResolvedTs := c.targetTs
 	prevMinCheckpointTs := c.targetTs
 	checkUpdateTs := func() {
@@ -732,7 +733,8 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 			}
 		}
 	}
-	checkUpdateTs()
+	prevMinCheckpointTs = minCheckpointTs
+	prevMinResolvedTs = minResolvedTs
 
 	for captureID, status := range c.taskStatus {
 		appliedTs := status.AppliedTs()
@@ -784,6 +786,7 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 			minResolvedTs = c.ddlResolvedTs
 		}
 	}
+	checkUpdateTs()
 
 	// if minResolvedTs is greater than the finishedTS of ddl job which is not executed,
 	// we need to execute this ddl job

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -149,15 +149,25 @@ func (s *etcdSuite) TestDeleteTaskStatus(c *check.C) {
 func (s *etcdSuite) TestGetPutTaskPosition(c *check.C) {
 	ctx := context.Background()
 	info := &model.TaskPosition{
-		ResolvedTs:   66,
+		ResolvedTs:   99,
 		CheckPointTs: 77,
 	}
 
 	feedID := "feedid"
 	captureID := "captureid"
 
-	err := s.client.PutTaskPosition(ctx, feedID, captureID, info)
+	updated, err := s.client.PutTaskPositionOnChange(ctx, feedID, captureID, info)
 	c.Assert(err, check.IsNil)
+	c.Assert(updated, check.IsTrue)
+
+	updated, err = s.client.PutTaskPositionOnChange(ctx, feedID, captureID, info)
+	c.Assert(err, check.IsNil)
+	c.Assert(updated, check.IsFalse)
+
+	info.CheckPointTs = 99
+	updated, err = s.client.PutTaskPositionOnChange(ctx, feedID, captureID, info)
+	c.Assert(err, check.IsNil)
+	c.Assert(updated, check.IsTrue)
 
 	_, getInfo, err := s.client.GetTaskPosition(ctx, feedID, captureID)
 	c.Assert(err, check.IsNil)
@@ -178,7 +188,7 @@ func (s *etcdSuite) TestDeleteTaskPosition(c *check.C) {
 	feedID := "feedid"
 	captureID := "captureid"
 
-	err := s.client.PutTaskPosition(ctx, feedID, captureID, info)
+	_, err := s.client.PutTaskPositionOnChange(ctx, feedID, captureID, info)
 	c.Assert(err, check.IsNil)
 
 	err = s.client.DeleteTaskPosition(ctx, feedID, captureID)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Some debug logs are too noisy, remove some debug logs that don't carry more debug information.

### What is changed and how it works?

- In the `checkUpdateTs` function, the `prevMinCheckpointTs` and `prevMinResolvedTs` are initialized with `targetTs`, so the first time check is always logged, we can remove this log.
- The processor always performs an etcd write operation when `flushTaskPosition` is called and has one line log. The `PutTaskPosition` operation can be optimized to `PutTaskPositionOnChange` operation, which means the processor only writes to etcd when the value of task position is changed (or etcd doesn't have the initialized key value). After this optimization etcd write ops in `flushTaskPosition` decreases from 30 to 2. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note