### PR TITLE
kv-client: add resolved ts heap for quick resolve lock

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -72,7 +72,7 @@ const (
 	// hard code switch
 	// true: use kv client v2, which has a region worker for each stream
 	// false: use kv client v1, which runs a goroutine for every single region
-	enableKVClientV2 = false
+	enableKVClientV2 = true
 )
 
 type singleRegionInfo struct {
@@ -104,6 +104,17 @@ func newSingleRegionInfo(verID tikv.RegionVerID, span regionspan.ComparableSpan,
 		ts:     ts,
 		rpcCtx: rpcCtx,
 	}
+}
+
+// partialClone clones part fields of singleRegionInfo, this is used when error
+// happens, kv client needs to recover region request from singleRegionInfo
+func (s *singleRegionInfo) partialClone() singleRegionInfo {
+	sri := singleRegionInfo{
+		verID: s.verID,
+		span:  s.span.Clone(),
+		ts:    s.ts,
+	}
+	return sri
 }
 
 type regionErrorInfo struct {

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2225,9 +2225,8 @@ func (s *etcdSuite) TestOutOfRegionRangeEvent(c *check.C) {
 	cancel()
 }
 
-func (s *etcdSuite) TestSingleRegionInfoClone(c *check.C) {
+func (s *clientSuite) TestSingleRegionInfoClone(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer s.TearDownTest(c)
 	sri := newSingleRegionInfo(
 		tikv.RegionVerID{},
 		regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")},

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2241,6 +2241,8 @@ func (s *etcdSuite) TestSingleRegionInfoClone(c *check.C) {
 	c.Assert(sri2.rpcCtx, check.IsNil)
 }
 
+// TestResolveLockNoCandidate tests the resolved ts manager can work normally
+// when no region exceeds reslove lock interval, that is what candidate means.
 func (s *etcdSuite) TestResolveLockNoCandidate(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer s.TearDownTest(c)

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2230,7 +2230,7 @@ func (s *etcdSuite) TestSingleRegionInfoClone(c *check.C) {
 	sri := newSingleRegionInfo(
 		tikv.RegionVerID{},
 		regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")},
-		1000, nil)
+		1000, &tikv.RPCContext{})
 	sri2 := sri.partialClone()
 	sri2.ts = 2000
 	sri2.span.End[0] = 'b'
@@ -2238,4 +2238,84 @@ func (s *etcdSuite) TestSingleRegionInfoClone(c *check.C) {
 	c.Assert(sri.span.String(), check.Equals, "[61, 63)")
 	c.Assert(sri2.ts, check.Equals, uint64(2000))
 	c.Assert(sri2.span.String(), check.Equals, "[61, 62)")
+	c.Assert(sri2.rpcCtx, check.IsNil)
+}
+
+func (s *etcdSuite) TestResolveLockNoCandidate(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+
+	ch1 := make(chan *cdcpb.ChangeDataEvent, 10)
+	srv1 := newMockChangeDataService(c, ch1)
+	server1, addr1 := newMockService(ctx, c, srv1, wg)
+
+	defer func() {
+		close(ch1)
+		server1.Stop()
+		wg.Wait()
+	}()
+
+	rpcClient, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
+	c.Assert(err, check.IsNil)
+	pdClient = &mockPDClient{Client: pdClient, versionGen: defaultVersionGen}
+	tiStore, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
+	c.Assert(err, check.IsNil)
+	kvStorage := newStorageWithCurVersionCache(tiStore, addr1)
+	defer kvStorage.Close() //nolint:errcheck
+
+	regionID := uint64(3)
+	storeID := uint64(1)
+	peerID := uint64(4)
+	cluster.AddStore(storeID, addr1)
+	cluster.Bootstrap(regionID, []uint64{storeID}, []uint64{peerID}, peerID)
+
+	baseAllocatedID := currentRequestID()
+	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
+	isPullInit := &mockPullerInit{}
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
+	eventCh := make(chan *model.RegionFeedEvent, 10)
+	wg.Add(1)
+	go func() {
+		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")}, 100, false, lockresolver, isPullInit, eventCh)
+		c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+		cdcClient.Close() //nolint:errcheck
+		wg.Done()
+	}()
+
+	// wait request id allocated with: new session, new request
+	waitRequestID(c, baseAllocatedID+1)
+	initialized := mockInitializedEvent(regionID, currentRequestID())
+	ch1 <- initialized
+
+	var wg2 sync.WaitGroup
+	wg2.Add(1)
+	go func() {
+		defer wg2.Done()
+		for i := 0; i < 6; i++ {
+			physical, logical, err := pdClient.GetTS(ctx)
+			c.Assert(err, check.IsNil)
+			tso := oracle.ComposeTS(physical, logical)
+			resolved := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
+				{
+					RegionId:  regionID,
+					RequestId: currentRequestID(),
+					Event:     &cdcpb.Event_ResolvedTs{ResolvedTs: tso},
+				},
+			}}
+			ch1 <- resolved
+			select {
+			case event := <-eventCh:
+				c.Assert(event.Resolved, check.NotNil)
+			case <-time.After(time.Second):
+				c.Error("resovled event not received")
+			}
+			// will sleep 6s totally, to ensure resolve lock fired once
+			time.Sleep(time.Second)
+		}
+	}()
+
+	wg2.Wait()
+	cancel()
 }

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2227,6 +2227,7 @@ func (s *etcdSuite) TestOutOfRegionRangeEvent(c *check.C) {
 
 func (s *etcdSuite) TestSingleRegionInfoClone(c *check.C) {
 	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
 	sri := newSingleRegionInfo(
 		tikv.RegionVerID{},
 		regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")},

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2224,3 +2224,18 @@ func (s *etcdSuite) TestOutOfRegionRangeEvent(c *check.C) {
 
 	cancel()
 }
+
+func (s *etcdSuite) TestSingleRegionInfoClone(c *check.C) {
+	defer testleak.AfterTest(c)()
+	sri := newSingleRegionInfo(
+		tikv.RegionVerID{},
+		regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")},
+		1000, nil)
+	sri2 := sri.partialClone()
+	sri2.ts = 2000
+	sri2.span.End[0] = 'b'
+	c.Assert(sri.ts, check.Equals, uint64(1000))
+	c.Assert(sri.span.String(), check.Equals, "[61, 63)")
+	c.Assert(sri2.ts, check.Equals, uint64(2000))
+	c.Assert(sri2.span.String(), check.Equals, "[61, 62)")
+}

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -193,14 +193,7 @@ func (s *eventFeedSession) receiveFromStreamV2(
 
 	// always create a new region worker, because `receiveFromStreamV2` is ensured
 	// to call exactly once from outter code logic
-	worker := &regionWorker{
-		session:        s,
-		limiter:        limiter,
-		inputCh:        make(chan *regionStatefulEvent, 1024),
-		outputCh:       s.eventCh,
-		regionStates:   make(map[uint64]*regionFeedState),
-		enableOldValue: s.enableOldValue,
-	}
+	worker := newRegionWorker(s, limiter)
 	s.workersLock.Lock()
 	s.workers[addr] = worker
 	s.workersLock.Unlock()

--- a/cdc/kv/resolvedts_heap.go
+++ b/cdc/kv/resolvedts_heap.go
@@ -1,0 +1,96 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import "container/heap"
+
+// regionResolvedTs contains region resolvedTs information
+type regionResolvedTs struct {
+	regionID   uint64
+	resolvedTs uint64
+	index      int
+}
+
+type resolvedTsHeap []*regionResolvedTs
+
+func (rh resolvedTsHeap) Len() int { return len(rh) }
+
+func (rh resolvedTsHeap) Less(i, j int) bool {
+	return rh[i].resolvedTs < rh[j].resolvedTs
+}
+
+func (rh resolvedTsHeap) Swap(i, j int) {
+	rh[i], rh[j] = rh[j], rh[i]
+	rh[i].index = i
+	rh[j].index = j
+}
+
+func (rh *resolvedTsHeap) Push(x interface{}) {
+	n := len(*rh)
+	item := x.(*regionResolvedTs)
+	item.index = n
+	*rh = append(*rh, item)
+}
+
+func (rh *resolvedTsHeap) Pop() interface{} {
+	old := *rh
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*rh = old[0 : n-1]
+	return item
+}
+
+// resolvedTsManager is a used to maintain resolved ts information for N regions.
+// This struct is not thread safe
+type resolvedTsManager struct {
+	// mapping from regionID to regionResolvedTs object
+	m map[uint64]*regionResolvedTs
+	h resolvedTsHeap
+}
+
+func newResolvedTsManager() *resolvedTsManager {
+	return &resolvedTsManager{
+		m: make(map[uint64]*regionResolvedTs),
+		h: make(resolvedTsHeap, 0),
+	}
+}
+
+// Upsert implements insert	and update on duplicated key
+func (rm *resolvedTsManager) Upsert(item *regionResolvedTs) {
+	if old, ok := rm.m[item.regionID]; ok {
+		// in a single resolved ts manager, the resolved ts of a region should not be fallen back
+		if item.resolvedTs > old.resolvedTs {
+			old.resolvedTs = item.resolvedTs
+			heap.Fix(&rm.h, old.index)
+		}
+	} else {
+		heap.Push(&rm.h, item)
+		rm.m[item.regionID] = item
+	}
+}
+
+// Pop pops a regionResolvedTs from rts heap, delete it from region rts map
+func (rm *resolvedTsManager) Pop() *regionResolvedTs {
+	if rm.Len() == 0 {
+		return nil
+	}
+	item := heap.Pop(&rm.h).(*regionResolvedTs)
+	delete(rm.m, item.regionID)
+	return item
+}
+
+func (rm *resolvedTsManager) Len() int {
+	return len(rm.m)
+}

--- a/cdc/kv/resolvedts_heap_test.go
+++ b/cdc/kv/resolvedts_heap_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+type rtsHeapSuite struct {
+}
+
+var _ = check.Suite(&rtsHeapSuite{})
+
+func (s *rtsHeapSuite) TestResolvedTsManager(c *check.C) {
+	defer testleak.AfterTest(c)()
+	mgr := newResolvedTsManager()
+	initRegions := []*regionResolvedTs{
+		{regionID: 102, resolvedTs: 1040},
+		{regionID: 100, resolvedTs: 1000},
+		{regionID: 101, resolvedTs: 1020},
+	}
+	for _, rts := range initRegions {
+		mgr.Upsert(rts)
+	}
+	c.Assert(mgr.Len(), check.Equals, 3)
+	rts := mgr.Pop()
+	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 100, resolvedTs: 1000, index: -1})
+
+	// resolved ts is not updated
+	mgr.Upsert(rts)
+	rts = mgr.Pop()
+	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 100, resolvedTs: 1000, index: -1})
+
+	// resolved ts updated
+	rts.resolvedTs = 1001
+	mgr.Upsert(rts)
+	mgr.Upsert(&regionResolvedTs{regionID: 100, resolvedTs: 1100})
+
+	rts = mgr.Pop()
+	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 101, resolvedTs: 1020, index: -1})
+	rts = mgr.Pop()
+	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 102, resolvedTs: 1040, index: -1})
+	rts = mgr.Pop()
+	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 100, resolvedTs: 1100, index: -1})
+	rts = mgr.Pop()
+	c.Assert(rts, check.IsNil)
+}

