### PR TITLE
github-action: use specific go version (#1445)

### DIFF
--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Go environment
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.15.0'
+        go-version: '1.15.8'
 
     - name: Cache Lint Tools
       id: cache-lint-tools

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.0'
+          go-version: '1.15.8'
 
       - name: Cache Vendor
         id: cache-vendor
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.0'
+          go-version: '1.15.8'
 
       - name: Cache Vendor
         id: cache-vendor
@@ -136,7 +136,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.0'
+          go-version: '1.15.8'
 
       - name: Cache Vendor
         id: cache-vendor
@@ -193,7 +193,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.0'
+          go-version: '1.15.8'
 
       - name: Cache Vendor
         id: cache-vendor
@@ -249,7 +249,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.0'
+          go-version: '1.15.8'
 
       - name: Cache Vendor
         id: cache-vendor


### PR DESCRIPTION
cherry-pick #1445 to release-4.0
You can switch your code base to this Pull Request by using [git-extras](https://github.com/tj/git-extras):
```bash
# In ticdc repo:
git pr https://github.com/pingcap/ticdc/pull/1446
```

After apply modifications, you can push your change to this PR via:
```bash
git push git@github.com:ti-srebot/ticdc.git pr/1446:release-4.0-8c2a183dc5f8
```

---

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`make check` failed with go1.16, ref: https://github.com/pingcap/ticdc/runs/1961364142

another fix related to #1444


### What is changed and how it works?

change to specific go version in github action, if using the `^x.y.z` way, github action will use a newer go version comparing to `x.y.z` if possible.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note