### PR TITLE
github/action: insert/update SQL could meet duplicated entry error

### DIFF
--- a/cdc/sink/simple_mysql_tester.go
+++ b/cdc/sink/simple_mysql_tester.go
@@ -131,10 +131,10 @@ func (s *simpleMySQLSink) executeRowChangedEvents(ctx context.Context, rows ...*
 						return errors.Trace(err)
 					}
 				}
-				sql, args = prepareUpdate(row.Table.QuoteString(), row.PreColumns, row.Columns, true)
+				sql, args = prepareReplace(row.Table.QuoteString(), row.Columns, true, false /* translateToInsert */)
 			} else if len(row.PreColumns) == 0 {
 				// insert
-				sql, args = prepareReplace(row.Table.QuoteString(), row.Columns, true, true)
+				sql, args = prepareReplace(row.Table.QuoteString(), row.Columns, true, false /* translateToInsert */)
 			} else if len(row.Columns) == 0 {
 				// delete
 				if s.enableCheckOldValue {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The old value test in github action often fails because of the following error:

```
[2021/04/14 03:56:12.480 +00:00] [ERROR] [processor.go:145] ["run processor failed"] [changefeed=b3f67eb2-de83-4984-8576-8e7358a7e4a5] [capture-id=4abeb2ce-d9e5-42d7-924c-1827b959d847] [capture=capturer1:8300] [error="Error 1062: Duplicate entry '158' for key 'PRIMARY'"] [errorVerbose="Error 1062: Duplicate entry '158' for key 'PRIMARY'
github.com/pingcap/errors.AddStack
        github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/errors.go:174
github.com/pingcap/errors.Trace
        github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/juju_adaptor.go:15
github.com/pingcap/ticdc/cdc/sink.(*simpleMySQLSink).executeRowChangedEvents
        github.com/pingcap/ticdc/cdc/sink/simple_mysql_tester.go:150
github.com/pingcap/ticdc/cdc/sink.(*simpleMySQLSink).FlushRowChangedEvents
        github.com/pingcap/ticdc/cdc/sink/simple_mysql_tester.go:194
github.com/pingcap/ticdc/cdc/sink.(*bufferSink).run
        github.com/pingcap/ticdc/cdc/sink/manager.go:215
runtime.goexit
        runtime/asm_amd64.s:1373"]
```

### What is changed and how it works?

insert/update SQL can't handle DML reentrant problem, so keep using replace for insert or update.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note


- No release note
