### PR TITLE
ci: refine ci script to make downloading logs easier

### DIFF
--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -90,21 +90,23 @@ def tests(sink_type, node_label) {
                                 mkdir -p cov_dir
                                 ls /tmp/tidb_cdc_test
                                 cp /tmp/tidb_cdc_test/cov*out cov_dir || touch cov_dir/dummy_file_${step_name}
+                                cat aabbccdd
                             """
                             // cyclic tests do not run on kafka sink, so there is no cov* file.
                             sh """
                             tail /tmp/tidb_cdc_test/cov* || true
                             """
                         } catch (Exception e) {
-                            sh """
-                                echo "print all log"
-                                for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
-                                    echo "____________________________________"
-                                    echo "\$log"
-                                    cat "\$log"
-                                    echo "____________________________________"
-                                done
-                            """
+                            dir("/tmp/tidb_cdc_test/") {
+                                sh """
+                                    echo "archive all log"
+                                    for log in `ls */*.log`; do
+                                        echo "\$log"
+                                        tar zcvf "\$log.tar.gz" "\$log"
+                                    done
+                                """
+                                archiveArtifacts artifacts: '**/*.tar.gz'
+                            }
                             throw e;
                         }
                     }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -100,16 +100,14 @@ def tests(sink_type, node_label) {
                             sh """
                                 echo "archive all log"
                                 for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
-                                    echo "\$log"
                                     dirname=`dirname \$log`
                                     basename=`basename \$log`
-                                    echo "d: \$dirname b: \$basename"
                                     tar zcvf "\$log.tar.gz" -C "\$dirname" "\$basename"
                                 done
                                 ls -l /tmp/tidb_cdc_test/*/*.tar.gz
                             """
                             dir("/tmp/tidb_cdc_test/") {
-                                archiveArtifacts artifacts: '**/*.tar.gz'
+                                archiveArtifacts artifacts: '**/*.gz'
                             }
                             throw e;
                         }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -102,7 +102,8 @@ def tests(sink_type, node_label) {
                                 for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
                                     dirname=`dirname \$log`
                                     basename=`basename \$log`
-                                    tar zcvf "log/\${log%%.*}.tgz" -C "\$dirname" "\$basename"
+                                    mkdir -p "log\$dirname"
+                                    tar zcvf "log\${log%%.*}.tgz" -C "\$dirname" "\$basename"
                                 done
                                 ls -l /tmp/tidb_cdc_test/*/*.tgz
                                 chmod 777 /tmp/tidb_cdc_test/*/*.tgz

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -100,11 +100,11 @@ def tests(sink_type, node_label) {
                             sh """
                                 echo "archive all log"
                                 for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
-                                    echo "$log"
-                                    dirname=`dirname $log`
-                                    basename=`basename $log`
-                                    echo "d: $dirname b: $basename"
-                                    tar zcvf "$log.tar.gz" -C "$dirname" "$basename"
+                                    echo "\$log"
+                                    dirname=`dirname \$log`
+                                    basename=`basename \$log`
+                                    echo "d: \$dirname b: \$basename"
+                                    tar zcvf "\$log.tar.gz" -C "\$dirname" "\$basename"
                                 done
                                 ls -l /tmp/tidb_cdc_test/*/*.tar.gz
                             """

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -100,9 +100,13 @@ def tests(sink_type, node_label) {
                             sh """
                                 echo "archive all log"
                                 for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
-                                    echo "\$log"
-                                    tar zcvf "\$log.tar.gz" "\$log"
+                                    echo "$log"
+                                    dirname=`dirname $log`
+                                    basename=`basename $log`
+                                    echo "d: $dirname b: $basename"
+                                    tar zcvf "$log.tar.gz" -C "$dirname" "$basename"
                                 done
+                                ls -l /tmp/tidb_cdc_test/*/*.tar.gz
                             """
                             dir("/tmp/tidb_cdc_test/") {
                                 archiveArtifacts artifacts: '**/*.tar.gz'

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -107,7 +107,7 @@ def tests(sink_type, node_label) {
                                 ls -l /tmp/tidb_cdc_test/*/*.tar.gz
                             """
                             dir("/tmp/tidb_cdc_test/") {
-                                archiveArtifacts artifacts: '**/*.gz'
+                                archiveArtifacts artifacts: '**/*.log.tar.gz'
                             }
                             throw e;
                         }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -107,7 +107,7 @@ def tests(sink_type, node_label) {
                                 ls -l /tmp/tidb_cdc_test/*/*.tgz
                             """
                             dir("/tmp/tidb_cdc_test/") {
-                                archiveArtifacts artifacts: '**/*.tgz'
+                                archiveArtifacts artifacts: '*/*.tgz'
                             }
                             throw e;
                         }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -108,7 +108,7 @@ def tests(sink_type, node_label) {
                                 chmod 777 /tmp/tidb_cdc_test/*/*.tgz
                             """
                             dir("/tmp/tidb_cdc_test/") {
-                                archiveArtifacts artifacts: '*/*.*'
+                                archiveArtifacts artifacts: "**/*.tgz", caseSensitive: false
                             }
                             throw e;
                         }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -90,7 +90,6 @@ def tests(sink_type, node_label) {
                                 mkdir -p cov_dir
                                 ls /tmp/tidb_cdc_test
                                 cp /tmp/tidb_cdc_test/cov*out cov_dir || touch cov_dir/dummy_file_${step_name}
-                                cat aabbccdd
                             """
                             // cyclic tests do not run on kafka sink, so there is no cov* file.
                             sh """

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -104,7 +104,7 @@ def tests(sink_type, node_label) {
                                     basename=`basename \$log`
                                     tar zcvf "\${log%%.*}.tgz" -C "\$dirname" "\$basename"
                                 done
-                                ls -l /tmp/tidb_cdc_test/*/*.tar.gz
+                                ls -l /tmp/tidb_cdc_test/*/*.tgz
                             """
                             dir("/tmp/tidb_cdc_test/") {
                                 archiveArtifacts artifacts: '**/*.tgz'

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -102,14 +102,12 @@ def tests(sink_type, node_label) {
                                 for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
                                     dirname=`dirname \$log`
                                     basename=`basename \$log`
-                                    tar zcvf "\${log%%.*}.tgz" -C "\$dirname" "\$basename"
+                                    tar zcvf "log/\${log%%.*}.tgz" -C "\$dirname" "\$basename"
                                 done
                                 ls -l /tmp/tidb_cdc_test/*/*.tgz
                                 chmod 777 /tmp/tidb_cdc_test/*/*.tgz
                             """
-                            dir("/tmp/") {
-                                archiveArtifacts artifacts: "tidb_cdc_test/**/*.tgz", caseSensitive: false
-                            }
+                            archiveArtifacts artifacts: "log/tmp/tidb_cdc_test/**/*.tgz", caseSensitive: false
                             throw e;
                         }
                     }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -105,8 +105,6 @@ def tests(sink_type, node_label) {
                                     mkdir -p "log\$dirname"
                                     tar zcvf "log\${log%%.*}.tgz" -C "\$dirname" "\$basename"
                                 done
-                                ls -l /tmp/tidb_cdc_test/*/*.tgz
-                                chmod 777 /tmp/tidb_cdc_test/*/*.tgz
                             """
                             archiveArtifacts artifacts: "log/tmp/tidb_cdc_test/**/*.tgz", caseSensitive: false
                             throw e;

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -108,6 +108,9 @@ def tests(sink_type, node_label) {
                                 chmod 777 /tmp/tidb_cdc_test/*/*.tgz
                             """
                             dir("/tmp/tidb_cdc_test/") {
+                                sh """
+                                ls -l ./*/*.tgz
+                                """
                                 archiveArtifacts artifacts: "**/*.tgz", caseSensitive: false
                             }
                             throw e;

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -105,9 +105,10 @@ def tests(sink_type, node_label) {
                                     tar zcvf "\${log%%.*}.tgz" -C "\$dirname" "\$basename"
                                 done
                                 ls -l /tmp/tidb_cdc_test/*/*.tgz
+                                chmod 777 /tmp/tidb_cdc_test/*/*.tgz
                             """
                             dir("/tmp/tidb_cdc_test/") {
-                                archiveArtifacts artifacts: '*/*.tgz'
+                                archiveArtifacts artifacts: '*/*.*'
                             }
                             throw e;
                         }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -97,14 +97,14 @@ def tests(sink_type, node_label) {
                             tail /tmp/tidb_cdc_test/cov* || true
                             """
                         } catch (Exception e) {
+                            sh """
+                                echo "archive all log"
+                                for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
+                                    echo "\$log"
+                                    tar zcvf "\$log.tar.gz" "\$log"
+                                done
+                            """
                             dir("/tmp/tidb_cdc_test/") {
-                                sh """
-                                    echo "archive all log"
-                                    for log in `ls */*.log`; do
-                                        echo "\$log"
-                                        tar zcvf "\$log.tar.gz" "\$log"
-                                    done
-                                """
                                 archiveArtifacts artifacts: '**/*.tar.gz'
                             }
                             throw e;

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -102,12 +102,12 @@ def tests(sink_type, node_label) {
                                 for log in `ls /tmp/tidb_cdc_test/*/*.log`; do
                                     dirname=`dirname \$log`
                                     basename=`basename \$log`
-                                    tar zcvf "\$log.tar.gz" -C "\$dirname" "\$basename"
+                                    tar zcvf "\${log%%.*}.tgz" -C "\$dirname" "\$basename"
                                 done
                                 ls -l /tmp/tidb_cdc_test/*/*.tar.gz
                             """
                             dir("/tmp/tidb_cdc_test/") {
-                                archiveArtifacts artifacts: '**/*.log.tar.gz'
+                                archiveArtifacts artifacts: '**/*.tgz'
                             }
                             throw e;
                         }

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -107,11 +107,8 @@ def tests(sink_type, node_label) {
                                 ls -l /tmp/tidb_cdc_test/*/*.tgz
                                 chmod 777 /tmp/tidb_cdc_test/*/*.tgz
                             """
-                            dir("/tmp/tidb_cdc_test/") {
-                                sh """
-                                ls -l ./*/*.tgz
-                                """
-                                archiveArtifacts artifacts: "**/*.tgz", caseSensitive: false
+                            dir("/tmp/") {
+                                archiveArtifacts artifacts: "tidb_cdc_test/**/*.tgz", caseSensitive: false
                             }
                             throw e;
                         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

refine ci script to make downloading logs easier

![image](https://user-images.githubusercontent.com/33834665/104285929-4d8dfd00-54ef-11eb-869c-3ac85b0e6419.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. ->
 - No code


### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
