### PR TITLE
processor: fix a concurrency issues and goroutine leak when processor stopped

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -1143,19 +1143,32 @@ func (p *oldProcessor) stop(ctx context.Context) error {
 	p.globalResolvedTsNotifier.Close()
 	p.localCheckpointTsNotifier.Close()
 	p.localResolvedNotifier.Close()
+	var errRes error
+	if err := p.sinkManager.Close(); err != nil {
+		log.Warn("an error occurred when stopping the processor", zap.Error(err))
+		errRes = err
+	}
 	failpoint.Inject("processorStopDelay", nil)
+	// send an admin stop error to make goroutine created by processor.Run() exit
+	p.sendError(cerror.ErrAdminStopProcessor.GenWithStackByArgs())
 	atomic.StoreInt32(&p.stopped, 1)
-	syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureInfo.AdvertiseAddr).Set(0)
+	if p.wg != nil {
+		p.wg.Wait() //nolint:errcheck
+	}
 	if err := p.etcdCli.DeleteTaskPosition(ctx, p.changefeedID, p.captureInfo.ID); err != nil {
-		return err
+		log.Warn("an error occurred when stopping the processor", zap.Error(err))
+		errRes = err
 	}
 	if err := p.etcdCli.DeleteTaskStatus(ctx, p.changefeedID, p.captureInfo.ID); err != nil {
-		return err
+		log.Warn("an error occurred when stopping the processor", zap.Error(err))
+		errRes = err
 	}
 	if err := p.etcdCli.DeleteTaskWorkload(ctx, p.changefeedID, p.captureInfo.ID); err != nil {
-		return err
+		log.Warn("an error occurred when stopping the processor", zap.Error(err))
+		errRes = err
 	}
-	return p.sinkManager.Close()
+	syncTableNumGauge.WithLabelValues(p.changefeedID, p.captureInfo.AdvertiseAddr).Set(0)
+	return errRes
 }
 
 func (p *oldProcessor) isStopped() bool {

--- a/tests/changefeed_auto_stop/run.sh
+++ b/tests/changefeed_auto_stop/run.sh
@@ -37,7 +37,7 @@ function run() {
     done
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
-    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=return(true)' # old processor
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=sleep(1000)' # old processor
     # export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/processor/pipeline/ProcessorSyncResolvedError=1*return(true);github.com/pingcap/ticdc/cdc/processor/ProcessorUpdatePositionDelaying=sleep(1000)' # new processor
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "2" --addr "127.0.0.1:8302" --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
     export GO_FAILPOINTS=''

--- a/tests/processor_stop_delay_2/conf/diff_config.toml
+++ b/tests/processor_stop_delay_2/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "processor_stop_delay_2"
+    tables = ["~.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/processor_stop_delay_2/run.sh
+++ b/tests/processor_stop_delay_2/run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+TABLE_COUNT=3
+
+function check_position_removed() {
+    pd=$1
+    position=$(cdc cli unsafe show-metadata --pd=$pd | grep "position")
+    cdc cli unsafe show-metadata --pd=$pd
+    echo "AAposition: $position"
+    echo "AAposition: ${#position}"
+    if [[ ! "${#position}" -eq "0" ]]; then
+        echo "position: $position"
+        exit 1
+    fi
+}
+
+export -f check_position_removed
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+    TOPIC_NAME="ticdc-processor-stop-delay-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"
+    fi
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorDDLPullerExitDelaying=sleep(2000);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=sleep(2000)' # old processor
+    # this case should be skipped when new processor enabled
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
+    changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+    run_sql "CREATE DATABASE processor_stop_delay_2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table processor_stop_delay_2.t (id int primary key auto_increment, t datetime DEFAULT CURRENT_TIMESTAMP)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO processor_stop_delay_2.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    # pause changefeed first, and then resume the changefeed. The processor stop
+    # logic will be delayed by 10s, which is controlled by failpoint injection.
+    # The changefeed should be resumed and no data loss.
+    cdc cli changefeed pause --changefeed-id=$changefeed_id --pd=$pd_addr
+    ensure 10 check_position_removed $pd_addr
+    run_sql "INSERT INTO processor_stop_delay_2.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr
+    run_sql "INSERT INTO processor_stop_delay_2.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    export GO_FAILPOINTS=''
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #1546, this bug is only exist in old processor

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->

- processor: fix the bug of untimely release of resources when stopping a processor
