### PR TITLE
owner: cleanup checkpoint lag metric when owner exits

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -1143,6 +1143,8 @@ loop:
 	}
 	for _, cf := range o.changeFeeds {
 		cf.Close()
+		changefeedCheckpointTsGauge.DeleteLabelValues(cf.id)
+		changefeedCheckpointTsLagGauge.DeleteLabelValues(cf.id)
 	}
 	if o.stepDown != nil {
 		if err := o.stepDown(ctx); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If owner transfers, the metric `ticdc_owner_checkpoint_ts_lag` is still kept in the old owner, it is safe to remove them since new owner will maintain these metrics.

If we don't remove the outdated metric, we will see two values for the same metric, where the `max` operator will give an unexpected result in Grafana

### What is changed and how it works?

cleanup checkpoint lag metric when owner exits

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
