### PR TITLE
metrics: reduce mounter alerts

### DIFF
--- a/metrics/alertmanager/ticdc.rules.yml
+++ b/metrics/alertmanager/ticdc.rules.yml
@@ -49,17 +49,17 @@ groups:
       value: '{{ $value }}'
       summary: ticdc_puller_entry_sorter merge duration time more than 2s
 
-  - alert: ticdc_mounter_unmarshal_and_mount_time_more_than_10ms
-    expr: histogram_quantile(0.9, rate(ticdc_mounter_unmarshal_and_mount_bucket[1m])) * 1000 > 10
+  - alert: ticdc_mounter_unmarshal_and_mount_time_more_than_1s
+    expr: histogram_quantile(0.9, rate(ticdc_mounter_unmarshal_and_mount_bucket[1m])) * 1000 > 1000
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: histogram_quantile(0.9, rate(ticdc_mounter_unmarshal_and_mount_bucket[1m])) * 1000 > 10
+      expr: histogram_quantile(0.9, rate(ticdc_mounter_unmarshal_and_mount_bucket[1m])) * 1000 > 1000
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'
-      summary: cdc_mounter unmarshal and mount time more than 10ms
+      summary: cdc_mounter unmarshal and mount time more than 1s
 
   - alert: cdc_sink_execute_duration_time_more_than_10s
     expr: histogram_quantile(0.9, rate(ticdc_sink_txn_exec_duration_bucket[1m])) > 10


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

mounter unmarshal alert is too sensitive. It keeps firing while checkpoint ts lag is small.

![image](https://user-images.githubusercontent.com/2150711/95648829-c0f92a80-0b0c-11eb-9cb5-a7f0cc8a16b1.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note.
<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
