### PR TITLE
*:refine log output

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -377,7 +377,6 @@ type CDCClient struct {
 // NewCDCClient creates a CDCClient instance
 func NewCDCClient(ctx context.Context, pd pd.Client, kvStorage tikv.Storage, credential *security.Credential) (c CDCKVClient) {
 	clusterID := pd.GetClusterID(ctx)
-	log.Info("get clusterID", zap.Uint64("id", clusterID))
 
 	var store TiKVStorage
 	if kvStorage != nil {

--- a/cdc/puller/sorter/merger.go
+++ b/cdc/puller/sorter/merger.go
@@ -111,7 +111,6 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 		}
 
 		taskBuf.close()
-		log.Info("Merger has exited")
 	}()
 
 	lastOutputTs := uint64(0)

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -214,6 +214,10 @@ func newQueryChangefeedCommand() *cobra.Command {
 			if err != nil && cerror.ErrChangeFeedNotExists.NotEqual(err) {
 				return err
 			}
+			if err != nil && cerror.ErrChangeFeedNotExists.Equal(err) {
+				log.Error("This changefeed does not exist", zap.String("changefeed", changefeedID))
+				return err
+			}
 			taskPositions, err := cdcEtcdCli.GetAllTaskPositions(ctx, changefeedID)
 			if err != nil && cerror.ErrChangeFeedNotExists.NotEqual(err) {
 				return err
@@ -232,7 +236,7 @@ func newQueryChangefeedCommand() *cobra.Command {
 			}
 			meta := &cfMeta{Info: info, Status: status, Count: count, TaskStatus: taskStatus}
 			if info == nil {
-				log.Warn("this changefeed has been deleted, the residual meta data will be completely deleted within 24 hours.")
+				log.Warn("This changefeed has been deleted, the residual meta data will be completely deleted within 24 hours.", zap.String("changgefeed", changefeedID))
 			}
 			return jsonPrint(cmd, meta)
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#1765  
#1762 
#1761 

### What is changed and how it works?

Appropriate log output is added(#1765) and redundant log output is removed(#1761 #1762).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

1.For #1765 , the out put now is as below: 
```
$ cdc cli changefeed query -c ttl-test-12
>
[2021/05/14 11:47:30.324 +08:00] [ERROR] [client_changefeed.go:218] ["This changefeed does not exist"] [changefeed=ttl-test-12]
Error: [CDC:ErrChangeFeedNotExists]changefeed not exists, key: /tidb/cdc/job/ttl-test-12
Usage:
  cdc cli changefeed query [flags]

Flags:
  -c, --changefeed-id string   Replication task (changefeed) ID
  -h, --help                   help for query
  -s, --simple                 Output simplified replication status

Global Flags:
      --ca string          CA certificate path for TLS connection
      --cert string        Certificate path for TLS connection
  -i, --interact           Run cdc cli with readline
      --key string         Private key path for TLS connection
      --log-level string   log level (etc: debug|info|warn|error) (default "warn")
      --pd string          PD address, use ',' to separate multiple PDs (default "http://127.0.0.1:2379")

[CDC:ErrChangeFeedNotExists]changefeed not exists, key: /tidb/cdc/job/ttl-test-12
```

2. For #1761 the out put now is as below:
```
$ cat ticdc2.log | grep 'get clusterID' | wc -l
0
```

3. For #1762 the out put now is as below:
```
cat tmp1.log | grep -E 'merger exiting|Merger has exited' | wc -l
6

[2021/05/14 12:12:38.589 +08:00] [INFO] [merger.go:66] ["Unified Sorter: merger exiting, cleaning up resources"]
[pending-set-size=1]
[2021/05/14 12:12:48.592 +08:00] [INFO] [merger.go:66] ["Unified Sorter: merger exiting, cleaning up resources"]
[pending-set-size=0]
...

```
Related changes

 - Need to cherry-pick to the release branch

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
