### PR TITLE
owner: add error message for owner ddl errors

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -724,10 +724,6 @@ func (o *Owner) handleDDL(ctx context.Context) error {
 	for _, cf := range o.changeFeeds {
 		err := cf.handleDDL(ctx, o.captures)
 		if err != nil {
-			if cerror.ErrExecDDLFailed.NotEqual(err) {
-				return errors.Trace(err)
-			}
-
 			var code string
 			if terror, ok := err.(*errors.Error); ok {
 				code = string(terror.RFCCode())

--- a/tests/changefeed_error/run.sh
+++ b/tests/changefeed_error/run.sh
@@ -14,6 +14,7 @@ function check_changefeed_mark_failed() {
     changefeedid=$2
     error_msg=$3
     info=$(cdc cli changefeed query --pd=$endpoints -c $changefeedid -s)
+    echo "$info"
     state=$(echo $info|jq -r '.state')
     if [[ ! "$state" == "failed" ]]; then
         echo "changefeed state $state does not equal to failed"

--- a/tests/changefeed_error/run.sh
+++ b/tests/changefeed_error/run.sh
@@ -92,6 +92,14 @@ function run() {
 
     export GO_FAILPOINTS=''
     cleanup_process $CDC_BINARY
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/InjectChangefeedDDLError=return(true)'
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    changefeedid_1=$(cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+    ensure $MAX_RETRIES check_changefeed_mark_failed http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_1} "ErrExecDDLFailed"
+
+    export GO_FAILPOINTS=''
+    cleanup_process $CDC_BINARY
 }
 
 trap stop_tidb_cluster EXIT

--- a/tests/changefeed_error/run.sh
+++ b/tests/changefeed_error/run.sh
@@ -96,6 +96,9 @@ function run() {
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/InjectChangefeedDDLError=return(true)'
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
     changefeedid_1=$(cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+
+    run_sql "CREATE table changefeed_error.DDLERROR(id int primary key, val int);"
+
     ensure $MAX_RETRIES check_changefeed_mark_failed http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_1} "ErrExecDDLFailed"
 
     export GO_FAILPOINTS=''

--- a/tests/changefeed_error/run.sh
+++ b/tests/changefeed_error/run.sh
@@ -21,7 +21,7 @@ function check_changefeed_mark_failed() {
         exit 1
     fi
     message=$(echo $info|jq -r '.error.message')
-    if [[ ! "$message" =~ "$error_msg" ]]; then
+    if [[ ! "$message" =~ $error_msg ]]; then
         echo "error message '$message' is not as expected '$error_msg'"
         exit 1
     fi

--- a/tests/changefeed_error/run.sh
+++ b/tests/changefeed_error/run.sh
@@ -21,7 +21,25 @@ function check_changefeed_mark_failed() {
         exit 1
     fi
     message=$(echo $info|jq -r '.error.message')
-    if [[ ! "$message" =~ $error_msg ]]; then
+    if [[ ! "$message" =~ "$error_msg" ]]; then
+        echo "error message '$message' is not as expected '$error_msg'"
+        exit 1
+    fi
+}
+
+function check_changefeed_mark_stopped() {
+    endpoints=$1
+    changefeedid=$2
+    error_msg=$3
+    info=$(cdc cli changefeed query --pd=$endpoints -c $changefeedid -s)
+    echo "$info"
+    state=$(echo $info|jq -r '.state')
+    if [[ ! "$state" == "stopped" ]]; then
+        echo "changefeed state $state does not equal to stopped"
+        exit 1
+    fi
+    message=$(echo $info|jq -r '.error.message')
+    if [[ ! "$message" =~ "$error_msg" ]]; then
         echo "error message '$message' is not as expected '$error_msg'"
         exit 1
     fi
@@ -44,6 +62,7 @@ function check_no_capture() {
 }
 
 export -f check_changefeed_mark_failed
+export -f check_changefeed_mark_stopped
 export -f check_no_changefeed
 export -f check_no_capture
 
@@ -99,8 +118,7 @@ function run() {
     changefeedid_1=$(cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
 
     run_sql "CREATE table changefeed_error.DDLERROR(id int primary key, val int);"
-
-    ensure $MAX_RETRIES check_changefeed_mark_failed http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_1} "ErrExecDDLFailed"
+    ensure $MAX_RETRIES check_changefeed_mark_stopped http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_1} "[CDC:ErrExecDDLFailed]exec DDL failed"
 
     export GO_FAILPOINTS=''
     cleanup_process $CDC_BINARY


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Owner DDL error messages are not visible to the user.

### What is changed and how it works?
- Add error details to the AdminJob.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test


Related changes

 - Need to cherry-pick to the release branch

### Release note

- Expose owner DDL errors messages to the user


