### PR TITLE
scripts/ci: use fileserver to transfer third_party binaries

### DIFF
--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -141,7 +141,7 @@ def tests(sink_type, node_label) {
                         sh """
                             mkdir bin
                             curl -L http://fileserver.pingcap.net/download/test/cdc/ci/third_bin_${env.BUILD_NUMBER}.tar.gz | tar xvz -C .
-                            curl -L http://fileserver.pingcap.net/download/test/cdc/ci/ticdc_bin_${env.BUILD_NUMBER}.tar.gz | tar xvz -C ./bin
+                            curl -L http://fileserver.pingcap.net/download/test/cdc/ci/ticdc_bin_${env.BUILD_NUMBER}.tar.gz | tar xvz -C .
                             mv ./third_bin/* ./bin
                         """
                         try {

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -63,9 +63,9 @@ def prepare_binaries() {
                         mv jq third_bin
                         chmod a+x third_bin/*
                         rm -rf tmp
+                        tar czvf third_bin.tar.gz third_bin/*
+                        curl -F test/cdc/ci/third_bin_${env.BUILD_NUMBER}.tar.gz=@third_bin.tar.gz http://fileserver.pingcap.net/upload
                     """
-
-                    stash includes: "third_bin/**", name: "third_binaries"
                 }
             }
         }
@@ -84,9 +84,10 @@ def prepare_binaries() {
                             GO111MODULE=off GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make integration_test_build
                             GO111MODULE=off GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make kafka_consumer
                             GO111MODULE=off GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make check_failpoint_ctl
+                            tar czvf ticdc_bin.tar.gz bin/*
+                            curl -F test/cdc/ci/ticdc_bin_${env.BUILD_NUMBER}.tar.gz=@ticdc_bin.tar.gz http://fileserver.pingcap.net/upload
                         """
                     }
-                    stash includes: "go/src/github.com/pingcap/ticdc/bin/**", name: "ticdc_binaries", useDefaultExcludes: false
                 }
             }
         }
@@ -107,7 +108,6 @@ def tests(sink_type, node_label) {
                     println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
                     println "work space path:\n${ws}"
                     unstash 'ticdc'
-                    unstash 'ticdc_binaries'
 
                     dir("go/src/github.com/pingcap/ticdc") {
                         sh """
@@ -136,11 +136,14 @@ def tests(sink_type, node_label) {
                     println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
                     println "work space path:\n${ws}"
                     unstash 'ticdc'
-                    unstash 'third_binaries'
-                    unstash 'ticdc_binaries'
 
                     dir("go/src/github.com/pingcap/ticdc") {
-                        sh "mv ${ws}/third_bin/* ./bin/"
+                        sh """
+                            mkdir bin
+                            curl -L http://fileserver.pingcap.net/download/test/cdc/ci/third_bin_${env.BUILD_NUMBER}.tar.gz | tar xvz -C .
+                            curl -L http://fileserver.pingcap.net/download/test/cdc/ci/ticdc_bin_${env.BUILD_NUMBER}.tar.gz | tar xvz -C ./bin
+                            mv ./third_bin/* ./bin
+                        """
                         try {
                             sh """
                                 sudo pip install s3cmd


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

jenkins recommand file size for stash/restore is 5-100MB

> There's not a hard stash size limit, but between 5-100 MB you should probably consider alternatives. Name of a stash. Should be a simple identifier akin to a job name.

### What is changed and how it works?

Use fileserver to transfer third_party binaries

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
