### PR TITLE
makefile: pass ldflags in integration test build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ check_third_party_binary:
 integration_test_build: check_failpoint_ctl
 	./scripts/fix_lib_zstd.sh
 	$(FAILPOINT_ENABLE)
-	$(GOTEST) -c -cover -covemode=atomic \
+	$(GOTEST) -ldflags '$(LDFLAGS)' -c -cover -covemode=atomic \
 		-coverpkg=github.com/pingcap/ticdc/... \
 		-o bin/cdc.test github.com/pingcap/ticdc \
 	|| { $(FAILPOINT_DISABLE); exit 1; }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

integration test build binary doesn't contain ldflags, which leads to some constant variable missing, such as `RELEASE_VERSION`


### What is changed and how it works?

pass ldflags in integration test build

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note