### PR TITLE
changefeed: record only once if both ticker and ddl trigger syncpoint

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -698,6 +698,8 @@ func (c *changeFeed) handleSyncPoint(ctx context.Context) error {
 	if c.info.SyncPointEnabled {
 		c.syncpointMutex.Lock()
 		defer c.syncpointMutex.Unlock()
+		// ticker and ddl can trigger syncpoint record at the same time, only record once
+		syncpointRecorded := false
 		// ResolvedTs == CheckpointTs means a syncpoint reached;
 		// !c.updateResolvedTs means the syncpoint is setted by ticker;
 		// c.ddlTs == 0 means no DDL wait to exec and we can sink the syncpoint record securely ( c.ddlTs != 0 means some DDL should be sink to downstream and this syncpoint is fake ).
@@ -707,7 +709,9 @@ func (c *changeFeed) handleSyncPoint(ctx context.Context) error {
 			err := c.syncpointStore.SinkSyncpoint(ctx, c.id, c.status.CheckpointTs)
 			if err != nil {
 				log.Error("syncpoint sink fail", zap.Uint64("ResolvedTs", c.status.ResolvedTs), zap.Uint64("CheckpointTs", c.status.CheckpointTs), zap.Error(err))
+				return err
 			}
+			syncpointRecorded = true
 		}
 
 		if c.status.ResolvedTs == 0 {
@@ -719,9 +723,12 @@ func (c *changeFeed) handleSyncPoint(ctx context.Context) error {
 		// ddlTs <= ddlExecutedTs means the DDL has been execed.
 		if c.status.ResolvedTs == c.status.CheckpointTs && c.status.ResolvedTs == c.ddlTs && c.ddlTs <= c.ddlExecutedTs {
 			log.Info("sync point reached by ddl", zap.Uint64("ResolvedTs", c.status.ResolvedTs), zap.Uint64("CheckpointTs", c.status.CheckpointTs), zap.Bool("updateResolvedTs", c.updateResolvedTs), zap.Uint64("ddlResolvedTs", c.ddlResolvedTs), zap.Uint64("ddlTs", c.ddlTs), zap.Uint64("ddlExecutedTs", c.ddlExecutedTs))
-			err := c.syncpointStore.SinkSyncpoint(ctx, c.id, c.status.CheckpointTs)
-			if err != nil {
-				log.Error("syncpoint sink fail", zap.Uint64("ResolvedTs", c.status.ResolvedTs), zap.Uint64("CheckpointTs", c.status.CheckpointTs), zap.Error(err))
+			if !syncpointRecorded {
+				err := c.syncpointStore.SinkSyncpoint(ctx, c.id, c.status.CheckpointTs)
+				if err != nil {
+					log.Error("syncpoint sink fail", zap.Uint64("ResolvedTs", c.status.ResolvedTs), zap.Uint64("CheckpointTs", c.status.CheckpointTs), zap.Error(err))
+					return err
+				}
 			}
 			c.ddlTs = 0
 		}

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -729,6 +729,8 @@ func (c *changeFeed) handleSyncPoint(ctx context.Context) error {
 					log.Error("syncpoint sink fail", zap.Uint64("ResolvedTs", c.status.ResolvedTs), zap.Uint64("CheckpointTs", c.status.CheckpointTs), zap.Error(err))
 					return err
 				}
+				// syncpointRecorded is not used any more afterward, but we still maintain the right value of it.
+				syncpointRecorded = true
 			}
 			c.ddlTs = 0
 		}

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -729,8 +729,6 @@ func (c *changeFeed) handleSyncPoint(ctx context.Context) error {
 					log.Error("syncpoint sink fail", zap.Uint64("ResolvedTs", c.status.ResolvedTs), zap.Uint64("CheckpointTs", c.status.CheckpointTs), zap.Error(err))
 					return err
 				}
-				// syncpointRecorded is not used any more afterward, but we still maintain the right value of it.
-				syncpointRecorded = true
 			}
 			c.ddlTs = 0
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/1016

### What is changed and how it works?

Add a flag to prevent duplicated syncpoint persistent

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
