### PR TITLE
fix the memory leak in sink manager (#1401)

### DIFF
--- a/cdc/sink/manager.go
+++ b/cdc/sink/manager.go
@@ -146,7 +146,7 @@ func (t *tableSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64
 		return t.manager.flushBackendSink(ctx)
 	}
 	resolvedRows := t.buffer[:i]
-	t.buffer = t.buffer[i:]
+	t.buffer = append(make([]*model.RowChangedEvent, 0, len(t.buffer[i:])), t.buffer[i:]...)
 
 	err := t.manager.backendSink.EmitRowChangedEvents(ctx, resolvedRows...)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix the memory leak in sink manager, this bug is import by #1247 , fix #1398

### What is changed and how it works?

https://github.com/pingcap/ticdc/blob/6febbae2ec0425fcad6ad74a0644ec595ccc0189/cdc/sink/manager.go#L149

![image](https://user-images.githubusercontent.com/33834665/106743493-6a829f80-6659-11eb-94d6-13fc97e3d2cb.png)

- The blue squares represent the space referenced by `t.buffer`
- The yellow squares represent space that has been discarded by the `t.buffer`
- All squares that are not white hold a reference of `RowChangeEvnet`

The yellow squares is unreachable but can't be GC, because the `b.buffer` reference the `array` and the `array` include the yellow squares, the GO GC can't reclaim this space.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note
