### PR TITLE
sink/mysql: support to pass a timezone dsn parameter

### DIFF
--- a/kafka_consumer/main.go
+++ b/kafka_consumer/main.go
@@ -314,8 +314,9 @@ func NewConsumer(ctx context.Context) (*Consumer, error) {
 	}, kafkaPartitionNum)
 	ctx, cancel := context.WithCancel(ctx)
 	errCh := make(chan error, 1)
+	opts := map[string]string{}
 	for i := 0; i < int(kafkaPartitionNum); i++ {
-		s, err := sink.NewSink(ctx, "kafka-consumer", downstreamURIStr, filter, config.GetDefaultReplicaConfig(), nil, errCh)
+		s, err := sink.NewSink(ctx, "kafka-consumer", downstreamURIStr, filter, config.GetDefaultReplicaConfig(), opts, errCh)
 		if err != nil {
 			cancel()
 			return nil, errors.Trace(err)
@@ -325,7 +326,7 @@ func NewConsumer(ctx context.Context) (*Consumer, error) {
 			resolvedTs uint64
 		}{Sink: s}
 	}
-	sink, err := sink.NewSink(ctx, "kafka-consumer", downstreamURIStr, filter, config.GetDefaultReplicaConfig(), nil, errCh)
+	sink, err := sink.NewSink(ctx, "kafka-consumer", downstreamURIStr, filter, config.GetDefaultReplicaConfig(), opts, errCh)
 	if err != nil {
 		cancel()
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In some Cloud MySQL service, only timezone SYSTEM and CST is available, we need to allow user to pass a string represented timezone

### What is changed and how it works?

- cdc server keeps using the `timezone` parameter that is configured in `cdc server` command.
- The `time_zone` query string in sink DSN will be determined by the `time-zone` parameter in sink uri and cdc server's timezone. The decision sequence is as follows:
    1. if `time-zone` is provided in sink uri, but value is empty, the downstream sink DSN will not contain any `time_zone` parameter.
    2. if `time-zone` is provided in sink uri with any value, the downstream sink DSN will contain the same value in `time_zone`
    3. if `time-zone` is not provided in sink uri, query context for timezone and use timezone string value in DSN.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

- Support to pass a time-zone variable from sink uri, which will be used in sink DSN directly.