### PR TITLE
kv-client: add benchmark for kv client

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -68,12 +68,12 @@ const (
 	// failed region will be reloaded via `BatchLoadRegionsWithKeyRange` API. So we
 	// don't need to force reload region any more.
 	regionScheduleReload = false
-
-	// hard code switch
-	// true: use kv client v2, which has a region worker for each stream
-	// false: use kv client v1, which runs a goroutine for every single region
-	enableKVClientV2 = true
 )
+
+// hard code switch
+// true: use kv client v2, which has a region worker for each stream
+// false: use kv client v1, which runs a goroutine for every single region
+var enableKVClientV2 = true
 
 type singleRegionInfo struct {
 	verID  tikv.RegionVerID

--- a/cdc/kv/client_bench_test.go
+++ b/cdc/kv/client_bench_test.go
@@ -1,0 +1,498 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/cdcpb"
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/regionspan"
+	"github.com/pingcap/ticdc/pkg/retry"
+	"github.com/pingcap/ticdc/pkg/security"
+	"github.com/pingcap/ticdc/pkg/txnutil"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
+	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/oracle"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+)
+
+const batchResolvedSize = 100
+
+type mockChangeDataService2 struct {
+	b        *testing.B
+	ch       chan *cdcpb.ChangeDataEvent
+	recvLoop func(server cdcpb.ChangeData_EventFeedServer)
+}
+
+func newMockChangeDataService2(b *testing.B, ch chan *cdcpb.ChangeDataEvent) *mockChangeDataService2 {
+	s := &mockChangeDataService2{
+		b:  b,
+		ch: ch,
+	}
+	return s
+}
+
+func (s *mockChangeDataService2) EventFeed(server cdcpb.ChangeData_EventFeedServer) error {
+	if s.recvLoop != nil {
+		go func() {
+			s.recvLoop(server)
+		}()
+	}
+	for e := range s.ch {
+		if e == nil {
+			break
+		}
+		err := server.Send(e)
+		if err != nil {
+			s.b.Error(err)
+		}
+	}
+	return nil
+}
+
+func newMockService2(
+	ctx context.Context,
+	b *testing.B,
+	srv cdcpb.ChangeDataServer,
+	wg *sync.WaitGroup,
+) (grpcServer *grpc.Server, addr string) {
+	lc := &net.ListenConfig{}
+	listenAddr := "127.0.0.1:0"
+	lis, err := lc.Listen(ctx, "tcp", listenAddr)
+	if err != nil {
+		b.Error(err)
+	}
+	addr = lis.Addr().String()
+	grpcServer = grpc.NewServer()
+	cdcpb.RegisterChangeDataServer(grpcServer, srv)
+	wg.Add(1)
+	go func() {
+		err := grpcServer.Serve(lis)
+		if err != nil {
+			b.Error(err)
+		}
+		wg.Done()
+	}()
+	return
+}
+
+func prepareBenchMultiStore(b *testing.B, storeNum, regionNum int) (
+	*sync.Map, /* regionID -> requestID/storeID */
+	*sync.WaitGroup, /* ensure eventfeed routine exit */
+	context.CancelFunc, /* cancle both mock server and cdc kv client */
+	chan *model.RegionFeedEvent, /* kv client output channel */
+	[]chan *cdcpb.ChangeDataEvent, /* mock server data channels */
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	requestIDs := new(sync.Map)
+
+	servers := make([]*grpc.Server, storeNum)
+	inputs := make([]chan *cdcpb.ChangeDataEvent, storeNum)
+	addrs := make([]string, storeNum)
+	for i := 0; i < storeNum; i++ {
+		mockSrvCh := make(chan *cdcpb.ChangeDataEvent, 100000)
+		srv := newMockChangeDataService2(b, mockSrvCh)
+		srv.recvLoop = func(server cdcpb.ChangeData_EventFeedServer) {
+			for {
+				req, err := server.Recv()
+				if err != nil {
+					return
+				}
+				requestIDs.Store(req.RegionId, req.RequestId)
+			}
+		}
+		server, addr := newMockService2(ctx, b, srv, wg)
+		servers[i] = server
+		inputs[i] = mockSrvCh
+		addrs[i] = addr
+	}
+
+	for i := 0; i < storeNum; i++ {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			<-ctx.Done()
+			close(inputs[i])
+			servers[i].Stop()
+		}()
+	}
+
+	rpcClient, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
+	if err != nil {
+		b.Error(err)
+	}
+	pdClient = &mockPDClient{Client: pdClient, versionGen: defaultVersionGen}
+	tiStore, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
+	if err != nil {
+		b.Error(err)
+	}
+	kvStorage := newStorageWithCurVersionCache(tiStore, addrs[0])
+	defer kvStorage.Close() //nolint:errcheck
+
+	// we set each region has `storeNum` peers
+	regionID := uint64(1_000_000)
+	peers := make([]uint64, storeNum)
+	stores := make([]uint64, storeNum)
+	for i := 0; i < storeNum; i++ {
+		peers[i] = uint64(100_000_000*i) + regionID
+		stores[i] = uint64(i + 1)
+		cluster.AddStore(uint64(i+1), addrs[i])
+	}
+	// bootstrap cluster with the first region
+	cluster.Bootstrap(regionID, stores, peers, peers[0])
+	for i := 0; i < storeNum; i++ {
+		// first region of stores except for the first store
+		if i > 0 {
+			regionID += 1
+			peers := make([]uint64, storeNum)
+			for j := 0; j < storeNum; j++ {
+				peers[j] = uint64(100_000_000*j) + regionID
+			}
+			// peers[i] is the leader peer, locates in store with index i(storeID=i+1)
+			cluster.SplitRaw(regionID-1, regionID, []byte(fmt.Sprintf("a%d", regionID)), peers, peers[i])
+		}
+		// regions following, split from its previous region
+		for j := 1; j < regionNum; j++ {
+			regionID += 1
+			peers := make([]uint64, storeNum)
+			for k := 0; k < storeNum; k++ {
+				peers[k] = uint64(100_000_000*k) + regionID
+			}
+			// peers[i] is the leader peer, locates in store with index i(storeID=i+1)
+			cluster.SplitRaw(regionID-1, regionID, []byte(fmt.Sprintf("a%d", regionID)), peers, peers[i])
+		}
+	}
+
+	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
+	isPullInit := &mockPullerInit{}
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
+	eventCh := make(chan *model.RegionFeedEvent, 1000000)
+	wg.Add(1)
+	go func() {
+		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")}, 100, false, lockresolver, isPullInit, eventCh)
+		if errors.Cause(err) != context.Canceled {
+			b.Error(err)
+		}
+		cdcClient.Close() //nolint:errcheck
+		wg.Done()
+	}()
+
+	// wait all regions requested from cdc kv client
+	err = retry.Run(time.Millisecond*500, 20, func() error {
+		count := 0
+		requestIDs.Range(func(_, _ interface{}) bool {
+			count++
+			return true
+		})
+		if count == regionNum*storeNum {
+			return nil
+		}
+		return errors.Errorf("region number %d is not as expected %d", count, regionNum)
+	})
+	if err != nil {
+		b.Error(err)
+	}
+
+	return requestIDs, wg, cancel, eventCh, inputs
+}
+
+func prepareBench(b *testing.B, regionNum int) (
+	*sync.Map, /* regionID -> requestID */
+	*sync.WaitGroup, /* ensure eventfeed routine exit */
+	context.CancelFunc, /* cancle both mock server and cdc kv client */
+	chan *model.RegionFeedEvent, /* kv client output channel */
+	chan *cdcpb.ChangeDataEvent, /* mock server data channel */
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+
+	requestIDs := new(sync.Map)
+	mockSrvCh := make(chan *cdcpb.ChangeDataEvent, 100000)
+	srv1 := newMockChangeDataService2(b, mockSrvCh)
+	srv1.recvLoop = func(server cdcpb.ChangeData_EventFeedServer) {
+		for {
+			req, err := server.Recv()
+			if err != nil {
+				return
+			}
+			requestIDs.Store(req.RegionId, req.RequestId)
+		}
+	}
+	server1, addr1 := newMockService2(ctx, b, srv1, wg)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		close(mockSrvCh)
+		server1.Stop()
+	}()
+
+	rpcClient, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
+	if err != nil {
+		b.Error(err)
+	}
+	pdClient = &mockPDClient{Client: pdClient, versionGen: defaultVersionGen}
+	tiStore, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
+	if err != nil {
+		b.Error(err)
+	}
+	kvStorage := newStorageWithCurVersionCache(tiStore, addr1)
+	defer kvStorage.Close() //nolint:errcheck
+
+	storeID := uint64(1)
+	cluster.AddStore(storeID, addr1)
+	// bootstrap with region 100_000(100k)
+	cluster.Bootstrap(uint64(100_000), []uint64{storeID}, []uint64{100_001}, 100_001)
+	for i := 1; i < regionNum; i++ {
+		regionID := uint64(i + 100_000)
+		peerID := regionID + 1
+		// split regions to [min, b100_001), [b100_001, b100_002), ... [bN, max)
+		cluster.SplitRaw(regionID-1, regionID, []byte(fmt.Sprintf("b%d", regionID)), []uint64{peerID}, peerID)
+	}
+
+	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
+	isPullInit := &mockPullerInit{}
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
+	eventCh := make(chan *model.RegionFeedEvent, 1000000)
+	wg.Add(1)
+	go func() {
+		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("z")}, 100, false, lockresolver, isPullInit, eventCh)
+		if errors.Cause(err) != context.Canceled {
+			b.Error(err)
+		}
+		cdcClient.Close() //nolint:errcheck
+		wg.Done()
+	}()
+
+	// wait all regions requested from cdc kv client
+	err = retry.Run(time.Millisecond*500, 20, func() error {
+		count := 0
+		requestIDs.Range(func(_, _ interface{}) bool {
+			count++
+			return true
+		})
+		if count == regionNum {
+			return nil
+		}
+		return errors.Errorf("region number %d is not as expected %d", count, regionNum)
+	})
+	if err != nil {
+		b.Error(err)
+	}
+
+	return requestIDs, wg, cancel, eventCh, mockSrvCh
+}
+
+func benchmarkSingleWorkerResolvedTs(b *testing.B, clientV2 bool) {
+	enableKVClientV2 = clientV2
+	log.SetLevel(zapcore.ErrorLevel)
+	tests := []struct {
+		name      string
+		regionNum int
+	}{
+		{name: "10", regionNum: 10},
+		{name: "100", regionNum: 100},
+		{name: "1k", regionNum: 1000},
+		{name: "10k", regionNum: 10_000},
+		{name: "20k", regionNum: 20_000},
+	}
+
+	for _, test := range tests {
+		requestIDs, wg, cancel, eventCh, mockSrvCh := prepareBench(b, test.regionNum)
+
+		// copy to a normal map to reduce access latency
+		copyReqIDs := make(map[uint64]uint64, test.regionNum)
+		requestIDs.Range(func(key, value interface{}) bool {
+			regionID := key.(uint64)
+			requestID := value.(uint64)
+			initialized := mockInitializedEvent(regionID, requestID)
+			mockSrvCh <- initialized
+			copyReqIDs[regionID] = requestID
+			return true
+		})
+
+		b.Run(test.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				batch := 0
+				regions := make([]uint64, 0, batchResolvedSize)
+				rts := oracle.ComposeTS(oracle.GetPhysical(time.Now()), 0)
+				for regionID := range copyReqIDs {
+					batch++
+					regions = append(regions, regionID)
+					if batch == batchResolvedSize {
+						eventResolvedBatch := &cdcpb.ChangeDataEvent{
+							ResolvedTs: &cdcpb.ResolvedTs{
+								Regions: regions,
+								Ts:      rts,
+							},
+						}
+						mockSrvCh <- eventResolvedBatch
+						batch = 0
+						regions = regions[:0]
+					}
+				}
+				if len(regions) > 0 {
+					eventResolvedBatch := &cdcpb.ChangeDataEvent{
+						ResolvedTs: &cdcpb.ResolvedTs{
+							Regions: regions,
+							Ts:      rts,
+						},
+					}
+					mockSrvCh <- eventResolvedBatch
+				}
+				count := 0
+				for range eventCh {
+					count++
+					if count == test.regionNum {
+						break
+					}
+				}
+			}
+		})
+
+		err := retry.Run(time.Millisecond*500, 20, func() error {
+			if len(mockSrvCh) == 0 {
+				return nil
+			}
+			return errors.New("not all events are sent yet")
+		})
+		if err != nil {
+			b.Error(err)
+		}
+
+		cancel()
+		wg.Wait()
+	}
+}
+
+func BenchmarkResolvedTsClientV1(b *testing.B) {
+	benchmarkSingleWorkerResolvedTs(b, false /* clientV1 */)
+}
+
+func BenchmarkResolvedTsClientV2(b *testing.B) {
+	benchmarkSingleWorkerResolvedTs(b, true /* clientV2 */)
+}
+
+func benchmarkMultipleStoreResolvedTs(b *testing.B, clientV2 bool) {
+	enableKVClientV2 = clientV2
+	log.SetLevel(zapcore.ErrorLevel)
+	tests := []struct {
+		name      string
+		storeNum  int
+		regionNum int
+	}{
+		{name: "10", storeNum: 10, regionNum: 1},
+		{name: "100", storeNum: 10, regionNum: 10},
+		{name: "1k", storeNum: 10, regionNum: 100},
+		{name: "10k", storeNum: 10, regionNum: 1_000},
+		{name: "20k", storeNum: 10, regionNum: 2_000},
+	}
+
+	for _, test := range tests {
+		requestIDs, wg, cancel, eventCh, inputs := prepareBenchMultiStore(b, test.storeNum, test.regionNum)
+
+		// copy to a normal map to reduce access latency, mapping from store index to region id list
+		copyReqIDs := make(map[int][]uint64, test.regionNum*test.storeNum)
+		requestIDs.Range(func(key, value interface{}) bool {
+			regionID := key.(uint64)
+			requestID := value.(uint64)
+			initialized := mockInitializedEvent(regionID, requestID)
+			index := int(regionID-1_000_000) / test.regionNum
+			inputs[index] <- initialized
+			if _, ok := copyReqIDs[index]; !ok {
+				copyReqIDs[index] = make([]uint64, 0, test.regionNum)
+			}
+			copyReqIDs[index] = append(copyReqIDs[index], regionID)
+			return true
+		})
+
+		b.Run(test.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rts := oracle.ComposeTS(oracle.GetPhysical(time.Now()), 0)
+				for storeID, regionIDs := range copyReqIDs {
+					batch := 0
+					regions := make([]uint64, 0, batchResolvedSize)
+					for _, regionID := range regionIDs {
+						batch++
+						regions = append(regions, regionID)
+						if batch == batchResolvedSize {
+							eventResolvedBatch := &cdcpb.ChangeDataEvent{
+								ResolvedTs: &cdcpb.ResolvedTs{
+									Regions: regions,
+									Ts:      rts,
+								},
+							}
+							inputs[storeID] <- eventResolvedBatch
+							batch = 0
+							regions = regions[:0]
+						}
+					}
+					if len(regions) > 0 {
+						eventResolvedBatch := &cdcpb.ChangeDataEvent{
+							ResolvedTs: &cdcpb.ResolvedTs{
+								Regions: regions,
+								Ts:      rts,
+							},
+						}
+						inputs[storeID] <- eventResolvedBatch
+					}
+				}
+				count := 0
+				for range eventCh {
+					count++
+					if count == test.regionNum*test.storeNum {
+						break
+					}
+				}
+			}
+		})
+
+		err := retry.Run(time.Millisecond*500, 1000, func() error {
+			for _, input := range inputs {
+				if len(input) != 0 {
+					return errors.New("not all events are sent yet")
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			b.Error(err)
+		}
+
+		cancel()
+		wg.Wait()
+	}
+}
+
+func BenchmarkMultiStoreResolvedTsClientV1(b *testing.B) {
+	benchmarkMultipleStoreResolvedTs(b, false /* clientV1 */)
+}
+
+func BenchmarkMultiStoreResolvedTsClientV2(b *testing.B) {
+	benchmarkMultipleStoreResolvedTs(b, true /* clientV2 */)
+}

--- a/cdc/kv/client_mock_test.go
+++ b/cdc/kv/client_mock_test.go
@@ -1,0 +1,67 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+This file provides some common struct for unit tests an benchmark tests.
+*/
+package kv
+
+import (
+	"context"
+
+	"github.com/pingcap/kvproto/pkg/cdcpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/ticdc/pkg/version"
+	pd "github.com/tikv/pd/client"
+)
+
+type mockPDClient struct {
+	pd.Client
+	versionGen func() string
+}
+
+var _ pd.Client = &mockPDClient{}
+
+func (m *mockPDClient) GetStore(ctx context.Context, storeID uint64) (*metapb.Store, error) {
+	s, err := m.Client.GetStore(ctx, storeID)
+	if err != nil {
+		return nil, err
+	}
+	s.Version = m.versionGen()
+	return s, nil
+}
+
+var defaultVersionGen = func() string {
+	return version.MinTiKVVersion.String()
+}
+
+func mockInitializedEvent(regionID, requestID uint64) *cdcpb.ChangeDataEvent {
+	initialized := &cdcpb.ChangeDataEvent{
+		Events: []*cdcpb.Event{
+			{
+				RegionId:  regionID,
+				RequestId: requestID,
+				Event: &cdcpb.Event_Entries_{
+					Entries: &cdcpb.Event_Entries{
+						Entries: []*cdcpb.Event_Row{
+							{
+								Type: cdcpb.Event_INITIALIZED,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return initialized
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Benchmark for kv client. part of #1393. This PR is based on #1439

### What is changed and how it works?

- [x] Add benchmark for single TiKV store processing, with different region number 10,100,10k, 20k. With 16 cores, performance improvement is **2-4x**, the more regions, the better improvement
- [x] Add benchmark for multiple TiKV store processing (5 or10 stores), with different region number for each store, 10, 100,10k, 20k. With 16 cores, performance improvement is **3-5x**
- [ ] Benchmark for resolved ts manager, this is a separated logic, will be added in another PR

Besides we observed the performance of clientv1 decreases when CPU cores increase, while the clientv2 behaves better, this is as expected, which is described in #1439

TODO: currently kv client test still uses the deprecated `mocktikv` module, and the region management is not efficient in mocktikv, if we test with more than 100k regions, the current test framework can't behavior normally. In the future we need to refactor better test framework for kv client with the help of `unistore`. There is still a long way to go.

### Benchmark result

#### single store

```
➜  go test -test.bench="BenchmarkResolvedTs" -v client_bench_test.go client_mock_test.go $(find . -name \*.go|grep -v test.go)
goos: linux
goarch: amd64
BenchmarkResolvedTsClientV1
BenchmarkResolvedTsClientV1/100
BenchmarkResolvedTsClientV1/100-16                  1928            569194 ns/op
BenchmarkResolvedTsClientV1/1k
BenchmarkResolvedTsClientV1/1k-16                    206           5705813 ns/op
BenchmarkResolvedTsClientV1/10k
BenchmarkResolvedTsClientV1/10k-16                    38          30731666 ns/op
BenchmarkResolvedTsClientV1/50k
BenchmarkResolvedTsClientV1/50k-16                     3         346557151 ns/op
BenchmarkResolvedTsClientV2
BenchmarkResolvedTsClientV2/100
BenchmarkResolvedTsClientV2/100-16                  5767            199218 ns/op
BenchmarkResolvedTsClientV2/1k
BenchmarkResolvedTsClientV2/1k-16                    670           1754215 ns/op
BenchmarkResolvedTsClientV2/10k
BenchmarkResolvedTsClientV2/10k-16                    72          17771234 ns/op
BenchmarkResolvedTsClientV2/50k
BenchmarkResolvedTsClientV2/50k-16                    16          77188958 ns/op
PASS
ok      command-line-arguments  416.153s

➜  go test -test.bench="BenchmarkResolvedTs" -v client_bench_test.go client_mock_test.go $(find . -name \*.go|grep -v test.go) -cpu 2,4,8,16
goos: linux
goarch: amd64
BenchmarkResolvedTsClientV1
BenchmarkResolvedTsClientV1/10
BenchmarkResolvedTsClientV1/10-2           15470             75684 ns/op
BenchmarkResolvedTsClientV1/10-4           14494             79407 ns/op
BenchmarkResolvedTsClientV1/10-8           14211             83283 ns/op
BenchmarkResolvedTsClientV1/10-16          14370             84567 ns/op
BenchmarkResolvedTsClientV1/100
BenchmarkResolvedTsClientV1/100-2                   6270            210179 ns/op
BenchmarkResolvedTsClientV1/100-4                   3273            341361 ns/op
BenchmarkResolvedTsClientV1/100-8                   2607            423418 ns/op
BenchmarkResolvedTsClientV1/100-16                  2188            540176 ns/op
BenchmarkResolvedTsClientV1/1k
BenchmarkResolvedTsClientV1/1k-2                     975           1470865 ns/op
BenchmarkResolvedTsClientV1/1k-4                     354           3070627 ns/op
BenchmarkResolvedTsClientV1/1k-8                     254           4836909 ns/op
BenchmarkResolvedTsClientV1/1k-16                    204           5849652 ns/op
BenchmarkResolvedTsClientV1/10k
BenchmarkResolvedTsClientV1/10k-2                     72          17711405 ns/op
BenchmarkResolvedTsClientV1/10k-4                    100          19954722 ns/op
BenchmarkResolvedTsClientV1/10k-8                    100          23416775 ns/op
BenchmarkResolvedTsClientV1/10k-16                   100          30602296 ns/op
BenchmarkResolvedTsClientV1/20k
BenchmarkResolvedTsClientV1/20k-2                     63          34817618 ns/op
BenchmarkResolvedTsClientV1/20k-4                    100          67575606 ns/op
BenchmarkResolvedTsClientV1/20k-8                     38         116490290 ns/op
BenchmarkResolvedTsClientV1/20k-16                     9         139699407 ns/op
BenchmarkResolvedTsClientV2
BenchmarkResolvedTsClientV2/10
BenchmarkResolvedTsClientV2/10-2                   13989             85574 ns/op
BenchmarkResolvedTsClientV2/10-4                   14595             84207 ns/op
BenchmarkResolvedTsClientV2/10-8                   14074             81905 ns/op
BenchmarkResolvedTsClientV2/10-16                  14634             82997 ns/op
BenchmarkResolvedTsClientV2/100
BenchmarkResolvedTsClientV2/100-2                   5862            230353 ns/op
BenchmarkResolvedTsClientV2/100-4                   5485            206559 ns/op
BenchmarkResolvedTsClientV2/100-8                   6327            197400 ns/op
BenchmarkResolvedTsClientV2/100-16                  5739            197052 ns/op
BenchmarkResolvedTsClientV2/1k
BenchmarkResolvedTsClientV2/1k-2                     885           1435676 ns/op
BenchmarkResolvedTsClientV2/1k-4                     706           1697140 ns/op
BenchmarkResolvedTsClientV2/1k-8                     670           1738167 ns/op
BenchmarkResolvedTsClientV2/1k-16                    756           1823102 ns/op
BenchmarkResolvedTsClientV2/10k
BenchmarkResolvedTsClientV2/10k-2                     75          15179561 ns/op
BenchmarkResolvedTsClientV2/10k-4                    100          18376628 ns/op
BenchmarkResolvedTsClientV2/10k-8                    100          19581265 ns/op
BenchmarkResolvedTsClientV2/10k-16                   100          20228763 ns/op
BenchmarkResolvedTsClientV2/20k
BenchmarkResolvedTsClientV2/20k-2                     64          29323829 ns/op
BenchmarkResolvedTsClientV2/20k-4                    100          36613421 ns/op
BenchmarkResolvedTsClientV2/20k-8                    100          38070251 ns/op
BenchmarkResolvedTsClientV2/20k-16                   100          39602628 ns/op
PASS
ok      command-line-arguments  163.799s
```

#### multiple stores

```

➜  go test -test.bench="BenchmarkMultiStoreResolvedTs" -v client_bench_test.go client_mock_test.go $(find . -name \*.go|grep -v test.go) -cpu 2,4,8,16
goos: linux
goarch: amd64
BenchmarkMultiStoreResolvedTsClientV1
BenchmarkMultiStoreResolvedTsClientV1/10
BenchmarkMultiStoreResolvedTsClientV1/10-2          5772            204762 ns/op
BenchmarkMultiStoreResolvedTsClientV1/10-4         10000            113212 ns/op
BenchmarkMultiStoreResolvedTsClientV1/10-8         15168             82154 ns/op
BenchmarkMultiStoreResolvedTsClientV1/10-16        13296             87791 ns/op
BenchmarkMultiStoreResolvedTsClientV1/100
BenchmarkMultiStoreResolvedTsClientV1/100-2                 3560            312591 ns/op
BenchmarkMultiStoreResolvedTsClientV1/100-4                 5394            235522 ns/op
BenchmarkMultiStoreResolvedTsClientV1/100-8                 4213            300192 ns/op
BenchmarkMultiStoreResolvedTsClientV1/100-16                2990            439680 ns/op
BenchmarkMultiStoreResolvedTsClientV1/1k
BenchmarkMultiStoreResolvedTsClientV1/1k-2                   802           1653916 ns/op
BenchmarkMultiStoreResolvedTsClientV1/1k-4                   606           1878238 ns/op
BenchmarkMultiStoreResolvedTsClientV1/1k-8                   493           2512918 ns/op
BenchmarkMultiStoreResolvedTsClientV1/1k-16                  280           4163484 ns/op
BenchmarkMultiStoreResolvedTsClientV1/10k
BenchmarkMultiStoreResolvedTsClientV1/10k-2                  103          11585027 ns/op
BenchmarkMultiStoreResolvedTsClientV1/10k-4                  100          13296582 ns/op
BenchmarkMultiStoreResolvedTsClientV1/10k-8                  100          19161914 ns/op
BenchmarkMultiStoreResolvedTsClientV1/10k-16                 100          30118042 ns/op
BenchmarkMultiStoreResolvedTsClientV1/20k
BenchmarkMultiStoreResolvedTsClientV1/20k-2                   64          22619291 ns/op
BenchmarkMultiStoreResolvedTsClientV1/20k-4                  100          24677689 ns/op
BenchmarkMultiStoreResolvedTsClientV1/20k-8                  100          31977806 ns/op
BenchmarkMultiStoreResolvedTsClientV1/20k-16                  31          38625688 ns/op
BenchmarkMultiStoreResolvedTsClientV2
BenchmarkMultiStoreResolvedTsClientV2/10
BenchmarkMultiStoreResolvedTsClientV2/10-2                  5994            196473 ns/op
BenchmarkMultiStoreResolvedTsClientV2/10-4                 10000            124822 ns/op
BenchmarkMultiStoreResolvedTsClientV2/10-8                 14564             79922 ns/op
BenchmarkMultiStoreResolvedTsClientV2/10-16                16347             73689 ns/op
BenchmarkMultiStoreResolvedTsClientV2/100
BenchmarkMultiStoreResolvedTsClientV2/100-2                 4255            277017 ns/op
BenchmarkMultiStoreResolvedTsClientV2/100-4                 7011            169607 ns/op
BenchmarkMultiStoreResolvedTsClientV2/100-8                 9676            122424 ns/op
BenchmarkMultiStoreResolvedTsClientV2/100-16                9374            133310 ns/op
BenchmarkMultiStoreResolvedTsClientV2/1k
BenchmarkMultiStoreResolvedTsClientV2/1k-2                  1210           1048665 ns/op
BenchmarkMultiStoreResolvedTsClientV2/1k-4                  1773            682001 ns/op
BenchmarkMultiStoreResolvedTsClientV2/1k-8                  2199            578702 ns/op
BenchmarkMultiStoreResolvedTsClientV2/1k-16                 1466            882235 ns/op
BenchmarkMultiStoreResolvedTsClientV2/10k
BenchmarkMultiStoreResolvedTsClientV2/10k-2                  136           8306401 ns/op
BenchmarkMultiStoreResolvedTsClientV2/10k-4                  206           5616665 ns/op
BenchmarkMultiStoreResolvedTsClientV2/10k-8                  158           8205559 ns/op
BenchmarkMultiStoreResolvedTsClientV2/10k-16                 126           8877618 ns/op
BenchmarkMultiStoreResolvedTsClientV2/20k
BenchmarkMultiStoreResolvedTsClientV2/20k-2                  100          17828279 ns/op
BenchmarkMultiStoreResolvedTsClientV2/20k-4                  100          10794890 ns/op
BenchmarkMultiStoreResolvedTsClientV2/20k-8                  100          10498165 ns/op
BenchmarkMultiStoreResolvedTsClientV2/20k-16                 100          15294017 ns/op
PASS
ok      command-line-arguments  135.126s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
