### PR TITLE
owner: fix memory accumulated when owner consume etcd update slow

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1096,7 +1096,8 @@ func (o *Owner) watchFeedChange(ctx context.Context) chan struct{} {
 				return
 			default:
 			}
-			wch := o.etcdClient.Client.Watch(ctx, kv.TaskPositionKeyPrefix, clientv3.WithFilterDelete(), clientv3.WithPrefix())
+			cctx, cancel := context.WithCancel(ctx)
+			wch := o.etcdClient.Client.Watch(cctx, kv.TaskPositionKeyPrefix, clientv3.WithFilterDelete(), clientv3.WithPrefix())
 
 			for resp := range wch {
 				if resp.Err() != nil {
@@ -1109,10 +1110,12 @@ func (o *Owner) watchFeedChange(ctx context.Context) chan struct{} {
 				// operations should be resolved in future release.
 
 				select {
-				case <-ctx.Done():
 				case output <- struct{}{}:
+				default:
+					// in case output channel is full, just ignore this event
 				}
 			}
+			cancel()
 		}
 	}()
 	return output

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -928,3 +928,90 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 	err = capture.etcdClient.Close()
 	c.Assert(err, check.IsNil)
 }
+
+func (s *ownerSuite) TestWatchFeedChange(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := "127.0.0.1:12034"
+	ctx = util.PutCaptureAddrInCtx(ctx, addr)
+	capture, err := NewCapture(ctx, []string{s.clientURL.String()}, nil,
+		&security.Credential{}, addr, &processorOpts{})
+	c.Assert(err, check.IsNil)
+	owner, err := NewOwner(ctx, nil, &security.Credential{}, capture.session,
+		DefaultCDCGCSafePointTTL, time.Millisecond*200)
+	c.Assert(err, check.IsNil)
+
+	var (
+		wg              sync.WaitGroup
+		updateCount     = 0
+		recvChangeCount = 0
+	)
+	ctx1, cancel1 := context.WithCancel(ctx)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		changefeedID := "test-changefeed"
+		pos := &model.TaskPosition{CheckPointTs: 100, ResolvedTs: 102}
+		for {
+			select {
+			case <-ctx1.Done():
+				return
+			default:
+			}
+			pos.ResolvedTs++
+			pos.CheckPointTs++
+			updated, err := capture.etcdClient.PutTaskPositionOnChange(ctx1, changefeedID, capture.info.ID, pos)
+			if errors.Cause(err) == context.Canceled {
+				return
+			}
+			c.Assert(err, check.IsNil)
+			c.Assert(updated, check.IsTrue)
+			updateCount++
+			// sleep to avoid other goroutine starvation
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	ch := owner.watchFeedChange(ctx)
+	wg.Add(1)
+	go func() {
+		defer func() {
+			// there could be one message remaining in chan, try to consume it
+			select {
+			case <-ch:
+			default:
+			}
+			wg.Done()
+		}()
+		for {
+			select {
+			case <-ctx1.Done():
+				return
+			case <-ch:
+				recvChangeCount++
+				// sleep to simulate some owner work
+				time.Sleep(time.Millisecond * 50)
+			}
+		}
+	}()
+
+	time.Sleep(time.Second * 2)
+	// use cancel1 to avoid cancel the watchFeedChange
+	cancel1()
+	wg.Wait()
+	c.Assert(recvChangeCount, check.Greater, 0)
+	c.Assert(recvChangeCount, check.Less, updateCount)
+	select {
+	case <-ch:
+		c.Error("should not receive message from feed change chan any more")
+	default:
+	}
+
+	err = capture.etcdClient.Close()
+	if err != nil {
+		c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix for a memory accumulated issue in owner

https://github.com/pingcap/ticdc/blob/eed57c94491fd140f0a8a0528acc574bc542bb0b/cdc/owner.go#L1024-L1039

The output channel consume speed (which relays on how often L1035 can be run) may be much slower than the etcd key update frequency, which will lead to data accumulated in etcd watch client

If changefeed number is equal or larger than `2`, the bug is 100% triggered.

### What is changed and how it works?

use notifier to work as the event trigger

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)  (**Have tested in an internal test cluster**)
    - setup a ticdc cluster, create one or more changefeeds
    - running cdc for 10mins, get memory profile of cdc owner by `http://<ip>:<port>/debug/pprof/heap`
    - find the memory usage of `etcd.clientv3`, should be less than `5MB`

before fix:

<img src="https://user-images.githubusercontent.com/1527315/102600323-a5884c80-4159-11eb-99c4-ce7759b7e07d.png" width="500px">

after:

![image](https://user-images.githubusercontent.com/1527315/102599846-08c5af00-4159-11eb-96a3-74da768d70db.png)

### Release note

- Fix a bug that the cdc owner might consume too much memory in the etcd watch client