### PR TITLE
processor: fix task status is always flushed because of incorrect mod revision cache

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -551,8 +551,11 @@ func (p *processor) flushTaskStatusAndPosition(ctx context.Context) error {
 	for _, tableID := range tablesToRemove {
 		p.removeTable(tableID)
 	}
-	p.statusModRevision = newModRevision
-	p.status = newTaskStatus
+	// newModRevision == 0 means status is not updated
+	if newModRevision > 0 {
+		p.statusModRevision = newModRevision
+		p.status = newTaskStatus
+	}
 	syncTableNumGauge.
 		WithLabelValues(p.changefeedID, p.captureInfo.AdvertiseAddr).
 		Set(float64(len(p.status.Tables)))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

After investigating the https://github.com/pingcap/ticdc/issues/993, found key `/tidb/cdc/task/status/<capture-id>/<changefeed-id>` is always updated when processor calls `flushTaskStatusAndPosition`

This bug happens since v4.0.5

### What is changed and how it works?

The fix is straightforward, check `newModRevision` returned by `AtomicPutTaskStatus`, `newModRevision=0` means status is not updated, we don't update the mod revision cache.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note

- Fix a bug that processor always flushes task status to the etcd because of incorrect mod revision cache.
