### PR TITLE
processor: fix race when exit the processor

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -481,7 +481,7 @@ func (p *processor) flushTaskPosition(ctx context.Context) error {
 	if p.isStopped() {
 		return cerror.ErrAdminStopProcessor.GenWithStackByArgs()
 	}
-	//p.position.Count = p.sink.Count()
+	// p.position.Count = p.sink.Count()
 	updated, err := p.etcdCli.PutTaskPositionOnChange(ctx, p.changefeedID, p.captureInfo.ID, p.position)
 	if err != nil {
 		if errors.Cause(err) != context.Canceled {
@@ -1197,6 +1197,9 @@ func runProcessor(
 		err := <-errCh
 		cancel()
 		cause := errors.Cause(err)
+		if err := processor.wg.Wait(); err != nil {
+			processor.sendError(err)
+		}
 		if cause != nil && cause != context.Canceled && cerror.ErrAdminStopProcessor.NotEqual(cause) {
 			processorErrorCounter.WithLabelValues(changefeedID, captureInfo.AdvertiseAddr).Inc()
 			log.Error("error on running processor",

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -1202,8 +1202,8 @@ func runProcessor(
 	go func() {
 		err := <-errCh
 		cancel()
-		cause := errors.Cause(err)
 		processor.wait()
+		cause := errors.Cause(err)
 		if cause != nil && cause != context.Canceled && cerror.ErrAdminStopProcessor.NotEqual(cause) {
 			processorErrorCounter.WithLabelValues(changefeedID, captureInfo.AdvertiseAddr).Inc()
 			log.Error("error on running processor",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix race when exit the processor

```
==================
WARNING: DATA RACE
Write at 0x00c0007ee118 by goroutine 286:
  github.com/pingcap/ticdc/cdc.runProcessor.func1()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor.go:1213 +0x8df

Previous read at 0x00c0007ee118 by goroutine 266:
  encoding/json.ptrEncoder.encode()
      /usr/local/go/src/reflect/value.go:1065 +0x131
  encoding/json.ptrEncoder.encode-fm()
      /usr/local/go/src/encoding/json/encode.go:805 +0x7b
  encoding/json.structEncoder.encode()
      /usr/local/go/src/encoding/json/encode.go:664 +0x40d
  encoding/json.structEncoder.encode-fm()
      /usr/local/go/src/encoding/json/encode.go:635 +0xa0
  encoding/json.ptrEncoder.encode()
      /usr/local/go/src/encoding/json/encode.go:810 +0xfc
  encoding/json.ptrEncoder.encode-fm()
      /usr/local/go/src/encoding/json/encode.go:805 +0x7b
  encoding/json.(*encodeState).reflectValue()
      /usr/local/go/src/encoding/json/encode.go:337 +0x93
  encoding/json.(*encodeState).marshal()
      /usr/local/go/src/encoding/json/encode.go:309 +0xcc
  encoding/json.Marshal()
      /usr/local/go/src/encoding/json/encode.go:161 +0x73
  github.com/pingcap/ticdc/cdc/model.(*TaskPosition).Marshal()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/model/owner.go:90 +0x74
  github.com/pingcap/ticdc/cdc/kv.CDCEtcdClient.PutTaskPositionOnChange()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/kv/etcd.go:695 +0x6b
  github.com/pingcap/ticdc/cdc.(*processor).flushTaskPosition()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor.go:482 +0x26c
  github.com/pingcap/ticdc/cdc.(*processor).flushTaskStatusAndPosition()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor.go:548 +0x595
  github.com/pingcap/ticdc/cdc.(*processor).positionWorker.func1.1()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor.go:309 +0xad
  github.com/pingcap/ticdc/pkg/retry.Run.func1()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/pkg/retry/retry.go:32 +0x63
  github.com/cenkalti/backoff.RetryNotify()
      /go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0xc8
  github.com/pingcap/ticdc/pkg/retry.Run()
      /go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:24 +0x15f
  github.com/pingcap/ticdc/cdc.(*processor).positionWorker.func1()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor.go:308 +0x113
  github.com/pingcap/ticdc/cdc.(*processor).positionWorker()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor.go:378 +0x1408
  github.com/pingcap/ticdc/cdc.(*processor).Run.func1()
      /home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor.go:241 +0x8d
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:57 +0x71

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->

- No release note
