### PR TITLE
sink: Encoder configuration unit tests

### DIFF
--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -316,7 +316,7 @@ func (d *JSONEventBatchEncoder) GetMaxKafkaMessageSize() int {
 	return d.maxKafkaMessageSize
 }
 
-// GetMaxKafkaMessageSize is only for unit testing.
+// GetMaxBatchSize is only for unit testing.
 func (d *JSONEventBatchEncoder) GetMaxBatchSize() int {
 	return d.maxBatchSize
 }

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -37,6 +37,8 @@ const (
 	BatchVersion1 uint64 = 1
 	// DefaultMaxMessageBytes sets the default value for max-message-bytes
 	DefaultMaxMessageBytes int = 64 * 1024 * 1024 // 64M
+	// DefaultMaxBatchSize sets the default value for max-batch-size
+	DefaultMaxBatchSize int = 4096
 )
 
 type column struct {
@@ -529,21 +531,27 @@ func (d *JSONEventBatchEncoder) SetParams(params map[string]string) error {
 	if maxMessageBytes, ok := params["max-message-bytes"]; ok {
 		d.maxKafkaMessageSize, err = strconv.Atoi(maxMessageBytes)
 		if err != nil {
-			// TODO add error code
-			return errors.Trace(err)
+			return cerror.ErrKafkaInvalidConfig.Wrap(err)
 		}
 	} else {
 		d.maxKafkaMessageSize = DefaultMaxMessageBytes
 	}
 
+	if d.maxKafkaMessageSize <= 0 {
+		return cerror.ErrKafkaInvalidConfig.Wrap(errors.Errorf("invalid max-message-bytes %d", d.maxKafkaMessageSize))
+	}
+
 	if maxBatchSize, ok := params["max-batch-size"]; ok {
 		d.maxBatchSize, err = strconv.Atoi(maxBatchSize)
 		if err != nil {
-			// TODO add error code
-			return errors.Trace(err)
+			return cerror.ErrKafkaInvalidConfig.Wrap(err)
 		}
 	} else {
-		d.maxBatchSize = 4096
+		d.maxBatchSize = DefaultMaxBatchSize
+	}
+
+	if d.maxKafkaMessageSize <= 0 {
+		return cerror.ErrKafkaInvalidConfig.Wrap(errors.Errorf("invalid max-batch-size %d", d.maxKafkaMessageSize))
 	}
 	return nil
 }

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -550,7 +550,7 @@ func (d *JSONEventBatchEncoder) SetParams(params map[string]string) error {
 		d.maxBatchSize = DefaultMaxBatchSize
 	}
 
-	if d.maxKafkaMessageSize <= 0 {
+	if d.maxBatchSize <= 0 {
 		return cerror.ErrKafkaInvalidConfig.Wrap(errors.Errorf("invalid max-batch-size %d", d.maxKafkaMessageSize))
 	}
 	return nil

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -551,7 +551,7 @@ func (d *JSONEventBatchEncoder) SetParams(params map[string]string) error {
 	}
 
 	if d.maxBatchSize <= 0 {
-		return cerror.ErrKafkaInvalidConfig.Wrap(errors.Errorf("invalid max-batch-size %d", d.maxKafkaMessageSize))
+		return cerror.ErrKafkaInvalidConfig.Wrap(errors.Errorf("invalid max-batch-size %d", d.maxBatchSize))
 	}
 	return nil
 }

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -311,6 +311,16 @@ type JSONEventBatchEncoder struct {
 	maxBatchSize        int
 }
 
+// GetMaxKafkaMessageSize is only for unit testing.
+func (d *JSONEventBatchEncoder) GetMaxKafkaMessageSize() int {
+	return d.maxKafkaMessageSize
+}
+
+// GetMaxKafkaMessageSize is only for unit testing.
+func (d *JSONEventBatchEncoder) GetMaxBatchSize() int {
+	return d.maxBatchSize
+}
+
 // SetMixedBuildSupport is used by CDC Log
 func (d *JSONEventBatchEncoder) SetMixedBuildSupport(enabled bool) {
 	d.supportMixedBuild = enabled

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -16,9 +16,10 @@ package sink
 import (
 	"context"
 	"fmt"
+	"net/url"
+
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/cdc/sink/codec"
-	"net/url"
 
 	"github.com/Shopify/sarama"
 	"github.com/pingcap/check"

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -52,7 +52,7 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
 
 	uriTemplate := "kafka://%s/kafka-test?kafka-version=0.9.0.0&max-batch-size=1" +
-		"&max-message-bytes=4194304&max-batch-size=1048576&partition-num=1" +
+		"&max-message-bytes=4194304&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip"
 	uri := fmt.Sprintf(uriTemplate, leader.Addr())
 	sinkURI, err := url.Parse(uri)
@@ -199,8 +199,8 @@ func (s mqSinkSuite) TestPulsarSinkEncoderConfig(c *check.C) {
 	err := failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/pulsar/MockPulsar", "return(true)")
 	c.Assert(err, check.IsNil)
 
-	uri := "pulsar://127.0.0.1:1234/kafka-test?max-batch-size=1" +
-		"&max-message-bytes=4194304&max-batch-size=1048576"
+	uri := "pulsar://127.0.0.1:1234/kafka-test?" +
+		"max-message-bytes=4194304&max-batch-size=1"
 
 	sinkURI, err := url.Parse(uri)
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/producer/pulsar/producer.go
+++ b/cdc/sink/producer/pulsar/producer.go
@@ -19,11 +19,19 @@ import (
 	"strconv"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/pingcap/failpoint"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 )
 
 // NewProducer create a pulsar producer.
 func NewProducer(u *url.URL, errCh chan error) (*Producer, error) {
+	failpoint.Inject("MockPulsar", func() {
+		failpoint.Return(&Producer{
+			errCh:      errCh,
+			partitions: 4,
+		}, nil)
+	})
+
 	opt, err := parseSinkOptions(u)
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrPulsarNewProducer, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Lack of unit tests for the open protocol parameters `max-message-bytes` and `max-batch-size`.

### What is changed and how it works?
- Added unit tests for `max-message-bytes` and `max-batch-size`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has interface methods change

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note

