### PR TITLE
metrics: use tidb_cluster label get variable values

### DIFF
--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -5913,7 +5913,7 @@
         "options": [
 
         ],
-        "query": "label_values(ticdc_processor_resolved_ts, cluster)",
+        "query": "label_values(ticdc_processor_resolved_ts, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The latest version of tidb-operator will use the instance name as the cluster label. The previous expression uses the cluster label got the value of the tidb_cluster variable. It will cause Grafana can not to display the data.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Side effects

 - No effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update key monitor metrics in both TiCDC document and official document

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line
-->
- No release note

