### PR TITLE
owner: fix cleanup stale tasks before capture info is constructed

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -94,7 +95,8 @@ type Owner struct {
 	pdClient    pd.Client
 	etcdClient  kv.CDCEtcdClient
 
-	captures map[model.CaptureID]*model.CaptureInfo
+	captureLoaded int32
+	captures      map[model.CaptureID]*model.CaptureInfo
 
 	adminJobs     []model.AdminJob
 	adminJobsLock sync.Mutex
@@ -1251,6 +1253,11 @@ func (o *Owner) writeDebugInfo(w io.Writer) {
 // processor deletion. In this case, the new owner should check if the task
 // status is stale because of the processor deletion.
 func (o *Owner) cleanUpStaleTasks(ctx context.Context) error {
+	// captureLoaded == 0 means capture information is not built, owner can't
+	// clean up stale tasks now.
+	if atomic.LoadInt32(&o.captureLoaded) == int32(0) {
+		return nil
+	}
 	_, changefeeds, err := o.etcdClient.GetChangeFeeds(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -1410,6 +1417,15 @@ func (o *Owner) rebuildCaptureEvents(ctx context.Context, captures map[model.Cap
 			o.removeCapture(c)
 		}
 	}
+	// captureLoaded is used to check whether the owner can execute cleanup stale tasks job.
+	// Because at the very beginning of a new owner, it doesn't have capture information in
+	// memory, cleanup stale tasks could have a false positive (where positive means owner
+	// should cleanup the stale task of a specific capture). After the first time of capture
+	// rebuild, even the etcd compaction and watch capture is rerun, we don't need to check
+	// captureLoaded anymore because existing tasks must belong to a capture which is still
+	// maintained in owner's memory.
+	atomic.StoreInt32(&o.captureLoaded, 1)
+
 	// clean up stale tasks each time before watch capture event starts,
 	// for two reasons:
 	// 1. when a new owner is elected, it must clean up stale task status and positions.

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -908,8 +908,14 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 		},
 	}
 
+	// capture information is not built, owner.run does nothing
+	err = owner.run(ctx)
+	c.Assert(err, check.IsNil)
+	statuses, err := s.client.GetAllTaskStatus(ctx, changefeed)
+	c.Assert(err, check.IsNil)
+	// stale tasks are not cleaned up, since `cleanUpStaleTasks` does not run
+	c.Assert(len(statuses), check.Equals, 2)
 	c.Assert(len(owner.captures), check.Equals, 0)
-	c.Assert(atomic.LoadInt32(&owner.captureLoaded), check.Equals, int32(0))
 
 	err = owner.rebuildCaptureEvents(ctx, captures)
 	c.Assert(err, check.IsNil)
@@ -918,7 +924,7 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 	c.Assert(atomic.LoadInt32(&owner.captureLoaded), check.Equals, int32(1))
 	c.Assert(owner.changeFeeds[changefeed].orphanTables, check.DeepEquals, map[model.TableID]model.Ts{51: 100})
 	// check stale tasks are cleaned up
-	statuses, err := s.client.GetAllTaskStatus(ctx, changefeed)
+	statuses, err = s.client.GetAllTaskStatus(ctx, changefeed)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(statuses), check.Equals, 1)
 	c.Assert(statuses, check.HasKey, capture.info.ID)

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -907,21 +908,17 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 		},
 	}
 
-	// check cleaned up stale tasks should not be fired before `rebuildCaptureEvents`
-	err = owner.cleanUpStaleTasks(ctx)
-	c.Assert(err, check.IsNil)
-	statuses, err := s.client.GetAllTaskStatus(ctx, changefeed)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(statuses), check.Equals, 2)
 	c.Assert(len(owner.captures), check.Equals, 0)
+	c.Assert(atomic.LoadInt32(&owner.captureLoaded), check.Equals, int32(0))
 
 	err = owner.rebuildCaptureEvents(ctx, captures)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(owner.captures), check.Equals, 1)
 	c.Assert(owner.captures, check.HasKey, capture.info.ID)
+	c.Assert(atomic.LoadInt32(&owner.captureLoaded), check.Equals, int32(1))
 	c.Assert(owner.changeFeeds[changefeed].orphanTables, check.DeepEquals, map[model.TableID]model.Ts{51: 100})
 	// check stale tasks are cleaned up
-	statuses, err = s.client.GetAllTaskStatus(ctx, changefeed)
+	statuses, err := s.client.GetAllTaskStatus(ctx, changefeed)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(statuses), check.Equals, 1)
 	c.Assert(statuses, check.HasKey, capture.info.ID)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/ticdc/issues/1268, since #1268 has been merged into `release-4.0` before `4.0.10` is released, this PR needs to be shipped in `4.0.10` too.

No release since this is a bug fix in non-release version

### What is changed and how it works?

Add a flag to record whether capture information is initialized in owner.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
