### PR TITLE
sorter: fix unstable unit tests

### DIFF
--- a/cdc/puller/sorter/sorter_test.go
+++ b/cdc/puller/sorter/sorter_test.go
@@ -351,7 +351,7 @@ func (s *sorterSuite) TestSorterIOError(c *check.C) {
 
 	finishedCh := make(chan struct{})
 	go func() {
-		err := testSorter(ctx, c, sorter, 100000, true)
+		err := testSorter(ctx, c, sorter, 10000, true)
 		c.Assert(err, check.ErrorMatches, ".*injected alloc error.*")
 		close(finishedCh)
 	}()
@@ -373,7 +373,7 @@ func (s *sorterSuite) TestSorterIOError(c *check.C) {
 
 	finishedCh = make(chan struct{})
 	go func() {
-		err := testSorter(ctx, c, sorter, 100000, true)
+		err := testSorter(ctx, c, sorter, 10000, true)
 		c.Assert(err, check.ErrorMatches, ".*injected write error.*")
 		close(finishedCh)
 	}()
@@ -426,7 +426,7 @@ func (s *sorterSuite) TestSorterErrorReportCorrect(c *check.C) {
 
 	finishedCh := make(chan struct{})
 	go func() {
-		err := testSorter(ctx, c, sorter, 100000, true)
+		err := testSorter(ctx, c, sorter, 10000, true)
 		c.Assert(err, check.ErrorMatches, ".*injected alloc error.*")
 		close(finishedCh)
 	}()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- `TestSorterIOError` times out often.

### What is changed and how it works?
- Reduces the size of the test data

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch


### Release note

- No release note

