### PR TITLE
make: add build-failpoint command and fix failpoint build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ test: unit_test
 
 build: cdc
 
+build-failpoint: failpoint-enable cdc failpoint-disable
+
 cdc:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./main.go
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,10 @@ test: unit_test
 
 build: cdc
 
-build-failpoint: failpoint-enable cdc failpoint-disable
+build-failpoint: 
+	$(FAILPOINT_ENABLE)
+	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./main.go
+	$(FAILPOINT_DISABLE)
 
 cdc:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./main.go

--- a/scripts/fix_lib_zstd.sh
+++ b/scripts/fix_lib_zstd.sh
@@ -1,19 +1,10 @@
 #!/bin/bash
 
-user=$(whoami)
-GOOS=$(go env GOOS)
-GOARCH=$(go env GOARCH)
-module="github.com/valyala/gozstd@v1.7.0"
+GOPATH=$(go env GOPATH)
+module="github.com/apache/pulsar-client-go@v0.1.1"
 
 GO111MODULE=on go mod download ${module}
 # In CI environment, the gopath contains multiple dirs, choose the first one
-cd $(echo $GOPATH|awk -F':' '{print $1}')/pkg/mod/${module}
-sudo MOREFLAGS=-fPIC make clean libzstd.a
-
-sudo which go
-if [[ $? != 0 ]]; then
-    lib_name=libzstd_${GOOS}_${GOARCH}.a
-    echo "mv libzstd__.a ${lib_name}"
-    sudo mv libzstd__.a ${lib_name}
-    sudo chown ${user}:${user} ${lib_name}
-fi
+cd $(echo ${GOPATH}|awk -F':' '{print $1}')/pkg/mod/${module}/pulsar/internal/compression
+sudo rm zstd_cgo.go
+sudo sed -i '/build !cgo/d' zstd.go


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?

 - add a makefile command: `build-failpoint`, which can help us to build a binary with failpoint-enabled
 - refine `fix_lib_zstd.sh`: change the source code of pulsar client to make sure `github.com/valyala/gozstd` will never be built

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note
