### PR TITLE
kv/client: fix ErrNoPendingRegion because of shared map operation

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -751,27 +751,17 @@ MainLoop:
 				ExtraOp:      extraOp,
 			}
 
-			// The receiver thread need to know the span, which is only known in the sender thread. So create the
-			// receiver thread for region here so that it can know the span.
-			// TODO: Find a better way to handle this.
-			// TODO: Make sure there will not be goroutine leak.
-			// TODO: Here we use region id to index the regionInfo. However, in case that region merge is enabled, there
-			// may be multiple streams to the same regions. Maybe we need to add a requestID field to the protocol for it.
-
-			// Get region info collection of the addr
-			pendingRegions, ok := storePendingRegions[rpcCtx.Addr]
-			if !ok {
-				pendingRegions = newSyncRegionFeedStateMap()
-				storePendingRegions[rpcCtx.Addr] = pendingRegions
-			}
-
-			state := newRegionFeedState(sri, requestID)
-			pendingRegions.insert(requestID, state)
-			failpoint.Inject("kvClientPendingRegionDelay", nil)
+			// pendingRegions is store independent
+			var pendingRegions *syncRegionFeedStateMap
 
 			stream, ok := s.getStream(rpcCtx.Addr)
 			// Establish the stream if it has not been connected yet.
 			if !ok {
+				// when a new stream is established, always create a new pending
+				// regions map, the old map will be kept in old `receiveFromStream`
+				// until that goroutine exits.
+				pendingRegions = newSyncRegionFeedStateMap()
+				storePendingRegions[rpcCtx.Addr] = pendingRegions
 				storeID := rpcCtx.Peer.GetStoreId()
 				log.Info("creating new stream to store to send request",
 					zap.Uint64("regionID", sri.verID.GetID()),
@@ -796,12 +786,6 @@ MainLoop:
 					}
 					bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
 					s.client.regionCache.OnSendFail(bo, rpcCtx, regionScheduleReload, err)
-					// Take the pendingRegion from `pendingRegions`, if the region
-					// is deleted already, we don't retry for this region. Otherwise,
-					// retry to connect and send request for this region.
-					if _, exists := pendingRegions.take(requestID); !exists {
-						continue MainLoop
-					}
 					continue
 				}
 				s.addStream(rpcCtx.Addr, stream)
@@ -813,7 +797,18 @@ MainLoop:
 					}
 					return s.receiveFromStreamV2(ctx, g, rpcCtx.Addr, getStoreID(rpcCtx), stream, pendingRegions, limiter)
 				})
+			} else {
+				var ok bool
+				pendingRegions, ok = storePendingRegions[rpcCtx.Addr]
+				if !ok {
+					// Should never happen
+					log.Panic("pending regions is not found for store", zap.String("store", rpcCtx.Addr))
+				}
 			}
+
+			state := newRegionFeedState(sri, requestID)
+			pendingRegions.insert(requestID, state)
+			failpoint.Inject("kvClientPendingRegionDelay", nil)
 
 			logReq := log.Debug
 			if s.isPullerInit.IsInitialized() {
@@ -1215,7 +1210,7 @@ func (s *eventFeedSession) sendRegionChangeEvent(
 	isNewSubscription := !ok
 	if ok {
 		if state.requestID < event.RequestId {
-			log.Debug("region state entry will be replaced because received message of newer requestID",
+			log.Info("region state entry will be replaced because received message of newer requestID",
 				zap.Uint64("regionID", event.RegionId),
 				zap.Uint64("oldRequestID", state.requestID),
 				zap.Uint64("requestID", event.RequestId),

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2431,3 +2431,76 @@ func (s *etcdSuite) TestClientV1UnlockRangeReentrant(c *check.C) {
 	cancel()
 	wg.Wait()
 }
+
+// TestClientErrNoPendingRegion has the similar procedure with TestClientV1UnlockRangeReentrant
+// The difference is the delay injected point for region 2
+func (s *etcdSuite) TestClientErrNoPendingRegion(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
+
+	clientv2 := enableKVClientV2
+	enableKVClientV2 = false
+	defer func() {
+		enableKVClientV2 = clientv2
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+
+	ch1 := make(chan *cdcpb.ChangeDataEvent, 10)
+	srv1 := newMockChangeDataService(c, ch1)
+	server1, addr1 := newMockService(ctx, c, srv1, wg)
+
+	rpcClient, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
+	c.Assert(err, check.IsNil)
+	pdClient = &mockPDClient{Client: pdClient, versionGen: defaultVersionGen}
+	tiStore, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
+	c.Assert(err, check.IsNil)
+	kvStorage := newStorageWithCurVersionCache(tiStore, addr1)
+	defer kvStorage.Close() //nolint:errcheck
+
+	regionID3 := uint64(3)
+	regionID4 := uint64(4)
+	cluster.AddStore(1, addr1)
+	cluster.Bootstrap(regionID3, []uint64{1}, []uint64{4}, 4)
+	cluster.SplitRaw(regionID3, regionID4, []byte("b"), []uint64{5}, 5)
+
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientStreamRecvError", "1*return(true)")
+	c.Assert(err, check.IsNil)
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientPendingRegionDelay", "1*sleep(0)->2*sleep(1000)")
+	c.Assert(err, check.IsNil)
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientStreamCloseDelay", "sleep(2000)")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientStreamRecvError")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientPendingRegionDelay")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientStreamCloseDelay")
+	}()
+	lockresolver := txnutil.NewLockerResolver(kvStorage)
+	isPullInit := &mockPullerInit{}
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	eventCh := make(chan *model.RegionFeedEvent, 10)
+	wg.Add(1)
+	go func() {
+		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")}, 100, false, lockresolver, isPullInit, eventCh)
+		c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+		cdcClient.Close() //nolint:errcheck
+		wg.Done()
+	}()
+
+	baseAllocatedID := currentRequestID()
+	// wait the second region is scheduled
+	time.Sleep(time.Millisecond * 500)
+	waitRequestID(c, baseAllocatedID+1)
+	initialized := mockInitializedEvent(regionID3, currentRequestID())
+	ch1 <- initialized
+	waitRequestID(c, baseAllocatedID+2)
+	initialized = mockInitializedEvent(regionID4, currentRequestID())
+	ch1 <- initialized
+	// wait the kvClientPendingRegionDelay ends, and the second region is processed
+	time.Sleep(time.Second * 2)
+	cancel()
+	close(ch1)
+	server1.Stop()
+	wg.Wait()
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix ErrNoPendingRegion found in test

This error is caused by the following scenario

1. Two regions, naming region-1 and region-2, they belong to the same TiKV store
2. Region-1 is handled, and creates a new TiKV stream
3. Region-2 is dispatched, and in old logic, it will be inserted into `pendingRegions` first.
4. `stream.Recv` meets error, and the whole regions belonged to this store will be re-established. The pending region will be cleaned up, region-2 included
5. The step-3 continues, finds no TiKV stream, which has been deleted in step-4, it creates a new one and establishes request for region-2
6. New event of region-2 is received, but region-2 is no longer in `pendingRegions`

The root cause is the map of `pending regions` are shared in two goroutines and the access boundary is not defined correctly

### What is changed and how it works?

When a new TiKV stream is created, create a new `pendingRegions`, and the old `pendingRegions` is kept in old `receiveFromStream` routine.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix replication may be interrupted because of region operation conflict in kv client
