### PR TITLE
kv/client: fix force reconnect in client v2

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -168,6 +168,12 @@ func (s *regionFeedState) isStopped() bool {
 	return atomic.LoadInt32(&s.stopped) > 0
 }
 
+func (s *regionFeedState) IsInitialized() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.initialized
+}
+
 type syncRegionFeedStateMap struct {
 	mu            *sync.Mutex
 	regionInfoMap map[uint64]*regionFeedState

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -70,10 +70,8 @@ const (
 	regionScheduleReload = false
 )
 
-var (
-	// time interval to force kv client to terminate gRPC stream and reconnect
-	reconnectInterval = 15 * time.Minute
-)
+// time interval to force kv client to terminate gRPC stream and reconnect
+var reconnectInterval = 15 * time.Minute
 
 // hard code switch
 // true: use kv client v2, which has a region worker for each stream

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -68,7 +68,9 @@ const (
 	// failed region will be reloaded via `BatchLoadRegionsWithKeyRange` API. So we
 	// don't need to force reload region any more.
 	regionScheduleReload = false
+)
 
+var (
 	// time interval to force kv client to terminate gRPC stream and reconnect
 	reconnectInterval = 15 * time.Minute
 )

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2885,7 +2885,8 @@ func (s *etcdSuite) TestKVClientForceReconnect2(c *check.C) {
 
 	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval", "return(3)")
 	c.Assert(err, check.IsNil)
-	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval", "return(3)")
+	// check interval is less than reconnect interval, so we can test both the hit and miss case
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval", "return(1)")
 	c.Assert(err, check.IsNil)
 	defer func() {
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval")

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2718,11 +2718,15 @@ func (s *etcdSuite) testKVClientForceReconnect(c *check.C) {
 	cluster.AddStore(1, addr1)
 	cluster.Bootstrap(regionID3, []uint64{1}, []uint64{4}, 4)
 
-	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientForceReconnect", "return(true)")
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientResolveLockInterval", "return(1)")
+	c.Assert(err, check.IsNil)
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval", "return(3)")
 	c.Assert(err, check.IsNil)
 	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientForceReconnect")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientResolveLockInterval")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval")
 	}()
+
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2841,3 +2841,179 @@ func (s *etcdSuite) TestKVClientForceReconnect(c *check.C) {
 	enableKVClientV2 = true
 	s.testKVClientForceReconnect(c)
 }
+
+// TestKVClientForceReconnect2 tests force reconnect gRPC stream can work, this
+// test mocks the reconnectInterval tool, and simulate un-initialized regions
+// can be reconnected.
+func (s *etcdSuite) TestKVClientForceReconnect2(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+
+	server1Stopped := make(chan struct{})
+	ch1 := make(chan *cdcpb.ChangeDataEvent, 10)
+	srv1 := newMockChangeDataService(c, ch1)
+	server1, addr1 := newMockService(ctx, c, srv1, wg)
+	srv1.recvLoop = func(server cdcpb.ChangeData_EventFeedServer) {
+		defer func() {
+			close(ch1)
+			server1.Stop()
+			server1Stopped <- struct{}{}
+		}()
+		for {
+			_, err := server.Recv()
+			if err != nil {
+				log.Error("mock server error", zap.Error(err))
+				break
+			}
+		}
+	}
+
+	rpcClient, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
+	c.Assert(err, check.IsNil)
+	pdClient = &mockPDClient{Client: pdClient, versionGen: defaultVersionGen}
+	tiStore, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
+	c.Assert(err, check.IsNil)
+	kvStorage := newStorageWithCurVersionCache(tiStore, addr1)
+	defer kvStorage.Close() //nolint:errcheck
+
+	regionID3 := uint64(3)
+	cluster.AddStore(1, addr1)
+	cluster.Bootstrap(regionID3, []uint64{1}, []uint64{4}, 4)
+
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval", "return(3)")
+	c.Assert(err, check.IsNil)
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval", "return(3)")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval")
+	}()
+	lockresolver := txnutil.NewLockerResolver(kvStorage)
+	isPullInit := &mockPullerInit{}
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	eventCh := make(chan *model.RegionFeedEvent, 10)
+	wg.Add(1)
+	go func() {
+		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")}, 100, false, lockresolver, isPullInit, eventCh)
+		c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+		cdcClient.Close() //nolint:errcheck
+		wg.Done()
+	}()
+
+	baseAllocatedID := currentRequestID()
+	waitRequestID(c, baseAllocatedID+1)
+	committed := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
+		{
+			RegionId:  3,
+			RequestId: currentRequestID(),
+			Event: &cdcpb.Event_Entries_{
+				Entries: &cdcpb.Event_Entries{
+					Entries: []*cdcpb.Event_Row{{
+						Type:     cdcpb.Event_COMMITTED,
+						OpType:   cdcpb.Event_Row_PUT,
+						Key:      []byte("a"),
+						Value:    []byte("b"),
+						StartTs:  105,
+						CommitTs: 115,
+					}},
+				},
+			},
+		},
+	}}
+	ch1 <- committed
+
+	<-server1Stopped
+
+	var requestIds sync.Map
+	ch2 := make(chan *cdcpb.ChangeDataEvent, 10)
+	srv2 := newMockChangeDataService(c, ch2)
+	srv2.recvLoop = func(server cdcpb.ChangeData_EventFeedServer) {
+		for {
+			req, err := server.Recv()
+			if err != nil {
+				log.Error("mock server error", zap.Error(err))
+				return
+			}
+			requestIds.Store(req.RegionId, req.RequestId)
+		}
+	}
+	// Reuse the same listen addresss as server 1 to simulate TiKV handles the
+	// gRPC stream terminate and reconnect.
+	server2, _ := newMockServiceSpecificAddr(ctx, c, srv2, addr1, wg)
+	defer func() {
+		close(ch2)
+		server2.Stop()
+		wg.Wait()
+	}()
+
+	// The second TiKV could start up slowly, which causes the kv client retries
+	// to TiKV for more than one time, so we can't determine the correct requestID
+	// here, we must use the real request ID received by TiKV server
+	err = retry.Run(time.Millisecond*300, 10, func() error {
+		_, ok := requestIds.Load(regionID3)
+		if ok {
+			return nil
+		}
+		return errors.New("waiting for kv client requests received by server")
+	})
+	c.Assert(err, check.IsNil)
+	requestID, _ := requestIds.Load(regionID3)
+
+	initialized := mockInitializedEvent(regionID3, requestID.(uint64))
+	ch2 <- initialized
+
+	resolved := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
+		{
+			RegionId:  regionID3,
+			RequestId: requestID.(uint64),
+			Event:     &cdcpb.Event_ResolvedTs{ResolvedTs: 135},
+		},
+	}}
+	ch2 <- resolved
+
+	expected := []*model.RegionFeedEvent{
+		{
+			Resolved: &model.ResolvedSpan{
+				Span:       regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")},
+				ResolvedTs: 100,
+			},
+			RegionID: regionID3,
+		},
+		{
+			Val: &model.RawKVEntry{
+				OpType:   model.OpTypePut,
+				Key:      []byte("a"),
+				Value:    []byte("b"),
+				StartTs:  105,
+				CRTs:     115,
+				RegionID: 3,
+			},
+			RegionID: 3,
+		},
+		{
+			Resolved: &model.ResolvedSpan{
+				Span:       regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")},
+				ResolvedTs: 100,
+			},
+			RegionID: regionID3,
+		},
+		{
+			Resolved: &model.ResolvedSpan{
+				Span:       regionspan.ComparableSpan{Start: []byte("a"), End: []byte("c")},
+				ResolvedTs: 135,
+			},
+			RegionID: regionID3,
+		},
+	}
+
+	for _, expectedEv := range expected {
+		select {
+		case event := <-eventCh:
+			c.Assert(event, check.DeepEquals, expectedEv)
+		case <-time.After(time.Second):
+			c.Errorf("expected event %v not received", expectedEv)
+		}
+	}
+
+	cancel()
+}

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2846,6 +2846,9 @@ func (s *etcdSuite) TestKVClientForceReconnect(c *check.C) {
 // test mocks the reconnectInterval tool, and simulate un-initialized regions
 // can be reconnected.
 func (s *etcdSuite) TestKVClientForceReconnect2(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := &sync.WaitGroup{}
 

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -202,6 +202,10 @@ func (s *eventFeedSession) receiveFromStreamV2(
 	s.workers[addr] = worker
 	s.workersLock.Unlock()
 
+	failpoint.Inject("kvClientReconnectInterval", func(val failpoint.Value) {
+		reconnectInterval = time.Duration(val.(int)) * time.Second
+	})
+
 	g.Go(func() error {
 		return worker.run(ctx)
 	})

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -86,8 +86,12 @@ func (s *eventFeedSession) sendRegionChangeEventV2(
 		}
 
 		state.start()
-		// Then spawn the goroutine to process messages of this region.
 		worker.setRegionState(event.RegionId, state)
+		// TODO: If a region doesn't receive any event from TiKV, this region
+		// can't be reconnected since the region state is not initialized.
+		worker.uninitRegions.Lock()
+		worker.uninitRegions.m[event.RegionId] = time.Now()
+		worker.uninitRegions.Unlock()
 
 		// send resolved event when starting a single event feed
 		select {

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -89,9 +89,7 @@ func (s *eventFeedSession) sendRegionChangeEventV2(
 		worker.setRegionState(event.RegionId, state)
 		// TODO: If a region doesn't receive any event from TiKV, this region
 		// can't be reconnected since the region state is not initialized.
-		worker.uninitRegions.Lock()
-		worker.uninitRegions.m[event.RegionId] = time.Now()
-		worker.uninitRegions.Unlock()
+		worker.notifyEvTimeUpdate(event.RegionId, false /* isDelete */)
 
 		// send resolved event when starting a single event feed
 		select {

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -208,9 +208,6 @@ func (w *regionWorker) handleSingleRegionError(ctx context.Context, err error, s
 func (w *regionWorker) checkUnInitRegions(ctx context.Context) error {
 	checkInterval := time.Minute
 
-	failpoint.Inject("kvClientReconnectInterval", func(val failpoint.Value) {
-		reconnectInterval = time.Duration(val.(int)) * time.Second
-	})
 	failpoint.Inject("kvClientCheckUnInitRegionInterval", func(val failpoint.Value) {
 		checkInterval = time.Duration(val.(int)) * time.Second
 	})
@@ -255,9 +252,6 @@ func (w *regionWorker) resolveLock(ctx context.Context) error {
 	resolveLockInterval := 20 * time.Second
 	failpoint.Inject("kvClientResolveLockInterval", func(val failpoint.Value) {
 		resolveLockInterval = time.Duration(val.(int)) * time.Second
-	})
-	failpoint.Inject("kvClientReconnectInterval", func(val failpoint.Value) {
-		reconnectInterval = time.Duration(val.(int)) * time.Second
 	})
 	advanceCheckTicker := time.NewTicker(time.Second * 5)
 	defer advanceCheckTicker.Stop()

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -263,10 +263,6 @@ func (w *regionWorker) resolveLock(ctx context.Context) error {
 		case rtsUpdate := <-w.rtsUpdateCh:
 			w.rtsManager.Upsert(rtsUpdate)
 		case <-advanceCheckTicker.C:
-			if !w.session.isPullerInit.IsInitialized() {
-				// Initializing a puller may take a long time, skip resolved lock to save unnecessary overhead.
-				continue
-			}
 			version, err := w.session.kvStorage.GetCachedCurrentVersion()
 			if err != nil {
 				log.Warn("failed to get current version from PD", zap.Error(err))

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -108,7 +108,9 @@ type regionWorker struct {
 	rtsManager  *regionTsManager
 	rtsUpdateCh chan *regionTsInfo
 
-	// evTimeManager maintains the last event time of each un-initialized region
+	// evTimeManager maintains the time that last event is received of each
+	// uninitialized region, note the regionTsManager is not thread safe, so we
+	// use a single routine to handle evTimeUpdate and evTimeManager
 	evTimeManager  *regionTsManager
 	evTimeUpdateCh chan *evTimeUpdate
 

--- a/cdc/kv/resolvedts_heap_test.go
+++ b/cdc/kv/resolvedts_heap_test.go
@@ -25,35 +25,35 @@ var _ = check.Suite(&rtsHeapSuite{})
 
 func (s *rtsHeapSuite) TestResolvedTsManager(c *check.C) {
 	defer testleak.AfterTest(c)()
-	mgr := newResolvedTsManager()
-	initRegions := []*regionResolvedTs{
-		{regionID: 102, resolvedTs: 1040},
-		{regionID: 100, resolvedTs: 1000},
-		{regionID: 101, resolvedTs: 1020},
+	mgr := newRegionTsManager()
+	initRegions := []*regionTsInfo{
+		{regionID: 102, ts: tsItem{resolvedTs: 1040}},
+		{regionID: 100, ts: tsItem{resolvedTs: 1000}},
+		{regionID: 101, ts: tsItem{resolvedTs: 1020}},
 	}
 	for _, rts := range initRegions {
 		mgr.Upsert(rts)
 	}
 	c.Assert(mgr.Len(), check.Equals, 3)
 	rts := mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 100, resolvedTs: 1000, index: -1})
+	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1000), index: -1})
 
 	// resolved ts is not updated
 	mgr.Upsert(rts)
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 100, resolvedTs: 1000, index: -1})
+	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1000), index: -1})
 
 	// resolved ts updated
-	rts.resolvedTs = 1001
+	rts.ts.resolvedTs = 1001
 	mgr.Upsert(rts)
-	mgr.Upsert(&regionResolvedTs{regionID: 100, resolvedTs: 1100})
+	mgr.Upsert(&regionTsInfo{regionID: 100, ts: newResolvedTsItem(1100)})
 
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 101, resolvedTs: 1020, index: -1})
+	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 101, ts: newResolvedTsItem(1020), index: -1})
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 102, resolvedTs: 1040, index: -1})
+	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 102, ts: newResolvedTsItem(1040), index: -1})
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionResolvedTs{regionID: 100, resolvedTs: 1100, index: -1})
+	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1100), index: -1})
 	rts = mgr.Pop()
 	c.Assert(rts, check.IsNil)
 }

