### PR TITLE
processor: fix task status flushed too many before table is initialized

### DIFF
--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -209,6 +209,8 @@ type TaskStatus struct {
 	Operation    map[TableID]*TableOperation   `json:"operation"`
 	AdminJobType AdminJobType                  `json:"admin-job-type"`
 	ModRevision  int64                         `json:"-"`
+	// true means Operation record has been changed
+	Dirty bool `json:"-"`
 }
 
 // String implements fmt.Stringer interface.

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -535,7 +535,7 @@ func (p *processor) flushTaskStatusAndPosition(ctx context.Context) error {
 			if err != nil {
 				return false, backoff.Permanent(errors.Trace(err))
 			}
-			// processor reads latest task status from etcd, analyzes operations
+			// processor reads latest task status from etcd, analyzes operation
 			// field and processes table add or delete. If operation is unapplied
 			// but stays unchanged after processor handling tables, it means no
 			// status is changed and we don't need to flush task status neigher.
@@ -659,6 +659,9 @@ func (p *processor) handleTables(ctx context.Context, status *model.TaskStatus) 
 done:
 	if !status.SomeOperationsUnapplied() {
 		status.Operation = nil
+		// status.Dirty must be true when status changes from `unapplied` to `applied`,
+		// setting status.Dirty = true is not **must** here.
+		status.Dirty = true
 	}
 	return tablesToRemove, nil
 }

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -535,13 +535,13 @@ func (p *processor) flushTaskStatusAndPosition(ctx context.Context) error {
 			if err != nil {
 				return false, backoff.Permanent(errors.Trace(err))
 			}
-			err = p.flushTaskPosition(ctx)
-			if err != nil {
-				return true, errors.Trace(err)
-			}
 			// no operation is updated, it means no tables are handled and we
 			// don't need to flush task status neigher.
-			return taskStatus.Dirty, nil
+			if !taskStatus.Dirty {
+				return false, nil
+			}
+			err = p.flushTaskPosition(ctx)
+			return true, err
 		})
 	if err != nil {
 		// not need to check error
@@ -615,8 +615,8 @@ func (p *processor) handleTables(ctx context.Context, status *model.TaskStatus) 
 						tablesToRemove = append(tablesToRemove, tableID)
 						opt.Done = true
 						opt.Status = model.OperFinished
-						status.Dirty = true
 					}
+					status.Dirty = true
 				}
 			}
 		} else {

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -535,8 +535,10 @@ func (p *processor) flushTaskStatusAndPosition(ctx context.Context) error {
 			if err != nil {
 				return false, backoff.Permanent(errors.Trace(err))
 			}
-			// no operation is updated, it means no tables are handled and we
-			// don't need to flush task status neigher.
+			// processor reads latest task status from etcd, analyzes operations
+			// field and processes table add or delete. If operation is unapplied
+			// but stays unchanged after processor handling tables, it means no
+			// status is changed and we don't need to flush task status neigher.
 			if !taskStatus.Dirty {
 				return false, nil
 			}

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -535,16 +535,13 @@ func (p *processor) flushTaskStatusAndPosition(ctx context.Context) error {
 			if err != nil {
 				return false, backoff.Permanent(errors.Trace(err))
 			}
-			// no operation is updated, it means no tables are handled and we
-			// don't need to flush task status neigher.
-			if !taskStatus.Dirty {
-				return false, nil
-			}
 			err = p.flushTaskPosition(ctx)
 			if err != nil {
 				return true, errors.Trace(err)
 			}
-			return true, nil
+			// no operation is updated, it means no tables are handled and we
+			// don't need to flush task status neigher.
+			return taskStatus.Dirty, nil
 		})
 	if err != nil {
 		// not need to check error


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/1188. This is a hotfix for current codebase, we should process with the `Dirty` field of task status carefully.

### What is changed and how it works?

change flush check condition

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

   - hack puller `p.tsTracker.Frontier()` to force no forward to simulate long time incremental scan.
   - watch the task status key version in etcd doesn't change.

### Release note

- No release note