### PR TITLE
processor: switch on the new processor, refactor processor part five (#1187)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ install:
 	go install ./...
 
 unit_test: check_failpoint_ctl
+	./scripts/fix_lib_zstd.sh
 	mkdir -p "$(TEST_DIR)"
 	$(FAILPOINT_ENABLE)
 	@export log_level=error;\
@@ -84,6 +85,7 @@ unit_test: check_failpoint_ctl
 	$(FAILPOINT_DISABLE)
 
 leak_test: check_failpoint_ctl
+	./scripts/fix_lib_zstd.sh
 	$(FAILPOINT_ENABLE)
 	@export log_level=error;\
 	$(GOTEST) -count=1 --tags leak $(PACKAGES) || { $(FAILPOINT_DISABLE); exit 1; }

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -26,7 +26,10 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/cdc/processor"
+	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/orchestrator"
 	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/util"
 	pd "github.com/tikv/pd/client"
@@ -55,7 +58,9 @@ type Capture struct {
 	pdCli      pd.Client
 	credential *security.Credential
 
-	processors map[string]*processor
+	processorManager *processor.Manager
+
+	processors map[string]*oldProcessor
 	procLock   sync.Mutex
 
 	info *model.CaptureInfo
@@ -64,7 +69,8 @@ type Capture struct {
 	session  *concurrency.Session
 	election *concurrency.Election
 
-	opts *processorOpts
+	opts   *processorOpts
+	closed chan struct{}
 }
 
 // NewCapture returns a new Capture instance
@@ -122,17 +128,20 @@ func NewCapture(
 		AdvertiseAddr: advertiseAddr,
 		Version:       version.ReleaseVersion,
 	}
+	processorManager := processor.NewManager(pdCli, credential, info)
 	log.Info("creating capture", zap.String("capture-id", id), util.ZapFieldCapture(ctx))
 
 	c = &Capture{
-		processors: make(map[string]*processor),
-		etcdClient: cli,
-		credential: credential,
-		session:    sess,
-		election:   elec,
-		info:       info,
-		opts:       opts,
-		pdCli:      pdCli,
+		processors:       make(map[string]*oldProcessor),
+		etcdClient:       cli,
+		credential:       credential,
+		session:          sess,
+		election:         elec,
+		info:             info,
+		opts:             opts,
+		pdCli:            pdCli,
+		processorManager: processorManager,
+		closed:           make(chan struct{}),
 	}
 
 	return
@@ -143,56 +152,85 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	// TODO: we'd better to add some wait mechanism to ensure no routine is blocked
 	defer cancel()
+	defer close(c.closed)
 	err = c.register(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	taskWatcher := NewTaskWatcher(c, &TaskWatcherConfig{
-		Prefix:      kv.TaskStatusKeyPrefix + "/" + c.info.ID,
-		ChannelSize: 128,
-	})
-	log.Info("waiting for tasks", zap.String("capture-id", c.info.ID))
-	var ev *TaskEvent
-	wch := taskWatcher.Watch(ctx)
-	for {
-		// Return error when the session is done unexpectedly, it means the
-		// server does not send heartbeats in time, or network interrupted
-		// In this case, the state of the capture is undermined, the task may
-		// have or have not been rebalanced, the owner may be or not be held,
-		// so we must cancel context to let all sub routines exit.
-		select {
-		case <-c.session.Done():
-			if ctx.Err() != context.Canceled {
-				log.Info("capture session done, capture suicide itself", zap.String("capture-id", c.info.ID))
+	if config.NewReplicaImpl {
+		sessionCli := c.session.Client()
+		etcdWorker, err := orchestrator.NewEtcdWorker(kv.NewCDCEtcdClient(ctx, sessionCli).Client, kv.EtcdKeyBase, c.processorManager, processor.NewGlobalState(c.info.ID))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		log.Info("start to listen processor task...")
+		if err := etcdWorker.Run(ctx, c.session, 200*time.Millisecond); err != nil {
+			// We check ttl of lease instead of check `session.Done`, because
+			// `session.Done` is only notified when etcd client establish a
+			// new keepalive request, there could be a time window as long as
+			// 1/3 of session ttl that `session.Done` can't be triggered even
+			// the lease is already revoked.
+			if cerror.ErrEtcdSessionDone.Equal(err) {
 				return cerror.ErrCaptureSuicide.GenWithStackByArgs()
 			}
-		case ev = <-wch:
-			if ev == nil {
-				return nil
+			lease, inErr := c.etcdClient.Client.TimeToLive(ctx, c.session.Lease())
+			if inErr != nil {
+				return cerror.WrapError(cerror.ErrPDEtcdAPIError, inErr)
 			}
-			if ev.Err != nil {
-				return errors.Trace(ev.Err)
+			if lease.TTL == int64(-1) {
+				log.Warn("handle task event failed because session is disconnected", zap.Error(err))
+				return cerror.ErrCaptureSuicide.GenWithStackByArgs()
 			}
-			failpoint.Inject("captureHandleTaskDelay", nil)
-			if err := c.handleTaskEvent(ctx, ev); err != nil {
-				// We check ttl of lease instead of check `session.Done`, because
-				// `session.Done` is only notified when etcd client establish a
-				// new keepalive request, there could be a time window as long as
-				// 1/3 of session ttl that `session.Done` can't be triggered even
-				// the lease is already revoked.
-				lease, inErr := c.etcdClient.Client.TimeToLive(ctx, c.session.Lease())
-				if inErr != nil {
-					return cerror.WrapError(cerror.ErrPDEtcdAPIError, inErr)
-				}
-				if lease.TTL == int64(-1) {
-					log.Warn("handle task event failed because session is disconnected", zap.Error(err))
+			return errors.Trace(err)
+		}
+	} else {
+		taskWatcher := NewTaskWatcher(c, &TaskWatcherConfig{
+			Prefix:      kv.TaskStatusKeyPrefix + "/" + c.info.ID,
+			ChannelSize: 128,
+		})
+		log.Info("waiting for tasks", zap.String("capture-id", c.info.ID))
+		var ev *TaskEvent
+		wch := taskWatcher.Watch(ctx)
+		for {
+			// Return error when the session is done unexpectedly, it means the
+			// server does not send heartbeats in time, or network interrupted
+			// In this case, the state of the capture is undermined, the task may
+			// have or have not been rebalanced, the owner may be or not be held,
+			// so we must cancel context to let all sub routines exit.
+			select {
+			case <-c.session.Done():
+				if ctx.Err() != context.Canceled {
+					log.Info("capture session done, capture suicide itself", zap.String("capture-id", c.info.ID))
 					return cerror.ErrCaptureSuicide.GenWithStackByArgs()
 				}
-				return errors.Trace(err)
+			case ev = <-wch:
+				if ev == nil {
+					return nil
+				}
+				if ev.Err != nil {
+					return errors.Trace(ev.Err)
+				}
+				failpoint.Inject("captureHandleTaskDelay", nil)
+				if err := c.handleTaskEvent(ctx, ev); err != nil {
+					// We check ttl of lease instead of check `session.Done`, because
+					// `session.Done` is only notified when etcd client establish a
+					// new keepalive request, there could be a time window as long as
+					// 1/3 of session ttl that `session.Done` can't be triggered even
+					// the lease is already revoked.
+					lease, inErr := c.etcdClient.Client.TimeToLive(ctx, c.session.Lease())
+					if inErr != nil {
+						return cerror.WrapError(cerror.ErrPDEtcdAPIError, inErr)
+					}
+					if lease.TTL == int64(-1) {
+						log.Warn("handle task event failed because session is disconnected", zap.Error(err))
+						return cerror.ErrCaptureSuicide.GenWithStackByArgs()
+					}
+					return errors.Trace(err)
+				}
 			}
 		}
 	}
+	return nil
 }
 
 // Campaign to be an owner
@@ -223,6 +261,13 @@ func (c *Capture) Cleanup() {
 
 // Close closes the capture by unregistering it from etcd
 func (c *Capture) Close(ctx context.Context) error {
+	if config.NewReplicaImpl {
+		c.processorManager.AsyncClose()
+		select {
+		case <-c.closed:
+		case <-ctx.Done():
+		}
+	}
 	return errors.Trace(c.etcdClient.DeleteCaptureInfo(ctx, c.info.ID))
 }
 
@@ -247,7 +292,7 @@ func (c *Capture) handleTaskEvent(ctx context.Context, ev *TaskEvent) error {
 	return nil
 }
 
-func (c *Capture) assignTask(ctx context.Context, task *Task) (*processor, error) {
+func (c *Capture) assignTask(ctx context.Context, task *Task) (*oldProcessor, error) {
 	cf, err := c.etcdClient.GetChangeFeedInfo(ctx, task.ChangeFeedID)
 	if err != nil {
 		log.Error("get change feed info failed",

--- a/cdc/capture_test.go
+++ b/cdc/capture_test.go
@@ -106,6 +106,9 @@ func (s *captureSuite) TestCaptureSuicide(c *check.C) {
 func (s *captureSuite) TestCaptureSessionDoneDuringHandleTask(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer s.TearDownTest(c)
+	if config.NewReplicaImpl {
+		c.Skip("this case is designed for old processor")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -125,7 +128,7 @@ func (s *captureSuite) TestCaptureSessionDoneDuringHandleTask(c *check.C) {
 		ctx context.Context, _ pd.Client, _ *security.Credential,
 		session *concurrency.Session, info model.ChangeFeedInfo, changefeedID string,
 		captureInfo model.CaptureInfo, checkpointTs uint64, flushCheckpointInterval time.Duration,
-	) (*processor, error) {
+	) (*oldProcessor, error) {
 		runProcessorCount++
 		etcdCli := kv.NewCDCEtcdClient(ctx, session.Client())
 		_, _, err := etcdCli.GetTaskStatus(ctx, changefeedID, captureInfo.ID)

--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/version"
@@ -117,9 +118,13 @@ func (s *Server) handleDebugInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	fmt.Fprintf(w, "\n\n*** processors info ***:\n\n")
-	for _, p := range s.capture.processors {
-		p.writeDebugInfo(w)
-		fmt.Fprintf(w, "\n")
+	if config.NewReplicaImpl {
+		s.capture.processorManager.WriteDebugInfo(w)
+	} else {
+		for _, p := range s.capture.processors {
+			p.writeDebugInfo(w)
+			fmt.Fprintf(w, "\n")
+		}
 	}
 
 	fmt.Fprintf(w, "\n\n*** etcd info ***:\n\n")

--- a/cdc/metrics.go
+++ b/cdc/metrics.go
@@ -16,9 +16,12 @@ package cdc
 import (
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/cdc/processor"
+	tablepipeline "github.com/pingcap/ticdc/cdc/processor/pipeline"
 	"github.com/pingcap/ticdc/cdc/puller"
 	"github.com/pingcap/ticdc/cdc/puller/sorter"
 	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -33,7 +36,12 @@ func init() {
 	sink.InitMetrics(registry)
 	entry.InitMetrics(registry)
 	sorter.InitMetrics(registry)
-	initProcessorMetrics(registry)
+	if config.NewReplicaImpl {
+		processor.InitMetrics(registry)
+		tablepipeline.InitMetrics(registry)
+	} else {
+		initProcessorMetrics(registry)
+	}
 	initOwnerMetrics(registry)
 	initServerMetrics(registry)
 }

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/filter"
@@ -1041,6 +1042,13 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 			err = o.etcdClient.SaveChangeFeedInfo(ctx, cfInfo, job.CfID)
 			if err != nil {
 				return errors.Trace(err)
+			}
+			if config.NewReplicaImpl {
+				// remove all positions because the old positions may be include an error
+				err = o.etcdClient.RemoveAllTaskPositions(ctx, job.CfID)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 		}
 		// TODO: we need a better admin job workflow. Supposing uses create

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -90,6 +90,7 @@ func (t *tablePipelineImpl) AsyncStop(targetTs model.Ts) {
 		Tp:        pipeline.CommandTypeStopAtTs,
 		StoppedTs: targetTs,
 	}))
+	log.Info("send async stop signal to table", zap.Int64("tableID", t.tableID), zap.Uint64("targetTs", targetTs))
 	if err != nil && !cerror.ErrSendToClosedPipeline.Equal(err) {
 		log.Panic("unexpect error from send to first node", zap.Error(err))
 	}

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -372,6 +372,7 @@ func (p *processor) handleTableOperation(ctx context.Context) error {
 				})
 			case model.OperProcessed:
 				if table.Status() != tablepipeline.TableStatusStopped {
+					log.Debug("the table is still not stopped", zap.Uint64("checkpointTs", table.CheckpointTs()), zap.Int64("tableID", tableID))
 					continue
 				}
 				patchOperation(tableID, func(operation *model.TableOperation) error {

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -28,7 +28,7 @@ var _ = check.Suite(&processorSuite{})
 
 func (s *processorSuite) TestWriteDebugInfo(c *check.C) {
 	defer testleak.AfterTest(c)()
-	p := &processor{
+	p := &oldProcessor{
 		changefeedID: "test",
 		changefeed: model.ChangeFeedInfo{
 			SinkURI: "blackhole://",

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/puller/sorter"
+	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/httputil"
 	"github.com/pingcap/ticdc/pkg/security"
@@ -403,8 +404,9 @@ func (s *Server) run(ctx context.Context) (err error) {
 // Close closes the server.
 func (s *Server) Close() {
 	if s.capture != nil {
-		s.capture.Cleanup()
-
+		if !config.NewReplicaImpl {
+			s.capture.Cleanup()
+		}
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), time.Second*2)
 		err := s.capture.Close(closeCtx)
 		if err != nil {

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -149,7 +149,7 @@ func (s *mysqlSink) flushRowChangedEvents(ctx context.Context, receiver *notify.
 			continue
 		}
 
-		if s.cyclic != nil {
+		if !config.NewReplicaImpl && s.cyclic != nil {
 			// Filter rows if it is origined from downstream.
 			skippedRowCount := cyclic.FilterAndReduceTxns(
 				resolvedTxnsMap, s.cyclic.FilterReplicaID(), s.cyclic.ReplicaID())

--- a/cdc/task_test.go
+++ b/cdc/task_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/util/testleak"
 	"go.etcd.io/etcd/clientv3"
@@ -51,7 +52,7 @@ func (s *taskSuite) SetUpTest(c *check.C) {
 	// Create a task watcher
 	capture := &Capture{
 		etcdClient: kv.NewCDCEtcdClient(context.TODO(), client),
-		processors: make(map[string]*processor),
+		processors: make(map[string]*oldProcessor),
 		info:       &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
 	}
 	c.Assert(capture, check.NotNil)
@@ -78,9 +79,12 @@ func (s *taskSuite) TestNewTaskWatcher(c *check.C) {
 	// NewCapture can not be used because it requires to
 	// initialize the PD service witch does not support to
 	// be embeded.
+	if config.NewReplicaImpl {
+		c.Skip("this case is designed for old processor")
+	}
 	capture := &Capture{
 		etcdClient: kv.NewCDCEtcdClient(context.TODO(), s.c),
-		processors: make(map[string]*processor),
+		processors: make(map[string]*oldProcessor),
 		info:       &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
 	}
 	c.Assert(capture, check.NotNil)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,7 +26,7 @@ import (
 
 // NewReplicaImpl is true if we using new processor
 // new owner should be also switched on after it implemented
-const NewReplicaImpl = true
+const NewReplicaImpl = false
 
 var defaultReplicaConfig = &ReplicaConfig{
 	CaseSensitive:    true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// NewReplicaImpl is true if we using new processor
+// new owner should be also switched on after it implemented
+const NewReplicaImpl = true
+
 var defaultReplicaConfig = &ReplicaConfig{
 	CaseSensitive:    true,
 	EnableOldValue:   false,

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -325,7 +325,7 @@ func (worker *EtcdWorker) applyUpdates() error {
 }
 
 func logEtcdOps(ops []clientv3.Op, commited bool) {
-	if log.GetLevel() != zapcore.DebugLevel {
+	if log.GetLevel() != zapcore.DebugLevel || len(ops) == 0 {
 		return
 	}
 	log.Debug("[etcd worker] ==========Update State to ETCD==========")

--- a/tests/capture_session_done_during_task/run.sh
+++ b/tests/capture_session_done_during_task/run.sh
@@ -31,8 +31,8 @@ function run() {
     run_sql "CREATE table capture_session_done_during_task.t (id int primary key auto_increment, a int)" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
     run_sql "INSERT INTO capture_session_done_during_task.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/captureHandleTaskDelay=sleep(2000)' # old processor
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/processorManagerHandleNewChangefeedDelay=sleep(2000)' # new processor
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/captureHandleTaskDelay=sleep(2000)' # old processor
+    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/processorManagerHandleNewChangefeedDelay=sleep(2000)' # new processor
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
     # wait task is dispatched

--- a/tests/capture_session_done_during_task/run.sh
+++ b/tests/capture_session_done_during_task/run.sh
@@ -31,7 +31,8 @@ function run() {
     run_sql "CREATE table capture_session_done_during_task.t (id int primary key auto_increment, a int)" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
     run_sql "INSERT INTO capture_session_done_during_task.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/captureHandleTaskDelay=sleep(2000)'
+    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/captureHandleTaskDelay=sleep(2000)' # old processor
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/processorManagerHandleNewChangefeedDelay=sleep(2000)' # new processor
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
     # wait task is dispatched

--- a/tests/changefeed_auto_stop/run.sh
+++ b/tests/changefeed_auto_stop/run.sh
@@ -37,8 +37,8 @@ function run() {
     done
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
-    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=return(true)' # old processor
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/pipeline/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/processor/ProcessorUpdatePositionDelaying=sleep(1000)' # new processor
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=return(true)' # old processor
+    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/pipeline/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/processor/ProcessorUpdatePositionDelaying=sleep(1000)' # new processor
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "2" --addr "127.0.0.1:8302" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
     export GO_FAILPOINTS=''
 

--- a/tests/changefeed_auto_stop/run.sh
+++ b/tests/changefeed_auto_stop/run.sh
@@ -8,25 +8,19 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
-function check_changefeed_is_stopped() {
+function check_changefeed_state() {
     endpoints=$1
     changefeedid=$2
-    position=$(ETCDCTL_API=3 etcdctl --endpoints=$endpoints get /tidb/cdc/task/position --prefix)
-    if [[ $position != "" ]]; then
-        exit 1
-    fi
-    status=$(ETCDCTL_API=3 etcdctl --endpoints=$endpoints get /tidb/cdc/task/status --prefix)
-    if [[ $status != "" ]]; then
-        exit 1
-    fi
-    changefeed_info=$(ETCDCTL_API=3 etcdctl --endpoints=$endpoints get /tidb/cdc/changefeed/info/${changefeedid}|tail -n 1)
-    if [[ ! $changefeed_info == *"message\":\"processor sync resolved injected error"* ]]; then
-        echo "changefeed is not marked as failed: $changefeed_info"
+    expected=$3
+    output=$(cdc cli changefeed query --simple --changefeed-id $changefeedid --pd=http://$endpoints 2>&1)
+    state=$(echo $output | grep -oE "\"state\": \"[a-z]+\""|tr -d '" '|awk -F':' '{print $(NF)}')
+    if [ "$state" != "$expected" ]; then
+        echo "unexpected state $output, expected $expected"
         exit 1
     fi
 }
 
-export -f check_changefeed_is_stopped
+export -f check_changefeed_state
 
 function run() {
     DB_COUNT=4
@@ -43,7 +37,8 @@ function run() {
     done
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=return(true)'
+    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=return(true)' # old processor
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/pipeline/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/processor/ProcessorUpdatePositionDelaying=sleep(1000)' # new processor
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "2" --addr "127.0.0.1:8302" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
     export GO_FAILPOINTS=''
 
@@ -57,7 +52,7 @@ function run() {
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"
     fi
 
-    ensure 10 check_changefeed_is_stopped ${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid}
+    ensure 10 check_changefeed_state  ${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "stopped"
 
     cdc cli changefeed resume --changefeed-id=${changefeedid} --pd="http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
     for i in $(seq $DB_COUNT); do

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -175,7 +175,7 @@ EOF
     curl -X POST -d '"warn"' http://127.0.0.1:8300/admin/log
     sleep 3
     # make sure TiCDC does not panic
-    check_changefeed_state $uuid "normal"
+    curl http://127.0.0.1:8300/status
 
     cleanup_process $CDC_BINARY
 }

--- a/tests/cyclic_ab/run.sh
+++ b/tests/cyclic_ab/run.sh
@@ -61,14 +61,14 @@ function run() {
 
     # Echo y to ignore ineligible tables
     echo "y" | run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/" \
+        --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/?safe-mode=false" \
         --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" \
         --cyclic-replica-id 1 \
         --cyclic-filter-replica-ids 2 \
         --cyclic-sync-ddl true
 
     run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${UP_TIDB_HOST}:${UP_TIDB_PORT}/" \
+        --sink-uri="mysql://root@${UP_TIDB_HOST}:${UP_TIDB_PORT}/?safe-mode=false" \
         --pd "http://${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
         --cyclic-replica-id 2 \
         --cyclic-filter-replica-ids 1 \

--- a/tests/cyclic_abc/run.sh
+++ b/tests/cyclic_abc/run.sh
@@ -90,21 +90,21 @@ function run() {
         --cert-allowed-cn "client" # The common name of client.pem
 
     run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/" \
+        --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/?safe-mode=false" \
         --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" \
         --cyclic-replica-id 1 \
         --cyclic-filter-replica-ids 2 \
         --cyclic-sync-ddl true
 
     run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${TLS_TIDB_HOST}:${TLS_TIDB_PORT}/?ssl-ca=${TLS_DIR}/ca.pem&ssl-cert=${TLS_DIR}/server.pem?ssl-key=${TLS_DIR}/server-key.pem" \
+        --sink-uri="mysql://root@${TLS_TIDB_HOST}:${TLS_TIDB_PORT}/?safe-mode=false&ssl-ca=${TLS_DIR}/ca.pem&ssl-cert=${TLS_DIR}/server.pem?ssl-key=${TLS_DIR}/server-key.pem" \
         --pd "http://${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
         --cyclic-replica-id 2 \
         --cyclic-filter-replica-ids 3 \
         --cyclic-sync-ddl true
 
     run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${UP_TIDB_HOST}:${UP_TIDB_PORT}/" \
+        --sink-uri="mysql://root@${UP_TIDB_HOST}:${UP_TIDB_PORT}/?safe-mode=false" \
         --pd "https://${TLS_PD_HOST}:${TLS_PD_PORT}" \
         --changefeed-id "tls-changefeed" \
         --ca=$TLS_DIR/ca.pem \

--- a/tests/ddl_puller_lag/run.sh
+++ b/tests/ddl_puller_lag/run.sh
@@ -21,8 +21,8 @@ function prepare() {
     run_sql "CREATE table test.ddl_puller_lag1(id int primary key, val int);"
     run_sql "CREATE table test.ddl_puller_lag2(id int primary key, val int);"
 
-    # run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --failpoint 'github.com/pingcap/ticdc/cdc/processorDDLResolved=1*sleep(180000)' # old processor
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --failpoint 'github.com/pingcap/ticdc/cdc/processor/processorDDLResolved=1*sleep(180000)' # new processor
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --failpoint 'github.com/pingcap/ticdc/cdc/processorDDLResolved=1*sleep(180000)' # old processor
+    # run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --failpoint 'github.com/pingcap/ticdc/cdc/processor/processorDDLResolved=1*sleep(180000)' # new processor
 
     TOPIC_NAME="ticdc-ddl-puller-lag-test-$RANDOM"
     case $SINK_TYPE in

--- a/tests/ddl_puller_lag/run.sh
+++ b/tests/ddl_puller_lag/run.sh
@@ -21,8 +21,8 @@ function prepare() {
     run_sql "CREATE table test.ddl_puller_lag1(id int primary key, val int);"
     run_sql "CREATE table test.ddl_puller_lag2(id int primary key, val int);"
 
-
-    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --failpoint 'github.com/pingcap/ticdc/cdc/processorDDLResolved=1*sleep(180000)'
+    # run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --failpoint 'github.com/pingcap/ticdc/cdc/processorDDLResolved=1*sleep(180000)' # old processor
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --failpoint 'github.com/pingcap/ticdc/cdc/processor/processorDDLResolved=1*sleep(180000)' # new processor
 
     TOPIC_NAME="ticdc-ddl-puller-lag-test-$RANDOM"
     case $SINK_TYPE in

--- a/tests/processor_panic/run.sh
+++ b/tests/processor_panic/run.sh
@@ -18,8 +18,11 @@ function prepare() {
     # record tso before we create tables to skip the system table DDLs
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
 
+    # run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix 1 --addr 127.0.0.1:8300 --restart true \
+    #               --failpoint 'github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedPreEmit=return(true)' # old processor
+
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix 1 --addr 127.0.0.1:8300 --restart true \
-                   --failpoint 'github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedPreEmit=return(true)'
+                   --failpoint 'github.com/pingcap/ticdc/cdc/processor/pipeline/ProcessorSyncResolvedPreEmit=return(true)' # new processor
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix 2 --addr 127.0.0.1:8301
 

--- a/tests/processor_panic/run.sh
+++ b/tests/processor_panic/run.sh
@@ -18,11 +18,11 @@ function prepare() {
     # record tso before we create tables to skip the system table DDLs
     start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
 
-    # run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix 1 --addr 127.0.0.1:8300 --restart true \
-    #               --failpoint 'github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedPreEmit=return(true)' # old processor
-
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix 1 --addr 127.0.0.1:8300 --restart true \
-                   --failpoint 'github.com/pingcap/ticdc/cdc/processor/pipeline/ProcessorSyncResolvedPreEmit=return(true)' # new processor
+                  --failpoint 'github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedPreEmit=return(true)' # old processor
+
+    # run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix 1 --addr 127.0.0.1:8300 --restart true \
+    #                --failpoint 'github.com/pingcap/ticdc/cdc/processor/pipeline/ProcessorSyncResolvedPreEmit=return(true)' # new processor
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix 2 --addr 127.0.0.1:8301
 

--- a/tests/processor_stop_delay/run.sh
+++ b/tests/processor_stop_delay/run.sh
@@ -23,8 +23,8 @@ function run() {
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"
     fi
-
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processorStopDelay=1*sleep(10000)'
+    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processorStopDelay=1*sleep(10000)' # old processor
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/processorStopDelay=1*sleep(10000)' # new processor
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')

--- a/tests/processor_stop_delay/run.sh
+++ b/tests/processor_stop_delay/run.sh
@@ -23,8 +23,8 @@ function run() {
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"
     fi
-    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processorStopDelay=1*sleep(10000)' # old processor
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/processorStopDelay=1*sleep(10000)' # new processor
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processorStopDelay=1*sleep(10000)' # old processor
+    # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/processorStopDelay=1*sleep(10000)' # new processor
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')


### PR DESCRIPTION
cherry-pick #1187 to release-4.0


<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

 - switch on the new processor
 - add a flag `config.NewReplicaImpl` to enable the new processor
 - this is the last pr in refactor processor
 - fix a bug in the sink node of the table pipeline

#### Note that the new processor is disabled in release-4.0 branches

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
