### PR TITLE
CI: enable specific tiflash branch in CI

### DIFF
--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -191,7 +191,7 @@ def download_binaries(){
         tidb_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz"
         tikv_url="${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz"
         pd_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz"
-        tiflash_url="${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${tiflash_sha1}/centos7/tiflash-server.tar.gz"
+        tiflash_url="${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${TIFLASH_BRANCH}/${tiflash_sha1}/centos7/tiflash.tar.gz"
         minio_url="${FILE_SERVER_URL}/download/minio.tar.gz"
 
         curl \${tidb_url} | tar xz -C ./tmp bin/tidb-server

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -200,7 +200,8 @@ def download_binaries(){
         curl \${minio_url} | tar xz -C ./tmp/bin minio
         mv tmp/bin/* third_bin
         curl \${tiflash_url} | tar xz -C third_bin
-        mv third_bin/tiflash/* third_bin
+        mv third_bin/tiflash third_bin/_tiflash
+        mv third_bin/_tiflash/* third_bin
         curl ${FILE_SERVER_URL}/download/builds/pingcap/go-ycsb/test-br/go-ycsb -o third_bin/go-ycsb
         curl -L http://fileserver.pingcap.net/download/builds/pingcap/cdc/etcd-v3.4.7-linux-amd64.tar.gz | tar xz -C ./tmp
         mv tmp/etcd-v3.4.7-linux-amd64/etcdctl third_bin

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -171,11 +171,11 @@ def download_binaries(){
     println "PD_BRANCH=${PD_BRANCH}"
 
     // parse tiflash branch
-    def m2 = ghprbCommentBody =~ /tiflash\s*=\s*([^\s\\]+)(\s|\\|$)/
-    if (m2) {
-        TIFLASH_BRANCH = "${m2[0][1]}"
+    def m4 = ghprbCommentBody =~ /tiflash\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m4) {
+        TIFLASH_BRANCH = "${m4[0][1]}"
     }
-    m2 = null
+    m4 = null
     println "TIFLASH_BRANCH=${TIFLASH_BRANCH}"
 
     println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"

--- a/tests/clustered_index/run.sh
+++ b/tests/clustered_index/run.sh
@@ -36,7 +36,7 @@ function run() {
     check_table_exists clustered_index_test.t1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
     check_table_exists clustered_index_test.t2 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
     echo "check table exists success"
-    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 60
 
     cleanup_process $CDC_BINARY
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Nightly tiflash will meet following error in the integration test

```
[FATAL] [server.rs:683] ["failed to start node: Grpc(RpcFailure(RpcStatus { status: 2-UNKNOWN, details: Some(\"version should compatible with version  5.0.0-alpha, got 4.1.0-rc-43-g54f66c524\") }))"]
```

### What is changed and how it works?

- Change default branch in CI to `release-5.0-rc` for TiDB/TiKV/PD/TiFlash
- Enable specific tiflash branch in CI

`master` branch and `release-4.0` branch will be picked manually

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note