### PR TITLE
cpature: fix session done is not considered during handling task event

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -167,9 +167,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 			if ev.Err != nil {
 				return errors.Trace(ev.Err)
 			}
-			log.Info("before capture handle task")
 			failpoint.Inject("captureHandleTaskDelay", nil)
-			log.Info("after capture handle task")
 			if err := c.handleTaskEvent(ctx, ev); err != nil {
 				select {
 				case <-c.session.Done():

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -167,7 +167,16 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 			if ev.Err != nil {
 				return errors.Trace(ev.Err)
 			}
+			log.Info("before capture handle task")
+			failpoint.Inject("captureHandleTaskDelay", nil)
+			log.Info("after capture handle task")
 			if err := c.handleTaskEvent(ctx, ev); err != nil {
+				select {
+				case <-c.session.Done():
+					log.Warn("handle task event failed because session is done", zap.Error(err))
+					return cerror.ErrCaptureSuicide.GenWithStackByArgs()
+				default:
+				}
 				return errors.Trace(err)
 			}
 		}

--- a/tests/capture_session_done_during_task/conf/diff_config.toml
+++ b/tests/capture_session_done_during_task/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "capture_session_done_during_task"
+    tables = ["~.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/capture_session_done_during_task/run.sh
+++ b/tests/capture_session_done_during_task/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+    TOPIC_NAME="ticdc-capture-session-done-during-task-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4"
+    fi
+
+    # create database and table in both upstream and downstream to ensure there
+    # will be task dispatched after changefeed starts.
+    run_sql "CREATE DATABASE capture_session_done_during_task;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table capture_session_done_during_task.t (id int primary key auto_increment, a int)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE DATABASE capture_session_done_during_task;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    run_sql "CREATE table capture_session_done_during_task.t (id int primary key auto_increment, a int)" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
+    run_sql "INSERT INTO capture_session_done_during_task.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/captureHandleTaskDelay=sleep(2000)'
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
+    changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+    # wait task is dispatched
+    sleep 1
+
+    capture_key=$(ETCDCTL_API=3 etcdctl get /tidb/cdc/capture --prefix|head -n 1)
+    lease=$(ETCDCTL_API=3 etcdctl get $capture_key -w json|grep -o 'lease":[0-9]*'|awk -F: '{print $2}')
+    lease_hex=$(printf '%x\n' $lease)
+    # revoke lease of etcd capture key to simulate etcd session done
+    ETCDCTL_API=3 etcdctl lease revoke $lease_hex
+
+    # capture handle task delays 10s, minus 2s wait task dispatched
+    sleep 1
+    check_table_exists "capture_session_done_during_task.t" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+    run_sql "INSERT INTO capture_session_done_during_task.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    export GO_FAILPOINTS=''
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/1170

### What is changed and how it works?

If a capture's etcd session is disconnected, it should suicide and recover asap. However we have a selection of two channels, one is checking `etcd session done` and the other one is `handle task event`.
When an error happens after handling one task event, check whether the etcd session is already invalid, if it is disconnected, just ignore the error and suicide and recover the capture internal, instead of the process level exit.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix a bug that CDC could exit unexpected when etcd session is disconnected
