### PR TITLE
kafka_consumer: fix wrong timezone when 'TZ' env is not set and downstream is mysql

### DIFF
--- a/kafka_consumer/main.go
+++ b/kafka_consumer/main.go
@@ -291,13 +291,9 @@ type Consumer struct {
 // NewConsumer creates a new cdc kafka consumer
 func NewConsumer(ctx context.Context) (*Consumer, error) {
 	// TODO support filter in downstream sink
-	tz := time.Local
-	if strings.ToLower(timezone) != "system" {
-		var err error
-		tz, err = time.LoadLocation(timezone)
-		if err != nil {
-			return nil, errors.Annotate(err, "can not load timezone")
-		}
+	tz, err := util.GetTimezone(timezone)
+	if err != nil {
+		return nil, errors.Annotate(err, "can not load timezone")
 	}
 	ctx = util.PutTimezoneInCtx(ctx, tz)
 	filter, err := cdcfilter.NewFilter(config.GetDefaultReplicaConfig())


### PR DESCRIPTION
kafka_consumer: fix wrong timezone when 'TZ' env is not set and downstream is mysql

Improve robustness.

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[*: fix wrong timezone when env `TZ` is not set #512](https://github.com/pingcap/ticdc/pull/512) fix wrong timezone in cdc, but *kafka_consumer* demo still have this problem, see [kafka_consumer wrong timezone when no parameter ‘--timezone’ and env ‘TZ’ is not set #1082](https://github.com/pingcap/ticdc/issues/1082).
### What is changed and how it works?
This pr load local timezone by calling util.GetTimezone instead of use time.Local
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 ```shell
./kafka_consumer --upstream-uri="kafka://127.0.0.1:9092/cdc-test?kafka-version=2.4.0&partition-num=6&max-message-bytes=67108864&replication-factor=1" --downstream-uri="mysql://root:123456@127.0.0.1:3306/"
```
> **--upstream-uri:** the kafka sink uri of cdc
> **--downstream-uri:** mysql sink uri

Code changes

 - Has exported function/method change
Related changes

 - Need to cherry-pick to the release branch
 

### Release note
kafka_consumer: fix wrong timezone when 'TZ' env is not set and downstream is mysql
<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
