### PR TITLE
etcd_worker: fix a bug that etcd worker maybe lost data at starting

### DIFF
--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -217,6 +217,7 @@ func (worker *EtcdWorker) syncRawState(ctx context.Context) error {
 			return errors.Trace(err)
 		}
 	}
+
 	worker.revision = resp.Header.Revision
 	return nil
 }

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -85,7 +85,7 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 	ticker := time.NewTicker(timerInterval)
 	defer ticker.Stop()
 
-	watchCh := worker.client.Watch(ctx1, worker.prefix.String(), clientv3.WithPrefix())
+	watchCh := worker.client.Watch(ctx1, worker.prefix.String(), clientv3.WithPrefix(), clientv3.WithRev(worker.revision+1))
 	var (
 		pendingPatches []DataPatch
 		exiting        bool
@@ -217,7 +217,6 @@ func (worker *EtcdWorker) syncRawState(ctx context.Context) error {
 			return errors.Trace(err)
 		}
 	}
-
 	worker.revision = resp.Header.Revision
 	return nil
 }

--- a/pkg/orchestrator/etcd_worker_bank_test.go
+++ b/pkg/orchestrator/etcd_worker_bank_test.go
@@ -123,7 +123,6 @@ func (s *etcdWorkerSuite) TestEtcdBank(c *check.C) {
 	totalAccountNumber := 25
 	workerNumber := 10
 	var wg sync.WaitGroup
-	// ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 

--- a/pkg/orchestrator/etcd_worker_bank_test.go
+++ b/pkg/orchestrator/etcd_worker_bank_test.go
@@ -1,0 +1,163 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/orchestrator/util"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"go.uber.org/zap"
+)
+
+type bankReactorState struct {
+	c            *check.C
+	account      []int
+	pendingPatch []DataPatch
+	index        int
+	notFirstTick bool
+}
+
+const bankTestPrefix = "/ticdc/test/bank/"
+
+func (b *bankReactorState) Update(key util.EtcdKey, value []byte, isInit bool) error {
+	b.c.Assert(strings.HasPrefix(key.String(), bankTestPrefix), check.IsTrue)
+	indexStr := key.String()[len(bankTestPrefix):]
+	b.account[b.atoi(indexStr)] = b.atoi(string(value))
+	return nil
+}
+
+func (b *bankReactorState) GetPatches() []DataPatch {
+	pendingPatches := b.pendingPatch
+	b.pendingPatch = nil
+	return pendingPatches
+}
+
+func (b *bankReactorState) Check() {
+	var sum int
+	for _, money := range b.account {
+		sum += money
+	}
+	if sum != 0 {
+		log.Info("show account", zap.Int("index", b.index), zap.Int("sum", sum), zap.Ints("account", b.account))
+	}
+	b.c.Assert(sum, check.Equals, 0, check.Commentf("not ft:%t", b.notFirstTick))
+}
+
+func (b *bankReactorState) atoi(value string) int {
+	i, err := strconv.Atoi(value)
+	b.c.Assert(err, check.IsNil)
+	return i
+}
+
+func (b *bankReactorState) patchAccount(index int, fn func(int) int) {
+	b.pendingPatch = append(b.pendingPatch, &SingleDataPatch{
+		Key: util.NewEtcdKey(fmt.Sprintf("%s%d", bankTestPrefix, index)),
+		Func: func(old []byte) (newValue []byte, changed bool, err error) {
+			oldMoney := b.atoi(string(old))
+			newMoney := fn(oldMoney)
+			if oldMoney == newMoney {
+				return old, false, nil
+			}
+			log.Debug("change money", zap.Int("account", index), zap.Int("from", oldMoney), zap.Int("to", newMoney))
+			return []byte(strconv.Itoa(newMoney)), true, nil
+		},
+	})
+}
+
+func (b *bankReactorState) TransferRandomly(transferNumber int) {
+	for i := 0; i < transferNumber; i++ {
+		accountA := rand.Intn(len(b.account))
+		accountB := rand.Intn(len(b.account))
+		transferMoney := rand.Intn(100)
+		b.patchAccount(accountA, func(money int) int {
+			return money - transferMoney
+		})
+		b.patchAccount(accountB, func(money int) int {
+			return money + transferMoney
+		})
+		log.Debug("transfer money", zap.Int("accountA", accountA), zap.Int("accountB", accountB), zap.Int("money", transferMoney))
+	}
+}
+
+type bankReactor struct {
+	accountNumber int
+}
+
+func (b *bankReactor) Tick(ctx context.Context, state ReactorState) (nextState ReactorState, err error) {
+	bankState := (state).(*bankReactorState)
+	bankState.Check()
+	// transfer 20% of account
+	bankState.TransferRandomly(rand.Intn(b.accountNumber/5 + 2))
+	// there is a 20% chance of restarting etcd worker
+	if rand.Intn(10) < 2 {
+		err = cerror.ErrReactorFinished.GenWithStackByArgs()
+	}
+	bankState.notFirstTick = true
+	return state, err
+}
+
+func (s *etcdWorkerSuite) TestEtcdBank(c *check.C) {
+	defer testleak.AfterTest(c)()
+	totalAccountNumber := 25
+	workerNumber := 10
+	var wg sync.WaitGroup
+	// ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer func() {
+		_ = cli.Unwrap().Close()
+	}()
+
+	for i := 0; i < totalAccountNumber; i++ {
+		_, err := cli.Put(ctx, fmt.Sprintf("%s%d", bankTestPrefix, i), "0")
+		c.Check(err, check.IsNil)
+	}
+
+	for i := 0; i < workerNumber; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				worker, err := NewEtcdWorker(cli, bankTestPrefix, &bankReactor{
+					accountNumber: totalAccountNumber,
+				}, &bankReactorState{c: c, index: i, account: make([]int, totalAccountNumber)})
+				c.Check(err, check.IsNil)
+				err = worker.Run(ctx, nil, 100*time.Millisecond)
+				if err == nil || err.Error() == "etcdserver: request timed out" {
+					continue
+				}
+				c.Check(errors.Cause(err), check.Equals, context.DeadlineExceeded)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/orchestrator/reactor_state_tester.go
+++ b/pkg/orchestrator/reactor_state_tester.go
@@ -16,6 +16,7 @@ package orchestrator
 import (
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/orchestrator/util"
 )
 
