### PR TITLE
tests: turn on the tidb_enable_change_multi_schema switch in some tests

### DIFF
--- a/tests/common_1/run.sh
+++ b/tests/common_1/run.sh
@@ -40,6 +40,7 @@ function run() {
         # https://github.com/pingcap/tidb/pull/21533 disables multi_schema change
         # feature by default, turn it on first
         run_sql "set global tidb_enable_change_multi_schema = on" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+        run_sql "set global tidb_enable_change_multi_schema = on" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
         # TiDB global variables cache 2 seconds at most
         sleep 2
         run_sql_file $CUR/data/test_v5.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}

--- a/tests/common_1/run.sh
+++ b/tests/common_1/run.sh
@@ -15,6 +15,19 @@ function run() {
 
     cd $WORK_DIR
 
+    tidb_build_branch=$(mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} -e \
+        "select tidb_version()\G"|grep "Git Branch"|awk -F: '{print $(NF)}'|tr -d " ")
+    # TODO: refine the release detection after 5.0 tag of TiDB is ready
+    if [[ $tidb_build_branch =~ ^(master)$ ]]; then
+        # https://github.com/pingcap/tidb/pull/21533 disables multi_schema change
+        # feature by default, turn it on first
+        run_sql "set global tidb_enable_change_multi_schema = on" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+        # This must be set before cdc server starts
+        run_sql "set global tidb_enable_change_multi_schema = on" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+        # TiDB global variables cache 2 seconds at most
+        sleep 2
+    fi
+
     # record tso before we create tables to skip the system table DDLs
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
 
@@ -32,17 +45,9 @@ function run() {
 
     run_sql_file $CUR/data/test.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     # TODO: refine the release detection after 5.0 tag of TiDB is ready
-    tidb_build_branch=$(mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} -e \
-        "select tidb_version()\G"|grep "Git Branch"|awk -F: '{print $(NF)}'|tr -d " ")
     if [[ ! $tidb_build_branch =~ ^(master)$ ]]; then
         echo "skip some SQLs in tidb v4.0.x"
     else
-        # https://github.com/pingcap/tidb/pull/21533 disables multi_schema change
-        # feature by default, turn it on first
-        run_sql "set global tidb_enable_change_multi_schema = on" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-        run_sql "set global tidb_enable_change_multi_schema = on" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-        # TiDB global variables cache 2 seconds at most
-        sleep 2
         run_sql_file $CUR/data/test_v5.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     fi
     run_sql_file $CUR/data/test_finish.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}

--- a/tests/common_1/run.sh
+++ b/tests/common_1/run.sh
@@ -39,7 +39,7 @@ function run() {
     else
         # https://github.com/pingcap/tidb/pull/21533 disables multi_schema change
         # feature by default, turn it on first
-        run_sql "set @@global.tidb_enable_change_multi_schema = 'on'" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+        run_sql "set global tidb_enable_change_multi_schema = on" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
         # TiDB global variables cache 2 seconds at most
         sleep 2
         run_sql_file $CUR/data/test_v5.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -131,6 +131,7 @@ function run() {
         # https://github.com/pingcap/tidb/pull/21533 disables multi_schema change
         # feature by default, turn it on first
         run_sql "set global tidb_enable_change_multi_schema = on" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+        run_sql "set global tidb_enable_change_multi_schema = on" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
         # TiDB global variables cache 2 seconds at most
         sleep 2
     fi

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -31,8 +31,7 @@ ddls=("create database ddl_reentrant" false
 )
 
 function complete_ddls() {
-    tidb_build_branch=$(mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} -e \
-        "select tidb_version()\G"|grep "Git Branch"|awk -F: '{print $(NF)}'|tr -d " ")
+    # TODO: refine the release detection after 5.0 tag of TiDB is ready
     if [[ ! $tidb_build_branch =~ master ]]; then
         echo "skip some DDLs in tidb v4.0.x"
     else
@@ -87,6 +86,9 @@ function check_ddl_executed() {
 export -f check_ts_forward
 export -f check_ddl_executed
 
+tidb_build_branch=$(mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} -e \
+    "select tidb_version()\G"|grep "Git Branch"|awk -F: '{print $(NF)}'|tr -d " ")
+
 function ddl_test() {
     ddl=$1
     is_reentrant=$2
@@ -124,6 +126,14 @@ function run() {
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
     changefeedid=$(cdc cli changefeed create --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
 
+    # TODO: refine the release detection after 5.0 tag of TiDB is ready
+    if [[ $tidb_build_branch =~ master ]]; then
+        # https://github.com/pingcap/tidb/pull/21533 disables multi_schema change
+        # feature by default, turn it on first
+        run_sql "set @@global.tidb_enable_change_multi_schema = 'on'" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+        # TiDB global variables cache 2 seconds at most
+        sleep 2
+    fi
     OLDIFS=$IFS
     IFS=""
     idx=0

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -130,7 +130,7 @@ function run() {
     if [[ $tidb_build_branch =~ master ]]; then
         # https://github.com/pingcap/tidb/pull/21533 disables multi_schema change
         # feature by default, turn it on first
-        run_sql "set @@global.tidb_enable_change_multi_schema = 'on'" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+        run_sql "set global tidb_enable_change_multi_schema = on" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
         # TiDB global variables cache 2 seconds at most
         sleep 2
     fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/tidb/pull/21533 disables multi schema change feature by default, which leads to some tests failure caused by `ERROR 8200 (HY000) at line 12: Unsupported multi schema change`

### What is changed and how it works?

Turn on the `tidb_enable_change_multi_schema` switch in tests where multi schema change happens

Note cherry-pick just wants to keep the test code same as far as possible

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note