### PR TITLE
kv-client: use multiple sync.Map to reduce lock contention

### DIFF
--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -15,6 +15,7 @@ package kv
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"time"
 
@@ -33,6 +34,55 @@ import (
 	"golang.org/x/time/rate"
 )
 
+const (
+	minRegionStateBucket = 4
+	maxRegionStateBucket = 16
+)
+
+// regionStateManager provides the get/put way like a sync.Map, and it is divided
+// into several buckets to reduce lock contention
+type regionStateManager struct {
+	bucket int
+	states []*sync.Map
+}
+
+func newRegionStateManager(bucket int) *regionStateManager {
+	if bucket <= 0 {
+		bucket = runtime.NumCPU()
+		if bucket > maxRegionStateBucket {
+			bucket = maxRegionStateBucket
+		}
+		if bucket < minRegionStateBucket {
+			bucket = minRegionStateBucket
+		}
+	}
+	rsm := &regionStateManager{
+		bucket: bucket,
+		states: make([]*sync.Map, bucket),
+	}
+	for i := range rsm.states {
+		rsm.states[i] = new(sync.Map)
+	}
+	return rsm
+}
+
+func (rsm *regionStateManager) getBucket(regionID uint64) int {
+	return int(regionID) % rsm.bucket
+}
+
+func (rsm *regionStateManager) getState(regionID uint64) (*regionFeedState, bool) {
+	bucket := rsm.getBucket(regionID)
+	if val, ok := rsm.states[bucket].Load(regionID); ok {
+		return val.(*regionFeedState), true
+	}
+	return nil, false
+}
+
+func (rsm *regionStateManager) setState(regionID uint64, state *regionFeedState) {
+	bucket := rsm.getBucket(regionID)
+	rsm.states[bucket].Store(regionID, state)
+}
+
 /*
 `regionWorker` maintains N regions, it runs in background for each gRPC stream,
 corresponding to one TiKV store. It receives `regionStatefulEvent` in a channel
@@ -47,15 +97,18 @@ lock for each region state(each region state has one lock).
 for event processing to increase throughput.
 */
 type regionWorker struct {
-	session        *eventFeedSession
-	limiter        *rate.Limiter
-	inputCh        chan *regionStatefulEvent
-	outputCh       chan<- *model.RegionFeedEvent
-	regionStates   map[uint64]*regionFeedState
-	statesLock     sync.RWMutex
+	session *eventFeedSession
+	limiter *rate.Limiter
+
+	inputCh  chan *regionStatefulEvent
+	outputCh chan<- *model.RegionFeedEvent
+
+	statesManager *regionStateManager
+
+	rtsManager  *resolvedTsManager
+	rtsUpdateCh chan *regionResolvedTs
+
 	enableOldValue bool
-	rtsManager     *resolvedTsManager
-	rtsUpdateCh    chan *regionResolvedTs
 }
 
 func newRegionWorker(s *eventFeedSession, limiter *rate.Limiter) *regionWorker {
@@ -64,25 +117,20 @@ func newRegionWorker(s *eventFeedSession, limiter *rate.Limiter) *regionWorker {
 		limiter:        limiter,
 		inputCh:        make(chan *regionStatefulEvent, 1024),
 		outputCh:       s.eventCh,
-		regionStates:   make(map[uint64]*regionFeedState),
-		enableOldValue: s.enableOldValue,
+		statesManager:  newRegionStateManager(-1),
 		rtsManager:     newResolvedTsManager(),
 		rtsUpdateCh:    make(chan *regionResolvedTs, 1024),
+		enableOldValue: s.enableOldValue,
 	}
 	return worker
 }
 
 func (w *regionWorker) getRegionState(regionID uint64) (*regionFeedState, bool) {
-	w.statesLock.RLock()
-	defer w.statesLock.RUnlock()
-	state, ok := w.regionStates[regionID]
-	return state, ok
+	return w.statesManager.getState(regionID)
 }
 
 func (w *regionWorker) setRegionState(regionID uint64, state *regionFeedState) {
-	w.statesLock.Lock()
-	defer w.statesLock.Unlock()
-	w.regionStates[regionID] = state
+	w.statesManager.setState(regionID, state)
 }
 
 func (w *regionWorker) handleSingleRegionError(ctx context.Context, err error, state *regionFeedState) error {
@@ -166,9 +214,8 @@ func (w *regionWorker) resolveLock(ctx context.Context) error {
 				continue
 			}
 			maxVersion := oracle.ComposeTS(oracle.GetPhysical(currentTimeFromPD.Add(-10*time.Second)), 0)
-			w.statesLock.RLock()
 			for _, rts := range expired {
-				state, ok := w.regionStates[rts.regionID]
+				state, ok := w.getRegionState(rts.regionID)
 				if !ok || state.isStopped() {
 					// state is already deleted or stoppped, just continue,
 					// and don't need to push resolved ts back to heap.
@@ -193,7 +240,6 @@ func (w *regionWorker) resolveLock(ctx context.Context) error {
 				w.rtsManager.Upsert(rts)
 				state.lock.RUnlock()
 			}
-			w.statesLock.RUnlock()
 		}
 	}
 }
