### PR TITLE
tests: use normal mysql user in integration test

### DIFF
--- a/tests/_utils/start_tidb_cluster_impl
+++ b/tests/_utils/start_tidb_cluster_impl
@@ -228,6 +228,9 @@ done
 
 run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 run_sql "update mysql.tidb set variable_value='60m' where variable_name='tikv_gc_life_time';" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+run_sql "CREATE user 'normal'@'%' identified by '123456';" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+run_sql "GRANT select,insert,update,delete,index,create,drop,alter,create view ON *.* TO 'normal'@'%';" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+run_sql "FLUSH privileges" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
 cat - >"$OUT_DIR/tiflash-config.toml" <<EOF
 tmp_path = "${OUT_DIR}/tiflash/tmp"

--- a/tests/autorandom/run.sh
+++ b/tests/autorandom/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-autorandom-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/availability/run.sh
+++ b/tests/availability/run.sh
@@ -27,7 +27,7 @@ function prepare() {
     run_sql "CREATE table test.availability2(id int primary key, val int);"
     run_sql "CREATE table test.availability3(id int primary key, val int);"
 
-    run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="mysql://root@127.0.0.1:3306/"
+    run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="mysql://normal:123456@127.0.0.1:3306/"
 }
 
 trap stop_tidb_cluster EXIT

