### PR TITLE
http_server: add http handler for failpoint

### DIFF
--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/pkg/config"
@@ -53,6 +54,9 @@ func (s *Server) startStatusHTTP() error {
 	serverMux.HandleFunc("/capture/owner/changefeed/query", s.handleChangefeedQuery)
 
 	serverMux.HandleFunc("/admin/log", handleAdminLogLevel)
+
+	// `http.StripPrefix` is needed because `failpoint.HttpHandler` assumes that it handles the prefix `/`.
+	serverMux.Handle("/fail/", http.StripPrefix("/fail", &failpoint.HttpHandler{}))
 
 	prometheus.DefaultGatherer = registry
 	serverMux.Handle("/metrics", promhttp.Handler())

--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pingcap/ticdc/pkg/util"
 	"io"
 	"net"
 	"net/http"
@@ -55,8 +56,10 @@ func (s *Server) startStatusHTTP() error {
 
 	serverMux.HandleFunc("/admin/log", handleAdminLogLevel)
 
-	// `http.StripPrefix` is needed because `failpoint.HttpHandler` assumes that it handles the prefix `/`.
-	serverMux.Handle("/fail/", http.StripPrefix("/fail", &failpoint.HttpHandler{}))
+	if util.FailpointBuild {
+		// `http.StripPrefix` is needed because `failpoint.HttpHandler` assumes that it handles the prefix `/`.
+		serverMux.Handle("/fail/", http.StripPrefix("/fail", &failpoint.HttpHandler{}))
+	}
 
 	prometheus.DefaultGatherer = registry
 	serverMux.Handle("/metrics", promhttp.Handler())

--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -59,7 +59,7 @@ func (s *Server) startStatusHTTP() error {
 
 	if util.FailpointBuild {
 		// `http.StripPrefix` is needed because `failpoint.HttpHandler` assumes that it handles the prefix `/`.
-		serverMux.Handle("/fail/", http.StripPrefix("/fail", &failpoint.HttpHandler{}))
+		serverMux.Handle("/debug/fail/", http.StripPrefix("/debug/fail", &failpoint.HttpHandler{}))
 	}
 
 	prometheus.DefaultGatherer = registry

--- a/cdc/http_status.go
+++ b/cdc/http_status.go
@@ -17,12 +17,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/ticdc/pkg/util"
 	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
+
+	"github.com/pingcap/ticdc/pkg/util"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"

--- a/cdc/http_status_test.go
+++ b/cdc/http_status_test.go
@@ -21,9 +21,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/pingcap/failpoint"
-
 	"github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/util/testleak"

--- a/cdc/http_status_test.go
+++ b/cdc/http_status_test.go
@@ -14,11 +14,14 @@
 package cdc
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/pingcap/failpoint"
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/pkg/config"
@@ -72,6 +75,7 @@ func (s *httpStatusSuite) TestHTTPStatus(c *check.C) {
 	testHandleRebalance(c)
 	testHandleMoveTable(c)
 	testHandleChangefeedQuery(c)
+	testHandleFailpoint(c)
 }
 
 func testPprof(c *check.C) {
@@ -131,4 +135,38 @@ func testRequestNonOwnerFailed(c *check.C, uri string) {
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, check.Equals, http.StatusBadRequest)
 	c.Assert(string(data), check.Equals, concurrency.ErrElectionNotLeader.Error())
+}
+
+func testHandleFailpoint(c *check.C) {
+	fp := "github.com/pingcap/ticdc/cdc/TestHandleFailpoint"
+	uri := fmt.Sprintf("http://%s/fail/%s", advertiseAddr4Test, fp)
+	body := bytes.NewReader([]byte("return(true)"))
+	req, err := http.NewRequest("PUT", uri, body)
+	c.Assert(err, check.IsNil)
+
+	resp, err := http.DefaultClient.Do(req)
+	c.Assert(err, check.IsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, check.GreaterEqual, 200)
+	c.Assert(resp.StatusCode, check.Less, 300)
+
+	failpointHit := false
+	failpoint.Inject("TestHandleFailpoint", func() {
+		failpointHit = true
+	})
+	c.Assert(failpointHit, check.IsTrue)
+
+	req, err = http.NewRequest("DELETE", uri, body)
+	c.Assert(err, check.IsNil)
+	resp, err = http.DefaultClient.Do(req)
+	c.Assert(err, check.IsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, check.GreaterEqual, 200)
+	c.Assert(resp.StatusCode, check.Less, 300)
+
+	failpointHit = false
+	failpoint.Inject("TestHandleFailpoint", func() {
+		failpointHit = true
+	})
+	c.Assert(failpointHit, check.IsFalse)
 }

--- a/cdc/http_status_test.go
+++ b/cdc/http_status_test.go
@@ -138,7 +138,7 @@ func testRequestNonOwnerFailed(c *check.C, uri string) {
 
 func testHandleFailpoint(c *check.C) {
 	fp := "github.com/pingcap/ticdc/cdc/TestHandleFailpoint"
-	uri := fmt.Sprintf("http://%s/fail/%s", advertiseAddr4Test, fp)
+	uri := fmt.Sprintf("http://%s/debug/fail/%s", advertiseAddr4Test, fp)
 	body := bytes.NewReader([]byte("return(true)"))
 	req, err := http.NewRequest("PUT", uri, body)
 	c.Assert(err, check.IsNil)

--- a/go.sum
+++ b/go.sum
@@ -659,6 +659,7 @@ github.com/unrolled/render v1.0.1/go.mod h1:gN9T0NhL4Bfbwu8ann7Ry/TGHYfosul+J0ob
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/negroni v0.3.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/valyala/gozstd v1.7.0 h1:Ljh5c9zboqLhwTI33al32R72iCZfn0mCbVGcFWbGwRQ=
 github.com/valyala/gozstd v1.7.0/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1 h1:d71/KA0LhvkrJ/Ok+Wx9qK7bU8meKA1Hk0jpVI5kJjk=

--- a/go.sum
+++ b/go.sum
@@ -659,7 +659,6 @@ github.com/unrolled/render v1.0.1/go.mod h1:gN9T0NhL4Bfbwu8ann7Ry/TGHYfosul+J0ob
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/negroni v0.3.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
-github.com/valyala/gozstd v1.7.0 h1:Ljh5c9zboqLhwTI33al32R72iCZfn0mCbVGcFWbGwRQ=
 github.com/valyala/gozstd v1.7.0/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1 h1:d71/KA0LhvkrJ/Ok+Wx9qK7bU8meKA1Hk0jpVI5kJjk=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Lack of a convenient way to control failpoints at runtime.

### What is changed and how it works?
- Added an http API endpoint as `/fail/`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch

### Release note

- Aadd http handler for failpoint