### PR TITLE
owner: fix a bug which lead to replication stopped and no error report

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -572,6 +572,7 @@ func (c *changeFeed) handleMoveTableJobs(ctx context.Context, captures map[model
 			if !exist {
 				// the target capture is not exist, add table to orphanTables.
 				c.orphanTables[tableID] = replicaInfo.StartTs
+				delete(c.moveTableJobs, tableID)
 				log.Warn("the target capture is not exist, sent the table to orphanTables", zap.Reflect("job", job))
 				continue
 			}

--- a/cdc/changefeed_test.go
+++ b/cdc/changefeed_test.go
@@ -72,6 +72,7 @@ func (s *changefeedSuite) TearDownTest(c *check.C) {
 
 func (s *changefeedSuite) TestHandleMoveTableJobs(c *check.C) {
 	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
 	changefeed := new(changeFeed)
 	captureID1 := "capture1"
 	captureID2 := "capture2"

--- a/cdc/changefeed_test.go
+++ b/cdc/changefeed_test.go
@@ -1,0 +1,127 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/etcd"
+	"github.com/pingcap/ticdc/pkg/util"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/embed"
+	"golang.org/x/sync/errgroup"
+)
+
+type changefeedSuite struct {
+	e         *embed.Etcd
+	clientURL *url.URL
+	client    kv.CDCEtcdClient
+	sess      *concurrency.Session
+	ctx       context.Context
+	cancel    context.CancelFunc
+	errg      *errgroup.Group
+}
+
+var _ = check.Suite(&changefeedSuite{})
+
+func (s *changefeedSuite) SetUpTest(c *check.C) {
+	dir := c.MkDir()
+	var err error
+	s.clientURL, s.e, err = etcd.SetupEmbedEtcd(dir)
+	c.Assert(err, check.IsNil)
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{s.clientURL.String()},
+		DialTimeout: 3 * time.Second,
+	})
+	c.Assert(err, check.IsNil)
+	sess, err := concurrency.NewSession(client)
+	c.Assert(err, check.IsNil)
+	s.sess = sess
+	s.client = kv.NewCDCEtcdClient(context.Background(), client)
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.errg = util.HandleErrWithErrGroup(s.ctx, s.e.Err(), func(e error) { c.Log(e) })
+}
+
+func (s *changefeedSuite) TearDownTest(c *check.C) {
+	s.e.Close()
+	s.cancel()
+	err := s.errg.Wait()
+	if err != nil {
+		c.Errorf("Error group error: %s", err)
+	}
+	s.client.Close() //nolint:errcheck
+}
+
+func (s *changefeedSuite) TestHandleMoveTableJobs(c *check.C) {
+	changefeed := new(changeFeed)
+	captureID1 := "capture1"
+	captureID2 := "capture2"
+	changefeed.id = "changefeed-test"
+	changefeed.leaseID = s.sess.Lease()
+	changefeed.etcdCli = s.client
+	changefeed.status = new(model.ChangeFeedStatus)
+	changefeed.orphanTables = map[model.TableID]model.Ts{}
+	captures := make(map[model.CaptureID]*model.CaptureInfo)
+	captures[captureID1] = &model.CaptureInfo{
+		ID: captureID1,
+	}
+	captures[captureID2] = &model.CaptureInfo{
+		ID: captureID2,
+	}
+	changefeed.taskStatus = make(map[model.CaptureID]*model.TaskStatus)
+	changefeed.taskStatus[captureID1] = &model.TaskStatus{Tables: map[model.TableID]*model.TableReplicaInfo{1: {}}}
+	changefeed.taskStatus[captureID2] = &model.TaskStatus{Tables: map[model.TableID]*model.TableReplicaInfo{}}
+	changefeed.moveTableJobs = make(map[model.TableID]*model.MoveTableJob)
+	changefeed.moveTableJobs[1] = &model.MoveTableJob{
+		TableID:          1,
+		From:             captureID1,
+		To:               captureID2,
+		TableReplicaInfo: new(model.TableReplicaInfo),
+	}
+	err := changefeed.handleMoveTableJobs(s.ctx, captures)
+	c.Assert(err, check.IsNil)
+	taskStatuses, err := s.client.GetAllTaskStatus(s.ctx, changefeed.id)
+	c.Assert(err, check.IsNil)
+	taskStatuses[captureID1].ModRevision = 0
+	c.Assert(taskStatuses, check.DeepEquals, model.ProcessorsInfos{captureID1: {
+		Tables: map[model.TableID]*model.TableReplicaInfo{},
+		Operation: map[model.TableID]*model.TableOperation{1: {
+			Delete: true,
+			Flag:   model.OperFlagMoveTable,
+		}},
+	}})
+
+	// finish operation
+	err = s.client.PutTaskStatus(s.ctx, changefeed.id, captureID1, &model.TaskStatus{
+		Tables:    map[model.TableID]*model.TableReplicaInfo{},
+		Operation: map[model.TableID]*model.TableOperation{},
+	})
+	c.Assert(err, check.IsNil)
+	delete(changefeed.taskStatus[captureID1].Operation, 1)
+
+	// capture2 offline
+	delete(captures, captureID2)
+	delete(changefeed.taskStatus, captureID2)
+
+	err = changefeed.handleMoveTableJobs(s.ctx, captures)
+	c.Assert(err, check.IsNil)
+	c.Assert(changefeed.orphanTables, check.HasKey, model.TableID(1))
+	c.Assert(changefeed.moveTableJobs, check.HasLen, 0)
+}

--- a/cdc/changefeed_test.go
+++ b/cdc/changefeed_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
 	"go.etcd.io/etcd/embed"
@@ -70,6 +71,7 @@ func (s *changefeedSuite) TearDownTest(c *check.C) {
 }
 
 func (s *changefeedSuite) TestHandleMoveTableJobs(c *check.C) {
+	defer testleak.AfterTest(c)()
 	changefeed := new(changeFeed)
 	captureID1 := "capture1"
 	captureID2 := "capture2"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### Bug phenomenon

The resolved TS and checkpoint TS of a change feed is stopped, but no error reported

### How to confirm the bug
We can check the owner log, and find logs like this:
```

[2021/04/25 21:39:48.899 +08:00] [WARN] [changefeed.go:561] ["the target capture is not exist, sent the table to orphanTables"] [job="{\"From\":\"b51b0e86-373c-49a2-a7c4-42c98fde4e5e\",\"To\":\"5ec78795-88ea-43b3-803b-229a3ededc3b\",\"TableID\":694,\"TableReplicaInfo\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"Status\":1}"]
[2021/04/25 21:39:48.899 +08:00] [WARN] [changefeed.go:561] ["the target capture is not exist, sent the table to orphanTables"] [job="{\"From\":\"b51b0e86-373c-49a2-a7c4-42c98fde4e5e\",\"To\":\"5ec78795-88ea-43b3-803b-229a3ededc3b\",\"TableID\":1103,\"TableReplicaInfo\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"Status\":1}"]
[2021/04/25 21:39:48.989 +08:00] [INFO] [changefeed.go:374] ["dispatch table success"] [capture-id=1e8e5271-9340-4b08-b0b4-a00dd456eda6] [status="{\"tables\":{\"1103\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"312\":{\"start-ts\":424504976340680705,\"mark-table-id\":0},\"452\":{\"start-ts\":424504976340680705,\"mark-table-id\":0},\"694\":{\"start-ts\":424504976445538305,\"mark-table-id\":0}},\"operation\":null,\"admin-job-type\":0}"]
[2021/04/25 21:39:48.989 +08:00] [WARN] [changefeed.go:561] ["the target capture is not exist, sent the table to orphanTables"] [job="{\"From\":\"b51b0e86-373c-49a2-a7c4-42c98fde4e5e\",\"To\":\"5ec78795-88ea-43b3-803b-229a3ededc3b\",\"TableID\":694,\"TableReplicaInfo\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"Status\":1}"]
[2021/04/25 21:39:48.989 +08:00] [WARN] [changefeed.go:561] ["the target capture is not exist, sent the table to orphanTables"] [job="{\"From\":\"b51b0e86-373c-49a2-a7c4-42c98fde4e5e\",\"To\":\"5ec78795-88ea-43b3-803b-229a3ededc3b\",\"TableID\":1103,\"TableReplicaInfo\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"Status\":1}"]
[2021/04/25 21:39:49.049 +08:00] [INFO] [changefeed.go:374] ["dispatch table success"] [capture-id=1e8e5271-9340-4b08-b0b4-a00dd456eda6] [status="{\"tables\":{\"1103\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"312\":{\"start-ts\":424504976340680705,\"mark-table-id\":0},\"452\":{\"start-ts\":424504976340680705,\"mark-table-id\":0},\"694\":{\"start-ts\":424504976445538305,\"mark-table-id\":0}},\"operation\":null,\"admin-job-type\":0}"]
[2021/04/25 21:39:49.049 +08:00] [WARN] [changefeed.go:561] ["the target capture is not exist, sent the table to orphanTables"] [job="{\"From\":\"b51b0e86-373c-49a2-a7c4-42c98fde4e5e\",\"To\":\"5ec78795-88ea-43b3-803b-229a3ededc3b\",\"TableID\":1103,\"TableReplicaInfo\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"Status\":1}"]
[2021/04/25 21:39:49.049 +08:00] [WARN] [changefeed.go:561] ["the target capture is not exist, sent the table to orphanTables"] [job="{\"From\":\"b51b0e86-373c-49a2-a7c4-42c98fde4e5e\",\"To\":\"5ec78795-88ea-43b3-803b-229a3ededc3b\",\"TableID\":694,\"TableReplicaInfo\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"Status\":1}"]
[2021/04/25 21:39:49.111 +08:00] [INFO] [changefeed.go:374] ["dispatch table success"] [capture-id=1e8e5271-9340-4b08-b0b4-a00dd456eda6] [status="{\"tables\":{\"1103\":{\"start-ts\":424504976445538305,\"mark-table-id\":0},\"312\":{\"start-ts\":424504976340680705,\"mark-table-id\":0},\"452\":{\"start-ts\":424504976340680705,\"mark-table-id\":0},\"694\":{\"start-ts\":424504976445538305,\"mark-table-id\":0}},\"operation\":null,\"admin-job-type\":0}"]
```
### Trigger conditions

A capture is offline when some table is moving by the owner.

### Versions have this bug
[4.0.0, 4.0.13], 5.0.0-rc, [5.0.0, 5.0.1]

### Bug mechanism

when the owner moves a table, the owner tries to remove the table from source capture and add the table to target capture.
if the target capture is offline at the same time, the owner should add this table to orphan tables and dispatch this table in the next tick.

but the owner forget to remove the invalid move table job, so the owner will add the table to orphan table every tick, leads to the other logic does not work properly

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- fix a bug about resolved ts stopped when move a table.
