### PR TITLE
owner: fix memory accumulated when owner consume etcd update slow

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1110,7 +1110,6 @@ func (o *Owner) watchFeedChange(ctx context.Context) chan struct{} {
 				// operations should be resolved in future release.
 
 				select {
-				case <-cctx.Done():
 				case output <- struct{}{}:
 				default:
 					// in case output channel is full, just ignore this event

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1101,7 +1101,6 @@ func (o *Owner) watchFeedChange(ctx context.Context) chan struct{} {
 			for resp := range wch {
 				if resp.Err() != nil {
 					log.Error("position watcher restarted with error", zap.Error(resp.Err()))
-					cancel()
 					break
 				}
 
@@ -1115,6 +1114,7 @@ func (o *Owner) watchFeedChange(ctx context.Context) chan struct{} {
 					// in case output channel is full, just ignore this event
 				}
 			}
+			cancel()
 		}
 	}()
 	return output


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix for a memory accumulated issue in owner

https://github.com/pingcap/ticdc/blob/eed57c94491fd140f0a8a0528acc574bc542bb0b/cdc/owner.go#L1024-L1039

The output channel consume speed (which relays on how often L1035 can be run) may be much slower than the etcd key update frequency, which will lead to data accumulated in etcd watch client

### What is changed and how it works?

Ignore position update event if output channel is full, it is safe enough as the owner has a builtin ticker to trigger `o.run`

**NOTE: this is a release-4.0 quick fix, I will update master/release-5.0 and add test cases later**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)  (**Have tested in an internal test cluster**)
    - setup a ticdc cluster, create one or more changefeeds
    - running cdc for 10mins, get memory profile of cdc owner by `http://<ip>:<port>/debug/pprof/heap`
    - find the memory usage of `etcd.clientv3`, should be less than `5MB`

### Release note

- Fix a bug that too much memory may be consumed in etcd watch client in cdc owner.
