### PR TITLE
kv/client: fix region worker exited error

### DIFF
--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1236,6 +1238,13 @@ func (s *etcdSuite) TestStreamSendWithError(c *check.C) {
 	}
 	expectedInitRegions := map[uint64]struct{}{regionID3: {}, regionID4: {}}
 	c.Assert(initRegions, check.DeepEquals, expectedInitRegions)
+
+	// a hack way to check the goroutine count of region worker is 1
+	buf := make([]byte, 1<<20)
+	stacklen := runtime.Stack(buf, true)
+	stack := string(buf[:stacklen])
+	c.Assert(strings.Count(stack, "resolveLock"), check.Equals, 1)
+	c.Assert(strings.Count(stack, "collectWorkpoolError"), check.Equals, 1)
 
 	cancel()
 }

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -1348,7 +1348,6 @@ func (s *etcdSuite) testStreamRecvWithError(c *check.C, failpointStr string) {
 	for _, expectedEv := range expected {
 		select {
 		case event := <-eventCh:
-			log.Info("receive event", zap.Reflect("event", event), zap.Reflect("expected", expectedEv))
 			c.Assert(event, check.DeepEquals, expectedEv)
 		case <-time.After(time.Second):
 			c.Errorf("expected event %v not received", expectedEv)

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -450,6 +450,9 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 			log.Info("region worker closed by error")
 			exitEventHandler = true
 			err = w.evictAllRegions(ctx)
+			if err != nil {
+				log.Warn("region worker evict all regions error", zap.Error(err))
+			}
 			return
 		}
 		if event.state.isStopped() {
@@ -473,9 +476,6 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 		}
 		exitEventHandler, skipEvent, err := preprocess(event, ok)
 		if exitEventHandler {
-			if err != nil {
-				log.Warn("region worker process error", zap.Error(err))
-			}
 			return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 		}
 		if skipEvent {
@@ -504,7 +504,7 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 				}
 				exitEventHandler, skipEvent, err := preprocess(event, ok)
 				if exitEventHandler {
-					return err
+					return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 				}
 				if skipEvent {
 					continue

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -473,7 +473,10 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 		}
 		exitEventHandler, skipEvent, err := preprocess(event, ok)
 		if exitEventHandler {
-			return err
+			if err != nil {
+				log.Warn("region worker process error", zap.Error(err))
+			}
+			return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 		}
 		if skipEvent {
 			continue

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -474,7 +474,7 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		exitEventHandler, skipEvent, err := preprocess(event, ok)
+		exitEventHandler, skipEvent, _ := preprocess(event, ok)
 		if exitEventHandler {
 			return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 		}
@@ -502,7 +502,7 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				exitEventHandler, skipEvent, err := preprocess(event, ok)
+				exitEventHandler, skipEvent, _ := preprocess(event, ok)
 				if exitEventHandler {
 					return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 				}

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -442,14 +442,13 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 	preprocess := func(event *regionStatefulEvent, ok bool) (
 		exitEventHandler bool,
 		skipEvent bool,
-		err error,
 	) {
 		// event == nil means the region worker should exit and re-establish
 		// all existing regions.
 		if !ok || event == nil {
 			log.Info("region worker closed by error")
 			exitEventHandler = true
-			err = w.evictAllRegions(ctx)
+			err := w.evictAllRegions(ctx)
 			if err != nil {
 				log.Warn("region worker evict all regions error", zap.Error(err))
 			}
@@ -474,7 +473,7 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		exitEventHandler, skipEvent, _ := preprocess(event, ok)
+		exitEventHandler, skipEvent := preprocess(event, ok)
 		if exitEventHandler {
 			return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 		}
@@ -502,7 +501,7 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				exitEventHandler, skipEvent, _ := preprocess(event, ok)
+				exitEventHandler, skipEvent := preprocess(event, ok)
 				if exitEventHandler {
 					return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 				}

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -609,7 +609,13 @@ func (w *regionWorker) run(ctx context.Context) error {
 	wg.Go(func() error {
 		return w.collectWorkpoolError(ctx)
 	})
-	return wg.Wait()
+	err := wg.Wait()
+	// ErrRegionWorkerExit means the region worker exits normally, but we don't
+	// need to terminate the other goroutines in errgroup
+	if cerror.ErrRegionWorkerExit.Equal(err) {
+		return nil
+	}
+	return err
 }
 
 func (w *regionWorker) handleEventEntry(

--- a/errors.toml
+++ b/errors.toml
@@ -591,6 +591,11 @@ error = '''
 the reactor has done its job and should no longer be executed
 '''
 
+["CDC:ErrRegionWorkerExit"]
+error = '''
+region worker exited
+'''
+
 ["CDC:ErrRegionsNotCoverSpan"]
 error = '''
 regions not completely left cover span, span %v regions: %v

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -53,6 +53,7 @@ var (
 	ErrCachedTSONotExists     = errors.Normalize("GetCachedCurrentVersion: cache entry does not exist", errors.RFCCodeText("CDC:ErrCachedTSONotExists"))
 	ErrGetStoreSnapshot       = errors.Normalize("get snapshot failed", errors.RFCCodeText("CDC:ErrGetStoreSnapshot"))
 	ErrNewStore               = errors.Normalize("new store failed", errors.RFCCodeText("CDC:ErrNewStore"))
+	ErrRegionWorkerExit       = errors.Normalize("region worker exited", errors.RFCCodeText("CDC:ErrRegionWorkerExit"))
 
 	// rule related errors
 	ErrEncodeFailed      = errors.Normalize("encode failed: %s", errors.RFCCodeText("CDC:ErrEncodeFailed"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix `region_worker` does not exit when TiKV store disconnect happens and region worker is set to exit manually. Unit test will be added later. Fix https://github.com/pingcap/ticdc/issues/1905 and #1904

### What is changed and how it works?

The `eventHandler` should return a non-nil error when region worker is notified to exit, which will terminate other routines under the same `errgroup` to exit

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release note

- No release note