### PR TITLE
Remove integration binary file which added accidentally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ tiflash-config-preprocessed.toml
 # Files generated when running docker-compose
 docker/data
 docker/logs
+
+# Binary file when running intergration test
+integration/integration


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists--> 
Integration binary file is added accidentally when running integration test.

### What is changed and how it works?
Remove integration binary file, add corresponding record to `.gitignore`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


### Release note

- No release note