### PR TITLE
sorter: fix Unified Sorter resource release

### DIFF
--- a/cdc/puller/sorter/heap_sorter.go
+++ b/cdc/puller/sorter/heap_sorter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 PingCAP, Inc.
+// Copyright 2021 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/config"
+	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/pkg/workerpool"
 	"go.uber.org/zap"
@@ -43,8 +44,10 @@ type flushTask struct {
 	maxResolvedTs uint64
 	finished      chan error
 	dealloc       func() error
+	isDeallocated int32
 	dataSize      int64
 	lastTs        uint64 // for debugging TODO remove
+	canceller     *asyncCanceller
 }
 
 type heapSorter struct {
@@ -53,6 +56,7 @@ type heapSorter struct {
 	inputCh     chan *model.PolymorphicEvent
 	outputCh    chan *flushTask
 	heap        sortHeap
+	canceller   *asyncCanceller
 
 	poolHandle    workerpool.EventHandle
 	internalState *heapSorterInternalState
@@ -60,10 +64,11 @@ type heapSorter struct {
 
 func newHeapSorter(id int, out chan *flushTask) *heapSorter {
 	return &heapSorter{
-		id:       id,
-		inputCh:  make(chan *model.PolymorphicEvent, 1024*1024),
-		outputCh: out,
-		heap:     make(sortHeap, 0, 65536),
+		id:        id,
+		inputCh:   make(chan *model.PolymorphicEvent, 1024*1024),
+		outputCh:  out,
+		heap:      make(sortHeap, 0, 65536),
+		canceller: new(asyncCanceller),
 	}
 }
 
@@ -115,12 +120,16 @@ func (h *heapSorter) flush(ctx context.Context, maxResolvedTs uint64) error {
 		tsLowerBound:  lowerBound,
 		maxResolvedTs: maxResolvedTs,
 		finished:      finishCh,
+		canceller:     h.canceller,
 	}
 	h.taskCounter++
 
 	var oldHeap sortHeap
 	if !isEmptyFlush {
 		task.dealloc = func() error {
+			if atomic.SwapInt32(&task.isDeallocated, 1) == 1 {
+				return nil
+			}
 			if task.backend != nil {
 				task.backend = nil
 				return pool.dealloc(backEnd)
@@ -146,6 +155,21 @@ func (h *heapSorter) flush(ctx context.Context, maxResolvedTs uint64) error {
 	if !isEmptyFlush {
 		backEndFinal := backEnd
 		err := heapSorterIOPool.Go(ctx, func() {
+			failpoint.Inject("asyncFlushStartDelay", func() {
+				log.Debug("asyncFlushStartDelay")
+			})
+
+			h.canceller.EnterAsyncOp()
+			defer h.canceller.FinishAsyncOp()
+
+			if h.canceller.IsCanceled() {
+				if backEndFinal != nil {
+					_ = task.dealloc()
+				}
+				task.finished <- cerrors.ErrAsyncIOCancelled.GenWithStackByArgs()
+				return
+			}
+
 			writer, err := backEnd.writer()
 			if err != nil {
 				if backEndFinal != nil {
@@ -166,7 +190,18 @@ func (h *heapSorter) flush(ctx context.Context, maxResolvedTs uint64) error {
 				close(task.finished)
 			}()
 
+			counter := 0
 			for oldHeap.Len() > 0 {
+				failpoint.Inject("asyncFlushInProcessDelay", func() {
+					log.Debug("asyncFlushInProcessDelay")
+				})
+				// no need to check for cancellation so frequently.
+				if counter%10000 == 0 && h.canceller.IsCanceled() {
+					task.finished <- cerrors.ErrAsyncIOCancelled.GenWithStackByArgs()
+					return
+				}
+				counter++
+
 				event := heap.Pop(&oldHeap).(*sortItem).entry
 				err := writer.writeNext(event)
 				if err != nil {
@@ -282,6 +317,42 @@ func (h *heapSorter) init(ctx context.Context, onError func(err error)) {
 
 	h.poolHandle = poolHandle
 	h.internalState = state
+}
+
+// asyncCanceller is a shared object used to cancel async IO operations.
+// We do not use `context.Context` because (1) selecting on `ctx.Done()` is expensive
+// especially if the context is shared by many goroutines, and (2) due to the complexity
+// of managing contexts through the workerpools, using a special shared object seems more reasonable
+// and readable.
+type asyncCanceller struct {
+	exitRWLock sync.RWMutex // held when an asynchronous flush is taking place
+	hasExited  int32        // this flag should be accessed atomically
+}
+
+func (c *asyncCanceller) EnterAsyncOp() {
+	c.exitRWLock.RLock()
+}
+
+func (c *asyncCanceller) FinishAsyncOp() {
+	c.exitRWLock.RUnlock()
+}
+
+func (c *asyncCanceller) IsCanceled() bool {
+	return atomic.LoadInt32(&c.hasExited) == 1
+}
+
+func (c *asyncCanceller) Cancel() {
+	// Sets the flag
+	atomic.StoreInt32(&c.hasExited, 1)
+
+	// By taking the lock, we are making sure that all IO operations that started before setting the flag have finished,
+	// so that by the returning of this function, no more IO operations will finish successfully.
+	// Since IO operations that are NOT successful will clean up themselves, the goroutine in which this
+	// function was called is responsible for releasing files written by only those IO operations that complete BEFORE
+	// this function returns.
+	// In short, we are creating a linearization point here.
+	c.exitRWLock.Lock()
+	defer c.exitRWLock.Unlock()
 }
 
 func lazyInitWorkerPool() {

--- a/cdc/puller/sorter/merger.go
+++ b/cdc/puller/sorter/merger.go
@@ -24,12 +24,13 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/model"
+	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"go.uber.org/zap"
 )
 
-func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out chan *model.PolymorphicEvent) error {
+func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out chan *model.PolymorphicEvent, onExit func()) error {
 	captureAddr := util.CaptureAddrFromCtx(ctx)
 	changefeedID := util.ChangefeedIDFromCtx(ctx)
 	_, tableName := util.TableIDFromCtx(ctx)
@@ -46,21 +47,24 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 	lastResolvedTs := make([]uint64, numSorters)
 	minResolvedTs := uint64(0)
 
+	var workingSet map[*flushTask]struct{}
 	pendingSet := make(map[*flushTask]*model.PolymorphicEvent)
 	defer func() {
 		log.Info("Unified Sorter: merger exiting, cleaning up resources", zap.Int("pending-set-size", len(pendingSet)))
-		// clean up resources
-		cleanUpCtx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
-		defer cancel()
-		for task := range pendingSet {
+		// cancel pending async IO operations.
+		onExit()
+		cleanUpTask := func(task *flushTask) {
 			select {
-			case <-cleanUpCtx.Done():
-				// This should only happen when the workerpool is being cancelled, in which case
-				// the whole CDC process is exiting, so the leaked resource should not matter.
-				log.Warn("Unified Sorter: merger cleaning up timeout.")
-				return
 			case err := <-task.finished:
 				_ = printError(err)
+			default:
+				// The task has not finished, so we give up.
+				// It does not matter because:
+				// 1) if the async workerpool has exited, it means the CDC process is exiting, UnifiedSorterCleanUp will
+				// take care of the temp files,
+				// 2) if the async workerpool is not exiting, the unfinished tasks will eventually be executed,
+				// and by that time, since the `onExit` have canceled them, they will not do any IO and clean up themselves.
+				return
 			}
 
 			if task.reader != nil {
@@ -68,6 +72,13 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 				task.reader = nil
 			}
 			_ = printError(task.dealloc())
+		}
+
+		for task := range pendingSet {
+			cleanUpTask(task)
+		}
+		for task := range workingSet {
+			cleanUpTask(task)
 		}
 	}()
 
@@ -93,33 +104,8 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 
 	onMinResolvedTsUpdate := func() error {
 		metricSorterMergerStartTsGauge.Set(float64(oracle.ExtractPhysical(minResolvedTs)))
-
-		workingSet := make(map[*flushTask]struct{})
+		workingSet = make(map[*flushTask]struct{})
 		sortHeap := new(sortHeap)
-
-		defer func() {
-			// clean up
-			cleanUpCtx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
-			defer cancel()
-			for task := range workingSet {
-				select {
-				case <-cleanUpCtx.Done():
-					// This should only happen when the workerpool is being cancelled, in which case
-					// the whole CDC process is exiting, so the leaked resource should not matter.
-					log.Warn("Unified Sorter: merger cleaning up timeout.")
-					return
-				case err := <-task.finished:
-					_ = printError(err)
-				}
-
-				if task.reader != nil {
-					err := task.reader.resetAndClose()
-					task.reader = nil
-					_ = printError(err)
-				}
-				_ = printError(task.dealloc())
-			}
-		}()
 
 		for task, cache := range pendingSet {
 			if task.tsLowerBound > minResolvedTs {
@@ -224,9 +210,7 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 
 		counter := 0
 		for sortHeap.Len() > 0 {
-			failpoint.Inject("sorterMergeDelay", func() {
-				log.Debug("sorterMergeDelay")
-			})
+			failpoint.Inject("sorterMergeDelay", func() {})
 
 			item := heap.Pop(sortHeap).(*sortItem)
 			task := item.data.(*flushTask)
@@ -426,7 +410,8 @@ func printError(err error) error {
 	if err != nil && errors.Cause(err) != context.Canceled &&
 		errors.Cause(err) != context.DeadlineExceeded &&
 		!strings.Contains(err.Error(), "context canceled") &&
-		!strings.Contains(err.Error(), "context deadline exceeded") {
+		!strings.Contains(err.Error(), "context deadline exceeded") &&
+		cerrors.ErrAsyncIOCancelled.NotEqual(errors.Cause(err)) {
 
 		log.Warn("Unified Sorter: Error detected", zap.Error(err))
 	}

--- a/cdc/puller/sorter/merger_test.go
+++ b/cdc/puller/sorter/merger_test.go
@@ -105,7 +105,7 @@ func (s *sorterSuite) TestMergerSingleHeap(c *check.C) {
 	outChan := make(chan *model.PolymorphicEvent, 1024)
 
 	wg.Go(func() error {
-		return runMerger(ctx, 1, inChan, outChan)
+		return runMerger(ctx, 1, inChan, outChan, func() {})
 	})
 
 	totalCount := 0
@@ -176,7 +176,7 @@ func (s *sorterSuite) TestMergerSingleHeapRetire(c *check.C) {
 	outChan := make(chan *model.PolymorphicEvent, 1024)
 
 	wg.Go(func() error {
-		return runMerger(ctx, 1, inChan, outChan)
+		return runMerger(ctx, 1, inChan, outChan, func() {})
 	})
 
 	totalCount := 0
@@ -257,7 +257,7 @@ func (s *sorterSuite) TestMergerSortDelay(c *check.C) {
 	outChan := make(chan *model.PolymorphicEvent, 1024)
 
 	wg.Go(func() error {
-		return runMerger(ctx, 1, inChan, outChan)
+		return runMerger(ctx, 1, inChan, outChan, func() {})
 	})
 
 	totalCount := 0
@@ -337,7 +337,7 @@ func (s *sorterSuite) TestMergerCancel(c *check.C) {
 	outChan := make(chan *model.PolymorphicEvent, 1024)
 
 	wg.Go(func() error {
-		return runMerger(ctx, 1, inChan, outChan)
+		return runMerger(ctx, 1, inChan, outChan, func() {})
 	})
 
 	builder := newMockFlushTaskBuilder()
@@ -376,6 +376,62 @@ func (s *sorterSuite) TestMergerCancel(c *check.C) {
 	c.Assert(atomic.LoadInt64(&backEndCounterForTest), check.Equals, int64(0))
 }
 
+// TestMergerCancel simulates a situation where the merger is cancelled with pending data.
+// Expects proper clean-up of the data.
+func (s *sorterSuite) TestMergerCancelWithUnfinishedFlushTasks(c *check.C) {
+	defer testleak.AfterTest(c)()
+	err := failpoint.Enable("github.com/pingcap/ticdc/cdc/puller/sorter/sorterDebug", "return(true)")
+	c.Assert(err, check.IsNil)
+
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	wg, ctx := errgroup.WithContext(ctx)
+	inChan := make(chan *flushTask, 1024)
+	outChan := make(chan *model.PolymorphicEvent, 1024)
+
+	wg.Go(func() error {
+		return runMerger(ctx, 1, inChan, outChan, func() {})
+	})
+
+	builder := newMockFlushTaskBuilder()
+	task1 := builder.generateRowChanges(1000, 100000, 2048).addResolved(100001).build()
+	builder = newMockFlushTaskBuilder()
+	task2 := builder.generateRowChanges(100002, 200000, 2048).addResolved(200001).build()
+	builder = newMockFlushTaskBuilder()
+	task3 := builder.generateRowChanges(200002, 300000, 2048).addResolved(300001).build()
+
+	wg.Go(func() error {
+		inChan <- task1
+		inChan <- task2
+		inChan <- task3
+		close(task2.finished)
+		close(task1.finished)
+		time.Sleep(1 * time.Second)
+		cancel()
+		return nil
+	})
+
+	wg.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-outChan:
+				// We just drain the data here. We don't care about it.
+			}
+		}
+	})
+
+	c.Assert(wg.Wait(), check.ErrorMatches, ".*context canceled.*")
+	close(inChan)
+	mergerCleanUp(inChan)
+	// Leaking one task is expected
+	c.Assert(atomic.LoadInt64(&backEndCounterForTest), check.Equals, int64(1))
+	atomic.StoreInt64(&backEndCounterForTest, 0)
+}
+
 // TestMergerCancel simulates a situation where the input channel is abruptly closed.
 // There is expected to be NO fatal error.
 func (s *sorterSuite) TestMergerCloseChannel(c *check.C) {
@@ -399,7 +455,7 @@ func (s *sorterSuite) TestMergerCloseChannel(c *check.C) {
 	close(task1.finished)
 
 	wg.Go(func() error {
-		return runMerger(ctx, 1, inChan, outChan)
+		return runMerger(ctx, 1, inChan, outChan, func() {})
 	})
 
 	wg.Go(func() error {

--- a/cdc/puller/sorter/sorter_test.go
+++ b/cdc/puller/sorter/sorter_test.go
@@ -76,7 +76,7 @@ func (s *sorterSuite) TestSorterBasic(c *check.C) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-	testSorter(ctx, c, sorter, 10000)
+	testSorter(ctx, c, sorter, 10000, true)
 }
 
 func (s *sorterSuite) TestSorterCancel(c *check.C) {
@@ -102,21 +102,21 @@ func (s *sorterSuite) TestSorterCancel(c *check.C) {
 
 	finishedCh := make(chan struct{})
 	go func() {
-		testSorter(ctx, c, sorter, 10000000)
+		testSorter(ctx, c, sorter, 10000000, true)
 		close(finishedCh)
 	}()
 
 	after := time.After(30 * time.Second)
 	select {
 	case <-after:
-		c.FailNow()
+		c.Fatal("TestSorterCancel timed out")
 	case <-finishedCh:
 	}
 
 	log.Info("Sorter successfully cancelled")
 }
 
-func testSorter(ctx context.Context, c *check.C, sorter puller.EventSorter, count int) {
+func testSorter(ctx context.Context, c *check.C, sorter puller.EventSorter, count int, needWorkerPool bool) {
 	err := failpoint.Enable("github.com/pingcap/ticdc/cdc/puller/sorter/sorterDebug", "return(true)")
 	if err != nil {
 		log.Panic("Could not enable failpoint", zap.Error(err))
@@ -128,9 +128,11 @@ func testSorter(ctx context.Context, c *check.C, sorter puller.EventSorter, coun
 		return sorter.Run(ctx)
 	})
 
-	errg.Go(func() error {
-		return RunWorkerPool(ctx)
-	})
+	if needWorkerPool {
+		errg.Go(func() error {
+			return RunWorkerPool(ctx)
+		})
+	}
 
 	producerProgress := make([]uint64, numProducers)
 
@@ -158,7 +160,7 @@ func testSorter(ctx context.Context, c *check.C, sorter puller.EventSorter, coun
 
 	// launch the resolver
 	errg.Go(func() error {
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
@@ -270,4 +272,45 @@ func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
 
 	c.Assert(pool, check.NotNil)
 	c.Assert(pool.dir, check.Equals, "/tmp/sorter")
+}
+
+// TestSorterCancelRestart tests the situation where the Unified Sorter is repeatedly canceled and
+// restarted. There should not be any problem, especially file corruptions.
+func (s *sorterSuite) TestSorterCancelRestart(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer UnifiedSorterCleanUp()
+
+	conf := config.GetDefaultServerConfig()
+	conf.Sorter = &config.SorterConfig{
+		NumConcurrentWorker:    8,
+		ChunkSizeLimit:         1 * 1024 * 1024 * 1024,
+		MaxMemoryPressure:      0, // disable memory sort
+		MaxMemoryConsumption:   0,
+		NumWorkerPoolGoroutine: 4,
+	}
+	config.StoreGlobalServerConfig(conf)
+
+	err := os.MkdirAll("/tmp/sorter", 0o755)
+	c.Assert(err, check.IsNil)
+
+	// enable the failpoint to simulate delays
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/puller/sorter/asyncFlushStartDelay", "sleep(100)")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/puller/sorter/asyncFlushStartDelay")
+	}()
+
+	// enable the failpoint to simulate delays
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/puller/sorter/asyncFlushInProcessDelay", "1%sleep(1)")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/puller/sorter/asyncFlushInProcessDelay")
+	}()
+
+	for i := 0; i < 5; i++ {
+		sorter := NewUnifiedSorter("/tmp/sorter", "test-cf", "test", 0, "0.0.0.0:0")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		testSorter(ctx, c, sorter, 100000000, true)
+		cancel()
+	}
 }

--- a/errors.toml
+++ b/errors.toml
@@ -16,6 +16,11 @@ error = '''
 Async broadcasts not supported
 '''
 
+["CDC:ErrAsyncIOCancelled"]
+error = '''
+asynchronous IO operation is cancelled. Internal use only, report a bug if seen in log
+'''
+
 ["CDC:ErrAsyncPoolExited"]
 error = '''
 asyncPool has exited. Report a bug if seen externally.

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -201,6 +201,7 @@ var (
 	// unified sorter errors
 	ErrUnifiedSorterBackendTerminating = errors.Normalize("unified sorter backend is terminating", errors.RFCCodeText("CDC:ErrUnifiedSorterBackendTerminating"))
 	ErrIllegalUnifiedSorterParameter   = errors.Normalize("illegal parameter for unified sorter: %s", errors.RFCCodeText("CDC:ErrIllegalUnifiedSorterParameter"))
+	ErrAsyncIOCancelled                = errors.Normalize("asynchronous IO operation is cancelled. Internal use only, report a bug if seen in log", errors.RFCCodeText("CDC:ErrAsyncIOCancelled"))
 
 	// processor errors
 	ErrTableProcessorStoppedSafely = errors.Normalize("table processor stopped safely", errors.RFCCodeText("CDC:ErrTableProcessorStoppedSafely"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Unified Sorter recycles temp files prematurely, causing file corruption.

### What is changed and how it works?
- Added a mechanism to cancel asynchronous IO operations.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note

