### PR TITLE
tests: add unit tests for cdc/puller/puller.go

### DIFF
--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -51,10 +51,8 @@ func (s *clientSuite) TestNewClose(c *check.C) {
 	pdCli := mocktikv.NewPDClient(cluster)
 	defer pdCli.Close() //nolint:errcheck
 
-	cli, err := NewCDCClient(context.Background(), pdCli, nil, &security.Credential{})
-	c.Assert(err, check.IsNil)
-
-	err = cli.Close()
+	cli := NewCDCClient(context.Background(), pdCli, nil, &security.Credential{})
+	err := cli.Close()
 	c.Assert(err, check.IsNil)
 }
 
@@ -156,8 +154,7 @@ func (s *etcdSuite) TestConnectOfflineTiKV(c *check.C) {
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
 	isPullInit := &mockPullerInit{}
-	cdcClient, err := NewCDCClient(context.Background(), pdClient, kvStorage.(tikv.Storage), &security.Credential{})
-	c.Assert(err, check.IsNil)
+	cdcClient := NewCDCClient(context.Background(), pdClient, kvStorage.(tikv.Storage), &security.Credential{})
 	defer cdcClient.Close() //nolint:errcheck
 	eventCh := make(chan *model.RegionFeedEvent, 10)
 	wg.Add(1)
@@ -235,8 +232,7 @@ func (s *etcdSuite) TestRecvLargeMessageSize(c *check.C) {
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
 	isPullInit := &mockPullerInit{}
-	cdcClient, err := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
-	c.Assert(err, check.IsNil)
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
 	eventCh := make(chan *model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -294,8 +290,7 @@ func (s *etcdSuite) TodoTestIncompatibleTiKV(c *check.C) {
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
 	isPullInit := &mockPullerInit{}
-	cdcClient, err := NewCDCClient(context.Background(), pdClient, kvStorage.(tikv.Storage), &security.Credential{})
-	c.Assert(err, check.IsNil)
+	cdcClient := NewCDCClient(context.Background(), pdClient, kvStorage.(tikv.Storage), &security.Credential{})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	eventCh := make(chan *model.RegionFeedEvent, 10)

--- a/cdc/kv/testing.go
+++ b/cdc/kv/testing.go
@@ -144,8 +144,7 @@ func (*mockPullerInit) IsInitialized() bool {
 // TestSplit try split on every region, and test can get value event from
 // every region after split.
 func TestSplit(t require.TestingT, pdCli pd.Client, storage kv.Storage) {
-	cli, err := NewCDCClient(context.Background(), pdCli, storage.(tikv.Storage), &security.Credential{})
-	require.NoError(t, err)
+	cli := NewCDCClient(context.Background(), pdCli, storage.(tikv.Storage), &security.Credential{})
 	defer cli.Close()
 
 	eventCh := make(chan *model.RegionFeedEvent, 1<<20)
@@ -234,8 +233,7 @@ func mustDeleteKey(t require.TestingT, storage kv.Storage, key []byte) {
 
 // TestGetKVSimple test simple KV operations
 func TestGetKVSimple(t require.TestingT, pdCli pd.Client, storage kv.Storage) {
-	cli, err := NewCDCClient(context.Background(), pdCli, storage.(tikv.Storage), &security.Credential{})
-	require.NoError(t, err)
+	cli := NewCDCClient(context.Background(), pdCli, storage.(tikv.Storage), &security.Credential{})
 	defer cli.Close()
 
 	checker := newEventChecker(t)

--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -62,6 +62,11 @@ type ResolvedSpan struct {
 	ResolvedTs uint64
 }
 
+// String implements fmt.Stringer interface.
+func (rs *ResolvedSpan) String() string {
+	return fmt.Sprintf("span: %si, resolved-ts: %d", rs.Span, rs.ResolvedTs)
+}
+
 // RawKVEntry notify the KV operator
 type RawKVEntry struct {
 	OpType OpType `msg:"op_type"`

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -43,8 +43,9 @@ type ddlHandler struct {
 }
 
 func newDDLHandler(pdCli pd.Client, credential *security.Credential, kvStorage tidbkv.Storage, checkpointTS uint64) *ddlHandler {
-	plr := puller.NewPuller(pdCli, credential, kvStorage, checkpointTS, []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}, nil, false)
+	// TODO: context should be passed from outter caller
 	ctx, cancel := context.WithCancel(context.Background())
+	plr := puller.NewPuller(ctx, pdCli, credential, kvStorage, checkpointTS, []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}, nil, false)
 	h := &ddlHandler{
 		puller: plr,
 		cancel: cancel,

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -182,7 +182,7 @@ func newProcessor(
 		zap.Uint64("startts", checkpointTs), util.ZapFieldChangefeed(ctx))
 	ddlspans := []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}
 	kvStorage := util.KVStorageFromCtx(ctx)
-	ddlPuller := puller.NewPuller(pdCli, credential, kvStorage, checkpointTs, ddlspans, limitter, false)
+	ddlPuller := puller.NewPuller(ctx, pdCli, credential, kvStorage, checkpointTs, ddlspans, limitter, false)
 	filter, err := filter.NewFilter(changefeed.Config)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -986,7 +986,7 @@ func (p *processor) addTable(ctx context.Context, tableID int64, replicaInfo *mo
 		enableOldValue := p.changefeed.Config.EnableOldValue
 		span := regionspan.GetTableSpan(tableID, enableOldValue)
 		kvStorage := util.KVStorageFromCtx(ctx)
-		plr := puller.NewPuller(p.pdCli, p.credential, kvStorage, replicaInfo.StartTs, []regionspan.Span{span}, p.limitter, enableOldValue)
+		plr := puller.NewPuller(ctx, p.pdCli, p.credential, kvStorage, replicaInfo.StartTs, []regionspan.Span{span}, p.limitter, enableOldValue)
 		go func() {
 			err := plr.Run(ctx)
 			if errors.Cause(err) != context.Canceled {

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -51,6 +51,7 @@ type Puller interface {
 
 type pullerImpl struct {
 	pdCli          pd.Client
+	kvCli          kv.CDCKVClient
 	credential     *security.Credential
 	kvStorage      tikv.Storage
 	checkpointTs   uint64
@@ -66,6 +67,7 @@ type pullerImpl struct {
 // NewPuller create a new Puller fetch event start from checkpointTs
 // and put into buf.
 func NewPuller(
+	ctx context.Context,
 	pdCli pd.Client,
 	credential *security.Credential,
 	kvStorage tidbkv.Storage,
@@ -86,8 +88,10 @@ func NewPuller(
 	// the initial ts for frontier to 0. Once the puller level resolved ts
 	// initialized, the ts should advance to a non-zero value.
 	tsTracker := frontier.NewFrontier(0, comparableSpans...)
+	kvCli := kv.NewCDCKVClient(ctx, pdCli, tikvStorage, credential)
 	p := &pullerImpl{
 		pdCli:          pdCli,
+		kvCli:          kvCli,
 		credential:     credential,
 		kvStorage:      tikvStorage,
 		checkpointTs:   checkpointTs,
@@ -108,12 +112,7 @@ func (p *pullerImpl) Output() <-chan *model.RawKVEntry {
 
 // Run the puller, continually fetch event from TiKV and add event into buffer
 func (p *pullerImpl) Run(ctx context.Context) error {
-	cli, err := kv.NewCDCClient(ctx, p.pdCli, p.kvStorage, p.credential)
-	if err != nil {
-		return errors.Annotate(err, "create cdc client failed")
-	}
-
-	defer cli.Close()
+	defer p.kvCli.Close()
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -125,7 +124,7 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 		span := span
 
 		g.Go(func() error {
-			return cli.EventFeed(ctx, span, checkpointTs, p.enableOldValue, lockresolver, p, eventCh)
+			return p.kvCli.EventFeed(ctx, span, checkpointTs, p.enableOldValue, lockresolver, p, eventCh)
 		})
 	}
 
@@ -229,7 +228,11 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 			} else if e.Resolved != nil {
 				metricTxnCollectCounterResolved.Inc()
 				if !regionspan.IsSubSpan(e.Resolved.Span, p.spans...) {
-					log.Panic("the resolved span is not in the total span", zap.Reflect("resolved", e.Resolved), zap.Int64("tableID", tableID))
+					log.Panic("the resolved span is not in the total span",
+						zap.Reflect("resolved", e.Resolved),
+						zap.Int64("tableID", tableID),
+						zap.Reflect("spans", p.spans),
+					)
 				}
 				// Forward is called in a single thread
 				p.tsTracker.Forward(e.Resolved.Span, e.Resolved.ResolvedTs)

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -1,0 +1,205 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package puller
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/regionspan"
+	"github.com/pingcap/ticdc/pkg/security"
+	"github.com/pingcap/ticdc/pkg/txnutil"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+	tidbkv "github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/tikv"
+	pd "github.com/tikv/pd/client"
+)
+
+type pullerSuite struct {
+}
+
+var _ = check.Suite(&pullerSuite{})
+
+type mockPdClientForPullerTest struct {
+	pd.Client
+	clusterID uint64
+}
+
+func (mc *mockPdClientForPullerTest) GetClusterID(ctx context.Context) uint64 {
+	return mc.clusterID
+}
+
+type mockCDCKVClient struct {
+	expectations chan *model.RegionFeedEvent
+}
+
+type mockInjectedPuller struct {
+	Puller
+	cli *mockCDCKVClient
+}
+
+func newMockCDCKVClient(
+	ctx context.Context,
+	pd pd.Client,
+	kvStorage tikv.Storage,
+	credential *security.Credential,
+) kv.CDCKVClient {
+	return &mockCDCKVClient{
+		expectations: make(chan *model.RegionFeedEvent, 1024),
+	}
+}
+
+func (mc *mockCDCKVClient) EventFeed(
+	ctx context.Context,
+	span regionspan.ComparableSpan,
+	ts uint64,
+	enableOldValue bool,
+	lockResolver txnutil.LockResolver,
+	isPullerInit kv.PullerInitialization,
+	eventCh chan<- *model.RegionFeedEvent,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev := <-mc.expectations:
+			if ev == nil {
+				return nil
+			}
+			eventCh <- ev
+		}
+	}
+}
+
+func (mc *mockCDCKVClient) Close() error {
+	close(mc.expectations)
+	if len(mc.expectations) > 0 {
+		buf := bytes.NewBufferString("mockCDCKVClient: not all expectations were satisfied! Still waiting\n")
+		for e := range mc.expectations {
+			_, _ = buf.WriteString(fmt.Sprintf("%s", e.GetValue()))
+		}
+		return errors.New(buf.String())
+	}
+	return nil
+}
+
+func (mc *mockCDCKVClient) Returns(ev *model.RegionFeedEvent) {
+	mc.expectations <- ev
+}
+
+func (s *pullerSuite) newPullerForTest(
+	c *check.C,
+	spans []regionspan.Span,
+	checkpointTs uint64,
+) (*mockInjectedPuller, context.CancelFunc, *sync.WaitGroup, tidbkv.Storage) {
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	store, err := mockstore.NewMockStore()
+	c.Assert(err, check.IsNil)
+	enableOldValue := true
+	backupNewCDCKVClient := kv.NewCDCKVClient
+	kv.NewCDCKVClient = newMockCDCKVClient
+	defer func() {
+		kv.NewCDCKVClient = backupNewCDCKVClient
+	}()
+	pdCli := &mockPdClientForPullerTest{clusterID: uint64(1)}
+	plr := NewPuller(ctx, pdCli, nil /* credential */, store, checkpointTs, spans, nil /* limitter */, enableOldValue)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := plr.Run(ctx)
+		if err != nil {
+			c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+		}
+	}()
+	c.Assert(err, check.IsNil)
+	mockPlr := &mockInjectedPuller{
+		Puller: plr,
+		cli:    plr.(*pullerImpl).kvCli.(*mockCDCKVClient),
+	}
+	return mockPlr, cancel, &wg, store
+}
+
+func (s *pullerSuite) TestPullerResolvedForward(c *check.C) {
+	defer testleak.AfterTest(c)()
+	spans := []regionspan.Span{
+		{Start: []byte("t_a"), End: []byte("t_e")},
+	}
+	checkpointTs := uint64(996)
+	plr, cancel, wg, store := s.newPullerForTest(c, spans, checkpointTs)
+
+	plr.cli.Returns(&model.RegionFeedEvent{
+		Resolved: &model.ResolvedSpan{
+			Span:       regionspan.ToComparableSpan(regionspan.Span{Start: []byte("t_a"), End: []byte("t_c")}),
+			ResolvedTs: uint64(1001),
+		}})
+	plr.cli.Returns(&model.RegionFeedEvent{
+		Resolved: &model.ResolvedSpan{
+			Span:       regionspan.ToComparableSpan(regionspan.Span{Start: []byte("t_c"), End: []byte("t_d")}),
+			ResolvedTs: uint64(1002),
+		}})
+	plr.cli.Returns(&model.RegionFeedEvent{
+		Resolved: &model.ResolvedSpan{
+			Span:       regionspan.ToComparableSpan(regionspan.Span{Start: []byte("t_d"), End: []byte("t_e")}),
+			ResolvedTs: uint64(1000),
+		}})
+	ev := <-plr.Output()
+	c.Assert(ev.OpType, check.Equals, model.OpTypeResolved)
+	c.Assert(ev.CRTs, check.Equals, uint64(1000))
+	c.Assert(plr.IsInitialized(), check.IsTrue)
+	c.Assert(plr.GetResolvedTs(), check.Equals, uint64(1000))
+
+	store.Close()
+	cancel()
+	wg.Wait()
+}
+
+func (s *pullerSuite) TestPullerRawKV(c *check.C) {
+	defer testleak.AfterTest(c)()
+	spans := []regionspan.Span{
+		{Start: []byte("c"), End: []byte("e")},
+	}
+	checkpointTs := uint64(996)
+	plr, cancel, wg, store := s.newPullerForTest(c, spans, checkpointTs)
+
+	// key not in expected region spans, will be ignored
+	plr.cli.Returns(&model.RegionFeedEvent{
+		Val: &model.RawKVEntry{
+			OpType: model.OpTypePut,
+			Key:    []byte("a"),
+			Value:  []byte("test-value"),
+			CRTs:   uint64(1002),
+		}})
+	plr.cli.Returns(&model.RegionFeedEvent{
+		Val: &model.RawKVEntry{
+			OpType: model.OpTypePut,
+			Key:    []byte("d"),
+			Value:  []byte("test-value"),
+			CRTs:   uint64(1003),
+		}})
+	ev := <-plr.Output()
+	c.Assert(ev.OpType, check.Equals, model.OpTypePut)
+	c.Assert(ev.Key, check.DeepEquals, []byte("d"))
+
+	store.Close()
+	cancel()
+	wg.Wait()
+}

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -104,6 +104,7 @@ func (s *ctxValueSuite) TestTableInfoNotSet(c *check.C) {
 func (s *ctxValueSuite) TestShouldReturnKVStorage(c *check.C) {
 	defer testleak.AfterTest(c)()
 	kvStorage, _ := mockstore.NewMockStore()
+	defer kvStorage.Close()
 	ctx := PutKVStorageInCtx(context.Background(), kvStorage)
 	kvStorage2, err := KVStorageFromCtx(ctx)
 	c.Assert(kvStorage2, check.DeepEquals, kvStorage)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add unit tests for cdc/puller/puller.go

### What is changed and how it works?

- Extract kv client into a new interface `CDCKVClient`
- Add a simple injected mock puller, which can be injected with `RegionFeedEvent`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
