### PR TITLE
pkg: support timezone CST and null, re-enable some unit test

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -333,7 +333,9 @@ func configureSinkURI(
 	dsnCfg.DBName = ""
 	dsnCfg.InterpolateParams = true
 	dsnCfg.MultiStatements = true
-	dsnCfg.Params["time_zone"] = fmt.Sprintf(`"%s"`, tz.String())
+	if tz != nil {
+		dsnCfg.Params["time_zone"] = fmt.Sprintf(`"%s"`, tz.String())
+	}
 	dsnCfg.Params["readTimeout"] = params.readTimeout
 	dsnCfg.Params["writeTimeout"] = params.writeTimeout
 
@@ -483,7 +485,9 @@ func newMySQLSink(
 	if dsn.Params == nil {
 		dsn.Params = make(map[string]string, 1)
 	}
-	dsn.Params["time_zone"] = fmt.Sprintf(`"%s"`, tz.String())
+	if tz != nil {
+		dsn.Params["time_zone"] = fmt.Sprintf(`"%s"`, tz.String())
+	}
 	testDB, err := sql.Open("mysql", dsn.FormatDSN())
 	if err != nil {
 		return nil, errors.Annotate(
@@ -1185,7 +1189,9 @@ func newMySQLSyncpointStore(ctx context.Context, id string, sinkURI *url.URL) (S
 	if dsn.Params == nil {
 		dsn.Params = make(map[string]string, 1)
 	}
-	dsn.Params["time_zone"] = fmt.Sprintf(`"%s"`, tz.String())
+	if tz != nil {
+		dsn.Params["time_zone"] = fmt.Sprintf(`"%s"`, tz.String())
+	}
 	testDB, err := sql.Open("mysql", dsn.FormatDSN())
 	if err != nil {
 		return nil, errors.Annotate(

--- a/pkg/flags/urls_test.go
+++ b/pkg/flags/urls_test.go
@@ -14,8 +14,14 @@
 package flags
 
 import (
+	"testing"
+
 	. "github.com/pingcap/check"
 )
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
 
 var _ = Suite(&testUrlsSuite{})
 

--- a/pkg/util/test_helper_test.go
+++ b/pkg/util/test_helper_test.go
@@ -17,10 +17,15 @@ import (
 	"context"
 	"errors"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/pingcap/check"
 )
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
 
 type testHelperSuite struct{}
 

--- a/pkg/util/tz.go
+++ b/pkg/util/tz.go
@@ -29,6 +29,8 @@ func GetTimezone(name string) (tz *time.Location, err error) {
 		tz, err = GetLocalTimezone()
 		err = cerror.WrapError(cerror.ErrLoadTimezone, err)
 	case "cst":
+		// CST is ambiguous, it can represent 4 timezones, but here we treat it
+		// as China Standard Time (+08:00)
 		tz = time.FixedZone("CST", 3600*8)
 	case "null":
 		tz = nil

--- a/pkg/util/tz.go
+++ b/pkg/util/tz.go
@@ -28,6 +28,10 @@ func GetTimezone(name string) (tz *time.Location, err error) {
 	case "", "system", "local":
 		tz, err = GetLocalTimezone()
 		err = cerror.WrapError(cerror.ErrLoadTimezone, err)
+	case "cst":
+		tz = time.FixedZone("CST", 3600*8)
+	case "null":
+		tz = nil
 	default:
 		tz, err = time.LoadLocation(name)
 		err = cerror.WrapError(cerror.ErrLoadTimezone, err)

--- a/pkg/util/tz_test.go
+++ b/pkg/util/tz_test.go
@@ -45,3 +45,39 @@ func (s *tzSuite) TestGetTimezoneFromZonefile(c *check.C) {
 		}
 	}
 }
+
+func (s *tzSuite) TestGetTimezone(c *check.C) {
+	local, err := GetLocalTimezone()
+	c.Assert(err, check.IsNil)
+	var (
+		testCases = []struct {
+			hasErr bool
+			isNil  bool
+			tz     string
+			name   string
+		}{
+			{true, true, "unknown", ""},
+			{false, false, "UTC", "UTC"},
+			{false, false, "CST", "CST"},
+			{false, false, "", local.String()},
+			{false, false, "local", local.String()},
+			{false, false, "system", local.String()},
+			{false, false, "Asia/Shanghai", "Asia/Shanghai"},
+			{false, true, "NULL", ""},
+		}
+	)
+	for _, tc := range testCases {
+		tz, err := GetTimezone(tc.tz)
+		if tc.hasErr {
+			c.Assert(err, check.NotNil)
+		} else {
+			c.Assert(err, check.IsNil)
+			if tc.isNil {
+				c.Assert(tz, check.IsNil)
+			} else {
+				c.Assert(tz, check.NotNil)
+				c.Assert(tz.String(), check.Equals, tc.name)
+			}
+		}
+	}
+}

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -38,7 +38,7 @@ var minPDVersion *semver.Version = semver.New("4.0.0-rc.1")
 // MinTiKVVersion is the version of the minimal compatible TiKV.
 var MinTiKVVersion *semver.Version = semver.New("4.0.0-rc.1")
 
-var versionHash = regexp.MustCompile("-[0-9]+-g[0-9a-f]{7,}")
+var versionHash = regexp.MustCompile("-[0-9]+-g[0-9a-f]{7,}(-dev)?")
 
 func removeVAndHash(v string) string {
 	if v == "" {

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -63,6 +63,7 @@ func (s *checkSuite) TestCheckClusterVersion(c *check.C) {
 	pdHTTP := fmt.Sprintf("http://%s", pdURL.Host)
 	srv := http.Server{Addr: pdURL.Host, Handler: &mock}
 	go func() {
+		//nolint:errcheck
 		srv.ListenAndServe()
 	}()
 	defer srv.Close()

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"testing"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -26,6 +27,10 @@ import (
 	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/pkg/tempurl"
 )
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
 
 type checkSuite struct{}
 
@@ -56,11 +61,11 @@ func (s *checkSuite) TestCheckClusterVersion(c *check.C) {
 	}
 	pdURL, _ := url.Parse(tempurl.Alloc())
 	pdHTTP := fmt.Sprintf("http://%s", pdURL.Host)
-	svr := http.Server{Addr: pdURL.Host, Handler: &mock}
+	srv := http.Server{Addr: pdURL.Host, Handler: &mock}
 	go func() {
-		c.Assert(svr.ListenAndServe(), check.IsNil)
+		srv.ListenAndServe()
 	}()
-	defer svr.Close()
+	defer srv.Close()
 	for i := 0; i < 20; i++ {
 		time.Sleep(100 * time.Millisecond)
 		_, err := http.Get(pdHTTP)
@@ -68,7 +73,7 @@ func (s *checkSuite) TestCheckClusterVersion(c *check.C) {
 			break
 		}
 		c.Error(err)
-		if i == 199 {
+		if i == 19 {
 			c.Fatal("http server timeout", err)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In some Cloud MySQL service, only timezone `SYSTEM` and `CST` is available

### What is changed and how it works?

- translate `CST` to timezone `+08:00` and pass the timezone string directly
- re-enable some unit tests, maybe `check.TestingT(t)` is removed by accident in some code refactor

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Support to pass timezone `CST` and `NULL` in mysql sink uri.
