### PR TITLE
sink/mysql: explicit_defaults_for_timestamp compatibility with mysql

### DIFF
--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -359,6 +359,14 @@ func configureSinkURI(
 		dsnCfg.Params["tidb_txn_mode"] = txnMode
 	}
 
+	explicitDefaultsForTimestamp, err := checkTiDBVariable(ctx, testDB, "explicit_defaults_for_timestamp", "ON")
+	if err != nil {
+		return "", err
+	}
+	if explicitDefaultsForTimestamp != "" {
+		dsnCfg.Params["explicit_defaults_for_timestamp"] = explicitDefaultsForTimestamp
+	}
+
 	dsnClone := dsnCfg.Clone()
 	dsnClone.Passwd = "******"
 	log.Info("sink uri is configured", zap.String("format dsn", dsnClone.FormatDSN()))

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -309,10 +309,9 @@ var defaultParams = &sinkParams{
 }
 
 func checkIsTiDB(ctx context.Context, db *sql.DB) (bool, error) {
-	var name string
 	var value string
 	querySQL := "select version();"
-	err := db.QueryRowContext(ctx, querySQL).Scan(&name, &value)
+	err := db.QueryRowContext(ctx, querySQL).Scan(&value)
 	if err != nil && err != sql.ErrNoRows {
 		return false, errors.Annotate(cerror.WrapError(cerror.ErrMySQLQueryError, err), "failed to select version")
 	}

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -308,7 +308,7 @@ var defaultParams = &sinkParams{
 
 func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultValue string) (
 	sinkURIParameter string,
-	equalToDefaultValue bool,
+	dbVarEqualToDefault bool,
 	err error,
 ) {
 	var name string
@@ -320,12 +320,12 @@ func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultVal
 		err = errors.Annotate(cerror.WrapError(cerror.ErrMySQLQueryError, err), errMsg)
 		return
 	}
-	// session variable exists, use given default value
 	if err == nil {
+		// session variable exists, use given default value
 		sinkURIParameter = defaultValue
-		equalToDefaultValue = value == defaultValue
+		dbVarEqualToDefault = value == defaultValue
 	} else {
-		//session variable does not exist, sinkURIParameter is "" and will be ignored
+		// session variable does not exist, sinkURIParameter is "" and will be ignored
 		err = nil
 	}
 	return

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -903,7 +903,7 @@ func mockTestDB() (*sql.DB, error) {
 	)
 	// Simulate the default value in MySQL5.7 is OFF
 	mock.ExpectQuery("select version\\(\\);").WillReturnRows(
-		sqlmock.NewRows(columns).AddRow("version()", "5.7.32"),
+		sqlmock.NewRows([]string{"version"}).AddRow("5.7.32"),
 	)
 	// Simulate the default value in MySQL5.7 is OFF
 	mock.ExpectQuery("show session variables like 'explicit_defaults_for_timestamp';").WillReturnRows(
@@ -927,7 +927,7 @@ func mockTestDBTiDB() (*sql.DB, error) {
 		sqlmock.NewRows(columns).AddRow("tidb_txn_mode", "optimistic"),
 	)
 	mock.ExpectQuery("select version\\(\\);").WillReturnRows(
-		sqlmock.NewRows(columns).AddRow("version()", "5.7.25-TiDB-v5.0.0"),
+		sqlmock.NewRows([]string{"version"}).AddRow("5.7.25-TiDB-v5.0.0"),
 	)
 	mock.ExpectClose()
 	return db, nil

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -714,6 +714,7 @@ func (s MySQLSinkSuite) TestConfigureSinkURI(c *check.C) {
 			"readTimeout=2m",
 			"writeTimeout=2m",
 			"allow_auto_random_explicit_insert=1",
+			"explicit_defaults_for_timestamp=ON",
 		}
 		for _, param := range expectedParams {
 			c.Assert(strings.Contains(dsnStr, param), check.IsTrue)
@@ -876,6 +877,10 @@ func mockTestDB() (*sql.DB, error) {
 	)
 	mock.ExpectQuery("show session variables like 'tidb_txn_mode';").WillReturnRows(
 		sqlmock.NewRows(columns).AddRow("tidb_txn_mode", "pessimistic"),
+	)
+	// Simulate the default value in MySQL5.7 is OFF
+	mock.ExpectQuery("show session variables like 'explicit_defaults_for_timestamp';").WillReturnRows(
+		sqlmock.NewRows(columns).AddRow("explicit_defaults_for_timestamp", "OFF"),
 	)
 	mock.ExpectClose()
 	return db, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #1585 


### What is changed and how it works?

- Set session variable `explicit_defaults_for_timestamp` to `ON` in MySQL sink, which will keep the same behavior between upstream TiDB and downstream MySQL 5.7.
- Note only set this session variable when the value `explicit_defaults_for_timestamp`  in downstream is `OFF`, because in TiDB variable `explicit_defaults_for_timestamp` is readonly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

- Set session variable `explicit_defaults_for_timestamp` to `ON` to make downstream MySQL5.7 keeps the same behavior with upstream TiDB.
