### PR TITLE
cdclog: fix lint warning

### DIFF
--- a/cdc/sink/cdclog/utils.go
+++ b/cdc/sink/cdclog/utils.go
@@ -108,9 +108,9 @@ func (l *logSink) startFlush(ctx context.Context) error {
 				uReplica := u
 				eg.Go(func() error {
 					log.Info("start Flush asynchronously to storage by caller",
-						zap.Int64("table id", u.TableID()),
-						zap.Int64("size", u.Size().Load()),
-						zap.Int64("event count", u.Events().Load()),
+						zap.Int64("table id", uReplica.TableID()),
+						zap.Int64("size", uReplica.Size().Load()),
+						zap.Int64("event count", uReplica.Events().Load()),
 					)
 					return uReplica.flush(ectx, l)
 				})
@@ -129,9 +129,9 @@ func (l *logSink) startFlush(ctx context.Context) error {
 				if u.shouldFlush() {
 					eg.Go(func() error {
 						log.Info("start Flush asynchronously to storage",
-							zap.Int64("table id", u.TableID()),
-							zap.Int64("size", u.Size().Load()),
-							zap.Int64("event count", u.Events().Load()),
+							zap.Int64("table id", uReplica.TableID()),
+							zap.Int64("size", uReplica.Size().Load()),
+							zap.Int64("event count", uReplica.Events().Load()),
 						)
 						return uReplica.flush(ectx, l)
 					})


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
There is linter warning about 'capture variable in loop'.

### What is changed and how it works?
Use correct variable in goroutine.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

### Release note
- No release note
