### PR TITLE
sorter: reduce memory malloc to avoid too much CPU overhead

### DIFF
--- a/cdc/puller/sorter/heap_sorter.go
+++ b/cdc/puller/sorter/heap_sorter.go
@@ -158,7 +158,6 @@ func (h *heapSorter) flush(ctx context.Context, maxResolvedTs uint64) error {
 			}
 			return nil
 		}
-		h.heap = make(sortHeap, 0, sortHeapCapacity)
 	} else {
 		task.dealloc = func() error {
 			task.markDeallocated()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

ref: #1853

### What is changed and how it works?

~Since the access of `h.heap` is not concurrent, we can use the same `slice`~

The heap will be used in an async pool. We choose a conservative initialize size for sort heap slice.

- the heap is flushed every 100ms or accumulated data size execeeds `1GB`?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Reduce memory malloc in sort heap to avoid too much CPU overhead.