### PR TITLE
etcd worker: some features and bugfix for etcd worker

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -161,6 +161,11 @@ error = '''
 this patch should be excluded from the current etcd txn
 '''
 
+["CDC:ErrEtcdSessionDone"]
+error = '''
+the etcd session is done
+'''
+
 ["CDC:ErrEtcdTryAgain"]
 error = '''
 the etcd txn should be aborted and retried immediately

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -184,6 +184,8 @@ var (
 	ErrEtcdTryAgain = errors.Normalize("the etcd txn should be aborted and retried immediately", errors.RFCCodeText("CDC:ErrEtcdTryAgain"))
 	// ErrEtcdIgnore is used by a PatchFunc to signal that the reactor no longer wishes to update Etcd.
 	ErrEtcdIgnore = errors.Normalize("this patch should be excluded from the current etcd txn", errors.RFCCodeText("CDC:ErrEtcdIgnore"))
+	// ErrEtcdSessionDone is used by etcd worker to signal a session done
+	ErrEtcdSessionDone = errors.Normalize("the etcd session is done", errors.RFCCodeText("CDC:ErrEtcdSessionDone"))
 	// ErrReactorFinished is used by reactor to signal a **normal** exit.
 	ErrReactorFinished = errors.Normalize("the reactor has done its job and should no longer be executed", errors.RFCCodeText("CDC:ErrReactorFinished"))
 

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -141,3 +141,8 @@ func (c *Client) TimeToLive(ctx context.Context, lease clientv3.LeaseID, opts ..
 func (c *Client) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
 	return c.cli.Watch(ctx, key, opts...)
 }
+
+// RequestProgress requests a progress notify response be sent in all watch channels.
+func (c *Client) RequestProgress(ctx context.Context) error {
+	return c.cli.RequestProgress(ctx)
+}

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -66,6 +66,8 @@ func NewEtcdWorker(client *etcd.Client, prefix string, reactor Reactor, initStat
 	}, nil
 }
 
+const etcdRequestProgressDuration = 2 * time.Second
+
 // Run starts the EtcdWorker event loop.
 // A tick is generated either on a timer whose interval is timerInterval, or on an Etcd event.
 // If the specified etcd session is Done, this Run function will exit with cerrors.ErrEtcdSessionDone.
@@ -96,6 +98,7 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 		// should never be closed
 		sessionDone = make(chan struct{})
 	}
+	lastReceivedEventTime := time.Now()
 
 	for {
 		var response clientv3.WatchResponse
@@ -106,23 +109,29 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 			return cerrors.ErrEtcdSessionDone.GenWithStackByArgs()
 		case <-ticker.C:
 			// There is no new event to handle on timer ticks, so we have nothing here.
+			if time.Since(lastReceivedEventTime) > etcdRequestProgressDuration {
+				if err := worker.client.RequestProgress(ctx); err != nil {
+					log.Warn("failed to request progress for etcd watcher", zap.Error(err))
+				}
+			}
 		case response = <-watchCh:
 			// In this select case, we receive new events from Etcd, and call handleEvent if appropriate.
 
 			if err := response.Err(); err != nil {
 				return errors.Trace(err)
 			}
-
-			// ProgressNotify implies no new events.
-			if response.IsProgressNotify() {
-				continue
-			}
+			lastReceivedEventTime = time.Now()
 
 			// Check whether the response is stale.
 			if worker.revision >= response.Header.GetRevision() {
 				continue
 			}
 			worker.revision = response.Header.GetRevision()
+
+			// ProgressNotify implies no new events.
+			if response.IsProgressNotify() {
+				continue
+			}
 
 			for _, event := range response.Events {
 				// handleEvent will apply the event to our internal `rawState`.
@@ -160,7 +169,6 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 			if err := worker.applyUpdates(); err != nil {
 				return errors.Trace(err)
 			}
-
 			nextState, err := worker.reactor.Tick(ctx, worker.state)
 			if err != nil {
 				if !cerrors.ErrReactorFinished.Equal(errors.Cause(err)) {
@@ -184,7 +192,11 @@ func (worker *EtcdWorker) handleEvent(_ context.Context, event *clientv3.Event) 
 
 	switch event.Type {
 	case mvccpb.PUT:
-		worker.rawState[util.NewEtcdKeyFromBytes(event.Kv.Key)] = event.Kv.Value
+		value := event.Kv.Value
+		if value == nil {
+			value = []byte{}
+		}
+		worker.rawState[util.NewEtcdKeyFromBytes(event.Kv.Key)] = value
 	case mvccpb.DELETE:
 		delete(worker.rawState, util.NewEtcdKeyFromBytes(event.Kv.Key))
 	}

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -99,7 +99,7 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-sessionDone:
-			return cerrors.ErrEtcdSessionDone
+			return cerrors.ErrEtcdSessionDone.GenWithStackByArgs()
 		case <-ticker.C:
 			// There is no new event to handle on timer ticks, so we have nothing here.
 		case response = <-watchCh:
@@ -159,7 +159,7 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 
 			nextState, err := worker.reactor.Tick(ctx, worker.state)
 			if err != nil {
-				if errors.Cause(err) != cerrors.ErrReactorFinished {
+				if cerrors.ErrReactorFinished.Equal(err) {
 					return errors.Trace(err)
 				}
 				// normal exit

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -163,7 +163,7 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 
 			nextState, err := worker.reactor.Tick(ctx, worker.state)
 			if err != nil {
-				if cerrors.ErrReactorFinished.Equal(err) {
+				if !cerrors.ErrReactorFinished.Equal(errors.Cause(err)) {
 					return errors.Trace(err)
 				}
 				// normal exit

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -211,19 +211,48 @@ func (worker *EtcdWorker) syncRawState(ctx context.Context) error {
 	return nil
 }
 
-func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []*DataPatch) error {
-	cmpSet := make(map[util.EtcdKey]clientv3.Cmp)
-	opSet := make(map[util.EtcdKey]clientv3.Op)
-
-	// tmpRawState cache the changed values which are uncommitted to etcd.
-	tmpRawState := make(map[util.EtcdKey][]byte)
+func mergePatch(patches []*DataPatch) []*DataPatch {
+	patchMap := make(map[util.EtcdKey][]*DataPatch)
 	for _, patch := range patches {
-		// check the tmpRawState to get the newest uncommitted value if exists
-		old, ok := tmpRawState[patch.Key]
-		if !ok {
-			// get the committed value
-			old, ok = worker.rawState[patch.Key]
-		}
+		patchMap[patch.Key] = append(patchMap[patch.Key], patch)
+	}
+	result := make([]*DataPatch, 0, len(patchMap))
+	for key, patches := range patchMap {
+		patches := patches
+		result = append(result, &DataPatch{
+			Key: key,
+			Fun: func(old []byte) ([]byte, error) {
+				for _, patch := range patches {
+					newValue, err := patch.Fun(old)
+					if err != nil {
+						if cerrors.ErrEtcdIgnore.Equal(errors.Cause(err)) {
+							continue
+						}
+						return nil, err
+					}
+					old = newValue
+				}
+				return old, nil
+			},
+		})
+	}
+	return result
+}
+
+func etcdValueEqual(left, right []byte) bool {
+	if len(left) == 0 && len(right) == 0 {
+		return (left == nil && right == nil) || (left != nil && right != nil)
+	}
+	return bytes.Equal(left, right)
+}
+
+func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []*DataPatch) error {
+	patches = mergePatch(patches)
+	cmps := make([]clientv3.Cmp, 0, len(patches))
+	ops := make([]clientv3.Op, 0, len(patches))
+
+	for _, patch := range patches {
+		old, ok := worker.rawState[patch.Key]
 
 		value, err := patch.Fun(old)
 		if err != nil {
@@ -233,22 +262,18 @@ func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []*DataPatch
 			return errors.Trace(err)
 		}
 
-		// if there are multiple patches with the same key, we should keep the compare of the first patch
-		if _, cmpExist := cmpSet[patch.Key]; !cmpExist {
-			// make sure someone else has not updated the key after the last snapshot
-			var cmp clientv3.Cmp
-			// if ok is false, it means that the key of this patch is not exist in a committed state
-			// and also not exist in the uncommitted value cache(tmpRawState)
-			if ok {
-				cmp = clientv3.Compare(clientv3.ModRevision(patch.Key.String()), "<", worker.revision+1)
-			} else {
-				// this compare is equivalent to `patch.Key` is not exist
-				cmp = clientv3.Compare(clientv3.ModRevision(patch.Key.String()), "=", 0)
-			}
-			cmpSet[patch.Key] = cmp
+		// make sure someone else has not updated the key after the last snapshot
+		var cmp clientv3.Cmp
+		// if ok is false, it means that the key of this patch is not exist in a committed state
+		if ok {
+			cmp = clientv3.Compare(clientv3.ModRevision(patch.Key.String()), "<", worker.revision+1)
+		} else {
+			// this compare is equivalent to `patch.Key` is not exist
+			cmp = clientv3.Compare(clientv3.ModRevision(patch.Key.String()), "=", 0)
 		}
+		cmps = append(cmps, cmp)
 
-		if bytes.Equal(old, value) {
+		if etcdValueEqual(old, value) {
 			// Ignore patches that produce a new value that is the same as the old value.
 			continue
 		}
@@ -259,19 +284,8 @@ func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []*DataPatch
 		} else {
 			op = clientv3.OpDelete(patch.Key.String())
 		}
-		// if there are multiple patches with the same key, we should keep the value of the last patch
-		opSet[patch.Key] = op
-		tmpRawState[patch.Key] = value
-	}
-	cmps := make([]clientv3.Cmp, 0, len(cmpSet))
-	ops := make([]clientv3.Op, 0, len(opSet))
-	for _, cmp := range cmpSet {
-		cmps = append(cmps, cmp)
-	}
-	for _, op := range opSet {
 		ops = append(ops, op)
 	}
-
 	resp, err := worker.client.Txn(ctx).If(cmps...).Then(ops...).Commit()
 	if err != nil {
 		return errors.Trace(err)
@@ -282,6 +296,7 @@ func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []*DataPatch
 		worker.barrierRev = resp.Header.GetRevision()
 		return nil
 	}
+
 	return cerrors.ErrEtcdTryAgain.GenWithStackByArgs()
 }
 

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -316,15 +316,15 @@ func logEtcdOps(ops []clientv3.Op, commited bool) {
 	if log.GetLevel() != zapcore.DebugLevel {
 		return
 	}
+	log.Debug("[etcd worker] ==========Update State to ETCD==========")
 	for _, op := range ops {
-		log.Debug("[etcd worker] ==========Update State to ETCD==========")
 		if op.IsDelete() {
 			log.Debug("[etcd worker] delete key", zap.ByteString("key", op.KeyBytes()))
 		} else {
 			log.Debug("[etcd worker] put key", zap.ByteString("key", op.KeyBytes()), zap.ByteString("value", op.ValueBytes()))
 		}
-		log.Debug("[etcd worker] ============State Commit=============", zap.Bool("committed", commited))
 	}
+	log.Debug("[etcd worker] ============State Commit=============", zap.Bool("committed", commited))
 }
 
 func (worker *EtcdWorker) cleanUp() {

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -284,16 +284,17 @@ func (worker *EtcdWorker) applyUpdates() error {
 }
 
 func logEtcdOps(ops []clientv3.Op, commited bool) {
-	if log.GetLevel() == zapcore.DebugLevel {
-		for _, op := range ops {
-			log.Debug("[etcd worker] ==========Update State to ETCD==========")
-			if op.IsDelete() {
-				log.Debug("[etcd worker] delete key", zap.ByteString("key", op.KeyBytes()))
-			} else {
-				log.Debug("[etcd worker] put key", zap.ByteString("key", op.KeyBytes()), zap.ByteString("value", op.ValueBytes()))
-			}
-			log.Debug("[etcd worker] ============State Commit=============", zap.Bool("committed", commited))
+	if log.GetLevel() != zapcore.DebugLevel {
+		return
+	}
+	for _, op := range ops {
+		log.Debug("[etcd worker] ==========Update State to ETCD==========")
+		if op.IsDelete() {
+			log.Debug("[etcd worker] delete key", zap.ByteString("key", op.KeyBytes()))
+		} else {
+			log.Debug("[etcd worker] put key", zap.ByteString("key", op.KeyBytes()), zap.ByteString("value", op.ValueBytes()))
 		}
+		log.Debug("[etcd worker] ============State Commit=============", zap.Bool("committed", commited))
 	}
 }
 

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -477,11 +477,11 @@ func (r *coverReactor) Tick(ctx context.Context, state ReactorState) (nextState 
 		return
 	})
 	r.state.AppendPatch(util.NewEtcdKey(r.prefix+"/key2"), func(old []byte) (newValue []byte, err error) {
-		newValue = append(old, []byte("fin")...)
-		return
+		return nil, nil
 	})
 	r.state.AppendPatch(util.NewEtcdKey(r.prefix+"/key2"), func(old []byte) (newValue []byte, err error) {
-		return nil, nil
+		newValue = append(old, []byte("fin")...)
+		return
 	})
 	return r.state, cerrors.ErrReactorFinished
 }
@@ -511,7 +511,8 @@ func (s *etcdWorkerSuite) TestCover(c *check.C) {
 	c.Assert(string(resp.Kvs[0].Value), check.Equals, "abccbaabccbafinfin")
 	resp, err = cli.Get(ctx, prefix+"/key2")
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.Kvs, check.HasLen, 0)
+	c.Assert(string(resp.Kvs[0].Key), check.Equals, "/cdc_etcd_worker_test/cover/key2")
+	c.Assert(string(resp.Kvs[0].Value), check.Equals, "fin")
 	err = cli.Unwrap().Close()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -263,7 +263,7 @@ func (s *etcdWorkerSuite) TestEtcdSum(c *check.C) {
 				return errors.Trace(err)
 			}
 
-			return errors.Trace(etcdWorker.Run(ctx, 10*time.Millisecond))
+			return errors.Trace(etcdWorker.Run(ctx, nil, 10*time.Millisecond))
 		})
 	}
 
@@ -339,7 +339,7 @@ func (s *etcdWorkerSuite) TestLinearizability(c *check.C) {
 	c.Assert(err, check.IsNil)
 	errg := &errgroup.Group{}
 	errg.Go(func() error {
-		return reactor.Run(ctx, 10*time.Millisecond)
+		return reactor.Run(ctx, nil, 10*time.Millisecond)
 	})
 
 	time.Sleep(500 * time.Millisecond)
@@ -427,7 +427,7 @@ func (s *etcdWorkerSuite) TestFinished(c *check.C) {
 		state: make(map[string]string),
 	})
 	c.Assert(err, check.IsNil)
-	err = reactor.Run(ctx, 10*time.Millisecond)
+	err = reactor.Run(ctx, nil, 10*time.Millisecond)
 	c.Assert(err, check.IsNil)
 	resp, err := cli.Get(ctx, prefix+"/key1")
 	c.Assert(err, check.IsNil)
@@ -503,7 +503,7 @@ func (s *etcdWorkerSuite) TestCover(c *check.C) {
 		state: make(map[string]string),
 	})
 	c.Assert(err, check.IsNil)
-	err = reactor.Run(ctx, 10*time.Millisecond)
+	err = reactor.Run(ctx, nil, 10*time.Millisecond)
 	c.Assert(err, check.IsNil)
 	resp, err := cli.Get(ctx, prefix+"/key1")
 	c.Assert(err, check.IsNil)

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -541,7 +541,10 @@ func (r *emptyTxnReactor) Tick(ctx context.Context, state ReactorState) (nextSta
 	}
 	if r.tickNum == 1 {
 		// Simulating other client writes
-		r.cli.Put(ctx, "/key3", "123")
+		_, err := r.cli.Put(ctx, "/key3", "123")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 
 		r.state.AppendPatch(util.NewEtcdKey(r.prefix+"/key2"), func(old []byte) (newValue []byte, err error) {
 			return []byte("123"), nil

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -518,6 +518,7 @@ func (s *etcdWorkerSuite) TestCover(c *check.C) {
 }
 
 func (s *etcdWorkerSuite) TestMergePatches(c *check.C) {
+	defer testleak.AfterTest(c)()
 	testCases := []struct {
 		state   map[util.EtcdKey][]byte
 		patches []*DataPatch
@@ -652,6 +653,7 @@ func (s *etcdWorkerSuite) TestMergePatches(c *check.C) {
 }
 
 func (s *etcdWorkerSuite) TestEtcdValueEqual(c *check.C) {
+	defer testleak.AfterTest(c)()
 	c.Assert(etcdValueEqual(nil, nil), check.IsTrue)
 	c.Assert(etcdValueEqual(nil, []byte{}), check.IsFalse)
 	c.Assert(etcdValueEqual([]byte{}, nil), check.IsFalse)

--- a/pkg/orchestrator/jsonstate/json_reactor_state_test.go
+++ b/pkg/orchestrator/jsonstate/json_reactor_state_test.go
@@ -124,7 +124,7 @@ func (s *jsonReactorStateSuite) TestSimpleJSONRecord(c *check.C) {
 		c.Assert(err, check.IsNil)
 
 		errg.Go(func() error {
-			err := etcdWorker.Run(ctx, 10*time.Millisecond)
+			err := etcdWorker.Run(ctx, nil, 10*time.Millisecond)
 			if err != nil {
 				log.Error("etcdWorker returned error", zap.Error(err))
 			}

--- a/pkg/orchestrator/jsonstate/json_reactor_state_test.go
+++ b/pkg/orchestrator/jsonstate/json_reactor_state_test.go
@@ -55,7 +55,7 @@ type simpleJSONReactor struct {
 
 func (r *simpleJSONReactor) Tick(_ context.Context, state orchestrator.ReactorState) (nextState orchestrator.ReactorState, err error) {
 	if r.oldVal >= 100 {
-		return nil, cerrors.ErrReactorFinished
+		return r.state, cerrors.ErrReactorFinished
 	}
 	newState := state.(*JSONReactorState)
 	r.state = newState

--- a/testing_utils/cdc_state_checker/cdc_monitor.go
+++ b/testing_utils/cdc_state_checker/cdc_monitor.go
@@ -92,7 +92,7 @@ func newCDCMonitor(ctx context.Context, pd string, credential *security.Credenti
 
 func (m *cdcMonitor) run(ctx context.Context) error {
 	log.Debug("start running cdcMonitor")
-	err := m.etcdWorker.Run(ctx, 200*time.Millisecond)
+	err := m.etcdWorker.Run(ctx, nil, 200*time.Millisecond)
 	log.Error("etcdWorker exited: test-case-failed", zap.Error(err))
 	log.Info("CDC state", zap.Reflect("state", m.reactor.state))
 	return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
some features and bugfix for etcd worker:
 - make sure the pending patches will be committed when reactor returns an ErrReactorFinished
 - support update the same key multiple times in one tick
 - add a beautiful debug info when commit an etcd txn
 - exit the main loop when etcd session is done

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
