### PR TITLE
owner: fix owner doesn't clean up stale tasks

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1100,7 +1100,14 @@ func (o *Owner) run(ctx context.Context) error {
 	o.l.Lock()
 	defer o.l.Unlock()
 
-	err := o.loadChangeFeeds(ctx)
+	var err error
+
+	err = o.cleanUpStaleTasks(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = o.loadChangeFeeds(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1187,14 +1194,10 @@ func (o *Owner) writeDebugInfo(w io.Writer) {
 // When a new owner is elected, it does not know the events occurs before, like
 // processor deletion. In this case, the new owner should check if the task
 // status is stale because of the processor deletion.
-func (o *Owner) cleanUpStaleTasks(ctx context.Context, captures []*model.CaptureInfo) error {
+func (o *Owner) cleanUpStaleTasks(ctx context.Context) error {
 	_, changefeeds, err := o.etcdClient.GetChangeFeeds(ctx)
 	if err != nil {
 		return errors.Trace(err)
-	}
-	active := make(map[string]struct{})
-	for _, c := range captures {
-		active[c.ID] = struct{}{}
 	}
 	for changeFeedID := range changefeeds {
 		statuses, err := o.etcdClient.GetAllTaskStatus(ctx, changeFeedID)
@@ -1228,7 +1231,7 @@ func (o *Owner) cleanUpStaleTasks(ctx context.Context, captures []*model.Capture
 			zap.Reflect("workloads", workloads))
 
 		for captureID := range captureIDs {
-			if _, ok := active[captureID]; !ok {
+			if _, ok := o.captures[captureID]; !ok {
 				status, ok1 := statuses[captureID]
 				if ok1 {
 					pos, taskPosFound := positions[captureID]
@@ -1283,9 +1286,13 @@ func (o *Owner) watchCapture(ctx context.Context) error {
 	}
 	o.l.Unlock()
 
-	rev, captures, err := o.etcdClient.GetCaptures(ctx)
+	rev, captureList, err := o.etcdClient.GetCaptures(ctx)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	captures := make(map[model.CaptureID]*model.CaptureInfo)
+	for _, c := range captureList {
+		captures[c.ID] = c
 	}
 	// before watching, rebuild events according to
 	// the existed captures. This is necessary because
@@ -1338,14 +1345,12 @@ func (o *Owner) watchCapture(ctx context.Context) error {
 	return nil
 }
 
-func (o *Owner) rebuildCaptureEvents(ctx context.Context, captures []*model.CaptureInfo) error {
-	current := make(map[string]*model.CaptureInfo)
+func (o *Owner) rebuildCaptureEvents(ctx context.Context, captures map[model.CaptureID]*model.CaptureInfo) error {
 	for _, c := range captures {
-		current[c.ID] = c
 		o.addCapture(c)
 	}
 	for _, c := range o.captures {
-		if _, ok := current[c.ID]; !ok {
+		if _, ok := captures[c.ID]; !ok {
 			o.removeCapture(c)
 		}
 	}
@@ -1360,7 +1365,7 @@ func (o *Owner) rebuildCaptureEvents(ctx context.Context, captures []*model.Capt
 	//    from step-1, however other capture may crash just after step-2 returns
 	//    and before step-1 starts, the longer time gap between step-2 to step-1,
 	//    missing a crashed capture is more likey to happen.
-	return errors.Trace(o.cleanUpStaleTasks(ctx, captures))
+	return errors.Trace(o.cleanUpStaleTasks(ctx))
 }
 
 func (o *Owner) startCaptureWatcher(ctx context.Context) {

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -858,6 +858,8 @@ func (s *ownerSuite) TestWatchCampaignKey(c *check.C) {
 }
 
 func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr := "127.0.0.1:12034"
@@ -923,7 +925,6 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 	c.Assert(len(workloads), check.Equals, 1)
 	c.Assert(workloads, check.HasKey, capture.info.ID)
 
-	err = capture.session.Close()
+	err = capture.etcdClient.Close()
 	c.Assert(err, check.IsNil)
-	s.TearDownTest(c)
 }

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pingcap/check"
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -848,4 +849,71 @@ func (s *ownerSuite) TestWatchCampaignKey(c *check.C) {
 	time.Sleep(time.Millisecond * 100)
 	cancel()
 	wg.Wait()
+}
+
+func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := "127.0.0.1:12034"
+	ctx = util.PutCaptureAddrInCtx(ctx, addr)
+	capture, err := NewCapture(ctx, []string{s.clientURL.String()},
+		&security.Credential{}, addr, &processorOpts{})
+	c.Assert(err, check.IsNil)
+	err = s.client.PutCaptureInfo(ctx, capture.info, capture.session.Lease())
+	c.Assert(err, check.IsNil)
+
+	changefeed := "changefeed-name"
+	invalidCapture := uuid.New().String()
+	for _, captureID := range []string{capture.info.ID, invalidCapture} {
+		taskStatus := &model.TaskStatus{}
+		if captureID == invalidCapture {
+			taskStatus.Tables = map[model.TableID]*model.TableReplicaInfo{
+				51: {StartTs: 110},
+			}
+		}
+		err = s.client.PutTaskStatus(ctx, changefeed, captureID, taskStatus)
+		c.Assert(err, check.IsNil)
+		_, err = s.client.PutTaskPositionOnChange(ctx, changefeed, captureID, &model.TaskPosition{CheckPointTs: 100, ResolvedTs: 120})
+		c.Assert(err, check.IsNil)
+		err = s.client.PutTaskWorkload(ctx, changefeed, captureID, &model.TaskWorkload{})
+		c.Assert(err, check.IsNil)
+	}
+	s.client.SaveChangeFeedInfo(ctx, &model.ChangeFeedInfo{}, changefeed)
+
+	_, captureList, err := s.client.GetCaptures(ctx)
+	c.Assert(err, check.IsNil)
+	captures := make(map[model.CaptureID]*model.CaptureInfo)
+	for _, c := range captureList {
+		captures[c.ID] = c
+	}
+	owner, err := NewOwner(ctx, nil, &security.Credential{}, capture.session,
+		DefaultCDCGCSafePointTTL, time.Millisecond*200)
+	c.Assert(err, check.IsNil)
+	// It is better to update changefeed information by `loadChangeFeeds`, however
+	// `loadChangeFeeds` is too overweight, just mock enough information here.
+	owner.changeFeeds = map[model.ChangeFeedID]*changeFeed{
+		changefeed: {
+			id:           changefeed,
+			orphanTables: make(map[model.TableID]model.Ts),
+		},
+	}
+	err = owner.rebuildCaptureEvents(ctx, captures)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(owner.captures), check.Equals, 1)
+	c.Assert(owner.captures, check.HasKey, capture.info.ID)
+	c.Assert(owner.changeFeeds[changefeed].orphanTables, check.DeepEquals, map[model.TableID]model.Ts{51: 100})
+	// check stale tasks are cleaned up
+	statuses, err := s.client.GetAllTaskStatus(ctx, changefeed)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(statuses), check.Equals, 1)
+	c.Assert(statuses, check.HasKey, capture.info.ID)
+	positions, err := s.client.GetAllTaskPositions(ctx, changefeed)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(positions), check.Equals, 1)
+	c.Assert(positions, check.HasKey, capture.info.ID)
+	workloads, err := s.client.GetAllTaskWorkloads(ctx, changefeed)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(workloads), check.Equals, 1)
+	c.Assert(workloads, check.HasKey, capture.info.ID)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/1158

- TiCDC should clean the metadata of a changefeed as thoroughly as possible when removing a changefeed, but it is still possible to leave redundant metadata.
- Owner should choose whether to filter metadata when using it or clean up redundant data regularly, this PR chooses the second way.

### What is changed and how it works?

Owner clean up the stale tasks at the beginning of each run round.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix a bug that outdated metadata could cause the newly created changefeed abnormal.