--- a/tests/batch_add_table/run.sh
+++ b/tests/batch_add_table/run.sh
@@ -25,7 +25,7 @@ function run() {
     TOPIC_NAME="ticdc-batch-add-table-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/capture_session_done_during_task/run.sh
+++ b/tests/capture_session_done_during_task/run.sh
@@ -17,7 +17,7 @@ function run() {
     TOPIC_NAME="ticdc-capture-session-done-during-task-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/capture_suicide_while_balance_table/run.sh
+++ b/tests/capture_suicide_while_balance_table/run.sh
@@ -40,7 +40,7 @@ function run() {
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/sink/MySQLSinkHangLongTime=1*return(true)'
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr --logsuffix 2 --addr "127.0.0.1:8301"
 
-    SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1"
+    SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1"
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
 
     run_sql "CREATE DATABASE capture_suicide_while_balance_table;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}

--- a/tests/cdc/run.sh
+++ b/tests/cdc/run.sh
@@ -24,7 +24,7 @@ function prepare() {
     TOPIC_NAME="ticdc-cdc-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/changefeed_auto_stop/run.sh
+++ b/tests/changefeed_auto_stop/run.sh
@@ -45,7 +45,7 @@ function run() {
     TOPIC_NAME="ticdc-changefeed-auto-stop-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     changefeedid=$(cdc cli changefeed create --pd="http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/changefeed_error/run.sh
+++ b/tests/changefeed_error/run.sh
@@ -121,7 +121,7 @@ function run() {
     TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     changefeedid=$(cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/changefeed_finish/run.sh
+++ b/tests/changefeed_finish/run.sh
@@ -42,7 +42,7 @@ function run() {
     TOPIC_NAME="ticdc-changefeed-pause-resume-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/changefeed_pause_resume/run.sh
+++ b/tests/changefeed_pause_resume/run.sh
@@ -18,7 +18,7 @@ function run() {
     TOPIC_NAME="ticdc-changefeed-pause-resume-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/changefeed_reconstruct/run.sh
+++ b/tests/changefeed_reconstruct/run.sh
@@ -41,7 +41,7 @@ function run() {
     TOPIC_NAME="ticdc-changefeed-reconstruct-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -49,7 +49,7 @@ function run() {
     TOPIC_NAME="ticdc-cli-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
 
     uuid="custom-changefeed-name"

--- a/tests/clustered_index/run.sh
+++ b/tests/clustered_index/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-clustered-index-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/common_1/run.sh
+++ b/tests/common_1/run.sh
@@ -33,10 +33,12 @@ function run() {
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 
+    # this test contains `recover table`, which requires super privilege, so we
+    # can't use the normal user
     TOPIC_NAME="ticdc-common-1-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/common_1/run.sh
+++ b/tests/common_1/run.sh
@@ -36,7 +36,7 @@ function run() {
     TOPIC_NAME="ticdc-common-1-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/ddl_puller_lag/run.sh
+++ b/tests/ddl_puller_lag/run.sh
@@ -27,7 +27,7 @@ function prepare() {
     TOPIC_NAME="ticdc-ddl-puller-lag-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka+ssl://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-client-id=ddl_puller_lag&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql+ssl://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql+ssl://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -47,7 +47,7 @@ function complete_ddls() {
 }
 
 changefeedid=""
-SINK_URI="mysql://root@127.0.0.1:3306/"
+SINK_URI="mysql://normal:123456@127.0.0.1:3306/"
 
 function check_ts_forward() {
     changefeedid=$1

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -47,7 +47,9 @@ function complete_ddls() {
 }
 
 changefeedid=""
-SINK_URI="mysql://normal:123456@127.0.0.1:3306/"
+# this test contains `recover table`, which requires super privilege, so we
+# can't use the normal user
+SINK_URI="mysql://root@127.0.0.1:3306/"
 
 function check_ts_forward() {
     changefeedid=$1

--- a/tests/ddl_sequence/run.sh
+++ b/tests/ddl_sequence/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-ddl-sequence-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/drop_many_tables/run.sh
+++ b/tests/drop_many_tables/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-drop-tables-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/force_replicate_table/run.sh
+++ b/tests/force_replicate_table/run.sh
@@ -60,7 +60,7 @@ function run() {
     TOPIC_NAME="ticdc-force_replicate_table-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?safe-mode=true";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?safe-mode=true";;
     esac
     cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --config $CUR/conf/changefeed.toml
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -77,7 +77,7 @@ function run() {
     TOPIC_NAME="ticdc-gc-safepoint-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/generate_column/run.sh
+++ b/tests/generate_column/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-generate-column-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/kill_owner_with_ddl/run.sh
+++ b/tests/kill_owner_with_ddl/run.sh
@@ -46,7 +46,7 @@ function run() {
     cd $WORK_DIR
 
     pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
-    SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1"
+    SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1"
 
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI"

--- a/tests/kv_client_stream_reconnect/run.sh
+++ b/tests/kv_client_stream_reconnect/run.sh
@@ -20,7 +20,7 @@ function run() {
     TOPIC_NAME="kv-client-stream-reconnect-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/many_pk_or_uk/run.sh
+++ b/tests/many_pk_or_uk/run.sh
@@ -24,7 +24,7 @@ function prepare() {
     TOPIC_NAME="ticdc-many-pk-or-uk-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/move_table/run.sh
+++ b/tests/move_table/run.sh
@@ -24,7 +24,7 @@ function run() {
     TOPIC_NAME="ticdc-move-table-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
 
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"

--- a/tests/multi_capture/run.sh
+++ b/tests/multi_capture/run.sh
@@ -36,7 +36,7 @@ function run() {
     TOPIC_NAME="ticdc-multi-capture-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/multi_source/run.sh
+++ b/tests/multi_source/run.sh
@@ -24,7 +24,7 @@ function prepare() {
     TOPIC_NAME="ticdc-multi-source-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/new_ci_collation/run.sh
+++ b/tests/new_ci_collation/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-new_ci_collation-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?safe-mode=true";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?safe-mode=true";;
     esac
     cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --config $CUR/conf/changefeed.toml
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/owner_remove_table_error/run.sh
+++ b/tests/owner_remove_table_error/run.sh
@@ -24,7 +24,7 @@ function run() {
     cd $WORK_DIR
 
     pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
-    SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";
+    SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";
 
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/OwnerRemoveTableError=1*return(true)'
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr

--- a/tests/partition_table/run.sh
+++ b/tests/partition_table/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-partition-table-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/processor_err_chan/run.sh
+++ b/tests/processor_err_chan/run.sh
@@ -37,7 +37,7 @@ function run() {
     TOPIC_NAME="ticdc-processor-err-chan-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/processor_panic/run.sh
+++ b/tests/processor_panic/run.sh
@@ -29,7 +29,7 @@ function prepare() {
     TOPIC_NAME="ticdc-processor-panic-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-client-id=cdc_test_processor_panic&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/processor_resolved_ts_fallback/run.sh
+++ b/tests/processor_resolved_ts_fallback/run.sh
@@ -22,7 +22,7 @@ function run() {
     TOPIC_NAME="ticdc-processor-resolved-ts-fallback-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://kafka01:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/processor_stop_delay/run.sh
+++ b/tests/processor_stop_delay/run.sh
@@ -18,7 +18,7 @@ function run() {
     TOPIC_NAME="ticdc-processor-stop-delay-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/region_merge/run.sh
+++ b/tests/region_merge/run.sh
@@ -38,7 +38,7 @@ function run() {
     TOPIC_NAME="ticdc-region-merge-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/resolve_lock/run.sh
+++ b/tests/resolve_lock/run.sh
@@ -24,7 +24,7 @@ function prepare() {
     TOPIC_NAME="ticdc-resolve-lock-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/tidb-txn-mode=pessimistic";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/tidb-txn-mode=pessimistic";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/row_format/run.sh
+++ b/tests/row_format/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-row-format-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -22,7 +22,7 @@ if [ "${1-}" = '--debug' ]; then
 
     cdc server --log-file $WORK_DIR/cdc.log --log-level debug --addr 127.0.0.1:8300 > $WORK_DIR/stdout.log 2>&1 &
     sleep 1
-    cdc cli changefeed create --sink-uri="mysql://root@127.0.0.1:3306/"
+    cdc cli changefeed create --sink-uri="mysql://normal:123456@127.0.0.1:3306/"
 
     echo 'You may now debug from another terminal. Press [ENTER] to exit.'
     read line

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -26,7 +26,7 @@ function prepare() {
     TOPIC_NAME="ticdc-simple-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka+ssl://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-client-id=cdc_test_simple&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql+ssl://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql+ssl://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/sink_hang/run.sh
+++ b/tests/sink_hang/run.sh
@@ -39,7 +39,7 @@ function run() {
     TOPIC_NAME="ticdc-sink-hang-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     if [ "$SINK_TYPE" == "kafka" ]; then
       run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"

--- a/tests/sink_retry/run.sh
+++ b/tests/sink_retry/run.sh
@@ -27,7 +27,7 @@ function run() {
     TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/split_region/run.sh
+++ b/tests/split_region/run.sh
@@ -25,7 +25,7 @@ function run() {
     TOPIC_NAME="ticdc-split-region-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/syncpoint/run.sh
+++ b/tests/syncpoint/run.sh
@@ -132,7 +132,7 @@ function run() {
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 
     
-    SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1"
+    SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1"
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --sync-point --sync-interval=10s
 
     goSql

--- a/tests/tiflash/run.sh
+++ b/tests/tiflash/run.sh
@@ -23,7 +23,7 @@ function run() {
     TOPIC_NAME="ticdc-tiflash-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/";;
     esac
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
     if [ "$SINK_TYPE" == "kafka" ]; then

--- a/tests/unified_sorter/run.sh
+++ b/tests/unified_sorter/run.sh
@@ -27,7 +27,7 @@ function run() {
     TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&max-message-bytes=102400&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
     esac
     sort_dir="$WORK_DIR/unified_sort_cache"
     mkdir $sort_dir

--- a/tests/unified_sorter_sort_dir_conflict/run.sh
+++ b/tests/unified_sorter_sort_dir_conflict/run.sh
@@ -46,7 +46,7 @@ function prepare() {
     TOPIC_NAME="ticdc-simple-test-$RANDOM"
     case $SINK_TYPE in
         kafka) SINK_URI="kafka+ssl://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-client-id=cdc_test_simple&kafka-version=${KAFKA_VERSION}";;
-        *) SINK_URI="mysql+ssl://root@127.0.0.1:3306/";;
+        *) SINK_URI="mysql+ssl://normal:123456@127.0.0.1:3306/";;
     esac
     changefeedid=$(cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
     if [ "$SINK_TYPE" == "kafka" ]; then


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close item-1 in https://github.com/pingcap/ticdc/issues/1748

### What is changed and how it works?

- Create a normal MySQL user in the integration tests.
- The privilege of MySQL user is `select,insert,update,delete,index,create,drop,alter,create view`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
