### PR TITLE
pipeline: fix panic message could be ignore when pipeline is exiting

### DIFF
--- a/cdc/sink/common/common.go
+++ b/cdc/sink/common/common.go
@@ -41,9 +41,10 @@ func (t *txnsWithTheSameCommitTs) Append(row *model.RowChangedEvent) {
 	txn, exist := t.txns[row.StartTs]
 	if !exist {
 		txn = &model.SingleTableTxn{
-			StartTs:  row.StartTs,
-			CommitTs: row.CommitTs,
-			Table:    row.Table,
+			StartTs:   row.StartTs,
+			CommitTs:  row.CommitTs,
+			Table:     row.Table,
+			ReplicaID: row.ReplicaID,
 		}
 		t.txns[row.StartTs] = txn
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -85,7 +85,7 @@ func (p *Pipeline) AppendNode(ctx context.Context, name string, node Node) {
 
 func (p *Pipeline) driveRunner(ctx context.Context, previousRunner, runner runner) {
 	defer func() {
-		log.Info("a pipeline node is exited, stopping the hole pipeline", zap.String("name", runner.getName()))
+		log.Info("a pipeline node is exiting, stop the whole pipeline", zap.String("name", runner.getName()))
 		p.close()
 		blackhole(previousRunner)
 		p.runnersWg.Done()

--- a/scripts/jenkins_ci/integration_test_common.groovy
+++ b/scripts/jenkins_ci/integration_test_common.groovy
@@ -103,7 +103,7 @@ def tests(sink_type, node_label) {
                                     dirname=`dirname \$log`
                                     basename=`basename \$log`
                                     mkdir -p "log\$dirname"
-                                    tar zcvf "log\${log%%.*}.tgz" -C "\$dirname" "\$basename"
+                                    tar zcvf "log\${log}.tgz" -C "\$dirname" "\$basename"
                                 done
                             """
                             archiveArtifacts artifacts: "log/tmp/tidb_cdc_test/**/*.tgz", caseSensitive: false


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- fix panic message could be ignore when pipeline is exiting and a node is in panic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
