### PR TITLE
tests: fix tiflash storage engine in integration test

### DIFF
--- a/tests/_utils/start_tidb_cluster_impl
+++ b/tests/_utils/start_tidb_cluster_impl
@@ -276,7 +276,7 @@ runAsDaemon = true
 kvstore_path = "${OUT_DIR}/tiflash/kvstore"
 pd_addr = "${UP_PD_HOST_1}:${UP_PD_PORT_1}"
 ignore_databases = "system,default"
-storage_engine = "tmt"
+storage_engine = "dt"
 EOF
 
 cat - >"$OUT_DIR/tiflash-proxy.toml" <<EOF

--- a/tests/processor_panic/main.go
+++ b/tests/processor_panic/main.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	numTables          = 20
-	numQueriesPerTable = 2000
+	numTables          = 10
+	numQueriesPerTable = 200
 )
 
 func main() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the following error in CI when starting TiFlash

```
[2021/05/25 15:48:39.592 +08:00] [ERROR] [<unknown>] ["Application: DB::Exception: Illegal arguments: can not use DTFile to store snapshot data when the storage engine is not DeltaTree, [engine=1] [snapshot method=file1]"] [thread_id=1]
```

### What is changed and how it works?

- Use DeltaTree storage engine
- Besides descrease the data set size of one integration test, which is often timeout in integration test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
