### PR TITLE
tests: cleanup binaries and cluster data before each run

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -30,6 +30,9 @@ if [ "${1-}" = '--debug' ]; then
 fi
 
 run_case() {
+    # cleanup test binaries and data, preserve logs, if we debug one case,
+    # these files will be preserved since no more case will be run.
+    find /tmp/tidb_cdc_test/*/* -type d|xargs rm -rf
     local case=$1
     local script=$2
     local sink_type=$3


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Reduce disk usage in the integration test, since after https://github.com/tikv/tikv/pull/9497 the minimum TiKV reverse space will be 5G in CI environment

### What is changed and how it works?

cleanup test binaries and data, preserve logs before each case starts

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
