### PR TITLE
new_owner: let processor and owner use the same reactor state

### DIFF
--- a/cdc/model/reactor_state.go
+++ b/cdc/model/reactor_state.go
@@ -1,0 +1,399 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	cerrors "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/etcd"
+	"github.com/pingcap/ticdc/pkg/orchestrator"
+	"github.com/pingcap/ticdc/pkg/orchestrator/util"
+	"go.uber.org/zap"
+)
+
+// GlobalReactorState represents a global state which stores all key-value pairs in ETCD
+type GlobalReactorState struct {
+	Owner          map[string]struct{}
+	Captures       map[CaptureID]*CaptureInfo
+	Changefeeds    map[ChangeFeedID]*ChangefeedReactorState
+	pendingPatches []orchestrator.DataPatch
+}
+
+// NewGlobalState creates a new global state
+func NewGlobalState() orchestrator.ReactorState {
+	return &GlobalReactorState{
+		Owner:       map[string]struct{}{},
+		Captures:    make(map[CaptureID]*CaptureInfo),
+		Changefeeds: make(map[ChangeFeedID]*ChangefeedReactorState),
+	}
+}
+
+// Update implements the ReactorState interface
+func (s *GlobalReactorState) Update(key util.EtcdKey, value []byte, _ bool) error {
+	k := new(etcd.CDCKey)
+	err := k.Parse(key.String())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	switch k.Tp {
+	case etcd.CDCKeyTypeOwner:
+		if value != nil {
+			s.Owner[k.OwnerLeaseID] = struct{}{}
+		} else {
+			delete(s.Owner, k.OwnerLeaseID)
+		}
+		return nil
+	case etcd.CDCKeyTypeCapture:
+		if value == nil {
+			log.Info("remote capture offline", zap.String("capture-id", k.CaptureID))
+			delete(s.Captures, k.CaptureID)
+			return nil
+		}
+
+		var newCaptureInfo CaptureInfo
+		err := newCaptureInfo.Unmarshal(value)
+		if err != nil {
+			return cerrors.ErrUnmarshalFailed.Wrap(err).GenWithStackByArgs()
+		}
+
+		log.Info("remote capture online", zap.String("capture-id", k.CaptureID), zap.Any("info", newCaptureInfo))
+		s.Captures[k.CaptureID] = &newCaptureInfo
+	case etcd.CDCKeyTypeChangefeedInfo,
+		etcd.CDCKeyTypeChangeFeedStatus,
+		etcd.CDCKeyTypeTaskPosition,
+		etcd.CDCKeyTypeTaskStatus,
+		etcd.CDCKeyTypeTaskWorkload:
+		changefeedState, exist := s.Changefeeds[k.ChangefeedID]
+		if !exist {
+			if value == nil {
+				return nil
+			}
+			changefeedState = NewChangefeedReactorState(k.ChangefeedID)
+			s.Changefeeds[k.ChangefeedID] = changefeedState
+		}
+		if err := changefeedState.UpdateCDCKey(k, value); err != nil {
+			return errors.Trace(err)
+		}
+		if value == nil && !changefeedState.Exist() {
+			s.pendingPatches = append(s.pendingPatches, changefeedState.GetPatches()...)
+			delete(s.Changefeeds, k.ChangefeedID)
+		}
+	default:
+		log.Warn("receive an unexpected etcd event", zap.String("key", key.String()), zap.ByteString("value", value))
+	}
+	return nil
+}
+
+// GetPatches implements the ReactorState interface
+func (s *GlobalReactorState) GetPatches() []orchestrator.DataPatch {
+	pendingPatches := s.pendingPatches
+	for _, changefeedState := range s.Changefeeds {
+		pendingPatches = append(pendingPatches, changefeedState.GetPatches()...)
+	}
+	s.pendingPatches = nil
+	return pendingPatches
+}
+
+// CheckCaptureAlive checks if the capture is alive, if the capture offline,
+// the etcd worker will exit and throw the ErrLeaseExpired error.
+func (s *GlobalReactorState) CheckCaptureAlive(captureID CaptureID) {
+	k := etcd.CDCKey{
+		Tp:        etcd.CDCKeyTypeCapture,
+		CaptureID: captureID,
+	}
+	key := k.String()
+	patch := &orchestrator.SingleDataPatch{
+		Key: util.NewEtcdKey(key),
+		Func: func(v []byte) ([]byte, bool, error) {
+			if len(v) == 0 {
+				return v, false, cerrors.ErrLeaseExpired.GenWithStackByArgs()
+			}
+			return v, false, nil
+		},
+	}
+	s.pendingPatches = append(s.pendingPatches, patch)
+}
+
+// ChangefeedReactorState represents a changefeed state which stores all key-value pairs of a changefeed in ETCD
+type ChangefeedReactorState struct {
+	ID            ChangeFeedID
+	Info          *ChangeFeedInfo
+	Status        *ChangeFeedStatus
+	TaskPositions map[CaptureID]*TaskPosition
+	TaskStatuses  map[CaptureID]*TaskStatus
+	Workloads     map[CaptureID]TaskWorkload
+
+	pendingPatches        []orchestrator.DataPatch
+	skipPatchesInThisTick bool
+}
+
+// NewChangefeedReactorState creates a new changefeed reactor state
+func NewChangefeedReactorState(id ChangeFeedID) *ChangefeedReactorState {
+	return &ChangefeedReactorState{
+		ID:            id,
+		TaskPositions: make(map[CaptureID]*TaskPosition),
+		TaskStatuses:  make(map[CaptureID]*TaskStatus),
+		Workloads:     make(map[CaptureID]TaskWorkload),
+	}
+}
+
+// Update implements the ReactorState interface
+func (s *ChangefeedReactorState) Update(key util.EtcdKey, value []byte, _ bool) error {
+	k := new(etcd.CDCKey)
+	if err := k.Parse(key.String()); err != nil {
+		return errors.Trace(err)
+	}
+	if err := s.UpdateCDCKey(k, value); err != nil {
+		log.Error("failed to update status", zap.String("key", key.String()), zap.ByteString("value", value))
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// UpdateCDCKey updates the state by a parsed etcd key
+func (s *ChangefeedReactorState) UpdateCDCKey(key *etcd.CDCKey, value []byte) error {
+	var e interface{}
+	switch key.Tp {
+	case etcd.CDCKeyTypeChangefeedInfo:
+		if key.ChangefeedID != s.ID {
+			return nil
+		}
+		if value == nil {
+			s.Info = nil
+			return nil
+		}
+		s.Info = new(ChangeFeedInfo)
+		e = s.Info
+	case etcd.CDCKeyTypeChangeFeedStatus:
+		if key.ChangefeedID != s.ID {
+			return nil
+		}
+		if value == nil {
+			s.Status = nil
+			return nil
+		}
+		s.Status = new(ChangeFeedStatus)
+		e = s.Status
+	case etcd.CDCKeyTypeTaskPosition:
+		if key.ChangefeedID != s.ID {
+			return nil
+		}
+		if value == nil {
+			delete(s.TaskPositions, key.CaptureID)
+			return nil
+		}
+		position := new(TaskPosition)
+		s.TaskPositions[key.CaptureID] = position
+		e = position
+	case etcd.CDCKeyTypeTaskStatus:
+		if key.ChangefeedID != s.ID {
+			return nil
+		}
+		if value == nil {
+			delete(s.TaskStatuses, key.CaptureID)
+			return nil
+		}
+		status := new(TaskStatus)
+		s.TaskStatuses[key.CaptureID] = status
+		e = status
+	case etcd.CDCKeyTypeTaskWorkload:
+		if key.ChangefeedID != s.ID {
+			return nil
+		}
+		if value == nil {
+			delete(s.Workloads, key.CaptureID)
+			return nil
+		}
+		workload := make(TaskWorkload)
+		s.Workloads[key.CaptureID] = workload
+		e = &workload
+	default:
+		return nil
+	}
+	if err := json.Unmarshal(value, e); err != nil {
+		return errors.Trace(err)
+	}
+	if key.Tp == etcd.CDCKeyTypeChangefeedInfo {
+		if err := s.Info.VerifyAndFix(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// Exist returns false if all keys of this changefeed in ETCD is not exist
+func (s *ChangefeedReactorState) Exist() bool {
+	return s.Info != nil || s.Status != nil || len(s.TaskPositions) != 0 || len(s.TaskStatuses) != 0 || len(s.Workloads) != 0
+}
+
+// Active return true if the changefeed is ready to be processed
+func (s *ChangefeedReactorState) Active(captureID CaptureID) bool {
+	return s.Info != nil && s.Status != nil && s.TaskStatuses[captureID] != nil
+}
+
+// GetPatches implements the ReactorState interface
+func (s *ChangefeedReactorState) GetPatches() []orchestrator.DataPatch {
+	pendingPatches := s.pendingPatches
+	s.pendingPatches = nil
+	return pendingPatches
+}
+
+// CheckChangefeedNormal checks if the changefeed state is runable,
+// if the changefeed status is not runable, the etcd worker will skip all patch of this tick
+func (s *ChangefeedReactorState) CheckChangefeedNormal() {
+	s.skipPatchesInThisTick = false
+	s.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {
+		if info.AdminJobType.IsStopState() {
+			s.skipPatchesInThisTick = true
+			return info, false, cerrors.ErrEtcdTryAgain.GenWithStackByArgs()
+		}
+		return info, false, nil
+	})
+	s.PatchStatus(func(status *ChangeFeedStatus) (*ChangeFeedStatus, bool, error) {
+		if status == nil {
+			return status, false, nil
+		}
+		if status.AdminJobType.IsStopState() {
+			s.skipPatchesInThisTick = true
+			return status, false, cerrors.ErrEtcdTryAgain.GenWithStackByArgs()
+		}
+		return status, false, nil
+	})
+}
+
+// PatchInfo appends a DataPatch which can modify the ChangeFeedInfo
+func (s *ChangefeedReactorState) PatchInfo(fn func(*ChangeFeedInfo) (*ChangeFeedInfo, bool, error)) {
+	key := &etcd.CDCKey{
+		Tp:           etcd.CDCKeyTypeChangefeedInfo,
+		ChangefeedID: s.ID,
+	}
+	s.patchAny(key.String(), changefeedInfoTPI, func(e interface{}) (interface{}, bool, error) {
+		// e == nil means that the key is not exist before this patch
+		if e == nil {
+			return fn(nil)
+		}
+		return fn(e.(*ChangeFeedInfo))
+	})
+}
+
+// PatchStatus appends a DataPatch which can modify the ChangeFeedStatus
+func (s *ChangefeedReactorState) PatchStatus(fn func(*ChangeFeedStatus) (*ChangeFeedStatus, bool, error)) {
+	key := &etcd.CDCKey{
+		Tp:           etcd.CDCKeyTypeChangeFeedStatus,
+		ChangefeedID: s.ID,
+	}
+	s.patchAny(key.String(), changefeedStatusTPI, func(e interface{}) (interface{}, bool, error) {
+		// e == nil means that the key is not exist before this patch
+		if e == nil {
+			return fn(nil)
+		}
+		return fn(e.(*ChangeFeedStatus))
+	})
+}
+
+// PatchTaskPosition appends a DataPatch which can modify the TaskPosition of a specified capture
+func (s *ChangefeedReactorState) PatchTaskPosition(captureID CaptureID, fn func(*TaskPosition) (*TaskPosition, bool, error)) {
+	key := &etcd.CDCKey{
+		Tp:           etcd.CDCKeyTypeTaskPosition,
+		CaptureID:    captureID,
+		ChangefeedID: s.ID,
+	}
+	s.patchAny(key.String(), taskPositionTPI, func(e interface{}) (interface{}, bool, error) {
+		// e == nil means that the key is not exist before this patch
+		if e == nil {
+			return fn(nil)
+		}
+		return fn(e.(*TaskPosition))
+	})
+}
+
+// PatchTaskStatus appends a DataPatch which can modify the TaskStatus of a specified capture
+func (s *ChangefeedReactorState) PatchTaskStatus(captureID CaptureID, fn func(*TaskStatus) (*TaskStatus, bool, error)) {
+	key := &etcd.CDCKey{
+		Tp:           etcd.CDCKeyTypeTaskStatus,
+		CaptureID:    captureID,
+		ChangefeedID: s.ID,
+	}
+	s.patchAny(key.String(), taskStatusTPI, func(e interface{}) (interface{}, bool, error) {
+		// e == nil means that the key is not exist before this patch
+		if e == nil {
+			return fn(nil)
+		}
+		return fn(e.(*TaskStatus))
+	})
+}
+
+// PatchTaskWorkload appends a DataPatch which can modify the TaskWorkload of a specified capture
+func (s *ChangefeedReactorState) PatchTaskWorkload(captureID CaptureID, fn func(TaskWorkload) (TaskWorkload, bool, error)) {
+	key := &etcd.CDCKey{
+		Tp:           etcd.CDCKeyTypeTaskWorkload,
+		CaptureID:    captureID,
+		ChangefeedID: s.ID,
+	}
+	s.patchAny(key.String(), taskWorkloadTPI, func(e interface{}) (interface{}, bool, error) {
+		// e == nil means that the key is not exist before this patch
+		if e == nil {
+			return fn(nil)
+		}
+		return fn(*e.(*TaskWorkload))
+	})
+}
+
+var (
+	taskPositionTPI     *TaskPosition
+	taskStatusTPI       *TaskStatus
+	taskWorkloadTPI     *TaskWorkload
+	changefeedStatusTPI *ChangeFeedStatus
+	changefeedInfoTPI   *ChangeFeedInfo
+)
+
+func (s *ChangefeedReactorState) patchAny(key string, tpi interface{}, fn func(interface{}) (interface{}, bool, error)) {
+	patch := &orchestrator.SingleDataPatch{
+		Key: util.NewEtcdKey(key),
+		Func: func(v []byte) ([]byte, bool, error) {
+			if s.skipPatchesInThisTick {
+				return v, false, cerrors.ErrEtcdIgnore.GenWithStackByArgs()
+			}
+			var e interface{}
+			if v != nil {
+				tp := reflect.TypeOf(tpi)
+				e = reflect.New(tp.Elem()).Interface()
+				err := json.Unmarshal(v, e)
+				if err != nil {
+					return nil, false, errors.Trace(err)
+				}
+			}
+			ne, changed, err := fn(e)
+			if err != nil {
+				return nil, false, errors.Trace(err)
+			}
+			if !changed {
+				return v, false, nil
+			}
+			if reflect.ValueOf(ne).IsNil() {
+				return nil, true, nil
+			}
+			nv, err := json.Marshal(ne)
+			if err != nil {
+				return nil, false, errors.Trace(err)
+			}
+			return nv, true, nil
+		},
+	}
+	s.pendingPatches = append(s.pendingPatches, patch)
+}

--- a/cdc/model/reactor_state_test.go
+++ b/cdc/model/reactor_state_test.go
@@ -1,0 +1,687 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"time"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/orchestrator"
+	"github.com/pingcap/ticdc/pkg/orchestrator/util"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+type stateSuite struct{}
+
+var _ = check.Suite(&stateSuite{})
+
+func (s *stateSuite) TestCheckCaptureAlive(c *check.C) {
+	defer testleak.AfterTest(c)()
+	state := NewGlobalState().(*GlobalReactorState)
+	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
+	state.CheckCaptureAlive("6bbc01c8-0605-4f86-a0f9-b3119109b225")
+	c.Assert(stateTester.ApplyPatches(), check.ErrorMatches, ".*[CDC:ErrLeaseExpired].*")
+	err := stateTester.Update("/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225", []byte(`{"id":"6bbc01c8-0605-4f86-a0f9-b3119109b225","address":"127.0.0.1:8300"}`))
+	c.Assert(err, check.IsNil)
+	state.CheckCaptureAlive("6bbc01c8-0605-4f86-a0f9-b3119109b225")
+	stateTester.MustApplyPatches()
+}
+
+func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
+	defer testleak.AfterTest(c)()
+	createTime, err := time.Parse("2006-01-02", "2020-02-02")
+	c.Assert(err, check.IsNil)
+	testCases := []struct {
+		changefeedID string
+		updateKey    []string
+		updateValue  []string
+		expected     ChangefeedReactorState
+	}{
+		{ // common case
+			changefeedID: "test1",
+			updateKey: []string{
+				"/tidb/cdc/changefeed/info/test1",
+				"/tidb/cdc/job/test1",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+			},
+			updateValue: []string{
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
+				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
+				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				`{"45":{"workload":1}}`,
+				`{"id":"6bbc01c8-0605-4f86-a0f9-b3119109b225","address":"127.0.0.1:8300"}`,
+			},
+			expected: ChangefeedReactorState{
+				ID: "test1",
+				Info: &ChangeFeedInfo{
+					SinkURI:           "blackhole://",
+					Opts:              map[string]string{},
+					CreateTime:        createTime,
+					StartTs:           421980685886554116,
+					Engine:            SortInMemory,
+					SortDir:           ".",
+					State:             "normal",
+					SyncPointInterval: time.Minute * 10,
+					Config: &config.ReplicaConfig{
+						CaseSensitive:    true,
+						CheckGCSafePoint: true,
+						Filter:           &config.FilterConfig{Rules: []string{"*.*"}},
+						Mounter:          &config.MounterConfig{WorkerNum: 16},
+						Sink:             &config.SinkConfig{Protocol: "default"},
+						Cyclic:           &config.CyclicConfig{},
+						Scheduler:        &config.SchedulerConfig{Tp: "table-number", PollingTime: -1},
+					},
+				},
+				Status: &ChangeFeedStatus{CheckpointTs: 421980719742451713, ResolvedTs: 421980720003809281},
+				TaskStatuses: map[CaptureID]*TaskStatus{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {
+						Tables: map[int64]*TableReplicaInfo{45: {StartTs: 421980685886554116}},
+					},
+				},
+				TaskPositions: map[CaptureID]*TaskPosition{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {CheckPointTs: 421980720003809281, ResolvedTs: 421980720003809281},
+				},
+				Workloads: map[CaptureID]TaskWorkload{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {45: {Workload: 1}},
+				},
+			},
+		},
+		{ // test multiple capture
+			changefeedID: "test1",
+			updateKey: []string{
+				"/tidb/cdc/changefeed/info/test1",
+				"/tidb/cdc/job/test1",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+				"/tidb/cdc/task/position/666777888/test1",
+				"/tidb/cdc/task/status/666777888/test1",
+				"/tidb/cdc/task/workload/666777888/test1",
+				"/tidb/cdc/capture/666777888",
+			},
+			updateValue: []string{
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
+				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
+				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				`{"45":{"workload":1}}`,
+				`{"id":"6bbc01c8-0605-4f86-a0f9-b3119109b225","address":"127.0.0.1:8300"}`,
+				`{"checkpoint-ts":11332244,"resolved-ts":312321,"count":8,"error":null}`,
+				`{"tables":{"46":{"start-ts":412341234,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				`{"46":{"workload":3}}`,
+				`{"id":"666777888","address":"127.0.0.1:8300"}`,
+			},
+			expected: ChangefeedReactorState{
+				ID: "test1",
+				Info: &ChangeFeedInfo{
+					SinkURI:           "blackhole://",
+					Opts:              map[string]string{},
+					CreateTime:        createTime,
+					StartTs:           421980685886554116,
+					Engine:            SortInMemory,
+					SortDir:           ".",
+					State:             "normal",
+					SyncPointInterval: time.Minute * 10,
+					Config: &config.ReplicaConfig{
+						CaseSensitive:    true,
+						CheckGCSafePoint: true,
+						Filter:           &config.FilterConfig{Rules: []string{"*.*"}},
+						Mounter:          &config.MounterConfig{WorkerNum: 16},
+						Sink:             &config.SinkConfig{Protocol: "default"},
+						Cyclic:           &config.CyclicConfig{},
+						Scheduler:        &config.SchedulerConfig{Tp: "table-number", PollingTime: -1},
+					},
+				},
+				Status: &ChangeFeedStatus{CheckpointTs: 421980719742451713, ResolvedTs: 421980720003809281},
+				TaskStatuses: map[CaptureID]*TaskStatus{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {
+						Tables: map[int64]*TableReplicaInfo{45: {StartTs: 421980685886554116}},
+					},
+					"666777888": {
+						Tables: map[int64]*TableReplicaInfo{46: {StartTs: 412341234}},
+					},
+				},
+				TaskPositions: map[CaptureID]*TaskPosition{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {CheckPointTs: 421980720003809281, ResolvedTs: 421980720003809281},
+					"666777888":                            {CheckPointTs: 11332244, ResolvedTs: 312321, Count: 8},
+				},
+				Workloads: map[CaptureID]TaskWorkload{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {45: {Workload: 1}},
+					"666777888":                            {46: {Workload: 3}},
+				},
+			},
+		},
+		{ // testing changefeedID not match
+			changefeedID: "test1",
+			updateKey: []string{
+				"/tidb/cdc/changefeed/info/test1",
+				"/tidb/cdc/job/test1",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+				"/tidb/cdc/changefeed/info/test-fake",
+				"/tidb/cdc/job/test-fake",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test-fake",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test-fake",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test-fake",
+			},
+			updateValue: []string{
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
+				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
+				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				`{"45":{"workload":1}}`,
+				`{"id":"6bbc01c8-0605-4f86-a0f9-b3119109b225","address":"127.0.0.1:8300"}`,
+				`fake value`,
+				`fake value`,
+				`fake value`,
+				`fake value`,
+				`fake value`,
+			},
+			expected: ChangefeedReactorState{
+				ID: "test1",
+				Info: &ChangeFeedInfo{
+					SinkURI:           "blackhole://",
+					Opts:              map[string]string{},
+					CreateTime:        createTime,
+					StartTs:           421980685886554116,
+					Engine:            SortInMemory,
+					SortDir:           ".",
+					State:             "normal",
+					SyncPointInterval: time.Minute * 10,
+					Config: &config.ReplicaConfig{
+						CaseSensitive:    true,
+						CheckGCSafePoint: true,
+						Filter:           &config.FilterConfig{Rules: []string{"*.*"}},
+						Mounter:          &config.MounterConfig{WorkerNum: 16},
+						Sink:             &config.SinkConfig{Protocol: "default"},
+						Cyclic:           &config.CyclicConfig{},
+						Scheduler:        &config.SchedulerConfig{Tp: "table-number", PollingTime: -1},
+					},
+				},
+				Status: &ChangeFeedStatus{CheckpointTs: 421980719742451713, ResolvedTs: 421980720003809281},
+				TaskStatuses: map[CaptureID]*TaskStatus{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {
+						Tables: map[int64]*TableReplicaInfo{45: {StartTs: 421980685886554116}},
+					},
+				},
+				TaskPositions: map[CaptureID]*TaskPosition{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {CheckPointTs: 421980720003809281, ResolvedTs: 421980720003809281},
+				},
+				Workloads: map[CaptureID]TaskWorkload{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {45: {Workload: 1}},
+				},
+			},
+		},
+		{ // testing value is nil
+			changefeedID: "test1",
+			updateKey: []string{
+				"/tidb/cdc/changefeed/info/test1",
+				"/tidb/cdc/job/test1",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+				"/tidb/cdc/task/position/666777888/test1",
+				"/tidb/cdc/task/status/666777888/test1",
+				"/tidb/cdc/task/workload/666777888/test1",
+				"/tidb/cdc/changefeed/info/test1",
+				"/tidb/cdc/job/test1",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+				"/tidb/cdc/task/workload/666777888/test1",
+				"/tidb/cdc/task/status/666777888/test1",
+			},
+			updateValue: []string{
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
+				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
+				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				`{"45":{"workload":1}}`,
+				`{"id":"6bbc01c8-0605-4f86-a0f9-b3119109b225","address":"127.0.0.1:8300"}`,
+				`{"checkpoint-ts":11332244,"resolved-ts":312321,"count":8,"error":null}`,
+				`{"tables":{"46":{"start-ts":412341234,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				`{"46":{"workload":3}}`,
+				``,
+				``,
+				``,
+				``,
+				``,
+				``,
+				``,
+				``,
+			},
+			expected: ChangefeedReactorState{
+				ID:           "test1",
+				Info:         nil,
+				Status:       nil,
+				TaskStatuses: map[CaptureID]*TaskStatus{},
+				TaskPositions: map[CaptureID]*TaskPosition{
+					"666777888": {CheckPointTs: 11332244, ResolvedTs: 312321, Count: 8},
+				},
+				Workloads: map[CaptureID]TaskWorkload{},
+			},
+		},
+		{ // testing the same key case
+			changefeedID: "test1",
+			updateKey: []string{
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/status/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+			},
+			updateValue: []string{
+				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				`{"tables":{"46":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+				``,
+				`{"tables":{"47":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
+			},
+			expected: ChangefeedReactorState{
+				ID: "test1",
+				TaskStatuses: map[CaptureID]*TaskStatus{
+					"6bbc01c8-0605-4f86-a0f9-b3119109b225": {
+						Tables: map[int64]*TableReplicaInfo{47: {StartTs: 421980685886554116}},
+					},
+				},
+				TaskPositions: map[CaptureID]*TaskPosition{},
+				Workloads:     map[CaptureID]TaskWorkload{},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		state := NewChangefeedReactorState(tc.changefeedID)
+		for i, k := range tc.updateKey {
+			value := []byte(tc.updateValue[i])
+			if len(value) == 0 {
+				value = nil
+			}
+			err = state.Update(util.NewEtcdKey(k), value, false)
+			c.Assert(err, check.IsNil)
+		}
+		c.Assert(cmp.Equal(state, &tc.expected, cmpopts.IgnoreUnexported(ChangefeedReactorState{})), check.IsTrue,
+			check.Commentf("%s", cmp.Diff(state, &tc.expected, cmpopts.IgnoreUnexported(ChangefeedReactorState{}))))
+	}
+}
+
+func (s *stateSuite) TestPatchInfo(c *check.C) {
+	defer testleak.AfterTest(c)()
+	state := NewChangefeedReactorState("test1")
+	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
+	state.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {
+		c.Assert(info, check.IsNil)
+		return &ChangeFeedInfo{SinkURI: "123", Config: &config.ReplicaConfig{}}, true, nil
+	})
+	stateTester.MustApplyPatches()
+	defaultConfig := config.GetDefaultReplicaConfig()
+	c.Assert(state.Info, check.DeepEquals, &ChangeFeedInfo{
+		SinkURI: "123",
+		Engine:  SortUnified,
+		Config: &config.ReplicaConfig{
+			Filter:    defaultConfig.Filter,
+			Mounter:   defaultConfig.Mounter,
+			Sink:      defaultConfig.Sink,
+			Cyclic:    defaultConfig.Cyclic,
+			Scheduler: defaultConfig.Scheduler,
+		},
+	})
+	state.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {
+		info.StartTs = 6
+		return info, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Info, check.DeepEquals, &ChangeFeedInfo{
+		SinkURI: "123",
+		StartTs: 6,
+		Engine:  SortUnified,
+		Config: &config.ReplicaConfig{
+			Filter:    defaultConfig.Filter,
+			Mounter:   defaultConfig.Mounter,
+			Sink:      defaultConfig.Sink,
+			Cyclic:    defaultConfig.Cyclic,
+			Scheduler: defaultConfig.Scheduler,
+		},
+	})
+	state.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {
+		return nil, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Info, check.IsNil)
+}
+
+func (s *stateSuite) TestPatchStatus(c *check.C) {
+	defer testleak.AfterTest(c)()
+	state := NewChangefeedReactorState("test1")
+	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
+	state.PatchStatus(func(status *ChangeFeedStatus) (*ChangeFeedStatus, bool, error) {
+		c.Assert(status, check.IsNil)
+		return &ChangeFeedStatus{CheckpointTs: 5}, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Status, check.DeepEquals, &ChangeFeedStatus{CheckpointTs: 5})
+	state.PatchStatus(func(status *ChangeFeedStatus) (*ChangeFeedStatus, bool, error) {
+		status.ResolvedTs = 6
+		return status, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Status, check.DeepEquals, &ChangeFeedStatus{CheckpointTs: 5, ResolvedTs: 6})
+	state.PatchStatus(func(status *ChangeFeedStatus) (*ChangeFeedStatus, bool, error) {
+		return nil, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Status, check.IsNil)
+}
+
+func (s *stateSuite) TestPatchTaskPosition(c *check.C) {
+	defer testleak.AfterTest(c)()
+	state := NewChangefeedReactorState("test1")
+	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
+	captureID1 := "capture1"
+	captureID2 := "capture2"
+	state.PatchTaskPosition(captureID1, func(position *TaskPosition) (*TaskPosition, bool, error) {
+		c.Assert(position, check.IsNil)
+		return &TaskPosition{
+			CheckPointTs: 1,
+		}, true, nil
+	})
+	state.PatchTaskPosition(captureID2, func(position *TaskPosition) (*TaskPosition, bool, error) {
+		c.Assert(position, check.IsNil)
+		return &TaskPosition{
+			CheckPointTs: 2,
+		}, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.TaskPositions, check.DeepEquals, map[string]*TaskPosition{
+		captureID1: {
+			CheckPointTs: 1,
+		},
+		captureID2: {
+			CheckPointTs: 2,
+		},
+	})
+	state.PatchTaskPosition(captureID1, func(position *TaskPosition) (*TaskPosition, bool, error) {
+		position.CheckPointTs = 3
+		return position, true, nil
+	})
+	state.PatchTaskPosition(captureID2, func(position *TaskPosition) (*TaskPosition, bool, error) {
+		position.ResolvedTs = 2
+		return position, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.TaskPositions, check.DeepEquals, map[string]*TaskPosition{
+		captureID1: {
+			CheckPointTs: 3,
+		},
+		captureID2: {
+			CheckPointTs: 2,
+			ResolvedTs:   2,
+		},
+	})
+	state.PatchTaskPosition(captureID1, func(position *TaskPosition) (*TaskPosition, bool, error) {
+		return nil, false, nil
+	})
+	state.PatchTaskPosition(captureID2, func(position *TaskPosition) (*TaskPosition, bool, error) {
+		return nil, true, nil
+	})
+	state.PatchTaskPosition(captureID1, func(position *TaskPosition) (*TaskPosition, bool, error) {
+		position.Count = 6
+		return position, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.TaskPositions, check.DeepEquals, map[string]*TaskPosition{
+		captureID1: {
+			CheckPointTs: 3,
+			Count:        6,
+		},
+	})
+}
+
+func (s *stateSuite) TestPatchTaskStatus(c *check.C) {
+	defer testleak.AfterTest(c)()
+	state := NewChangefeedReactorState("test1")
+	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
+	captureID1 := "capture1"
+	captureID2 := "capture2"
+	state.PatchTaskStatus(captureID1, func(status *TaskStatus) (*TaskStatus, bool, error) {
+		c.Assert(status, check.IsNil)
+		return &TaskStatus{
+			Tables: map[TableID]*TableReplicaInfo{45: {StartTs: 1}},
+		}, true, nil
+	})
+	state.PatchTaskStatus(captureID2, func(status *TaskStatus) (*TaskStatus, bool, error) {
+		c.Assert(status, check.IsNil)
+		return &TaskStatus{
+			Tables: map[TableID]*TableReplicaInfo{46: {StartTs: 1}},
+		}, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.TaskStatuses, check.DeepEquals, map[CaptureID]*TaskStatus{
+		captureID1: {Tables: map[TableID]*TableReplicaInfo{45: {StartTs: 1}}},
+		captureID2: {Tables: map[TableID]*TableReplicaInfo{46: {StartTs: 1}}},
+	})
+	state.PatchTaskStatus(captureID1, func(status *TaskStatus) (*TaskStatus, bool, error) {
+		status.Tables[46] = &TableReplicaInfo{StartTs: 2}
+		return status, true, nil
+	})
+	state.PatchTaskStatus(captureID2, func(status *TaskStatus) (*TaskStatus, bool, error) {
+		status.Tables[46].StartTs++
+		return status, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.TaskStatuses, check.DeepEquals, map[CaptureID]*TaskStatus{
+		captureID1: {Tables: map[TableID]*TableReplicaInfo{45: {StartTs: 1}, 46: {StartTs: 2}}},
+		captureID2: {Tables: map[TableID]*TableReplicaInfo{46: {StartTs: 2}}},
+	})
+	state.PatchTaskStatus(captureID2, func(status *TaskStatus) (*TaskStatus, bool, error) {
+		return nil, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.TaskStatuses, check.DeepEquals, map[CaptureID]*TaskStatus{
+		captureID1: {Tables: map[TableID]*TableReplicaInfo{45: {StartTs: 1}, 46: {StartTs: 2}}},
+	})
+}
+
+func (s *stateSuite) TestPatchTaskWorkload(c *check.C) {
+	defer testleak.AfterTest(c)()
+	state := NewChangefeedReactorState("test1")
+	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
+	captureID1 := "capture1"
+	captureID2 := "capture2"
+	state.PatchTaskWorkload(captureID1, func(workload TaskWorkload) (TaskWorkload, bool, error) {
+		c.Assert(workload, check.IsNil)
+		return TaskWorkload{45: {Workload: 1}}, true, nil
+	})
+	state.PatchTaskWorkload(captureID2, func(workload TaskWorkload) (TaskWorkload, bool, error) {
+		c.Assert(workload, check.IsNil)
+		return TaskWorkload{46: {Workload: 1}}, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Workloads, check.DeepEquals, map[CaptureID]TaskWorkload{
+		captureID1: {45: {Workload: 1}},
+		captureID2: {46: {Workload: 1}},
+	})
+	state.PatchTaskWorkload(captureID1, func(workload TaskWorkload) (TaskWorkload, bool, error) {
+		workload[46] = WorkloadInfo{Workload: 2}
+		return workload, true, nil
+	})
+	state.PatchTaskWorkload(captureID2, func(workload TaskWorkload) (TaskWorkload, bool, error) {
+		workload[45] = WorkloadInfo{Workload: 3}
+		return workload, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Workloads, check.DeepEquals, map[CaptureID]TaskWorkload{
+		captureID1: {45: {Workload: 1}, 46: {Workload: 2}},
+		captureID2: {45: {Workload: 3}, 46: {Workload: 1}},
+	})
+	state.PatchTaskWorkload(captureID2, func(workload TaskWorkload) (TaskWorkload, bool, error) {
+		return nil, true, nil
+	})
+	stateTester.MustApplyPatches()
+	c.Assert(state.Workloads, check.DeepEquals, map[CaptureID]TaskWorkload{
+		captureID1: {45: {Workload: 1}, 46: {Workload: 2}},
+	})
+}
+
+func (s *stateSuite) TestGlobalStateUpdate(c *check.C) {
+	defer testleak.AfterTest(c)()
+	testCases := []struct {
+		updateKey   []string
+		updateValue []string
+		expected    GlobalReactorState
+	}{
+		{ // common case
+			updateKey: []string{
+				"/tidb/cdc/owner/22317526c4fc9a37",
+				"/tidb/cdc/owner/22317526c4fc9a38",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test2",
+				"/tidb/cdc/task/workload/55551111/test2",
+			},
+			updateValue: []string{
+				`6bbc01c8-0605-4f86-a0f9-b3119109b225`,
+				`55551111`,
+				`{"id":"6bbc01c8-0605-4f86-a0f9-b3119109b225","address":"127.0.0.1:8300"}`,
+				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
+				`{"45":{"workload":1}}`,
+				`{"46":{"workload":1}}`,
+			},
+			expected: GlobalReactorState{
+				Owner: map[string]struct{}{"22317526c4fc9a37": {}, "22317526c4fc9a38": {}},
+				Captures: map[CaptureID]*CaptureInfo{"6bbc01c8-0605-4f86-a0f9-b3119109b225": {
+					ID:            "6bbc01c8-0605-4f86-a0f9-b3119109b225",
+					AdvertiseAddr: "127.0.0.1:8300",
+				}},
+				Changefeeds: map[ChangeFeedID]*ChangefeedReactorState{
+					"test1": {
+						ID:           "test1",
+						TaskStatuses: map[string]*TaskStatus{},
+						TaskPositions: map[CaptureID]*TaskPosition{
+							"6bbc01c8-0605-4f86-a0f9-b3119109b225": {CheckPointTs: 421980719742451713, ResolvedTs: 421980720003809281},
+						},
+						Workloads: map[string]TaskWorkload{},
+					},
+					"test2": {
+						ID:            "test2",
+						TaskStatuses:  map[string]*TaskStatus{},
+						TaskPositions: map[CaptureID]*TaskPosition{},
+						Workloads: map[CaptureID]TaskWorkload{
+							"6bbc01c8-0605-4f86-a0f9-b3119109b225": {45: {Workload: 1}},
+							"55551111":                             {46: {Workload: 1}},
+						},
+					},
+				},
+			},
+		},
+		{ // testing remove changefeed
+			updateKey: []string{
+				"/tidb/cdc/owner/22317526c4fc9a37",
+				"/tidb/cdc/owner/22317526c4fc9a38",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test2",
+				"/tidb/cdc/task/workload/55551111/test2",
+				"/tidb/cdc/owner/22317526c4fc9a37",
+				"/tidb/cdc/task/position/6bbc01c8-0605-4f86-a0f9-b3119109b225/test1",
+				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test2",
+				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
+			},
+			updateValue: []string{
+				`6bbc01c8-0605-4f86-a0f9-b3119109b225`,
+				`55551111`,
+				`{"id":"6bbc01c8-0605-4f86-a0f9-b3119109b225","address":"127.0.0.1:8300"}`,
+				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
+				`{"45":{"workload":1}}`,
+				`{"46":{"workload":1}}`,
+				``,
+				``,
+				``,
+				``,
+			},
+			expected: GlobalReactorState{
+				Owner:    map[string]struct{}{"22317526c4fc9a38": {}},
+				Captures: map[CaptureID]*CaptureInfo{},
+				Changefeeds: map[ChangeFeedID]*ChangefeedReactorState{
+					"test2": {
+						ID:            "test2",
+						TaskStatuses:  map[string]*TaskStatus{},
+						TaskPositions: map[CaptureID]*TaskPosition{},
+						Workloads: map[CaptureID]TaskWorkload{
+							"55551111": {46: {Workload: 1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		state := NewGlobalState()
+		for i, k := range tc.updateKey {
+			value := []byte(tc.updateValue[i])
+			if len(value) == 0 {
+				value = nil
+			}
+			err := state.Update(util.NewEtcdKey(k), value, false)
+			c.Assert(err, check.IsNil)
+		}
+		c.Assert(cmp.Equal(state, &tc.expected, cmpopts.IgnoreUnexported(GlobalReactorState{}, ChangefeedReactorState{})), check.IsTrue,
+			check.Commentf("%s", cmp.Diff(state, &tc.expected, cmpopts.IgnoreUnexported(GlobalReactorState{}, ChangefeedReactorState{}))))
+	}
+}
+
+func (s *stateSuite) TestCheckChangefeedNormal(c *check.C) {
+	defer testleak.AfterTest(c)()
+	state := NewChangefeedReactorState("test1")
+	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
+	state.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {
+		return &ChangeFeedInfo{SinkURI: "123", AdminJobType: AdminNone, Config: &config.ReplicaConfig{}}, true, nil
+	})
+	state.PatchStatus(func(status *ChangeFeedStatus) (*ChangeFeedStatus, bool, error) {
+		return &ChangeFeedStatus{ResolvedTs: 1, AdminJobType: AdminNone}, true, nil
+	})
+	state.CheckChangefeedNormal()
+	stateTester.MustApplyPatches()
+	c.Assert(state.Status.ResolvedTs, check.Equals, uint64(1))
+
+	state.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {
+		info.AdminJobType = AdminStop
+		return info, true, nil
+	})
+	state.PatchStatus(func(status *ChangeFeedStatus) (*ChangeFeedStatus, bool, error) {
+		status.ResolvedTs = 2
+		return status, true, nil
+	})
+	state.CheckChangefeedNormal()
+	stateTester.MustApplyPatches()
+	c.Assert(state.Status.ResolvedTs, check.Equals, uint64(1))
+
+	state.PatchStatus(func(status *ChangeFeedStatus) (*ChangeFeedStatus, bool, error) {
+		status.ResolvedTs = 2
+		return status, true, nil
+	})
+	state.CheckChangefeedNormal()
+	stateTester.MustApplyPatches()
+	c.Assert(state.Status.ResolvedTs, check.Equals, uint64(2))
+}

--- a/cdc/model/reactor_state_test.go
+++ b/cdc/model/reactor_state_test.go
@@ -63,7 +63,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -78,7 +78,6 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 					CreateTime:        createTime,
 					StartTs:           421980685886554116,
 					Engine:            SortInMemory,
-					SortDir:           ".",
 					State:             "normal",
 					SyncPointInterval: time.Minute * 10,
 					Config: &config.ReplicaConfig{
@@ -120,7 +119,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/capture/666777888",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -139,7 +138,6 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 					CreateTime:        createTime,
 					StartTs:           421980685886554116,
 					Engine:            SortInMemory,
-					SortDir:           ".",
 					State:             "normal",
 					SyncPointInterval: time.Minute * 10,
 					Config: &config.ReplicaConfig{
@@ -187,7 +185,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test-fake",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -207,7 +205,6 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 					CreateTime:        createTime,
 					StartTs:           421980685886554116,
 					Engine:            SortInMemory,
-					SortDir:           ".",
 					State:             "normal",
 					SyncPointInterval: time.Minute * 10,
 					Config: &config.ReplicaConfig{
@@ -256,7 +253,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/task/status/666777888/test1",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -311,7 +308,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 			},
 		},
 	}
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		state := NewChangefeedReactorState(tc.changefeedID)
 		for i, k := range tc.updateKey {
 			value := []byte(tc.updateValue[i])
@@ -322,7 +319,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 			c.Assert(err, check.IsNil)
 		}
 		c.Assert(cmp.Equal(state, &tc.expected, cmpopts.IgnoreUnexported(ChangefeedReactorState{})), check.IsTrue,
-			check.Commentf("%s", cmp.Diff(state, &tc.expected, cmpopts.IgnoreUnexported(ChangefeedReactorState{}))))
+			check.Commentf("%d,%s", i, cmp.Diff(state, &tc.expected, cmpopts.IgnoreUnexported(ChangefeedReactorState{}))))
 	}
 }
 

--- a/errors.toml
+++ b/errors.toml
@@ -396,6 +396,11 @@ error = '''
 kafka send message failed
 '''
 
+["CDC:ErrLeaseExpired"]
+error = '''
+owner lease expired 
+'''
+
 ["CDC:ErrLeaseTimeout"]
 error = '''
 owner lease timeout

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -189,6 +189,7 @@ var (
 	// ErrReactorFinished is used by reactor to signal a **normal** exit.
 	ErrReactorFinished = errors.Normalize("the reactor has done its job and should no longer be executed", errors.RFCCodeText("CDC:ErrReactorFinished"))
 	ErrLeaseTimeout    = errors.Normalize("owner lease timeout", errors.RFCCodeText("CDC:ErrLeaseTimeout"))
+	ErrLeaseExpired    = errors.Normalize("owner lease expired ", errors.RFCCodeText("CDC:ErrLeaseExpired"))
 
 	// pipeline errors
 	ErrSendToClosedPipeline = errors.Normalize("pipeline is closed, cannot send message", errors.RFCCodeText("CDC:ErrSendToClosedPipeline"))

--- a/pkg/etcd/etcdkey.go
+++ b/pkg/etcd/etcdkey.go
@@ -17,7 +17,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/pingcap/ticdc/cdc/model"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 )
 
@@ -76,8 +75,8 @@ const (
 */
 type CDCKey struct {
 	Tp           CDCKeyType
-	ChangefeedID model.ChangeFeedID
-	CaptureID    model.CaptureID
+	ChangefeedID string
+	CaptureID    string
 	OwnerLeaseID string
 }
 

--- a/pkg/orchestrator/reactor_state_tester.go
+++ b/pkg/orchestrator/reactor_state_tester.go
@@ -93,10 +93,6 @@ RetryLoop:
 	}
 }
 
-func (t *ReactorStateTester) MustUpdateKey(key string, value []byte) {
-	t.c.Assert(t.Update(key, value), check.IsNil)
-}
-
 // MustApplyPatches calls ApplyPatches and must successfully
 func (t *ReactorStateTester) MustApplyPatches() {
 	t.c.Assert(t.ApplyPatches(), check.IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
a reactor state implement in model package, and I will remove the state implement in processor package in next pr.
the reactor state implements in model package and processor pacakge are roughly the same
it's order to let processor and owner use the same reactor state


FYI: what is recator state and how it works? see: https://github.com/pingcap/ticdc/blob/master/pkg/orchestrator/doc.go


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
