### PR TITLE
sink: fix Canal sink bugs

### DIFF
--- a/cdc/sink/codec/canal.go
+++ b/cdc/sink/codec/canal.go
@@ -216,7 +216,7 @@ func (b *canalEntryBuilder) buildColumn(c *model.Column, colName string, updated
 func (b *canalEntryBuilder) buildRowData(e *model.RowChangedEvent) (*canal.RowData, error) {
 	var columns []*canal.Column
 	for _, column := range e.Columns {
-		if e == nil {
+		if column == nil {
 			continue
 		}
 		c, err := b.buildColumn(column, column.Name, !e.IsDelete())
@@ -227,7 +227,7 @@ func (b *canalEntryBuilder) buildRowData(e *model.RowChangedEvent) (*canal.RowDa
 	}
 	var preColumns []*canal.Column
 	for _, column := range e.PreColumns {
-		if e == nil {
+		if column == nil {
 			continue
 		}
 		c, err := b.buildColumn(column, column.Name, !e.IsDelete())
@@ -378,12 +378,18 @@ func (d *CanalEventBatchEncoder) Build() []*MQMessage {
 	if err != nil {
 		log.Fatal("Error when generating Canal packet", zap.Error(err))
 	}
+
+	if len(d.messages.Messages) == 0 {
+		return nil
+	}
+
 	value, err := proto.Marshal(d.packet)
 	if err != nil {
 		log.Fatal("Error when serializing Canal packet", zap.Error(err))
 	}
 	ret := NewMQMessage(nil, value, 0)
 	d.messages.Reset()
+	d.resetPacket()
 	return []*MQMessage{ret}
 }
 
@@ -414,24 +420,30 @@ func (d *CanalEventBatchEncoder) refreshPacketBody() error {
 	if newSize > oldSize {
 		// resize packet body slice
 		d.packet.Body = append(d.packet.Body, make([]byte, newSize-oldSize)...)
+	} else {
+		d.packet.Body = d.packet.Body[:newSize]
 	}
-	_, err := d.messages.MarshalToSizedBuffer(d.packet.Body[:newSize])
+
+	_, err := d.messages.MarshalToSizedBuffer(d.packet.Body)
 	return err
 }
 
-// NewCanalEventBatchEncoder creates a new CanalEventBatchEncoder.
-func NewCanalEventBatchEncoder() EventBatchEncoder {
-	p := &canal.Packet{
+func (d *CanalEventBatchEncoder) resetPacket() {
+	d.packet = &canal.Packet{
 		VersionPresent: &canal.Packet_Version{
 			Version: CanalPacketVersion,
 		},
 		Type: canal.PacketType_MESSAGES,
 	}
+}
 
+// NewCanalEventBatchEncoder creates a new CanalEventBatchEncoder.
+func NewCanalEventBatchEncoder() EventBatchEncoder {
 	encoder := &CanalEventBatchEncoder{
 		messages:     &canal.Messages{},
-		packet:       p,
 		entryBuilder: NewCanalEntryBuilder(),
 	}
+
+	encoder.resetPacket()
 	return encoder
 }

--- a/cdc/sink/codec/canal.go
+++ b/cdc/sink/codec/canal.go
@@ -374,13 +374,13 @@ func (d *CanalEventBatchEncoder) EncodeDDLEvent(e *model.DDLEvent) (*MQMessage, 
 
 // Build implements the EventBatchEncoder interface
 func (d *CanalEventBatchEncoder) Build() []*MQMessage {
+	if len(d.messages.Messages) == 0 {
+		return nil
+	}
+
 	err := d.refreshPacketBody()
 	if err != nil {
 		log.Fatal("Error when generating Canal packet", zap.Error(err))
-	}
-
-	if len(d.messages.Messages) == 0 {
-		return nil
 	}
 
 	value, err := proto.Marshal(d.packet)

--- a/cdc/sink/codec/canal_test.go
+++ b/cdc/sink/codec/canal_test.go
@@ -91,6 +91,12 @@ func (s *canalBatchSuite) TestCanalEventBatchEncoder(c *check.C) {
 		}
 		size := encoder.Size()
 		res := encoder.Build()
+
+		if len(cs) == 0 {
+			c.Assert(res, check.IsNil)
+			continue
+		}
+
 		c.Assert(res, check.HasLen, 1)
 		c.Assert(res[0].Key, check.IsNil)
 		c.Assert(len(res[0].Value), check.Equals, size)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Repeated Canal messages caused by not resetting the state.
2. Panics on deletes caused by nil Columns pointer.
3. Sending empty messages when there's no new data.
4. Defective buffer resizing logic.


### What is changed and how it works?
1. Reset the packet after building the message. 
2. Check whether Column and PreColumn pointers are nil.
3. Check whether a message is empty.
4. Shrink the packet buffer appropriately.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test **(Pending)**


### Release note

- No release note
