### PR TITLE
cmd: fix pd parameter in update config

### DIFF
--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -531,11 +531,11 @@ func newUpdateChangefeedCommand() *cobra.Command {
 					info.SyncPointEnabled = syncPointEnabled
 				case "sync-interval":
 					info.SyncPointInterval = syncPointInterval
-				case "tz", "start-ts", "changefeed-id", "no-confirm":
+				case "pd", "tz", "start-ts", "changefeed-id", "no-confirm":
 					// do nothing
 				default:
 					// use this default branch to prevent new added parameter is not added
-					log.Panic("unknown flag, please report a bug", zap.String("flagName", flag.Name))
+					log.Warn("unsupported flag, please report a bug", zap.String("flagName", flag.Name))
 				}
 			})
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a new bug introduced by #1554


### What is changed and how it works?

- `--pd` parameter should be ignored
- other unsupported parameter doesn't panic, log a warnning

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release note

- No release note
