### PR TITLE
go mod: add indirect version of shirou/gopsutil to fix freebsd build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/prometheus/client_golang v1.5.1
 	github.com/r3labs/diff v1.1.0
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/shirou/gopsutil v3.20.12+incompatible // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -558,6 +558,8 @@ github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq
 github.com/shirou/gopsutil v2.19.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.20.3+incompatible h1:0JVooMPsT7A7HqEYdydp/OfjSOYSjhXV7w1hkKj/NPQ=
 github.com/shirou/gopsutil v2.20.3+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v3.20.12+incompatible h1:6VEGkOXP/eP4o2Ilk8cSsX0PhOEfX6leqAnD+urrp9M=
+github.com/shirou/gopsutil v3.20.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix build failure in darwin/freebsd, related to https://github.com/shirou/gopsutil/issues/853, https://github.com/shirou/gopsutil/pull/958. `master` branch is ok

```
[2021-01-30T03:02:49.692Z] + make build
[2021-01-30T03:02:49.692Z] CGO_ENABLED=0 GO111MODULE=on go build  -trimpath  -ldflags '-X "github.com/pingcap/ticdc/pkg/version.ReleaseVersion=v4.0.11" -X "github.com/pingcap/ticdc/pkg/version.BuildTS=2021-01-30 03:02:49" -X "github.com/pingcap/ticdc/pkg/version.GitHash=f9ecdb2b448419d0770b44c579ef96c9d58bcac7" -X "github.com/pingcap/ticdc/pkg/version.GitBranch=heads/refs/tags/v4.0.11" -X "github.com/pingcap/ticdc/pkg/version.GoVersion=go version go1.13.4 darwin/amd64"' -o bin/cdc ./main.go
[2021-01-30T03:03:46.787Z] # github.com/shirou/gopsutil/disk
[2021-01-30T03:03:46.787Z] /Users/pingcap/gopkg/pkg/mod/github.com/shirou/gopsutil@v2.20.3+incompatible/disk/disk_darwin.go:67:51: cannot use stat.Mntfromname[:] (type []byte) as type []int8 in argument to common.IntToString
[2021-01-30T03:03:46.787Z] /Users/pingcap/gopkg/pkg/mod/github.com/shirou/gopsutil@v2.20.3+incompatible/disk/disk_darwin.go:68:49: cannot use stat.Mntonname[:] (type []byte) as type []int8 in argument to common.IntToString
[2021-01-30T03:03:46.787Z] /Users/pingcap/gopkg/pkg/mod/github.com/shirou/gopsutil@v2.20.3+incompatible/disk/disk_darwin.go:69:50: cannot use stat.Fstypename[:] (type []byte) as type []int8 in argument to common.IntToString
[2021-01-30T03:03:46.787Z] /Users/pingcap/gopkg/pkg/mod/github.com/shirou/gopsutil@v2.20.3+incompatible/disk/disk_darwin.go:85:43: cannot use stat.Fstypename[:] (type []byte) as type []int8 in argument to common.IntToString
[2021-01-30T03:03:46.787Z] make: *** [cdc] Error 2
script returned exit code 2
```

### What is changed and how it works?

`github.com/shirou/gopsutil` is used in `github.com/pingcap/sysutil`, since `3.x` and `2.x` of `gopsutil` are not compatible, this is a workaround for ticdc build.

The root cause is `github.com/shirou/gopsutil` must be compatible with `golang.org/x/sys`

It is better to upgrade `github.com/shirou/gopsutil` in `github.com/pingcap/sysutil`, and the dependency in `pd`/`tidb` will be updated cascade

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
### Release note

- No release note