### PR TITLE
kv-client: filter key overflow region before sending to puller

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1387,6 +1387,14 @@ func (s *eventFeedSession) singleEventFeed(
 			switch x := event.changeEvent.Event.(type) {
 			case *cdcpb.Event_Entries_:
 				for _, entry := range x.Entries.GetEntries() {
+					// if a region with kv range [a, z)
+					// and we only want the get [b, c) from this region,
+					// tikv will return all key events in the region although we specified [b, c) int the request.
+					// we can make tikv only return the events about the keys in the specified range.
+					comparableKey := regionspan.ToComparableKey(entry.GetKey())
+					if !regionspan.KeyInSpan(comparableKey, span) && entry.Type != cdcpb.Event_INITIALIZED {
+						continue
+					}
 					switch entry.Type {
 					case cdcpb.Event_INITIALIZED:
 						if time.Since(startFeedTime) > 20*time.Second {

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1392,6 +1392,7 @@ func (s *eventFeedSession) singleEventFeed(
 					// tikv will return all key events in the region although we specified [b, c) int the request.
 					// we can make tikv only return the events about the keys in the specified range.
 					comparableKey := regionspan.ToComparableKey(entry.GetKey())
+					// key for initialized event is nil
 					if !regionspan.KeyInSpan(comparableKey, span) && entry.Type != cdcpb.Event_INITIALIZED {
 						continue
 					}

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2006,3 +2006,209 @@ func (s *etcdSuite) TestEventAfterFeedStop(c *check.C) {
 	}
 	cancel()
 }
+
+func (s *etcdSuite) TestOutOfRegionRangeEvent(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+
+	ch1 := make(chan *cdcpb.ChangeDataEvent, 10)
+	srv1 := newMockChangeDataService(c, ch1)
+	server1, addr1 := newMockService(ctx, c, srv1, wg)
+
+	defer func() {
+		close(ch1)
+		server1.Stop()
+		wg.Wait()
+	}()
+
+	rpcClient, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
+	c.Assert(err, check.IsNil)
+	pdClient = &mockPDClient{Client: pdClient, versionGen: defaultVersionGen}
+	kvStorage, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
+	c.Assert(err, check.IsNil)
+	defer kvStorage.Close() //nolint:errcheck
+
+	cluster.AddStore(1, addr1)
+	cluster.Bootstrap(3, []uint64{1}, []uint64{4}, 4)
+
+	baseAllocatedID := currentRequestID()
+	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
+	isPullInit := &mockPullerInit{}
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
+	eventCh := make(chan *model.RegionFeedEvent, 10)
+	wg.Add(1)
+	go func() {
+		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")}, 100, false, lockresolver, isPullInit, eventCh)
+		c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+		cdcClient.Close() //nolint:errcheck
+		wg.Done()
+	}()
+
+	// wait request id allocated with: new session, new request
+	waitRequestID(c, baseAllocatedID+1)
+
+	eventsBeforeInit := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
+		// will be filtered out
+		{
+			RegionId:  3,
+			RequestId: currentRequestID(),
+			Event: &cdcpb.Event_Entries_{
+				Entries: &cdcpb.Event_Entries{
+					Entries: []*cdcpb.Event_Row{{
+						Type:     cdcpb.Event_COMMITTED,
+						OpType:   cdcpb.Event_Row_PUT,
+						Key:      []byte("ccc"),
+						Value:    []byte("key out of region range"),
+						StartTs:  105,
+						CommitTs: 115,
+					}},
+				},
+			},
+		},
+		{
+			RegionId:  3,
+			RequestId: currentRequestID(),
+			Event: &cdcpb.Event_Entries_{
+				Entries: &cdcpb.Event_Entries{
+					Entries: []*cdcpb.Event_Row{{
+						Type:     cdcpb.Event_COMMITTED,
+						OpType:   cdcpb.Event_Row_PUT,
+						Key:      []byte("aaaa"),
+						Value:    []byte("committed put event before init"),
+						StartTs:  105,
+						CommitTs: 115,
+					}},
+				},
+			},
+		},
+	}}
+	initialized := mockInitializedEvent(3 /*regionID */, currentRequestID())
+	eventsAfterInit := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
+		// will be filtered out
+		{
+			RegionId:  3,
+			RequestId: currentRequestID(),
+			Event: &cdcpb.Event_Entries_{
+				Entries: &cdcpb.Event_Entries{
+					Entries: []*cdcpb.Event_Row{{
+						Type:    cdcpb.Event_PREWRITE,
+						OpType:  cdcpb.Event_Row_PUT,
+						Key:     []byte("cccd"),
+						Value:   []byte("key out of region range"),
+						StartTs: 135,
+					}},
+				},
+			},
+		},
+		// will be filtered out
+		{
+			RegionId:  3,
+			RequestId: currentRequestID(),
+			Event: &cdcpb.Event_Entries_{
+				Entries: &cdcpb.Event_Entries{
+					Entries: []*cdcpb.Event_Row{{
+						Type:     cdcpb.Event_COMMIT,
+						OpType:   cdcpb.Event_Row_PUT,
+						Key:      []byte("cccd"),
+						StartTs:  135,
+						CommitTs: 145,
+					}},
+				},
+			},
+		},
+		{
+			RegionId:  3,
+			RequestId: currentRequestID(),
+			Event: &cdcpb.Event_Entries_{
+				Entries: &cdcpb.Event_Entries{
+					Entries: []*cdcpb.Event_Row{{
+						Type:    cdcpb.Event_PREWRITE,
+						OpType:  cdcpb.Event_Row_PUT,
+						Key:     []byte("a-normal-put"),
+						Value:   []byte("normal put event"),
+						StartTs: 135,
+					}},
+				},
+			},
+		},
+		{
+			RegionId:  3,
+			RequestId: currentRequestID(),
+			Event: &cdcpb.Event_Entries_{
+				Entries: &cdcpb.Event_Entries{
+					Entries: []*cdcpb.Event_Row{{
+						Type:     cdcpb.Event_COMMIT,
+						OpType:   cdcpb.Event_Row_PUT,
+						Key:      []byte("a-normal-put"),
+						StartTs:  135,
+						CommitTs: 145,
+					}},
+				},
+			},
+		},
+	}}
+	// batch resolved ts
+	eventResolvedBatch := &cdcpb.ChangeDataEvent{
+		ResolvedTs: &cdcpb.ResolvedTs{
+			Regions: []uint64{3},
+			Ts:      145,
+		},
+	}
+
+	expected := []*model.RegionFeedEvent{
+		{
+			Resolved: &model.ResolvedSpan{
+				Span:       regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")},
+				ResolvedTs: 100,
+			},
+			RegionID: 3,
+		},
+		{
+			Val: &model.RawKVEntry{
+				OpType:   model.OpTypePut,
+				Key:      []byte("aaaa"),
+				Value:    []byte("committed put event before init"),
+				StartTs:  105,
+				CRTs:     115,
+				RegionID: 3,
+			},
+			RegionID: 3,
+		},
+		{
+			Val: &model.RawKVEntry{
+				OpType:   model.OpTypePut,
+				Key:      []byte("a-normal-put"),
+				Value:    []byte("normal put event"),
+				StartTs:  135,
+				CRTs:     145,
+				RegionID: 3,
+			},
+			RegionID: 3,
+		},
+		{
+			Resolved: &model.ResolvedSpan{
+				Span:       regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")},
+				ResolvedTs: 145,
+			},
+			RegionID: 3,
+		},
+	}
+
+	ch1 <- eventsBeforeInit
+	ch1 <- initialized
+	ch1 <- eventsAfterInit
+	ch1 <- eventResolvedBatch
+
+	for _, expectedEv := range expected {
+		select {
+		case event := <-eventCh:
+			c.Assert(event, check.DeepEquals, expectedEv)
+		case <-time.After(time.Second):
+			c.Errorf("expected event %v not received", expectedEv)
+		}
+	}
+
+	cancel()
+}

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -167,6 +167,9 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 		for {
 			select {
 			case e := <-eventCh:
+				// Note: puller will process anything received from event channel.
+				// If one key is not expected in given region, it must be filtered
+				// out before sending to puller.
 				if e.Val != nil {
 					metricEventCounterKv.Inc()
 					if err := p.buffer.AddEntry(ctx, *e); err != nil {

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -169,17 +169,6 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 			case e := <-eventCh:
 				if e.Val != nil {
 					metricEventCounterKv.Inc()
-					val := e.Val
-					// if a region with kv range [a, z)
-					// and we only want the get [b, c) from this region,
-					// tikv will return all key events in the region although we specified [b, c) int the request.
-					// we can make tikv only return the events about the keys in the specified range.
-					comparableKey := regionspan.ToComparableKey(val.Key)
-					if !regionspan.KeyInSpans(comparableKey, p.spans) {
-						// log.Warn("key not in spans range", zap.Binary("key", val.Key), zap.Stringer("span", p.spans))
-						continue
-					}
-
 					if err := p.buffer.AddEntry(ctx, *e); err != nil {
 						return errors.Trace(err)
 					}

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -192,7 +192,6 @@ func (s *pullerSuite) TestPullerRawKV(c *check.C) {
 	checkpointTs := uint64(996)
 	plr, cancel, wg, store := s.newPullerForTest(c, spans, checkpointTs)
 
-	// key not in expected region spans, will be ignored
 	plr.cli.Returns(&model.RegionFeedEvent{
 		Val: &model.RawKVEntry{
 			OpType: model.OpTypePut,
@@ -209,7 +208,11 @@ func (s *pullerSuite) TestPullerRawKV(c *check.C) {
 			CRTs:   uint64(1003),
 		},
 	})
-	ev := <-plr.Output()
+	var ev *model.RawKVEntry
+	ev = <-plr.Output()
+	c.Assert(ev.OpType, check.Equals, model.OpTypePut)
+	c.Assert(ev.Key, check.DeepEquals, []byte("a"))
+	ev = <-plr.Output()
 	c.Assert(ev.OpType, check.Equals, model.OpTypePut)
 	c.Assert(ev.Key, check.DeepEquals, []byte("d"))
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix duplicated DDL output from puller.

DDL puller watches two region range, [mDDLJobListl, mDDLJobListm) and [mDDLJobAddIdxListl, mDDLJobAddIdxListm), two ranges belong to the same region. If we filter region-uncover event in puller, we will get duplicated DDL events.

In most cases, regions should not be overlapped, such as each table owns one or more independent regions. However DDL update subscription is a particular case.

There is no bug exposed to user, so we don't need to update release note.

### What is changed and how it works?

Filter key overflow region in kv-client before sending to the puller. The CPU cost for checking region coverage is almost same between checking in kv-client and in puller, while check in kv-client can save some time for event entry processing and channel send operation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
