### PR TITLE
pipeline: fix unstable unit test

### DIFF
--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/context"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/util/testleak"
 	"go.uber.org/zap"
 )
@@ -281,7 +282,7 @@ func (n *throwNode) Receive(ctx NodeContext) error {
 }
 
 func (n *throwNode) Destroy(ctx NodeContext) error {
-	n.c.Assert(n.index, check.Equals, 6)
+	n.c.Assert(map[int]bool{4: true, 6: true}, check.HasKey, n.index)
 	return nil
 }
 
@@ -302,9 +303,11 @@ func (s *pipelineSuite) TestPipelineThrow(c *check.C) {
 		},
 	}))
 	c.Assert(err, check.IsNil)
-	// this line may be return an error because the pipeline maybe closed before this line was executed
-	//nolint:errcheck
-	p.SendToFirstNode(PolymorphicEventMessage(&model.PolymorphicEvent{
+	// whether err is nil is not determined
+	// If add some delay here, such as sleep 50ms, there will be more probability
+	// that the second message is not sent.
+	// time.Sleep(time.Millisecond * 50)
+	err = p.SendToFirstNode(PolymorphicEventMessage(&model.PolymorphicEvent{
 		Row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "I am built by test function",
@@ -312,12 +315,22 @@ func (s *pipelineSuite) TestPipelineThrow(c *check.C) {
 			},
 		},
 	}))
-	errs := p.Wait()
-	c.Assert(len(errs), check.Equals, 4)
-	c.Assert(errs[0].Error(), check.Equals, "error node throw an error, index: 3")
-	c.Assert(errs[1].Error(), check.Equals, "error node throw an error, index: 4")
-	c.Assert(errs[2].Error(), check.Equals, "error node throw an error, index: 5")
-	c.Assert(errs[3].Error(), check.Equals, "error node throw an error, index: 6")
+	if err != nil {
+		// pipeline closed before the second message was sent
+		c.Assert(cerror.ErrSendToClosedPipeline.Equal(err), check.IsTrue)
+		errs := p.Wait()
+		c.Assert(len(errs), check.Equals, 2)
+		c.Assert(errs[0].Error(), check.Equals, "error node throw an error, index: 3")
+		c.Assert(errs[1].Error(), check.Equals, "error node throw an error, index: 4")
+	} else {
+		// the second message was sent before pipeline closed
+		errs := p.Wait()
+		c.Assert(len(errs), check.Equals, 4)
+		c.Assert(errs[0].Error(), check.Equals, "error node throw an error, index: 3")
+		c.Assert(errs[1].Error(), check.Equals, "error node throw an error, index: 4")
+		c.Assert(errs[2].Error(), check.Equals, "error node throw an error, index: 5")
+		c.Assert(errs[3].Error(), check.Equals, "error node throw an error, index: 6")
+	}
 }
 
 func (s *pipelineSuite) TestPipelineAppendNode(c *check.C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix unstable unit test found in https://github.com/pingcap/ticdc/issues/1501#issuecomment-812846556

```
[2021-04-02T16:20:07.344Z] [2021/04/03 00:17:07.593 +08:00] [ERROR] [pipeline.go:96] ["found error when running the node"] [name="error node"] [error="error node throw an error, index: 3"] [errorVerbose="error node throw an error, index: 3\ngithub.com/pingcap/ticdc/pkg/pipeline.(*errorNode).Receive\n\t/home/jenkins/agent/workspace/cdc_ghpr_test/go/src/github.com/pingcap/ticdc/pkg/pipeline/pipeline_test.go:197\ngithub.com/pingcap/ticdc/pkg/pipeline.(*nodeRunner).run\n\t/home/jenkins/agent/workspace/cdc_ghpr_test/go/src/github.com/pingcap/ticdc/pkg/pipeline/runner.go:60\ngithub.com/pingcap/ticdc/pkg/pipeline.(*Pipeline).driveRunner\n\t/home/jenkins/agent/workspace/cdc_ghpr_test/go/src/github.com/pingcap/ticdc/pkg/pipeline/pipeline.go:93\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1357"] [stack="github.com/pingcap/ticdc/pkg/pipeline.(*Pipeline).driveRunner\n\t/home/jenkins/agent/workspace/cdc_ghpr_test/go/src/github.com/pingcap/ticdc/pkg/pipeline/pipeline.go:96"]
[2021-04-02T16:20:07.344Z] 
[2021-04-02T16:20:07.344Z] ----------------------------------------------------------------------
[2021-04-02T16:20:07.344Z] FAIL: pipeline_test.go:288: pipelineSuite.TestPipelineThrow
[2021-04-02T16:20:07.344Z] 
[2021-04-02T16:20:07.344Z] pipeline_test.go:284:
[2021-04-02T16:20:07.344Z]     n.c.Assert(n.index, check.Equals, 6)
[2021-04-02T16:20:07.344Z] ... obtained int = 4
[2021-04-02T16:20:07.344Z] ... expected int = 6
[2021-04-02T16:20:07.344Z] 
[2021-04-02T16:20:07.344Z] pipeline_test.go:316:
[2021-04-02T16:20:07.344Z]     c.Assert(len(errs), check.Equals, 4)
[2021-04-02T16:20:07.344Z] ... obtained int = 2
[2021-04-02T16:20:07.344Z] ... expected int = 4
[2021-04-02T16:20:07.344Z] 
[2021-04-02T16:20:07.344Z] OOPS: 3 passed, 1 skipped, 1 FAILED
[2021-04-02T16:20:07.344Z] --- FAIL: TestSuite (1.12s)
[2021-04-02T16:20:07.344Z] FAIL
[2021-04-02T16:20:07.344Z] coverage: 73.3% of statements
[2021-04-02T16:20:07.344Z] FAIL	github.com/pingcap/ticdc/pkg/pipeline	1.182s
```

### What is changed and how it works?

Add one more check for the logic that send message to closed pipeline.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note