### PR TITLE
kv/client: fix time is not updated when receiving committed event

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1440,9 +1440,6 @@ func (s *eventFeedSession) singleEventFeed(
 	failpoint.Inject("kvClientResolveLockInterval", func(val failpoint.Value) {
 		resolveLockInterval = time.Duration(val.(int)) * time.Second
 	})
-	failpoint.Inject("kvClientReconnectInterval", func(val failpoint.Value) {
-		reconnectInterval = time.Duration(val.(int)) * time.Second
-	})
 
 	for {
 		var event *regionEvent

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -2803,11 +2803,11 @@ func (s *etcdSuite) testKVClientForceReconnect(c *check.C) {
 
 	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientResolveLockInterval", "return(1)")
 	c.Assert(err, check.IsNil)
-	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval", "return(3)")
-	c.Assert(err, check.IsNil)
+	originalReconnectInterval := reconnectInterval
+	reconnectInterval = 3 * time.Second
 	defer func() {
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientResolveLockInterval")
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval")
+		reconnectInterval = originalReconnectInterval
 	}()
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
@@ -2970,14 +2970,14 @@ func (s *etcdSuite) TestKVClientForceReconnect2(c *check.C) {
 	cluster.AddStore(1, addr1)
 	cluster.Bootstrap(regionID3, []uint64{1}, []uint64{4}, 4)
 
-	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval", "return(3)")
-	c.Assert(err, check.IsNil)
+	originalReconnectInterval := reconnectInterval
+	reconnectInterval = 3 * time.Second
 	// check interval is less than reconnect interval, so we can test both the hit and miss case
 	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval", "return(1)")
 	c.Assert(err, check.IsNil)
 	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientReconnectInterval")
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval")
+		reconnectInterval = originalReconnectInterval
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
@@ -3222,6 +3222,123 @@ checkEvent:
 			}
 		case <-time.After(time.Second):
 			c.Errorf("no more events received")
+		}
+	}
+
+	cancel()
+}
+
+// TestEvTimeUpdate creates a new event feed, send N committed events every 100ms,
+// use failpoint to set reconnect interval to 1s, the last event time of region
+// should be updated correctly and no reconnect is triggered
+func (s *etcdSuite) TestEvTimeUpdate(c *check.C) {
+	defer testleak.AfterTest(c)()
+
+	defer s.TearDownTest(c)
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+
+	ch1 := make(chan *cdcpb.ChangeDataEvent, 10)
+	srv1 := newMockChangeDataService(c, ch1)
+	server1, addr1 := newMockService(ctx, c, srv1, wg)
+
+	defer func() {
+		close(ch1)
+		server1.Stop()
+		wg.Wait()
+	}()
+
+	rpcClient, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("", mockcopr.NewCoprRPCHandler())
+	c.Assert(err, check.IsNil)
+	pdClient = &mockPDClient{Client: pdClient, versionGen: defaultVersionGen}
+	tiStore, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
+	c.Assert(err, check.IsNil)
+	kvStorage := newStorageWithCurVersionCache(tiStore, addr1)
+	defer kvStorage.Close() //nolint:errcheck
+
+	cluster.AddStore(1, addr1)
+	cluster.Bootstrap(3, []uint64{1}, []uint64{4}, 4)
+
+	originalReconnectInterval := reconnectInterval
+	reconnectInterval = 1500 * time.Millisecond
+	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval", "return(2)")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/kv/kvClientCheckUnInitRegionInterval")
+		reconnectInterval = originalReconnectInterval
+	}()
+
+	baseAllocatedID := currentRequestID()
+	lockresolver := txnutil.NewLockerResolver(kvStorage)
+	isPullInit := &mockPullerInit{}
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	eventCh := make(chan *model.RegionFeedEvent, 10)
+	wg.Add(1)
+	go func() {
+		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")}, 100, false, lockresolver, isPullInit, eventCh)
+		c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+		cdcClient.Close() //nolint:errcheck
+		wg.Done()
+	}()
+
+	// wait request id allocated with: new session, new request
+	waitRequestID(c, baseAllocatedID+1)
+
+	eventCount := 20
+	for i := 0; i < eventCount; i++ {
+		events := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
+			{
+				RegionId:  3,
+				RequestId: currentRequestID(),
+				Event: &cdcpb.Event_Entries_{
+					Entries: &cdcpb.Event_Entries{
+						Entries: []*cdcpb.Event_Row{{
+							Type:     cdcpb.Event_COMMITTED,
+							OpType:   cdcpb.Event_Row_PUT,
+							Key:      []byte("aaaa"),
+							Value:    []byte("committed put event before init"),
+							StartTs:  105,
+							CommitTs: 115,
+						}},
+					},
+				},
+			},
+		}}
+		ch1 <- events
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	expected := []*model.RegionFeedEvent{
+		{
+			Resolved: &model.ResolvedSpan{
+				Span:       regionspan.ComparableSpan{Start: []byte("a"), End: []byte("b")},
+				ResolvedTs: 100,
+			},
+			RegionID: 3,
+		},
+		{
+			Val: &model.RawKVEntry{
+				OpType:   model.OpTypePut,
+				Key:      []byte("aaaa"),
+				Value:    []byte("committed put event before init"),
+				StartTs:  105,
+				CRTs:     115,
+				RegionID: 3,
+			},
+			RegionID: 3,
+		},
+	}
+
+	for i := 0; i < eventCount+1; i++ {
+		select {
+		case event := <-eventCh:
+			if i == 0 {
+				c.Assert(event, check.DeepEquals, expected[0])
+			} else {
+				c.Assert(event, check.DeepEquals, expected[1])
+			}
+		case <-time.After(time.Second):
+			c.Errorf("expected event not received, %d received", i)
 		}
 	}
 

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -214,10 +214,6 @@ func (s *eventFeedSession) receiveFromStreamV2(
 	s.workers[addr] = worker
 	s.workersLock.Unlock()
 
-	failpoint.Inject("kvClientReconnectInterval", func(val failpoint.Value) {
-		reconnectInterval = time.Duration(val.(int)) * time.Second
-	})
-
 	g.Go(func() error {
 		return worker.run(ctx)
 	})

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -94,9 +94,6 @@ func (s *eventFeedSession) sendRegionChangeEventV2(
 
 		state.start()
 		worker.setRegionState(event.RegionId, state)
-		// TODO: If a region doesn't receive any event from TiKV, this region
-		// can't be reconnected since the region state is not initialized.
-		worker.notifyEvTimeUpdate(event.RegionId, false /* isDelete */)
 
 		// send resolved event when starting a single event feed
 		select {
@@ -116,6 +113,12 @@ func (s *eventFeedSession) sendRegionChangeEventV2(
 			zap.Uint64("requestID", event.RequestId),
 			zap.String("addr", addr))
 		return nil
+	}
+
+	// TODO: If a region doesn't receive any event from TiKV, this region
+	// can't be reconnected since the region state is not initialized.
+	if !state.isInitialized() {
+		worker.notifyEvTimeUpdate(event.RegionId, false /* isDelete */)
 	}
 
 	select {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a bug in kv client v2 that committed events are not counted in event ts manager

### What is changed and how it works?

- Always send ts update notification to event ts manager when region receives any event and it is not initialized.
- Remove a failpoint in test case, and we can update global variable directly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note