--- a/pkg/regionspan/span.go
+++ b/pkg/regionspan/span.go
@@ -54,6 +54,14 @@ func (s ComparableSpan) Hack() ComparableSpan {
 	return s
 }
 
+// Clone clones a ComparableSpan
+func (s ComparableSpan) Clone() ComparableSpan {
+	return ComparableSpan{
+		Start: append(make([]byte, 0, len(s.Start)), s.Start...),
+		End:   append(make([]byte, 0, len(s.End)), s.End...),
+	}
+}
+
 // Hack will set End as UpperBoundKey if End is Nil.
 func (s Span) Hack() Span {
 	s.Start, s.End = hackSpan(s.Start, s.End)

--- a/pkg/regionspan/span_test.go
+++ b/pkg/regionspan/span_test.go
@@ -137,3 +137,16 @@ func (s *spanSuite) TestSpanHack(c *check.C) {
 		c.Assert(tc.input.Hack(), check.DeepEquals, tc.expect)
 	}
 }
+
+func (s *spanSuite) TestSpanClone(c *check.C) {
+	defer testleak.AfterTest(c)()
+	sp := ComparableSpan{
+		Start: []byte{1},
+		End:   []byte{2},
+	}
+	sp2 := sp.Clone()
+	c.Assert(sp2.String(), check.Equals, "[01, 02)")
+	sp2.End[0] = 9
+	c.Assert(sp.String(), check.Equals, "[01, 02)")
+	c.Assert(sp2.String(), check.Equals, "[01, 09)")
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

part 2 of #1393, please review this PR after #1397 is merged

### What is changed and how it works?

- Add a heap to manage region resolved ts, so we don't need to iterate each region every time, and this can reduce lock contention for region state.
- Use a channel to pass resolved ts update event, so resolved ts update will not block event processing

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