--- a/cdc/kv/resolvedts_heap_test.go
+++ b/cdc/kv/resolvedts_heap_test.go
@@ -25,6 +25,13 @@ type rtsHeapSuite struct {
 
 var _ = check.Suite(&rtsHeapSuite{})
 
+func checkRegionTsInfoWithoutEvTime(c *check.C, obtained, expected *regionTsInfo) {
+	c.Assert(obtained.regionID, check.Equals, expected.regionID)
+	c.Assert(obtained.index, check.Equals, expected.index)
+	c.Assert(obtained.ts.resolvedTs, check.Equals, expected.ts.resolvedTs)
+	c.Assert(obtained.ts.sortByEvTime, check.IsFalse)
+}
+
 func (s *rtsHeapSuite) TestRegionTsManagerResolvedTs(c *check.C) {
 	defer testleak.AfterTest(c)()
 	mgr := newRegionTsManager()
@@ -38,12 +45,12 @@ func (s *rtsHeapSuite) TestRegionTsManagerResolvedTs(c *check.C) {
 	}
 	c.Assert(mgr.Len(), check.Equals, 3)
 	rts := mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1000), index: -1})
+	checkRegionTsInfoWithoutEvTime(c, rts, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1000), index: -1})
 
 	// resolved ts is not updated
 	mgr.Upsert(rts)
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1000), index: -1})
+	checkRegionTsInfoWithoutEvTime(c, rts, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1000), index: -1})
 
 	// resolved ts updated
 	rts.ts.resolvedTs = 1001
