### PR TITLE
fix panic issue in update changefeed config.

### DIFF
--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -499,7 +499,7 @@ func newUpdateChangefeedCommand() *cobra.Command {
 		Use:   "update",
 		Short: "Update config of an existing replication task (changefeed)",
 		Long:  ``,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			ctx := defaultContext
 
 			old, err := cdcEtcdCli.GetChangeFeedInfo(ctx, changefeedID)
@@ -519,8 +519,8 @@ func newUpdateChangefeedCommand() *cobra.Command {
 					info.SinkURI = sinkURI
 				case "config":
 					cfg := info.Config
-					if err := strictDecodeFile(configFile, "TiCDC changefeed", cfg); err != nil {
-						log.Panic("decode config file error", zap.Error(err))
+					if err = strictDecodeFile(configFile, "TiCDC changefeed", cfg); err != nil {
+						log.Error("decode config file error", zap.Error(err))
 					}
 				case "opts":
 					for _, opt := range opts {
@@ -562,6 +562,9 @@ func newUpdateChangefeedCommand() *cobra.Command {
 					log.Warn("unsupported flag, please report a bug", zap.String("flagName", flag.Name))
 				}
 			})
+			if err != nil {
+				return err
+			}
 
 			resp, err := applyOwnerChangefeedQuery(ctx, changefeedID, getCredential())
 			// if no cdc owner exists, allow user to update changefeed config


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#1622 

### What is changed and how it works?

do not panic if parse config file get error, just return it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- 
-->
No release note