### PR TITLE
tests: add unit tests for mysql sink

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -252,7 +252,7 @@ func (s *mysqlSink) execDDL(ctx context.Context, ddl *model.DDLEvent) error {
 func (s *mysqlSink) adjustSQLMode(ctx context.Context) error {
 	// Must relax sql mode to support cyclic replication, as downstream may have
 	// extra columns (not null and no default value).
-	if s.cyclic == nil {
+	if s.cyclic == nil || !s.cyclic.Enabled() {
 		return nil
 	}
 	var oldMode, newMode string

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -252,7 +252,7 @@ func (s *mysqlSink) execDDL(ctx context.Context, ddl *model.DDLEvent) error {
 func (s *mysqlSink) adjustSQLMode(ctx context.Context) error {
 	// Must relax sql mode to support cyclic replication, as downstream may have
 	// extra columns (not null and no default value).
-	if s.cyclic != nil {
+	if s.cyclic == nil {
 		return nil
 	}
 	var oldMode, newMode string

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -263,12 +263,11 @@ func (s *mysqlSink) adjustSQLMode(ctx context.Context) error {
 	}
 
 	newMode = cyclic.RelaxSQLMode(oldMode)
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("SET sql_mode = '%s';", newMode))
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf("SET sql_mode = '%s';", newMode))
 	if err != nil {
 		return cerror.WrapError(cerror.ErrMySQLQueryError, err)
 	}
-	err = rows.Close()
-	return cerror.WrapError(cerror.ErrMySQLQueryError, err)
+	return nil
 }
 
 var _ Sink = &mysqlSink{}

--- a/pkg/cyclic/replication.go
+++ b/pkg/cyclic/replication.go
@@ -69,6 +69,11 @@ func (*Cyclic) UdpateSourceTableCyclicMark(sourceSchema, sourceTable string, buc
 		quotes.QuoteSchema(schema, table), bucket, replicaID, startTs)
 }
 
+// Enabled returns whether cyclic replication is enabled
+func (c *Cyclic) Enabled() bool {
+	return c.config.Enable
+}
+
 // FilterReplicaID return a slice of replica IDs needs to be filtered.
 func (c *Cyclic) FilterReplicaID() []uint64 {
 	return c.config.FilterReplicaID

--- a/pkg/cyclic/replication_test.go
+++ b/pkg/cyclic/replication_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	"github.com/pingcap/ticdc/pkg/util/testleak"
 )
@@ -27,6 +28,25 @@ type cyclicSuite struct{}
 var _ = check.Suite(&cyclicSuite{})
 
 func Test(t *testing.T) { check.TestingT(t) }
+
+func (s *cyclicSuite) TestCyclicConfig(c *check.C) {
+	defer testleak.AfterTest(c)()
+	cfg := &config.CyclicConfig{
+		Enable:          true,
+		ReplicaID:       1,
+		FilterReplicaID: []uint64{2, 3},
+	}
+	cyc := NewCyclic(cfg)
+	c.Assert(cyc, check.NotNil)
+	c.Assert(cyc.Enabled(), check.IsTrue)
+	c.Assert(cyc.ReplicaID(), check.Equals, uint64(1))
+	c.Assert(cyc.FilterReplicaID(), check.DeepEquals, []uint64{2, 3})
+
+	cyc = NewCyclic(nil)
+	c.Assert(cyc, check.IsNil)
+	cyc = NewCyclic(&config.CyclicConfig{ReplicaID: 0})
+	c.Assert(cyc, check.IsNil)
+}
 
 func (s *cyclicSuite) TestRelaxSQLMode(c *check.C) {
 	defer testleak.AfterTest(c)()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add unit tests for MySQL sink

### What is changed and how it works?

- Fix a bug that cyclic replication doesn't relax SQL mode.
- use sql mock to test MySQL sink

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release note

- No release note
