### PR TITLE
sink/mysql: fix confused error log when creating new changefeed

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -132,12 +132,7 @@ func (s *mysqlSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64
 	return checkpointTs, nil
 }
 
-func (s *mysqlSink) flushRowChangedEvents(ctx context.Context) {
-	receiver, err := s.resolvedNotifier.NewReceiver(50 * time.Millisecond)
-	if err != nil {
-		log.Error("flush row changed events routine starts failed", zap.Error(err))
-		return
-	}
+func (s *mysqlSink) flushRowChangedEvents(ctx context.Context, receiver *notify.Receiver) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -616,7 +611,11 @@ func newMySQLSink(
 		return nil, err
 	}
 
-	go sink.flushRowChangedEvents(ctx)
+	receiver, err := sink.resolvedNotifier.NewReceiver(50 * time.Millisecond)
+	if err != nil {
+		return nil, err
+	}
+	go sink.flushRowChangedEvents(ctx, receiver)
 
 	return sink, nil
 }

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -1211,3 +1211,43 @@ func (s MySQLSinkSuite) TestNewMySQLSinkExecDDL(c *check.C) {
 	err = sink.Close()
 	c.Assert(err, check.IsNil)
 }
+
+func (s MySQLSinkSuite) TestNewMySQLSink(c *check.C) {
+	defer testleak.AfterTest(c)()
+
+	dbIndex := 0
+	mockGetDBConn := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		defer func() {
+			dbIndex++
+		}()
+		if dbIndex == 0 {
+			// test db
+			db, err := mockTestDB()
+			c.Assert(err, check.IsNil)
+			return db, nil
+		}
+		// normal db
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		mock.ExpectClose()
+		c.Assert(err, check.IsNil)
+		return db, nil
+	}
+	backupGetDBConn := getDBConnImpl
+	getDBConnImpl = mockGetDBConn
+	defer func() {
+		getDBConnImpl = backupGetDBConn
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changefeed := "test-changefeed"
+	sinkURI, err := url.Parse("mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=4")
+	c.Assert(err, check.IsNil)
+	rc := config.GetDefaultReplicaConfig()
+	f, err := filter.NewFilter(rc)
+	c.Assert(err, check.IsNil)
+	sink, err := newMySQLSink(ctx, changefeed, sinkURI, f, rc, map[string]string{})
+	c.Assert(err, check.IsNil)
+	err = sink.Close()
+	c.Assert(err, check.IsNil)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #1406 

### What is changed and how it works?

Create receiver when creating the MySQL sink, it doesn't affect the normal workflow of MySQL sink.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
