### PR TITLE
Makefile: fix goimports not found in leak test check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ check-copyright:
 	@./scripts/check-copyright.sh
 
 check-leaktest-added:
+	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 	@echo "check leak test added in all unit tests"
 	./scripts/add-leaktest.sh $(TEST_FILES)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix `./scripts/add-leaktest.sh: 29: ./scripts/add-leaktest.sh: goimports: not found`

### What is changed and how it works?

install `golang.org/x/tools/cmd/goimports` before running add-leaktest.sh

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