@@ -440,21 +486,21 @@ func (w *regionWorker) handleResolvedTs(
 // evictAllRegions is used when gRPC stream meets error and re-establish, notify
 // all existing regions to re-establish
 func (w *regionWorker) evictAllRegions(ctx context.Context) error {
-	w.statesLock.Lock()
-	defer w.statesLock.Unlock()
-	for _, state := range w.regionStates {
-		state.lock.RLock()
-		singleRegionInfo := state.sri.partialClone()
-		state.lock.RUnlock()
-		err := w.session.onRegionFail(ctx, regionErrorInfo{
-			singleRegionInfo: singleRegionInfo,
-			err: &rpcCtxUnavailableErr{
-				verID: singleRegionInfo.verID,
-			},
+	var err error
+	for _, states := range w.statesManager.states {
+		states.Range(func(_, value interface{}) bool {
+			state := value.(*regionFeedState)
+			state.lock.RLock()
+			singleRegionInfo := state.sri.partialClone()
+			state.lock.RUnlock()
+			err = w.session.onRegionFail(ctx, regionErrorInfo{
+				singleRegionInfo: singleRegionInfo,
+				err: &rpcCtxUnavailableErr{
+					verID: singleRegionInfo.verID,
+				},
+			})
+			return err == nil
 		})
-		if err != nil {
-			return err
-		}
 	}
-	return nil
+	return err
 }

--- a/cdc/kv/region_worker_test.go
+++ b/cdc/kv/region_worker_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"math/rand"
+	"sync"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+type regionWorkerSuite struct{}
+
+var _ = check.Suite(&regionWorkerSuite{})
+
+func (s *regionWorkerSuite) TestRegionStateManager(c *check.C) {
+	defer testleak.AfterTest(c)()
+	rsm := newRegionStateManager(4)
+
+	regionID := uint64(1000)
+	_, ok := rsm.getState(regionID)
+	c.Assert(ok, check.IsFalse)
+
+	rsm.setState(regionID, &regionFeedState{requestID: 2})
+	state, ok := rsm.getState(regionID)
+	c.Assert(ok, check.IsTrue)
+	c.Assert(state.requestID, check.Equals, uint64(2))
+}
+
+func (s *regionWorkerSuite) TestRegionStateManagerThreadSafe(c *check.C) {
+	defer testleak.AfterTest(c)()
+	rsm := newRegionStateManager(4)
+	regionCount := 100
+	regionIDs := make([]uint64, regionCount)
+	for i := 0; i < regionCount; i++ {
+		regionID := uint64(1000 + i)
+		regionIDs[i] = regionID
+		rsm.setState(regionID, &regionFeedState{requestID: uint64(i + 1), lastResolvedTs: uint64(1000)})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10000; i++ {
+			idx := rand.Intn(regionCount)
+			regionID := regionIDs[idx]
+			s, ok := rsm.getState(regionID)
+			c.Assert(ok, check.IsTrue)
+			s.lock.RLock()
+			c.Assert(s.requestID, check.Equals, uint64(idx+1))
+			s.lock.RUnlock()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10000; i++ {
+			// simulate write less than read
+			if i%5 != 0 {
+				continue
+			}
+			regionID := regionIDs[rand.Intn(regionCount)]
+			s, ok := rsm.getState(regionID)
+			c.Assert(ok, check.IsTrue)
+			s.lock.Lock()
+			s.lastResolvedTs += 10
+			s.lock.Unlock()
+			rsm.setState(regionID, s)
+		}
+	}()
+	wg.Wait()
+
+	totalResolvedTs := uint64(0)
+	for _, regionID := range regionIDs {
+		s, ok := rsm.getState(regionID)
+		c.Assert(ok, check.IsTrue)
+		c.Assert(s.lastResolvedTs, check.Greater, uint64(1000))
+		totalResolvedTs += s.lastResolvedTs
+	}
+	// 100 regions, initial resolved ts 1000;
+	// 2000 * resolved ts forward, increased by 10 each time.
+	c.Assert(totalResolvedTs, check.Equals, uint64(100*1000+2000*10))
+}
+
+func (s *regionWorkerSuite) TestRegionStateManagerBucket(c *check.C) {
+	defer testleak.AfterTest(c)()
+	rsm := newRegionStateManager(-1)
+	c.Assert(rsm.bucket, check.GreaterEqual, minRegionStateBucket)
+	c.Assert(rsm.bucket, check.LessEqual, maxRegionStateBucket)
+
+	bucket := rsm.bucket * 2
+	rsm = newRegionStateManager(bucket)
+	c.Assert(rsm.bucket, check.Equals, bucket)
+}

--- a/cdc/kv/region_worker_test.go
+++ b/cdc/kv/region_worker_test.go
@@ -51,8 +51,9 @@ func (s *regionWorkerSuite) TestRegionStateManagerThreadSafe(c *check.C) {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(20)
-	for j := 0; j < 10; j++ {
+	concurrency := 20
+	wg.Add(concurrency * 2)
+	for j := 0; j < concurrency; j++ {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 10000; i++ {
@@ -66,7 +67,7 @@ func (s *regionWorkerSuite) TestRegionStateManagerThreadSafe(c *check.C) {
 			}
 		}()
 	}
-	for j := 0; j < 10; j++ {
+	for j := 0; j < concurrency; j++ {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 10000; i++ {
@@ -94,8 +95,8 @@ func (s *regionWorkerSuite) TestRegionStateManagerThreadSafe(c *check.C) {
 		totalResolvedTs += s.lastResolvedTs
 	}
 	// 100 regions, initial resolved ts 1000;
-	// 2000 * resolved ts forward, increased by 10 each time, 10 routines
-	c.Assert(totalResolvedTs, check.Equals, uint64(100*1000+2000*10*10))
+	// 2000 * resolved ts forward, increased by 10 each time, routine number is `concurrency`.
+	c.Assert(totalResolvedTs, check.Equals, uint64(100*1000+2000*10*concurrency))
 }
 
 func (s *regionWorkerSuite) TestRegionStateManagerBucket(c *check.C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

part 3 of #1393, please review this PR after #1426 is merged

- In write less, read more scenario, `sync.Map` is faster than RWMutex and Mutex. Note this is concluded from some benchmarks, such as https://github.com/golang/go/issues/17973, https://www.jianshu.com/p/cffffa914381, but maybe not quite suitable for our scene, we need more tests for this point, the most important thing here is to simulate the real world workload.
- Separate into multiple `sync.Map` can accelerate map access

### What is changed and how it works?

- Use multiple `sync.Map`s for regionFeedState get/put operation.
- The bucket size of `sync.Map` pool is determined by cpu number, min threshold, and max threshold

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
### Release note

- No release note