### PR TITLE
kv/client: fix panic caused by reentrant unlock pending region

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -765,6 +765,7 @@ MainLoop:
 
 			state := newRegionFeedState(sri, requestID)
 			pendingRegions.insert(requestID, state)
+			failpoint.Inject("kvClientPendingRegionDelay", nil)
 
 			stream, ok := s.getStream(rpcCtx.Addr)
 			// Establish the stream if it has not been connected yet.
@@ -793,8 +794,12 @@ MainLoop:
 					}
 					bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
 					s.client.regionCache.OnSendFail(bo, rpcCtx, regionScheduleReload, err)
-					// Delete the pendingRegion info from `pendingRegions` and retry connecting and sending the request.
-					pendingRegions.take(requestID)
+					// Take the pendingRegion from `pendingRegions`, if the region
+					// is deleted already, we don't retry for this region. Otherwise,
+					// retry to connect and send request for this region.
+					if _, exists := pendingRegions.take(requestID); !exists {
+						continue MainLoop
+					}
 					continue
 				}
 				s.addStream(rpcCtx.Addr, stream)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix bug described in https://github.com/pingcap/ticdc/issues/1457, for kv client V1

### What is changed and how it works?

The error case is as follows

1. kv client establishes two regions request, naming region-1, region-2, they
    belong to the same TiKV store.
2. The region-1 is firstly established, yet region-2 has some delay after its
    region state is inserted into `pendingRegions`
3. At this time the TiKV store crashes and `stream.Recv` returns error. In the
   defer function of `receiveFromStream`, all pending regions will be cleaned
   up, which means the region lock will be unlocked once for these regions.
4. In step-2, the region-2 continues to run, it can't get store stream which
   has been deleted in step-3, so it will create new stream but fails because
   of unstable TiKV store, at this point, the kv client should handle with the
   pending region correctly.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix a bug that TiCDC could panic when some regions are reconnecting and the TiKV store is unstable.
