### PR TITLE
processor: fix incorrect fatal detect in processor

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -838,7 +838,6 @@ func (p *processor) syncResolved(ctx context.Context) error {
 		return nil
 	}
 
-	var resolvedTs uint64
 	for {
 		select {
 		case <-ctx.Done():
@@ -855,11 +854,11 @@ func (p *processor) syncResolved(ctx context.Context) error {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				resolvedTs = row.CRTs
 				atomic.StoreUint64(&p.sinkEmittedResolvedTs, row.CRTs)
 				p.sinkEmittedResolvedNotifier.Notify()
 				continue
 			}
+			resolvedTs := atomic.LoadUint64(&p.localResolvedTs)
 			if row.CRTs <= resolvedTs {
 				log.Fatal("The CRTs must be greater than the resolvedTs",
 					zap.String("model", "processor"),

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -860,6 +860,9 @@ func (p *processor) syncResolved(ctx context.Context) error {
 				p.sinkEmittedResolvedNotifier.Notify()
 				continue
 			}
+			// Global resolved ts should fallback in some table rebalance cases,
+			// since the start-ts(from checkpoint ts) or a rebalanced table could
+			// be less then the global resolved ts.
 			localResolvedTs := atomic.LoadUint64(&p.localResolvedTs)
 			if resolvedTs > localResolvedTs {
 				log.Info("global resolved ts fallback",

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -863,6 +863,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 			localResolvedTs := atomic.LoadUint64(&p.localResolvedTs)
 			if resolvedTs > localResolvedTs {
 				log.Info("global resolved ts fallback",
+					zap.String("changefeed", p.changefeedID),
 					zap.Uint64("localResolvedTs", localResolvedTs),
 					zap.Uint64("resolvedTs", resolvedTs),
 				)
@@ -871,6 +872,7 @@ func (p *processor) syncResolved(ctx context.Context) error {
 			if row.CRTs <= resolvedTs {
 				log.Fatal("The CRTs must be greater than the resolvedTs",
 					zap.String("model", "processor"),
+					zap.String("changefeed", p.changefeedID),
 					zap.Uint64("resolvedTs", resolvedTs),
 					zap.Any("row", row))
 			}

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -885,6 +885,10 @@ func (s *mysqlSink) prepareDMLs(rows []*model.RowChangedEvent, replicaID uint64,
 }
 
 func (s *mysqlSink) execDMLs(ctx context.Context, rows []*model.RowChangedEvent, replicaID uint64, bucket int) error {
+	failpoint.Inject("SinkFlushDMLPanic", func() {
+		time.Sleep(time.Second)
+		log.Fatal("SinkFlushDMLPanic")
+	})
 	failpoint.Inject("MySQLSinkExecDMLError", func() {
 		// Add a delay to ensure the sink worker with `MySQLSinkHangLongTime`
 		// failpoint injected is executed first.

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -99,6 +99,11 @@ func (k *kafkaSaramaProducer) SendMessage(ctx context.Context, key []byte, value
 		failpoint.Return(nil)
 	})
 
+	failpoint.Inject("SinkFlushDMLPanic", func() {
+		time.Sleep(time.Second)
+		log.Fatal("SinkFlushDMLPanic")
+	})
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/tests/processor_resolved_ts_fallback/conf/diff_config.toml
+++ b/tests/processor_resolved_ts_fallback/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "processor_resolved_ts_fallback"
+    tables = ["~t.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/processor_resolved_ts_fallback/run.sh
+++ b/tests/processor_resolved_ts_fallback/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+
+function run() {
+    # TODO: kafka sink has bug with this case, remove this after bug is fixed
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      return
+    fi
+
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    TOPIC_NAME="ticdc-processor-resolved-ts-fallback-test-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://kafka01:9092/$TOPIC_NAME?partition-num=4";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+    esac
+    run_cdc_cli changefeed create --sink-uri="$SINK_URI"
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sink/SinkFlushDMLPanic=return(true);github.com/pingcap/ticdc/cdc/sink/producer/kafka/SinkFlushDMLPanic=return(true)'
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
+    run_sql "CREATE database processor_resolved_ts_fallback;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table processor_resolved_ts_fallback.t1(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    # wait table t1 is processed by cdc server
+    ensure 10 "cdc cli processor list|jq '.|length'|grep -E '^1$'"
+    export GO_FAILPOINTS=''
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "2" --addr "127.0.0.1:8302" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
+    run_sql "CREATE table processor_resolved_ts_fallback.t2(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table processor_resolved_ts_fallback.t3(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_table_exists "processor_resolved_ts_fallback.t1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_table_exists "processor_resolved_ts_fallback.t2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_table_exists "processor_resolved_ts_fallback.t3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    ensure 10 "cdc cli processor list|jq '.|length'|grep -E '^2$'"
+
+    run_sql "INSERT INTO processor_resolved_ts_fallback.t1 values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    # wait cdc server 1 is panic
+    ensure 10 "cdc cli capture list|jq '.|length'|grep -E '^1$'"
+    run_sql "INSERT INTO processor_resolved_ts_fallback.t1 values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO processor_resolved_ts_fallback.t2 values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #981 

The global resolved ts could be fallback when a table is rebalanced, so
we should use the local resolved ts of a processor instead of the
received global resolved ts, which is similar to the logic in following codes

https://github.com/pingcap/ticdc/blob/b901c90678bbcce66ae7568a54dcbd137eaded7d/cdc/processor.go#L689-L696


### What is changed and how it works?

Use the local resolved ts of a processor instead of the received global resolved ts to check the rule that CRTs is larger than `resolved ts`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
