### PR TITLE
sink: increase statistics interval

### DIFF
--- a/cdc/sink/statistics.go
+++ b/cdc/sink/statistics.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	printStatusInterval  = 30 * time.Second
+	printStatusInterval  = 10 * time.Minute
 	flushMetricsInterval = 5 * time.Second
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

related to #1392 

Statistics is **changefeed independent**, it works more like a sink keepalive sign.

If TiCDC supports to replicate thousands of changefeeds in the future, the statistic way should be optimized. But currently, it is all right to keep the periodic statistics

### What is changed and how it works?

Increase sink statistics interval to `10 minutes`, which will not be logged too much.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
