### PR TITLE
*:some helper functions add error return value and add some unit tests in ctx_test.go

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -209,7 +209,10 @@ func (o *Owner) newChangeFeed(
 		failpoint.Return(nil, errors.New("failpoint injected retriable error"))
 	})
 
-	kvStore := util.KVStorageFromCtx(ctx)
+	kvStore, err := util.KVStorageFromCtx(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	meta, err := kv.GetSnapshotMeta(kvStore, checkpointTs)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -181,7 +181,10 @@ func newProcessor(
 	log.Info("start processor with startts",
 		zap.Uint64("startts", checkpointTs), util.ZapFieldChangefeed(ctx))
 	ddlspans := []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}
-	kvStorage := util.KVStorageFromCtx(ctx)
+	kvStorage, err := util.KVStorageFromCtx(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	ddlPuller := puller.NewPuller(pdCli, credential, kvStorage, checkpointTs, ddlspans, limitter, false)
 	filter, err := filter.NewFilter(changefeed.Config)
 	if err != nil {
@@ -985,7 +988,11 @@ func (p *processor) addTable(ctx context.Context, tableID int64, replicaInfo *mo
 		// start table puller
 		enableOldValue := p.changefeed.Config.EnableOldValue
 		span := regionspan.GetTableSpan(tableID, enableOldValue)
-		kvStorage := util.KVStorageFromCtx(ctx)
+		kvStorage, err := util.KVStorageFromCtx(ctx)
+		if err != nil {
+			p.errCh <- err
+			return nil
+		}
 		plr := puller.NewPuller(p.pdCli, p.credential, kvStorage, replicaInfo.StartTs, []regionspan.Span{span}, p.limitter, enableOldValue)
 		go func() {
 			err := plr.Run(ctx)

--- a/pkg/util/ctx.go
+++ b/pkg/util/ctx.go
@@ -15,6 +15,7 @@ package util
 
 import (
 	"context"
+	"github.com/pingcap/errors"
 	"time"
 
 	"github.com/pingcap/tidb/kv"
@@ -86,12 +87,12 @@ func TimezoneFromCtx(ctx context.Context) *time.Location {
 }
 
 // KVStorageFromCtx returns a tikv store
-func KVStorageFromCtx(ctx context.Context) kv.Storage {
+func KVStorageFromCtx(ctx context.Context) (kv.Storage, error) {
 	store, ok := ctx.Value(ctxKeyKVStorage).(kv.Storage)
 	if !ok {
-		return nil
+		return nil, errors.Errorf("context can not find the value associated with key: %s", ctxKeyKVStorage)
 	}
-	return store
+	return store, nil
 }
 
 // SetOwnerInCtx returns a new child context with the owner flag set.

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -15,11 +15,9 @@ package util
 
 import (
 	"context"
-	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store/tikv/oracle"
-
 	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"github.com/pingcap/tidb/store/mockstore"
 	"go.uber.org/zap"
 )
 
@@ -105,10 +103,10 @@ func (s *ctxValueSuite) TestTableInfoNotSet(c *check.C) {
 
 func (s *ctxValueSuite) TestShouldReturnKVStorage(c *check.C) {
 	defer testleak.AfterTest(c)()
-	kvStorage := newMockStorage()
+	kvStorage, _ := mockstore.NewMockStore()
 	ctx := PutKVStorageInCtx(context.Background(), kvStorage)
-	kvStorage, err := KVStorageFromCtx(ctx)
-	c.Assert(kvStorage.Name(), check.Equals, "KVMockStorage")
+	kvStorage2, err := KVStorageFromCtx(ctx)
+	c.Assert(kvStorage2, check.DeepEquals, kvStorage)
 	c.Assert(err, check.IsNil)
 }
 
@@ -123,69 +121,6 @@ func (s *ctxValueSuite) TestKVStorageNotSet(c *check.C) {
 	kvStorage, err = KVStorageFromCtx(ctx)
 	c.Assert(kvStorage, check.IsNil)
 	c.Assert(err, check.NotNil)
-}
-
-type mockStorage struct {
-}
-
-func (s *mockStorage) Begin() (kv.Transaction, error) {
-	return nil, nil
-}
-
-func (s *mockStorage) BeginWithStartTS(startTS uint64) (kv.Transaction, error) {
-	return nil, nil
-}
-
-func (s *mockStorage) Close() error {
-	return nil
-}
-
-func (s *mockStorage) UUID() string {
-	return ""
-}
-
-func (s *mockStorage) CurrentVersion() (kv.Version, error) {
-	return kv.Version{}, nil
-}
-
-func (s *mockStorage) GetMPPClient() kv.MPPClient {
-	return nil
-}
-func (s *mockStorage) GetClient() kv.Client {
-	return nil
-}
-
-func (s *mockStorage) GetOracle() oracle.Oracle {
-	return nil
-}
-
-func (s *mockStorage) SupportDeleteRange() (supported bool) {
-	return false
-}
-
-func (s *mockStorage) Name() string {
-	return "KVMockStorage"
-}
-
-func (s *mockStorage) Describe() string {
-	return "KVMockStorage is a mock Store implementation, only for unittests in KV package"
-}
-
-func (s *mockStorage) ShowStatus(ctx context.Context, key string) (interface{}, error) {
-	return nil, nil
-}
-
-func (s *mockStorage) GetMemCache() kv.MemManager {
-	return nil
-}
-
-func (s *mockStorage) GetSnapshot(ver kv.Version) kv.Snapshot {
-	return nil
-}
-
-// newMockStorage creates a new mockStorage.
-func newMockStorage() kv.Storage {
-	return &mockStorage{}
 }
 
 func (s *ctxValueSuite) TestZapFieldWithContext(c *check.C) {

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -146,7 +146,7 @@ func (s *mockStorage) UUID() string {
 }
 
 func (s *mockStorage) CurrentVersion() (kv.Version, error) {
-	return kv.Version{1}, nil
+	return kv.Version{}, nil
 }
 
 func (s *mockStorage) GetMPPClient() kv.MPPClient {

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -103,7 +103,6 @@ func (s *ctxValueSuite) TestTableInfoNotSet(c *check.C) {
 	c.Assert(tableName, check.Equals, "")
 }
 
-
 func (s *ctxValueSuite) TestShouldReturnKVStorage(c *check.C) {
 	defer testleak.AfterTest(c)()
 	kvStorage := newMockStorage()


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[#1102](https://github.com/pingcap/ticdc/issues/1102)

### What is changed and how it works?
Return an **error** for `util.KVStorageFromCtx`, and add some unit test functions in `ctx_text.go`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 

Code changes

 - Has exported function/method change
 

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as



- No release note
-->
