### PR TITLE
ci: change default tidb cluster to release-5.0

### DIFF
--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -142,12 +142,12 @@ def tests(sink_type, node_label) {
 }
 
 def download_binaries(){
-    def TIDB_BRANCH = params.getOrDefault("release_test__tidb_commit", "master")
-    def TIKV_BRANCH = params.getOrDefault("release_test__tikv_commit", "master")
-    def PD_BRANCH = params.getOrDefault("release_test__pd_commit", "master")
+    def TIDB_BRANCH = params.getOrDefault("release_test__tidb_commit", "release-5.0")
+    def TIKV_BRANCH = params.getOrDefault("release_test__tikv_commit", "release-5.0")
+    def PD_BRANCH = params.getOrDefault("release_test__pd_commit", "release-5.0")
     // TODO master tiflash release version is 4.1.0-rc-43-gxxx, which is not compatible
     // with TiKV 5.0.0-rc.x. Change default branch to master after TiFlash fixes it.
-    def TIFLASH_BRANCH = params.getOrDefault("release_test__release_branch", "release-5.0-rc")
+    def TIFLASH_BRANCH = params.getOrDefault("release_test__release_branch", "release-5.0")
     def TIFLASH_COMMIT = params.getOrDefault("release_test__tiflash_commit", null)
 
     // parse tidb branch


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

ci: change default tidb cluster to release-5.0

### What is changed and how it works?

ci: change default tidb cluster to release-5.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
