### PR TITLE
metrics: add owner in memory table count metrics

### DIFF
--- a/cdc/metrics_owner.go
+++ b/cdc/metrics_owner.go
@@ -37,6 +37,18 @@ var (
 			Name:      "ownership_counter",
 			Help:      "The counter of ownership increases every 5 seconds on a owner capture",
 		})
+	ownerMaintainTableNumGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "owner",
+			Name:      "maintain_table_num",
+			Help:      "number of replicated tables maintained in owner",
+		}, []string{"changefeed", "capture", "type"})
+)
+
+const (
+	maintainTableTypeTotal string = "total"
+	maintainTableTypeWip   string = "wip"
 )
 
 // initOwnerMetrics registers all metrics used in owner
@@ -44,4 +56,5 @@ func initOwnerMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(changefeedCheckpointTsGauge)
 	registry.MustRegister(changefeedCheckpointTsLagGauge)
 	registry.MustRegister(ownershipCounter)
+	registry.MustRegister(ownerMaintainTableNumGauge)
 }

--- a/cdc/metrics_owner.go
+++ b/cdc/metrics_owner.go
@@ -47,8 +47,10 @@ var (
 )
 
 const (
+	// total tables that have been dispatched to a single processor
 	maintainTableTypeTotal string = "total"
-	maintainTableTypeWip   string = "wip"
+	// tables that are dispatched to a processor and have not been finished yet
+	maintainTableTypeWip string = "wip"
 )
 
 // initOwnerMetrics registers all metrics used in owner

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -975,7 +975,7 @@
           "description": "Internal resolved ts of TiCDC nodes",
           "fontSize": "100%",
           "gridPos": {
-            "h": 5,
+            "h": 10,
             "w": 7,
             "x": 7,
             "y": 2
@@ -1057,7 +1057,7 @@
           "description": "Internal resolved ts of captured tables",
           "fontSize": "100%",
           "gridPos": {
-            "h": 5,
+            "h": 10,
             "w": 10,
             "x": 14,
             "y": 2
@@ -1130,6 +1130,82 @@
           "type": "table"
         },
         {
+          "columns": [
+            {
+              "$$hashKey": "object:139",
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The number of replicated tables maintained in owner",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 5,
+            "w": 7,
+            "x": 0,
+            "y": 7
+          },
+          "id": 138,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:141",
+              "alias": "Time",
+              "align": "auto",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "$$hashKey": "object:142",
+              "alias": "",
+              "align": "auto",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum(ticdc_owner_maintain_table_num{tidb_cluster=\"$tidb_cluster\", changefeed=~\"$changefeed\",capture=~\"$capture\",type=\"total\"}) by (capture)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{capture}}-total",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(ticdc_owner_maintain_table_num{tidb_cluster=\"$tidb_cluster\", changefeed=~\"$changefeed\",capture=~\"$capture\",type=\"wip\"}) by (capture)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{capture}}-wip",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Table count maintained by owner",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
           "aliasColors": {},
           "bars": true,
           "cacheTimeout": null,
@@ -1142,7 +1218,7 @@
             "h": 7,
             "w": 9,
             "x": 0,
-            "y": 7
+            "y": 12
           },
           "id": 86,
           "legend": {
@@ -1248,7 +1324,7 @@
             "h": 7,
             "w": 8,
             "x": 9,
-            "y": 7
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 102,
@@ -1344,7 +1420,7 @@
             "h": 7,
             "w": 7,
             "x": 17,
-            "y": 7
+            "y": 12
           },
           "id": 82,
           "legend": {
@@ -1433,7 +1509,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 3,
@@ -1528,7 +1604,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 2,
@@ -1633,7 +1709,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 26
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1704,7 +1780,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 35,
@@ -1812,7 +1888,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 34,
@@ -1915,7 +1991,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 36,
@@ -2032,7 +2108,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 40
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2101,7 +2177,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 98,
@@ -2217,7 +2293,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 42
+            "y": 47
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2287,7 +2363,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 42
+            "y": 47
           },
           "hiddenSeries": false,
           "id": 83,
@@ -2397,7 +2473,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 42
+            "y": 47
           },
           "hiddenSeries": false,
           "id": 95,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

part 2 of https://github.com/pingcap/ticdc/issues/1533

### What is changed and how it works?

Add table count in metric, with labels of `changefeed-id`, `capture-addr` and `type`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release note

- No release note