### PR TITLE
changefeed: log start-ts when applying ddl job

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -678,6 +678,7 @@ func (c *changeFeed) handleDDL(ctx context.Context, captures map[string]*model.C
 	log.Info("apply job", zap.Stringer("job", todoDDLJob),
 		zap.String("schema", todoDDLJob.SchemaName),
 		zap.String("query", todoDDLJob.Query),
+		zap.Uint64("start-ts", todoDDLJob.StartTS),
 		zap.Uint64("ts", todoDDLJob.BinlogInfo.FinishedTS))
 
 	ddlEvent := new(model.DDLEvent)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

[TiCDC FAQ](https://docs.pingcap.com/tidb/stable/troubleshoot-ticdc#when-the-downstream-of-a-changefeed-is-a-database-similar-to-mysql-and-ticdc-executes-a-time-consuming-ddl-statement-all-other-changefeeds-are-blocked-how-should-i-handle-the-issue) describes we can use the following way to find the `start-ts` of a DDL when we want to skip it.

> Search for the apply job field in the TiCDC log and confirm the StartTs of the DDL statement.

However the `apply job` log doesn't print `start-ts` of the DDL job.

### What is changed and how it works?

- Log start-ts in the `apply job` log.
- Besides we can also update document, to instruct user to find the correct `start-ts` of a DDL job by TiDB DDL history.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
