### PR TITLE
*: fix flow control deadlock (release-4.0)

### DIFF
--- a/cdc/sink/common/flow_control_test.go
+++ b/cdc/sink/common/flow_control_test.go
@@ -433,6 +433,7 @@ func (s *flowControlSuite) TestFlowControlCallBackNotBlockingRelease(c *check.C)
 			c.Fatalf("unreachable")
 			return nil
 		})
+		c.Assert(err, check.IsNil)
 
 		var isBlocked int32
 		wg.Add(1)

--- a/cdc/sink/common/flow_control_test.go
+++ b/cdc/sink/common/flow_control_test.go
@@ -417,6 +417,47 @@ func (s *flowControlSuite) TestFlowControlCallBack(c *check.C) {
 	c.Assert(atomic.LoadUint64(&consumedBytes), check.Equals, uint64(0))
 }
 
+func (s *flowControlSuite) TestFlowControlCallBackNotBlockingRelease(c *check.C) {
+	defer testleak.AfterTest(c)()
+
+	var wg sync.WaitGroup
+	controller := NewTableFlowController(512)
+	wg.Add(1)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	go func() {
+		defer wg.Done()
+		err := controller.Consume(1, 511, func() error {
+			c.Fatalf("unreachable")
+			return nil
+		})
+
+		var isBlocked int32
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-time.After(time.Second * 1)
+			// makes sure that this test case is valid
+			c.Assert(atomic.LoadInt32(&isBlocked), check.Equals, int32(1))
+			controller.Release(1)
+			cancel()
+		}()
+
+		err = controller.Consume(2, 511, func() error {
+			atomic.StoreInt32(&isBlocked, 1)
+			<-ctx.Done()
+			atomic.StoreInt32(&isBlocked, 0)
+			return ctx.Err()
+		})
+
+		c.Assert(err, check.ErrorMatches, ".*context canceled.*")
+	}()
+
+	wg.Wait()
+}
+
 func (s *flowControlSuite) TestFlowControlCallBackError(c *check.C) {
 	defer testleak.AfterTest(c)()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Fix release-4.0 deadlock caused by flow-control when the sorter's input channel has been blocked.

```
goroutine 2776 [select, 363 minutes]:
github.com/pingcap/ticdc/cdc.(*oldProcessor).runFlowControl.func1(0xc0895d7918, 0x2189526)
        github.com/pingcap/ticdc@/cdc/processor.go:990 +0x1d8
github.com/pingcap/ticdc/cdc/sink/common.(*TableMemoryQuota).ConsumeWithBlocking(0xc096495da0, 0x13, 0xc0895d7c20, 0x0, 0x0)
        github.com/pingcap/ticdc@/cdc/sink/common/flow_control.go:77 +0xfc
github.com/pingcap/ticdc/cdc/sink/common.(*TableFlowController).Consume(0xc096495dd0, 0x5e5a0ae09d400ea, 0x13, 0xc0895d7c20, 0x0, 0x0)
        github.com/pingcap/ticdc@/cdc/sink/common/flow_control.go:174 +0x8a
github.com/pingcap/ticdc/cdc.(*oldProcessor).runFlowControl(0xc0026606c0, 0x2f71160, 0xc095bf2440, 0x34, 0xc096495dd0, 0xc019019aa0, 0xc019019da0)
        github.com/pingcap/ticdc@/cdc/processor.go:981 +0x45d
github.com/pingcap/ticdc/cdc.(*oldProcessor).sorterConsume.func6(0xc0026606c0, 0x2f71160, 0xc095bf2440, 0x34, 0xc096495dd0, 0x2f5d420, 0xc096495a10, 0xc019019da0)
        github.com/pingcap/ticdc@/cdc/processor.go:1183 +0x82
created by github.com/pingcap/ticdc/cdc.(*oldProcessor).sorterConsume
        github.com/pingcap/ticdc@/cdc/processor.go:1182 +0xb76


goroutine 2774 [semacquire, 363 minutes]:
sync.runtime_SemacquireMutex(0xc096495db0, 0xc036227500, 0x1)
        runtime/sema.go:71 +0x47
sync.(*Mutex).lockSlow(0xc096495dac)
        sync/mutex.go:138 +0xfc
sync.(*Mutex).Lock(...)
        sync/mutex.go:81
github.com/pingcap/ticdc/cdc/sink/common.(*TableMemoryQuota).Release(0xc096495da0, 0x0)
        github.com/pingcap/ticdc@/cdc/sink/common/flow_control.go:105 +0x2f4
github.com/pingcap/ticdc/cdc/sink/common.(*TableFlowController).Release(0xc096495dd0, 0x5e5a0a21b240228)
        github.com/pingcap/ticdc@/cdc/sink/common/flow_control.go:215 +0x102
github.com/pingcap/ticdc/cdc.(*oldProcessor).sorterConsume.func5(0xc036227e30, 0xc03622788c)
        github.com/pingcap/ticdc@/cdc/processor.go:1175 +0x100
github.com/pingcap/ticdc/cdc.(*oldProcessor).sorterConsume(0xc0026606c0, 0x2f71160, 0xc095bf2440, 0x34, 0xc095c064e0, 0x11, 0x2f5d420, 0xc096495a10, 0xc0961d18c8, 0xc0961d18d0, ...)
        github.com/pingcap/ticdc@/cdc/processor.go:1256 +0x18ec
github.com/pingcap/ticdc/cdc.(*oldProcessor).addTable.func2.5(0xc0026606c0, 0x2f71160, 0xc095bf2440, 0x34, 0xc096256740, 0x2f5d420, 0xc096495a10, 0xc0961d18c8, 0xc0961d18d0, 0xc095c3e1b0, ...)
        github.com/pingcap/ticdc@/cdc/processor.go:881 +0xca
created by github.com/pingcap/ticdc/cdc.(*oldProcessor).addTable.func2
        github.com/pingcap/ticdc@/cdc/processor.go:880 +0x664
```

- goroutine 2776 is blocked by `blockCallback` function, which will send event to `flowControlOutCh`, the channel is full at that time.
- The consumer of `flowControlOutCh` is blocked by `sendResolvedTs2Sink` (because they are in the same select branch)
- There is a flow controller release operation in `sendResolvedTs2Sink`, which needs to require a lock, however that lock is held by goroutine 2776

### What is changed and how it works?
- Made sure that the flow controller is not locked when the block callback is being called.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note

- Fix bug in flow control
