### PR TITLE
processor: flow control for controlling sorter output speed

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -56,9 +56,9 @@ const (
 	dialTimeout               = 10 * time.Second
 	maxRetry                  = 100
 	tikvRequestMaxBackoff     = 20000   // Maximum total sleep time(in ms)
-	grpcInitialWindowSize     = 1 << 30 // The value for initial window size on a stream
-	grpcInitialConnWindowSize = 1 << 30 // The value for initial window size on a connection
-	grpcMaxCallRecvMsgSize    = 1 << 30 // The maximum message size the client can receive
+	grpcInitialWindowSize     = 1 << 27 // 128 MB The value for initial window size on a stream
+	grpcInitialConnWindowSize = 1 << 27 // 128 MB The value for initial window size on a connection
+	grpcMaxCallRecvMsgSize    = 1 << 30 // 1024 MB The maximum message size the client can receive
 	grpcConnCount             = 10
 
 	// The threshold of warning a message is too large. TiKV split events into 6MB per-message.

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -1075,11 +1075,14 @@ func (p *oldProcessor) sorterConsume(
 					}
 					return
 				case <-globalResolvedTsReceiver.C:
-				}
-
-				if err := sendResolvedTs2Sink(); err != nil {
-					// error is already sent to processor, so we can just ignore it
-					return
+					if err := sendResolvedTs2Sink(); err != nil {
+						// error is already sent to processor, so we can just ignore it
+						return
+					}
+				case <-checkDoneTicker.C:
+					if !opDone {
+						checkDone()
+					}
 				}
 			}
 

--- a/cdc/puller/sorter/unified_sorter.go
+++ b/cdc/puller/sorter/unified_sorter.go
@@ -96,8 +96,8 @@ func NewUnifiedSorter(
 
 	lazyInitWorkerPool()
 	return &UnifiedSorter{
-		inputCh:  make(chan *model.PolymorphicEvent, 128000),
-		outputCh: make(chan *model.PolymorphicEvent, 128000),
+		inputCh:  make(chan *model.PolymorphicEvent, 128),
+		outputCh: make(chan *model.PolymorphicEvent, 128),
 		dir:      dir,
 		pool:     pool,
 		metricsInfo: &metricsInfo{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Avoiding OOM problems

### What is changed and how it works?

block sorter output channel when a table's resolved ts is far greater than checkpoint ts to avoid existing too many events in the buffer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- Support a flow controler to avoid cdc server OOM