@@ -60,30 +61,36 @@ func (t *ReactorStateTester) Update(key string, value []byte) error {
 // ApplyPatches calls the GetPatches method on the ReactorState and apply the changes to the mocked kv-store.
 func (t *ReactorStateTester) ApplyPatches() error {
 	patches := t.state.GetPatches()
-
-	tmpKVEntries := make(map[util.EtcdKey][]byte)
-	for k, v := range t.kvEntries {
-		tmpKVEntries[util.NewEtcdKey(k)] = []byte(v)
-	}
-	changedSet := make(map[util.EtcdKey]struct{})
-	for _, patch := range patches {
-		err := patch.Patch(tmpKVEntries, changedSet)
-		if err != nil {
-			return err
+RetryLoop:
+	for {
+		tmpKVEntries := make(map[util.EtcdKey][]byte)
+		for k, v := range t.kvEntries {
+			tmpKVEntries[util.NewEtcdKey(k)] = []byte(v)
 		}
-	}
-	for k := range changedSet {
-		err := t.state.Update(k, tmpKVEntries[k], false)
-		if err != nil {
-			return err
+		changedSet := make(map[util.EtcdKey]struct{})
+		for _, patch := range patches {
+			err := patch.Patch(tmpKVEntries, changedSet)
+			if cerrors.ErrEtcdIgnore.Equal(errors.Cause(err)) {
+				continue
+			} else if cerrors.ErrEtcdTryAgain.Equal(errors.Cause(err)) {
+				continue RetryLoop
+			} else if err != nil {
+				return errors.Trace(err)
+			}
 		}
-		if value := tmpKVEntries[k]; value != nil {
-			t.kvEntries[k.String()] = string(value)
-		} else {
-			delete(t.kvEntries, k.String())
+		for k := range changedSet {
+			err := t.state.Update(k, tmpKVEntries[k], false)
+			if err != nil {
+				return err
+			}
+			if value := tmpKVEntries[k]; value != nil {
+				t.kvEntries[k.String()] = string(value)
+			} else {
+				delete(t.kvEntries, k.String())
+			}
 		}
+		return nil
 	}
-	return nil
 }
 
 // MustApplyPatches calls ApplyPatches and must successfully

--- a/pkg/orchestrator/reactor_state_tester.go
+++ b/pkg/orchestrator/reactor_state_tester.go
@@ -16,7 +16,6 @@ package orchestrator
 import (
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
-	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/orchestrator/util"
 )
 
@@ -61,36 +60,30 @@ func (t *ReactorStateTester) Update(key string, value []byte) error {
 // ApplyPatches calls the GetPatches method on the ReactorState and apply the changes to the mocked kv-store.
 func (t *ReactorStateTester) ApplyPatches() error {
 	patches := t.state.GetPatches()
-RetryLoop:
-	for {
-		tmpKVEntries := make(map[util.EtcdKey][]byte)
-		for k, v := range t.kvEntries {
-			tmpKVEntries[util.NewEtcdKey(k)] = []byte(v)
-		}
-		changedSet := make(map[util.EtcdKey]struct{})
-		for _, patch := range patches {
-			err := patch.Patch(tmpKVEntries, changedSet)
-			if cerrors.ErrEtcdIgnore.Equal(errors.Cause(err)) {
-				continue
-			} else if cerrors.ErrEtcdTryAgain.Equal(errors.Cause(err)) {
-				continue RetryLoop
-			} else if err != nil {
-				return errors.Trace(err)
-			}
-		}
-		for k := range changedSet {
-			err := t.state.Update(k, tmpKVEntries[k], false)
-			if err != nil {
-				return err
-			}
-			if value := tmpKVEntries[k]; value != nil {
-				t.kvEntries[k.String()] = string(value)
-			} else {
-				delete(t.kvEntries, k.String())
-			}
-		}
-		return nil
+
+	tmpKVEntries := make(map[util.EtcdKey][]byte)
+	for k, v := range t.kvEntries {
+		tmpKVEntries[util.NewEtcdKey(k)] = []byte(v)
 	}
+	changedSet := make(map[util.EtcdKey]struct{})
+	for _, patch := range patches {
+		err := patch.Patch(tmpKVEntries, changedSet)
+		if err != nil {
+			return err
+		}
+	}
+	for k := range changedSet {
+		err := t.state.Update(k, tmpKVEntries[k], false)
+		if err != nil {
+			return err
+		}
+		if value := tmpKVEntries[k]; value != nil {
+			t.kvEntries[k.String()] = string(value)
+		} else {
+			delete(t.kvEntries, k.String())
+		}
+	}
+	return nil
 }
 
 // MustApplyPatches calls ApplyPatches and must successfully


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

 - Fix a bug that etcd worker lost data
 - a etcd worker bank test

### What is changed and how it works?
the etcd worker have two steps when it's starting:
1. read entire data snapshot and apply it to the reactor state
2. start to watch the data change log from etcd and apply logs to the reacator state

the data lost between step 1 and step 2 because the start reversion of the watch is not set

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
