### PR TITLE
owner: wait all task metadata cleaned before creating new changefeed

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -1237,6 +1237,7 @@ func (p *processor) stop(ctx context.Context) error {
 	p.ddlPullerCancel()
 	// mark tables share the same context with its original table, don't need to cancel
 	p.stateMu.Unlock()
+	failpoint.Inject("processorStopDelay", nil)
 	atomic.StoreInt32(&p.stopped, 1)
 	if err := p.etcdCli.DeleteTaskPosition(ctx, p.changefeedID, p.captureInfo.ID); err != nil {
 		return err

--- a/tests/processor_stop_delay/conf/diff_config.toml
+++ b/tests/processor_stop_delay/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "processor_stop_delay"
+    tables = ["~.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/processor_stop_delay/run.sh
+++ b/tests/processor_stop_delay/run.sh
@@ -46,9 +46,9 @@ function run() {
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 
     export GO_FAILPOINTS=''
-    # cleanup_process $CDC_BINARY
+    cleanup_process $CDC_BINARY
 }
 
-# trap stop_tidb_cluster EXIT
+trap stop_tidb_cluster EXIT
 run $*
 echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/processor_stop_delay/run.sh
+++ b/tests/processor_stop_delay/run.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+TABLE_COUNT=3
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+    TOPIC_NAME="ticdc-processor-stop-delay-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processorStopDelay=1*sleep(10000)'
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
+    changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+    run_sql "CREATE DATABASE processor_stop_delay;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table processor_stop_delay.t (id int primary key auto_increment, t datetime DEFAULT CURRENT_TIMESTAMP)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO processor_stop_delay.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_table_exists "processor_stop_delay.t" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    # pause changefeed first, and then resume the changefeed. The processor stop
+    # logic will be delayed by 10s, which is controlled by failpoint injection.
+    # The changefeed should be resumed and no data loss.
+    cdc cli changefeed pause --changefeed-id=$changefeed_id --pd=$pd_addr
+    sleep 1
+    run_sql "INSERT INTO processor_stop_delay.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr
+    run_sql "INSERT INTO processor_stop_delay.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    export GO_FAILPOINTS=''
+    # cleanup_process $CDC_BINARY
+}
+
+# trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/1211

Root cause: There exists race condition when CDC owner creates a new changefeed (which will assign new task status) and a stale processor stops (which is responsible for replicating the same changefeed). The latest task status written by owner could be deleted by a stale processor.

### What is changed and how it works?

This PR changes the update of `task status` to a linearizable way, which means a paused/removed task status can be deleted, but cannot be put.

TODO: We should summary the schedule model of CDC owner and processor to make it works in a provable automaton.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix a bug that some tables' row change could be lost when the network between CDC and PD has jitter, and there exist changefeed resume operation at the same time.