### PR TITLE
tests: fix session variable is not reload in row format case

### DIFF
--- a/tests/row_format/data/step1.sql
+++ b/tests/row_format/data/step1.sql
@@ -1,0 +1,37 @@
+drop database if exists `row_format`;
+create database `row_format`;
+use `row_format`;
+
+CREATE TABLE multi_data_type
+(
+    id          INT AUTO_INCREMENT,
+    t_boolean   BOOLEAN,
+    t_bigint    BIGINT,
+    t_double    DOUBLE,
+    t_decimal   DECIMAL(38, 19),
+    t_bit       BIT(64),
+    t_date      DATE,
+    t_datetime  DATETIME,
+    t_timestamp TIMESTAMP NULL,
+    t_time      TIME,
+    t_year      YEAR,
+    t_char      CHAR,
+    t_varchar   VARCHAR(10),
+    t_blob      BLOB,
+    t_text      TEXT,
+    t_enum      ENUM ('enum1', 'enum2', 'enum3'),
+    t_set       SET ('a', 'b', 'c'),
+    t_json      JSON,
+    PRIMARY KEY (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COLLATE = utf8_bin;
+
+INSERT INTO multi_data_type( t_boolean, t_bigint, t_double, t_decimal, t_bit
+                           , t_date, t_datetime, t_timestamp, t_time, t_year
+                           , t_char, t_varchar, t_blob, t_text, t_enum
+                           , t_set, t_json)
+VALUES ( true, 9223372036854775807, 123.123, 123456789012.123456789012, b'1000001'
+       , '1000-01-01', '9999-12-31 23:59:59', '19731230153000', '23:59:59', 1970
+       , '测', '测试', 'blob', '测试text', 'enum2'
+       , 'a,b', NULL);

--- a/tests/row_format/data/step2.sql
+++ b/tests/row_format/data/step2.sql
@@ -1,0 +1,14 @@
+use `row_format`;
+
+INSERT INTO multi_data_type( t_boolean, t_bigint, t_double, t_decimal, t_bit
+                           , t_date, t_datetime, t_timestamp, t_time, t_year
+                           , t_char, t_varchar, t_blob, t_text, t_enum
+                           , t_set, t_json)
+VALUES ( false, 666, 123.777, 123456789012.123456789012, b'1000001'
+       , '1000-01-01', '9999-12-31 23:59:59', '19731230153000', '23:59:59', 1970
+       , '测', '测试', 'blob', '测试text11', 'enum3'
+       , 'a,b', NULL);
+
+UPDATE multi_data_type
+SET t_bigint = 555
+WHERE id = 1;

--- a/tests/row_format/data/step3.sql
+++ b/tests/row_format/data/step3.sql
@@ -1,59 +1,4 @@
-drop database if exists `row_format`;
-create database `row_format`;
 use `row_format`;
-
-SET GLOBAL tidb_row_format_version = 2;
-
-CREATE TABLE multi_data_type
-(
-    id          INT AUTO_INCREMENT,
-    t_boolean   BOOLEAN,
-    t_bigint    BIGINT,
-    t_double    DOUBLE,
-    t_decimal   DECIMAL(38, 19),
-    t_bit       BIT(64),
-    t_date      DATE,
-    t_datetime  DATETIME,
-    t_timestamp TIMESTAMP NULL,
-    t_time      TIME,
-    t_year      YEAR,
-    t_char      CHAR,
-    t_varchar   VARCHAR(10),
-    t_blob      BLOB,
-    t_text      TEXT,
-    t_enum      ENUM ('enum1', 'enum2', 'enum3'),
-    t_set       SET ('a', 'b', 'c'),
-    t_json      JSON,
-    PRIMARY KEY (id)
-) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_bin;
-
-INSERT INTO multi_data_type( t_boolean, t_bigint, t_double, t_decimal, t_bit
-                           , t_date, t_datetime, t_timestamp, t_time, t_year
-                           , t_char, t_varchar, t_blob, t_text, t_enum
-                           , t_set, t_json)
-VALUES ( true, 9223372036854775807, 123.123, 123456789012.123456789012, b'1000001'
-       , '1000-01-01', '9999-12-31 23:59:59', '19731230153000', '23:59:59', 1970
-       , '测', '测试', 'blob', '测试text', 'enum2'
-       , 'a,b', NULL);
-
-SET GLOBAL tidb_row_format_version = 1;
-
-INSERT INTO multi_data_type( t_boolean, t_bigint, t_double, t_decimal, t_bit
-                           , t_date, t_datetime, t_timestamp, t_time, t_year
-                           , t_char, t_varchar, t_blob, t_text, t_enum
-                           , t_set, t_json)
-VALUES ( false, 666, 123.777, 123456789012.123456789012, b'1000001'
-       , '1000-01-01', '9999-12-31 23:59:59', '19731230153000', '23:59:59', 1970
-       , '测', '测试', 'blob', '测试text11', 'enum3'
-       , 'a,b', NULL);
-
-UPDATE multi_data_type
-SET t_bigint = 555
-WHERE id = 1;
-
-SET GLOBAL tidb_row_format_version = 2;
 
 INSERT INTO multi_data_type( t_boolean, t_bigint, t_double, t_decimal, t_bit
                            , t_date, t_datetime, t_timestamp, t_time, t_year
@@ -139,8 +84,6 @@ create table tp_other
         primary key (id)
 );
 
-SET GLOBAL tidb_row_format_version = 2;
-
 insert into tp_int()
 values ();
 
@@ -151,7 +94,7 @@ values (1, 2, 3, 4, 5);
 insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
 values (127, 32767, 8388607, 2147483647, 9223372036854775807);
 
--- insert max value
+-- insert min value
 insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
 values (-128, -32768, -8388608, -2147483648, -9223372036854775808);
 
@@ -184,56 +127,3 @@ values ('a', 'a,b', b'1000001', '{
   "key1": "value1",
   "key2": "value2"
 }');
-
-SET GLOBAL tidb_row_format_version = 1;
-
-
-insert into tp_int()
-values ();
-
-insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
-values (1, 2, 3, 4, 5);
-
--- insert max value
-insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
-values (127, 32767, 8388607, 2147483647, 9223372036854775807);
-
--- insert max value
-insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
-values (-128, -32768, -8388608, -2147483648, -9223372036854775808);
-
-insert into tp_text()
-values ();
-
-insert into tp_text(c_tinytext, c_text, c_mediumtext, c_longtext, c_varchar, c_char, c_tinyblob, c_blob, c_mediumblob,
-                    c_longblob, c_binary, c_varbinary)
-values ('89504E470D0A1A0A', '89504E470D0A1A0A', '89504E470D0A1A0A', '89504E470D0A1A0A', '89504E470D0A1A0A',
-        '89504E470D0A1A0A', x'89504E470D0A1A0A', x'89504E470D0A1A0A', x'89504E470D0A1A0A'
-           , x'89504E470D0A1A0A', x'89504E470D0A1A0A', x'89504E470D0A1A0A');
-
-insert into tp_time()
-values ();
-
-insert into tp_time(c_date, c_datetime, c_timestamp, c_time, c_year)
-values ('2020-02-20', '2020-02-20 02:20:20', '2020-02-20 02:20:20', '02:20:20', '2020');
-
-insert into tp_real()
-values ();
-
-insert into tp_real(c_float, c_double, c_decimal)
-values (2020.0202, 2020.0303, 2020.0404);
-
-insert into tp_other()
-values ();
-
-insert into tp_other(c_enum, c_set, c_bit, c_json)
-values ('a', 'a,b', b'1000001', '{
-  "key1": "value1",
-  "key2": "value2"
-}');
-
-
-create table finish_mark
-(
-    id int PRIMARY KEY
-);

--- a/tests/row_format/data/step4.sql
+++ b/tests/row_format/data/step4.sql
@@ -1,0 +1,51 @@
+use `row_format`;
+
+insert into tp_int()
+values ();
+
+insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
+values (1, 2, 3, 4, 5);
+
+-- insert max value
+insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
+values (127, 32767, 8388607, 2147483647, 9223372036854775807);
+
+-- insert min value
+insert into tp_int(c_tinyint, c_smallint, c_mediumint, c_int, c_bigint)
+values (-128, -32768, -8388608, -2147483648, -9223372036854775808);
+
+insert into tp_text()
+values ();
+
+insert into tp_text(c_tinytext, c_text, c_mediumtext, c_longtext, c_varchar, c_char, c_tinyblob, c_blob, c_mediumblob,
+                    c_longblob, c_binary, c_varbinary)
+values ('89504E470D0A1A0A', '89504E470D0A1A0A', '89504E470D0A1A0A', '89504E470D0A1A0A', '89504E470D0A1A0A',
+        '89504E470D0A1A0A', x'89504E470D0A1A0A', x'89504E470D0A1A0A', x'89504E470D0A1A0A'
+           , x'89504E470D0A1A0A', x'89504E470D0A1A0A', x'89504E470D0A1A0A');
+
+insert into tp_time()
+values ();
+
+insert into tp_time(c_date, c_datetime, c_timestamp, c_time, c_year)
+values ('2020-02-20', '2020-02-20 02:20:20', '2020-02-20 02:20:20', '02:20:20', '2020');
+
+insert into tp_real()
+values ();
+
+insert into tp_real(c_float, c_double, c_decimal)
+values (2020.0202, 2020.0303, 2020.0404);
+
+insert into tp_other()
+values ();
+
+insert into tp_other(c_enum, c_set, c_bit, c_json)
+values ('a', 'a,b', b'1000001', '{
+  "key1": "value1",
+  "key2": "value2"
+}');
+
+
+create table finish_mark
+(
+    id int PRIMARY KEY
+);

--- a/tests/row_format/run.sh
+++ b/tests/row_format/run.sh
@@ -29,7 +29,23 @@ function run() {
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
     fi
-    run_sql_file $CUR/data/prepare.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    run_sql "SET GLOBAL tidb_row_format_version = 1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    sleep 2
+    run_sql_file $CUR/data/step1.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    run_sql "SET GLOBAL tidb_row_format_version = 2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    sleep 2
+    run_sql_file $CUR/data/step2.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    run_sql "SET GLOBAL tidb_row_format_version = 1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    sleep 2
+    run_sql_file $CUR/data/step3.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    run_sql "SET GLOBAL tidb_row_format_version = 2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    sleep 2
+    run_sql_file $CUR/data/step4.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
     # sync_diff can't check non-exist table, so we check expected tables are created in downstream first
     check_table_exists row_format.finish_mark ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

After global level variable is changed, the existing session doesn't reload this variable.

### What is changed and how it works?

Re-create a new tidb session after variable `tidb_row_format_version` value is changed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