@@ -51,11 +58,11 @@ func (s *rtsHeapSuite) TestRegionTsManagerResolvedTs(c *check.C) {
 	mgr.Upsert(&regionTsInfo{regionID: 100, ts: newResolvedTsItem(1100)})
 
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 101, ts: newResolvedTsItem(1020), index: -1})
+	checkRegionTsInfoWithoutEvTime(c, rts, &regionTsInfo{regionID: 101, ts: newResolvedTsItem(1020), index: -1})
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 102, ts: newResolvedTsItem(1040), index: -1})
+	checkRegionTsInfoWithoutEvTime(c, rts, &regionTsInfo{regionID: 102, ts: newResolvedTsItem(1040), index: -1})
 	rts = mgr.Pop()
-	c.Assert(rts, check.DeepEquals, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1100), index: -1})
+	checkRegionTsInfoWithoutEvTime(c, rts, &regionTsInfo{regionID: 100, ts: newResolvedTsItem(1100), index: -1})
 	rts = mgr.Pop()
 	c.Assert(rts, check.IsNil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Fix a potential deadlock when a reconnect is performed
- Fix un initialized regions are not reconnected.

note release-5.0 should be picked manually.

### What is changed and how it works?

- Reuse the `resolvedTsManager` to manage the time of last event in each un-initialized region, rename `resolvedTsManager` to `regionTsManager`
- Separate the reconnect check of un-initialized regions from the lock resolver routine to reduce lock contention.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
