### PR TITLE
tests: add more unit tests in kv client

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -425,6 +425,11 @@ func allocID() uint64 {
 	return atomic.AddUint64(&currentID, 1)
 }
 
+// used in test only
+func currentRequestID() uint64 {
+	return atomic.LoadUint64(&currentID)
+}
+
 type eventFeedSession struct {
 	client      *CDCClient
 	regionCache *tikv.RegionCache
@@ -486,7 +491,7 @@ func newEventFeedSession(
 		enableOldValue:    enableOldValue,
 		lockResolver:      lockResolver,
 		isPullerInit:      isPullerInit,
-		id:                strconv.FormatUint(allocID(), 10),
+		id:                id,
 		regionChSizeGauge: clientChannelSize.WithLabelValues(id, "region"),
 		errChSizeGauge:    clientChannelSize.WithLabelValues(id, "err"),
 		rangeChSizeGauge:  clientChannelSize.WithLabelValues(id, "range"),

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -212,7 +212,6 @@ func (s *etcdSuite) TestConnectOfflineTiKV(c *check.C) {
 	initialized := mockInitializedEvent(3 /* regionID */, currentRequestID())
 	ch2 <- initialized
 
-	time.Sleep(time.Millisecond * 10)
 	cluster.ChangeLeader(3, 5)
 
 	ts, err := kvStorage.CurrentVersion()

--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -64,7 +64,7 @@ type ResolvedSpan struct {
 
 // String implements fmt.Stringer interface.
 func (rs *ResolvedSpan) String() string {
-	return fmt.Sprintf("span: %si, resolved-ts: %d", rs.Span, rs.ResolvedTs)
+	return fmt.Sprintf("span: %s, resolved-ts: %d", rs.Span, rs.ResolvedTs)
 }
 
 // RawKVEntry notify the KV operator

--- a/cdc/model/kv_test.go
+++ b/cdc/model/kv_test.go
@@ -30,7 +30,7 @@ func (s *kvSuite) TestRegionFeedEvent(c *check.C) {
 		OpType: OpTypePut,
 	}
 	resolved := &ResolvedSpan{
-		Span:       regionspan.ComparableSpan{},
+		Span:       regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")},
 		ResolvedTs: 111,
 	}
 
@@ -42,6 +42,8 @@ func (s *kvSuite) TestRegionFeedEvent(c *check.C) {
 
 	ev = &RegionFeedEvent{Resolved: resolved}
 	c.Assert(ev.GetValue(), check.DeepEquals, resolved)
+
+	c.Assert(resolved.String(), check.Equals, "span: [61, 62), resolved-ts: 111")
 }
 
 func (s *kvSuite) TestRawKVEntry(c *check.C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add more unit tests in kv client

### What is changed and how it works?

- Fix a minor bug that `requestID` increased twice each time when creating a new `eventFeedSession`
- Add test cases covering event error handling
- Add test cases covering KV event processing

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note