### PR TITLE
cmd: add pd addr in pd connect failed error message

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -163,7 +163,7 @@ func newCliCommand() *cobra.Command {
 			})
 			if err != nil {
 				// PD embeds an etcd server.
-				return errors.Annotate(err, "fail to open PD etcd client")
+				return errors.Annotatef(err, "fail to open PD etcd client, pd-addr=\"%s\"", cliPdAddr)
 			}
 			cdcEtcdCli = kv.NewCDCEtcdClient(defaultContext, etcdCli)
 			pdCli, err = pd.NewClientWithContext(
@@ -182,7 +182,7 @@ func newCliCommand() *cobra.Command {
 					}),
 				))
 			if err != nil {
-				return errors.Annotate(err, "fail to open PD client")
+				return errors.Annotatef(err, "fail to open PD client, pd-addr=\"%s\"", cliPdAddr)
 			}
 			ctx := defaultContext
 			errorTiKVIncompatible := true // Error if TiKV is incompatible.

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -88,7 +88,7 @@ func initCmd(cmd *cobra.Command, logCfg *logutil.Config) context.CancelFunc {
 		cmd.Printf("init logger error %v\n", errors.ErrorStack(err))
 		os.Exit(1)
 	}
-	log.Info("init log", zap.String("file", logFile), zap.String("level", logLevel))
+	log.Info("init log", zap.String("file", logFile), zap.String("level", logCfg.Level))
 
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In a user test, an `Em space` is added after pd addr, which leads the wrong recognization of pd address.

Such as

```
./cdc cli changefeed create --pd=http://127.0.0.1:2379　--sink-uri="mysql://127.0.0.1:3306/"
```

the pd addr will be recognized as

```
http://127.0.0.1:2379　--sink-uri="mysql://127.0.0.1:3306/
```

### What is changed and how it works?

- Add better error message when meeting pd connect failure
- Correct log level in log util init function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
