### PR TITLE
cmd: check changefeed start-ts when creating or resuming

### DIFF
--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -67,6 +67,19 @@ func newChangefeedCommand() *cobra.Command {
 	return command
 }
 
+func resumeChangefeedCheck(ctx context.Context, cmd *cobra.Command) error {
+	resp, err := applyOwnerChangefeedQuery(ctx, changefeedID, getCredential())
+	if err != nil {
+		return err
+	}
+	info := &cdc.ChangefeedResp{}
+	err = json.Unmarshal([]byte(resp), info)
+	if err != nil {
+		return err
+	}
+	return confirmLargeDataGap(ctx, cmd, info.TSO)
+}
+
 func newAdminChangefeedCommand() []*cobra.Command {
 	cmds := []*cobra.Command{
 		{
@@ -89,6 +102,9 @@ func newAdminChangefeedCommand() []*cobra.Command {
 				job := model.AdminJob{
 					CfID: changefeedID,
 					Type: model.AdminResume,
+				}
+				if err := resumeChangefeedCheck(ctx, cmd); err != nil {
+					return err
 				}
 				return applyAdminChangefeed(ctx, job, getCredential())
 			},
@@ -115,6 +131,9 @@ func newAdminChangefeedCommand() []*cobra.Command {
 		_ = cmd.MarkPersistentFlagRequired("changefeed-id")
 		if cmd.Use == "remove" {
 			cmd.PersistentFlags().BoolVarP(&optForceRemove, "force", "f", false, "remove all information of the changefeed")
+		}
+		if cmd.Use == "resume" {
+			cmd.PersistentFlags().BoolVar(&noConfirm, "no-confirm", false, "Don't ask user whether to ignore ineligible table")
 		}
 	}
 	return cmds
@@ -233,6 +252,9 @@ func verifyChangefeedParamers(ctx context.Context, cmd *cobra.Command, isCreate 
 			startTs = oracle.ComposeTS(ts, logical)
 		}
 		if err := verifyStartTs(ctx, startTs); err != nil {
+			return nil, err
+		}
+		if err := confirmLargeDataGap(ctx, cmd, startTs); err != nil {
 			return nil, err
 		}
 		if err := verifyTargetTs(ctx, startTs, targetTs); err != nil {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -14,15 +14,19 @@
 package cmd
 
 import (
+	"context"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/util/testleak"
-
-	"github.com/pingcap/check"
+	"github.com/pingcap/tidb/store/tikv/oracle"
+	"github.com/spf13/cobra"
+	pd "github.com/tikv/pd/client"
 )
 
 func TestSuite(t *testing.T) { check.TestingT(t) }
@@ -197,4 +201,65 @@ func (s *decodeFileSuite) TestShouldReturnErrForUnknownCfgs(c *check.C) {
 	err = strictDecodeFile(path, "cdc", &cfg)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, ".*unknown config.*")
+}
+
+type mockPDClient struct {
+	pd.Client
+	ts uint64
+}
+
+func (m *mockPDClient) GetTS(ctx context.Context) (int64, int64, error) {
+	return oracle.ExtractPhysical(m.ts), 0, nil
+}
+
+type commonUtilSuite struct{}
+
+var _ = check.Suite(&commonUtilSuite{})
+
+func (s *commonUtilSuite) TestConfirmLargeDataGap(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := context.Background()
+	currentTs := uint64(423482306736160769) // 2021-03-11 17:59:57.547
+	startTs := uint64(423450030227042420)   // 2021-03-10 07:47:52.435
+	pdCli = &mockPDClient{ts: currentTs}
+	cmd := &cobra.Command{}
+
+	// check start ts more than 1 day before current ts, and type N when confirming
+	dir := c.MkDir()
+	path := filepath.Join(dir, "confirm.txt")
+	err := ioutil.WriteFile(path, []byte("n"), 0o644)
+	c.Assert(err, check.IsNil)
+	f, err := os.Open(path)
+	c.Assert(err, check.IsNil)
+	stdin := os.Stdin
+	os.Stdin = f
+	defer func() {
+		os.Stdin = stdin
+	}()
+	err = confirmLargeDataGap(ctx, cmd, startTs)
+	c.Assert(err, check.ErrorMatches, "abort changefeed create or resume")
+
+	// check no confirm works
+	originNoConfirm := noConfirm
+	noConfirm = true
+	defer func() {
+		noConfirm = originNoConfirm
+	}()
+	err = confirmLargeDataGap(ctx, cmd, startTs)
+	c.Assert(err, check.IsNil)
+	noConfirm = false
+
+	// check start ts more than 1 day before current ts, and type Y when confirming
+	err = ioutil.WriteFile(path, []byte("Y"), 0o644)
+	c.Assert(err, check.IsNil)
+	f, err = os.Open(path)
+	c.Assert(err, check.IsNil)
+	os.Stdin = f
+	err = confirmLargeDataGap(ctx, cmd, startTs)
+	c.Assert(err, check.IsNil)
+
+	// check start ts does not exceed threshold
+	pdCli = &mockPDClient{ts: startTs}
+	err = confirmLargeDataGap(ctx, cmd, startTs)
+	c.Assert(err, check.IsNil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add check described in https://github.com/pingcap/ticdc/issues/1150, TODO list item 1

### What is changed and how it works?

- The check is enabled when
   - create a new changefeed, comparing `start-ts` with current tso.
   - or resume a changefeed, comparing changefeed `checkpoint-ts` with current tso.
- The threshold is **1 day**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Add double confirm when creating or resuming changefeed with `start-ts` or `checkpoint-ts` 1 day before current ts.
