### PR TITLE
*: Using the global singleton for pd client and tikv client, and fix pd client freeze

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -27,6 +27,7 @@ import (
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/util"
+	pd "github.com/tikv/pd/client"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
 	"go.etcd.io/etcd/mvcc"
@@ -49,6 +50,7 @@ type processorOpts struct {
 // Capture represents a Capture server, it monitors the changefeed information in etcd and schedules Task on it.
 type Capture struct {
 	etcdClient kv.CDCEtcdClient
+	pdCli      pd.Client
 	credential *security.Credential
 
 	processors map[string]*processor
@@ -67,6 +69,7 @@ type Capture struct {
 func NewCapture(
 	ctx context.Context,
 	pdEndpoints []string,
+	pdCli pd.Client,
 	credential *security.Credential,
 	advertiseAddr string,
 	opts *processorOpts,
@@ -126,6 +129,7 @@ func NewCapture(
 		election:   elec,
 		info:       info,
 		opts:       opts,
+		pdCli:      pdCli,
 	}
 
 	return
@@ -245,7 +249,7 @@ func (c *Capture) assignTask(ctx context.Context, task *Task) (*processor, error
 		zap.String("changefeed", task.ChangeFeedID))
 
 	p, err := runProcessor(
-		ctx, c.credential, c.session, *cf, task.ChangeFeedID, *c.info, task.CheckpointTS, c.opts.flushCheckpointInterval)
+		ctx, c.pdCli, c.credential, c.session, *cf, task.ChangeFeedID, *c.info, task.CheckpointTS, c.opts.flushCheckpointInterval)
 	if err != nil {
 		log.Error("run processor failed",
 			zap.String("changefeed", task.ChangeFeedID),

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -504,7 +504,7 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	defer sink.Close() //nolint:errcheck
 	sampleCF.sink = sink
 
-	capture, err := NewCapture(ctx, []string{s.clientURL.String()},
+	capture, err := NewCapture(ctx, []string{s.clientURL.String()}, nil,
 		&security.Credential{}, "127.0.0.1:12034", &processorOpts{flushCheckpointInterval: time.Millisecond * 200})
 	c.Assert(err, check.IsNil)
 	err = capture.Campaign(ctx)
@@ -806,7 +806,7 @@ func (s *ownerSuite) TestWatchCampaignKey(c *check.C) {
 	defer s.TearDownTest(c)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	capture, err := NewCapture(ctx, []string{s.clientURL.String()},
+	capture, err := NewCapture(ctx, []string{s.clientURL.String()}, nil,
 		&security.Credential{}, "127.0.0.1:12034", &processorOpts{})
 	c.Assert(err, check.IsNil)
 	err = capture.Campaign(ctx)
@@ -864,7 +864,7 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 	defer cancel()
 	addr := "127.0.0.1:12034"
 	ctx = util.PutCaptureAddrInCtx(ctx, addr)
-	capture, err := NewCapture(ctx, []string{s.clientURL.String()},
+	capture, err := NewCapture(ctx, []string{s.clientURL.String()}, nil,
 		&security.Credential{}, addr, &processorOpts{})
 	c.Assert(err, check.IsNil)
 	err = s.client.PutCaptureInfo(ctx, capture.info, capture.session.Lease())

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -66,8 +66,6 @@ const (
 	schemaStorageGCLag = time.Minute * 20
 )
 
-var fNewPDCli = pd.NewClientWithContext
-
 type processor struct {
 	id           string
 	captureInfo  model.CaptureInfo
@@ -156,6 +154,7 @@ func (t *tableInfo) safeStop() (stopped bool, checkpointTs model.Ts) {
 // newProcessor creates and returns a processor for the specified change feed
 func newProcessor(
 	ctx context.Context,
+	pdCli pd.Client,
 	credential *security.Credential,
 	session *concurrency.Session,
 	changefeed model.ChangeFeedInfo,
@@ -167,12 +166,6 @@ func newProcessor(
 	flushCheckpointInterval time.Duration,
 ) (*processor, error) {
 	etcdCli := session.Client()
-	endpoints := session.Client().Endpoints()
-	pdCli, err := fNewPDCli(ctx, endpoints, credential.PDSecurityOption())
-	if err != nil {
-		return nil, errors.Annotatef(
-			cerror.WrapError(cerror.ErrNewProcessorFailed, err), "create pd client failed, addr: %v", endpoints)
-	}
 	cdcEtcdCli := kv.NewCDCEtcdClient(ctx, etcdCli)
 	limitter := puller.NewBlurResourceLimmter(defaultMemBufferCapacity)
 
@@ -1257,6 +1250,7 @@ func (p *processor) isStopped() bool {
 // runProcessor creates a new processor then starts it.
 func runProcessor(
 	ctx context.Context,
+	pdCli pd.Client,
 	credential *security.Credential,
 	session *concurrency.Session,
 	info model.ChangeFeedInfo,
@@ -1283,7 +1277,7 @@ func runProcessor(
 		cancel()
 		return nil, errors.Trace(err)
 	}
-	processor, err := newProcessor(ctx, credential, session, info, sink,
+	processor, err := newProcessor(ctx, pdCli, credential, session, info, sink,
 		changefeedID, captureInfo, checkpointTs, errCh, flushCheckpointInterval)
 	if err != nil {
 		cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Using the global singleton for pd client and tikv client, and fix pd client freeze

### What is changed and how it works?
The modification of this PR bypasses the bug about pd client freeze by using a global singleton for pd client

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->

- Fix the bug of possible TiCDC server freeze
