### PR TITLE
ci/action: upgrade golangci-lint-action to v2

### DIFF
--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.30
           args: --timeout 10m0s


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Try to fix lint CI in github action. ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

detail error logs: https://github.com/pingcap/ticdc/commit/da768202b97ecdbdeccf42fc076ae2bc4ceaf217/checks/1410676409/logs
```
2020-11-17T07:33:08.7069919Z Finding needed golangci-lint version...
2020-11-17T07:33:08.7071210Z Setup go stable version spec 1
2020-11-17T07:33:08.7235182Z ##[error]Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.15.4/x64' successfully.
2020-11-17T07:33:08.7264613Z ##[error]The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
2020-11-17T07:33:08.7409550Z ##[error]Unable to process command '::add-path::/opt/hostedtoolcache/go/1.15.4/x64/bin' successfully.
2020-11-17T07:33:08.7414259Z ##[error]The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
2020-11-17T07:33:08.7417625Z Added go to the path
2020-11-17T07:33:09.3549556Z ##[error]Unable to process command '::add-path::/home/runner/go/bin' successfully.
2020-11-17T07:33:09.3555854Z ##[error]The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
### What is changed and how it works?

upgrade golangci-lint-action to v2

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release note

- No release note
