### PR TITLE
Revert "cmd: make update config conservative, only update listed parameter (#1554) (#1562)"

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -171,17 +171,6 @@ func (info *ChangeFeedInfo) Unmarshal(data []byte) error {
 	return nil
 }
 
-// Clone returns a cloned ChangeFeedInfo
-func (info *ChangeFeedInfo) Clone() (*ChangeFeedInfo, error) {
-	s, err := info.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	cloned := new(ChangeFeedInfo)
-	err = cloned.Unmarshal([]byte(s))
-	return cloned, err
-}
-
 // VerifyAndFix verifies changefeed info and may fillin some fields.
 // If a must field is not provided, return an error.
 // If some necessary filed is missing but can use a default value, fillin it.

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -189,30 +189,6 @@ func (s *configSuite) TestVerifyAndFix(c *check.C) {
 	c.Assert(marshalConfig1, check.Equals, marshalConfig2)
 }
 
-func (s *configSuite) TestChangeFeedInfoClone(c *check.C) {
-	defer testleak.AfterTest(c)()
-	info := &ChangeFeedInfo{
-		SinkURI: "blackhole://",
-		Opts:    map[string]string{},
-		StartTs: 417257993615179777,
-		Config: &config.ReplicaConfig{
-			CaseSensitive:    true,
-			EnableOldValue:   true,
-			CheckGCSafePoint: true,
-		},
-	}
-
-	cloned, err := info.Clone()
-	c.Assert(err, check.IsNil)
-	sinkURI := "mysql://unix:/var/run/tidb.sock"
-	cloned.SinkURI = sinkURI
-	cloned.Config.EnableOldValue = false
-	c.Assert(cloned.SinkURI, check.Equals, sinkURI)
-	c.Assert(cloned.Config.EnableOldValue, check.IsFalse)
-	c.Assert(info.SinkURI, check.Equals, "blackhole://")
-	c.Assert(info.Config.EnableOldValue, check.IsTrue)
-}
-
 type changefeedSuite struct{}
 
 var _ = check.Suite(&changefeedSuite{})

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/r3labs/diff"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 )
 
@@ -482,62 +481,17 @@ func newUpdateChangefeedCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			info, err := old.Clone()
+
+			info, err := verifyChangefeedParamers(ctx, cmd, false /* isCreate */, getCredential())
 			if err != nil {
 				return err
 			}
-
-			cmd.Flags().Visit(func(flag *pflag.Flag) {
-				switch flag.Name {
-				case "target-ts":
-					info.TargetTs = targetTs
-				case "sink-uri":
-					info.SinkURI = sinkURI
-				case "config":
-					cfg := info.Config
-					if err := strictDecodeFile(configFile, "TiCDC changefeed", cfg); err != nil {
-						log.Panic("decode config file error", zap.Error(err))
-					}
-				case "opts":
-					for _, opt := range opts {
-						s := strings.SplitN(opt, "=", 2)
-						if len(s) <= 0 {
-							cmd.Printf("omit opt: %s", opt)
-							continue
-						}
-
-						var key string
-						var value string
-						key = s[0]
-						if len(s) > 1 {
-							value = s[1]
-						}
-						info.Opts[key] = value
-					}
-
-				case "sort-engine":
-					info.Engine = sortEngine
-				case "sort-dir":
-					info.SortDir = sortDir
-				case "cyclic-replica-id":
-					filter := make([]uint64, 0, len(cyclicFilterReplicaIDs))
-					for _, id := range cyclicFilterReplicaIDs {
-						filter = append(filter, uint64(id))
-					}
-					info.Config.Cyclic.FilterReplicaID = filter
-				case "cyclic-sync-ddl":
-					info.Config.Cyclic.SyncDDL = cyclicSyncDDL
-				case "sync-point":
-					info.SyncPointEnabled = syncPointEnabled
-				case "sync-interval":
-					info.SyncPointInterval = syncPointInterval
-				case "tz", "start-ts", "changefeed-id", "no-confirm":
-					// do nothing
-				default:
-					// use this default branch to prevent new added parameter is not added
-					log.Panic("unknown flag, please report a bug", zap.String("flagName", flag.Name))
-				}
-			})
+			// Fix some fields that can't be updated.
+			info.CreateTime = old.CreateTime
+			info.AdminJobType = old.AdminJobType
+			info.StartTs = old.StartTs
+			info.ErrorHis = old.ErrorHis
+			info.Error = old.Error
 
 			resp, err := applyOwnerChangefeedQuery(ctx, changefeedID, getCredential())
 			// if no cdc owner exists, allow user to update changefeed config


### PR DESCRIPTION




<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This reverts commit 0427c2565aa050bb0a868b88deaa7d7b1ccbab1d.

### What is changed and how it works?

make `cdc cli changefeed update` works with `--pd`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
