### PR TITLE
new_owner: a capture implement, the capture manages and runs the owner and processor

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -1,0 +1,332 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package capture
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/cdc/owner"
+	"github.com/pingcap/ticdc/cdc/processor"
+	"github.com/pingcap/ticdc/pkg/config"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/orchestrator"
+	"github.com/pingcap/ticdc/pkg/version"
+	tidbkv "github.com/pingcap/tidb/kv"
+	pd "github.com/tikv/pd/client"
+	"go.etcd.io/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/mvcc"
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
+)
+
+// Capture represents a Capture server, it monitors the changefeed information in etcd and schedules Task on it.
+type Capture struct {
+	captureMu sync.Mutex
+	info      *model.CaptureInfo
+
+	owner            *owner.Owner
+	ownerMu          sync.Mutex
+	processorManager *processor.Manager
+
+	// session keeps alive between the capture and etcd
+	session  *concurrency.Session
+	election *concurrency.Election
+
+	pdClient   pd.Client
+	kvStorage  tidbkv.Storage
+	etcdClient *kv.CDCEtcdClient
+
+	newProcessorManager func() *processor.Manager
+	newOwner            func() *owner.Owner
+	stopCampaign        int32
+}
+
+// NewCapture returns a new Capture instance
+func NewCapture(pdClient pd.Client, kvStorage tidbkv.Storage, etcdClient *kv.CDCEtcdClient) *Capture {
+	return &Capture{
+		pdClient:   pdClient,
+		kvStorage:  kvStorage,
+		etcdClient: etcdClient,
+
+		newProcessorManager: processor.NewManager,
+		newOwner:            owner.NewOwner,
+	}
+}
+
+func (c *Capture) reset() error {
+	c.captureMu.Lock()
+	defer c.captureMu.Unlock()
+	conf := config.GetGlobalServerConfig()
+	c.info = &model.CaptureInfo{
+		ID:            uuid.New().String(),
+		AdvertiseAddr: conf.AdvertiseAddr,
+		Version:       version.ReleaseVersion,
+	}
+	c.processorManager = c.newProcessorManager()
+	if c.session != nil {
+		c.session.Close() //nolint:errcheck
+	}
+	sess, err := concurrency.NewSession(c.etcdClient.Client.Unwrap(),
+		concurrency.WithTTL(conf.CaptureSessionTTL))
+	if err != nil {
+		return errors.Annotate(cerror.WrapError(cerror.ErrNewCaptureFailed, err), "create capture session")
+	}
+	c.session = sess
+	c.election = concurrency.NewElection(sess, kv.CaptureOwnerKey)
+	atomic.StoreInt32(&c.stopCampaign, 0)
+	log.Info("init capture", zap.String("capture-id", c.info.ID), zap.String("capture-addr", c.info.AdvertiseAddr))
+	return nil
+}
+
+// Run runs the capture
+func (c *Capture) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+		err := c.reset()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = c.run(ctx)
+		// if no error returned or capture suicide, reset the capture and run again
+		if err == nil || cerror.ErrCaptureSuicide.Equal(errors.Cause(err)) {
+			log.Info("capture recovered", zap.String("capture-id", c.info.ID))
+			continue
+		}
+		return errors.Trace(err)
+	}
+}
+
+func (c *Capture) run(stdCtx context.Context) error {
+	ctx := cdcContext.NewContext(stdCtx, &cdcContext.GlobalVars{
+		PDClient:    c.pdClient,
+		KVStorage:   c.kvStorage,
+		CaptureInfo: c.info,
+		EtcdClient:  c.etcdClient,
+	})
+	err := c.register(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer func() {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := ctx.GlobalVars().EtcdClient.DeleteCaptureInfo(timeoutCtx, c.info.ID); err != nil {
+			log.Warn("failed to delete capture info when capture exited", zap.Error(err))
+		}
+		cancel()
+	}()
+	wg := new(sync.WaitGroup)
+	wg.Add(2)
+	var ownerErr, processorErr error
+	go func() {
+		defer log.Info("owner goroutine is exited")
+		defer wg.Done()
+		defer c.AsyncClose()
+		ownerErr = c.campaignOwner(ctx)
+	}()
+	go func() {
+		defer log.Info("processor goroutine is exited")
+		defer wg.Done()
+		defer c.AsyncClose()
+		conf := config.GetGlobalServerConfig()
+		processorFlushInterval := time.Duration(conf.ProcessorFlushInterval)
+		// no matter why the processor is exited, return to let capture restart or exit
+		processorErr = c.runEtcdWorker(ctx, c.processorManager, model.NewGlobalState(), processorFlushInterval)
+	}()
+	wg.Wait()
+	if ownerErr != nil {
+		return errors.Annotate(ownerErr, "owner exited with error")
+	}
+	if processorErr != nil {
+		return errors.Annotate(processorErr, "processor exited with error")
+	}
+	return nil
+}
+
+// Info gets the capture info
+func (c *Capture) Info() model.CaptureInfo {
+	c.captureMu.Lock()
+	defer c.captureMu.Unlock()
+	return *c.info
+}
+
+func (c *Capture) campaignOwner(ctx cdcContext.Context) error {
+	// In most failure cases, we don't return error directly, just run another
+	// campaign loop. We treat campaign loop as a special background routine.
+	conf := config.GetGlobalServerConfig()
+	ownerFlushInterval := time.Duration(conf.OwnerFlushInterval)
+	failpoint.Inject("ownerFlushIntervalInject", func(val failpoint.Value) {
+		ownerFlushInterval = time.Millisecond * time.Duration(val.(int))
+	})
+	rl := rate.NewLimiter(0.05, 2)
+	for {
+		if atomic.LoadInt32(&c.stopCampaign) != 0 {
+			return nil
+		}
+		err := rl.Wait(ctx)
+		if err != nil {
+			if errors.Cause(err) == context.Canceled {
+				return nil
+			}
+			return errors.Trace(err)
+		}
+		// Campaign to be an owner, it blocks until it becomes the owner
+		if err := c.campaign(ctx); err != nil {
+			switch errors.Cause(err) {
+			case context.Canceled:
+				return nil
+			case mvcc.ErrCompacted:
+				continue
+			}
+			log.Warn("campaign owner failed", zap.Error(err))
+			// if campaign owner failed, restart capture
+			return cerror.ErrCaptureSuicide.GenWithStackByArgs()
+		}
+
+		log.Info("campaign owner successfully", zap.String("capture-id", c.info.ID))
+		owner := c.newOwner()
+		c.setOwner(owner)
+		err = c.runEtcdWorker(ctx, owner, model.NewGlobalState(), ownerFlushInterval)
+		c.setOwner(nil)
+		log.Info("run owner exited", zap.Error(err))
+		// if owner exits, resign the owner key
+		if resignErr := c.resign(ctx); resignErr != nil {
+			// if regisn owner failed, return error to let capture exits
+			return errors.Annotatef(resignErr, "resign owner failed, capture: %s", c.info.ID)
+		}
+		if err != nil {
+			// for errors, return error and let capture exits or restart
+			return errors.Trace(err)
+		}
+		// if owner exits normally, continue the campaign loop and try to election owner again
+	}
+}
+
+func (c *Capture) runEtcdWorker(ctx cdcContext.Context, reactor orchestrator.Reactor, reactorState orchestrator.ReactorState, timerInterval time.Duration) error {
+	etcdWorker, err := orchestrator.NewEtcdWorker(ctx.GlobalVars().EtcdClient.Client, kv.EtcdKeyBase, reactor, reactorState)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := etcdWorker.Run(ctx, c.session, timerInterval); err != nil {
+		// We check ttl of lease instead of check `session.Done`, because
+		// `session.Done` is only notified when etcd client establish a
+		// new keepalive request, there could be a time window as long as
+		// 1/3 of session ttl that `session.Done` can't be triggered even
+		// the lease is already revoked.
+		switch {
+		case cerror.ErrEtcdSessionDone.Equal(errors.Cause(err)),
+			cerror.ErrLeaseExpired.Equal(errors.Cause(err)):
+			return cerror.ErrCaptureSuicide.GenWithStackByArgs()
+		}
+		lease, inErr := ctx.GlobalVars().EtcdClient.Client.TimeToLive(ctx, c.session.Lease())
+		if inErr != nil {
+			return cerror.WrapError(cerror.ErrPDEtcdAPIError, inErr)
+		}
+		if lease.TTL == int64(-1) {
+			log.Warn("session is disconnected", zap.Error(err))
+			return cerror.ErrCaptureSuicide.GenWithStackByArgs()
+		}
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *Capture) setOwner(owner *owner.Owner) {
+	c.ownerMu.Lock()
+	defer c.ownerMu.Unlock()
+	c.owner = owner
+}
+
+// OperateOwnerUnderLock operates the owner with lock
+func (c *Capture) OperateOwnerUnderLock(fn func(*owner.Owner) error) error {
+	c.ownerMu.Lock()
+	defer c.ownerMu.Unlock()
+	if c.owner == nil {
+		return cerror.ErrNotOwner.GenWithStackByArgs()
+	}
+	return fn(c.owner)
+}
+
+// Campaign to be an owner
+func (c *Capture) campaign(ctx cdcContext.Context) error {
+	failpoint.Inject("capture-campaign-compacted-error", func() {
+		failpoint.Return(errors.Trace(mvcc.ErrCompacted))
+	})
+	return cerror.WrapError(cerror.ErrCaptureCampaignOwner, c.election.Campaign(ctx, c.info.ID))
+}
+
+// Resign lets a owner start a new election.
+func (c *Capture) resign(ctx cdcContext.Context) error {
+	failpoint.Inject("capture-resign-failed", func() {
+		failpoint.Return(errors.New("capture resign failed"))
+	})
+	return cerror.WrapError(cerror.ErrCaptureResignOwner, c.election.Resign(ctx))
+}
+
+// register registers the capture information in etcd
+func (c *Capture) register(ctx cdcContext.Context) error {
+	err := ctx.GlobalVars().EtcdClient.PutCaptureInfo(ctx, c.info, c.session.Lease())
+	if err != nil {
+		return cerror.WrapError(cerror.ErrCaptureRegister, err)
+	}
+	return nil
+}
+
+// AsyncClose closes the capture by unregistering it from etcd
+func (c *Capture) AsyncClose() {
+	atomic.StoreInt32(&c.stopCampaign, 1)
+	c.OperateOwnerUnderLock(func(o *owner.Owner) error { //nolint:errcheck
+		o.AsyncStop()
+		return nil
+	})
+	c.captureMu.Lock()
+	defer c.captureMu.Unlock()
+	if c.processorManager != nil {
+		c.processorManager.AsyncClose()
+	}
+}
+
+// DebugInfo writes the debug info into writer.
+func (c *Capture) DebugInfo(w io.Writer) {
+	c.OperateOwnerUnderLock(func(o *owner.Owner) error { //nolint:errcheck
+		o.WriteDebugInfo(w)
+		return nil
+	})
+	c.captureMu.Lock()
+	defer c.captureMu.Unlock()
+	if c.processorManager != nil {
+		c.processorManager.WriteDebugInfo(w)
+	}
+}
+
+// IsOwner returns whether the capture is an owner
+func (c *Capture) IsOwner() bool {
+	return c.OperateOwnerUnderLock(func(o *owner.Owner) error {
+		return nil
+	}) == nil
+}

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -231,7 +231,7 @@ func (c *Capture) campaignOwner(ctx cdcContext.Context) error {
 		log.Info("run owner exited", zap.Error(err))
 		// if owner exits, resign the owner key
 		if resignErr := c.resign(ctx); resignErr != nil {
-			// if regisn owner failed, return error to let capture exits
+			// if resigning owner failed, return error to let capture exits
 			return errors.Annotatef(resignErr, "resign owner failed, capture: %s", c.info.ID)
 		}
 		if err != nil {

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -15,6 +15,7 @@ package capture
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -311,15 +312,17 @@ func (c *Capture) AsyncClose() {
 	}
 }
 
-// DebugInfo writes the debug info into writer.
-func (c *Capture) DebugInfo(w io.Writer) {
+// WriteDebugInfo writes the debug info into writer.
+func (c *Capture) WriteDebugInfo(w io.Writer) {
 	c.OperateOwnerUnderLock(func(o *owner.Owner) error { //nolint:errcheck
+		fmt.Fprintf(w, "\n\n*** owner info ***:\n\n")
 		o.WriteDebugInfo(w)
 		return nil
 	})
 	c.captureMu.Lock()
 	defer c.captureMu.Unlock()
 	if c.processorManager != nil {
+		fmt.Fprintf(w, "\n\n*** processors info ***:\n\n")
 		c.processorManager.WriteDebugInfo(w)
 	}
 }

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -46,8 +46,8 @@ type Capture struct {
 	captureMu sync.Mutex
 	info      *model.CaptureInfo
 
-	owner            *owner.Owner
 	ownerMu          sync.Mutex
+	owner            *owner.Owner
 	processorManager *processor.Manager
 
 	// session keeps alive between the capture and etcd
@@ -70,6 +70,7 @@ func NewCapture(pdClient pd.Client, kvStorage tidbkv.Storage, etcdClient *kv.CDC
 		pdClient:   pdClient,
 		kvStorage:  kvStorage,
 		etcdClient: etcdClient,
+		cancel:     func() {},
 
 		newProcessorManager: processor.NewManager,
 		newOwner:            owner.NewOwner,
@@ -102,7 +103,7 @@ func (c *Capture) reset() error {
 
 // Run runs the capture
 func (c *Capture) Run(ctx context.Context) error {
-	defer log.Info("the capture routine is exited")
+	defer log.Info("the capture routine has exited")
 	for {
 		select {
 		case <-ctx.Done():
@@ -116,7 +117,10 @@ func (c *Capture) Run(ctx context.Context) error {
 		ctx, cancel := context.WithCancel(ctx)
 		c.cancel = cancel
 		err = c.run(ctx)
-		// if capture suicided, reset the capture and run again
+		// if capture suicided, reset the capture and run again.
+		// if the canceled error throw, there are two possible scenarios:
+		//   1. the internal context canceled, it means some error happened in the internal, and the routine is exited, we should restart the capture
+		//   2. the parent context canceled, it means that the caller of the capture hope the capture to exit, and this loop will return in the above `select` block
 		if cerror.ErrCaptureSuicide.Equal(err) || context.Canceled == errors.Cause(err) {
 			log.Info("capture recovered", zap.String("capture-id", c.info.ID))
 			continue
@@ -147,7 +151,7 @@ func (c *Capture) run(stdCtx context.Context) error {
 	wg.Add(2)
 	var ownerErr, processorErr error
 	go func() {
-		defer log.Info("the owner routine is exited", zap.Error(ownerErr))
+		defer log.Info("the owner routine has exited", zap.Error(ownerErr))
 		defer wg.Done()
 		defer c.AsyncClose()
 		// when the campaignOwner returns an error, it means that the the owner throws an unrecoverable serious errors
@@ -156,7 +160,7 @@ func (c *Capture) run(stdCtx context.Context) error {
 		ownerErr = c.campaignOwner(ctx)
 	}()
 	go func() {
-		defer log.Info("the processor routine is exited", zap.Error(processorErr))
+		defer log.Info("the processor routine has exited", zap.Error(processorErr))
 		defer wg.Done()
 		defer c.AsyncClose()
 		conf := config.GetGlobalServerConfig()
@@ -211,6 +215,7 @@ func (c *Capture) campaignOwner(ctx cdcContext.Context) error {
 			case context.Canceled:
 				return nil
 			case mvcc.ErrCompacted:
+				// the revision we requested is compacted, just retry
 				continue
 			}
 			log.Warn("campaign owner failed", zap.Error(err))
@@ -251,7 +256,7 @@ func (c *Capture) runEtcdWorker(ctx cdcContext.Context, reactor orchestrator.Rea
 		switch {
 		case cerror.ErrEtcdSessionDone.Equal(err),
 			cerror.ErrLeaseExpired.Equal(err):
-			return cerror.ErrCaptureSuicide.GenWithStackByArgs()
+			return cerror.WrapError(cerror.ErrCaptureSuicide, err)
 		}
 		lease, inErr := ctx.GlobalVars().EtcdClient.Client.TimeToLive(ctx, c.session.Lease())
 		if inErr != nil {

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -121,6 +121,7 @@ func (c *Capture) Run(ctx context.Context) error {
 		// if the canceled error throw, there are two possible scenarios:
 		//   1. the internal context canceled, it means some error happened in the internal, and the routine is exited, we should restart the capture
 		//   2. the parent context canceled, it means that the caller of the capture hope the capture to exit, and this loop will return in the above `select` block
+		// TODO: make sure the internal cancel should return the real error instead of context.Canceled
 		if cerror.ErrCaptureSuicide.Equal(err) || context.Canceled == errors.Cause(err) {
 			log.Info("capture recovered", zap.String("capture-id", c.info.ID))
 			continue

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -258,6 +258,9 @@ func (c *changefeed) preflightCheck(captures map[model.CaptureID]*model.CaptureI
 		c.state.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 			if status == nil {
 				status = &model.ChangeFeedStatus{
+					// the changefeed status is nil when the changefeed is just created.
+					// the txn in start ts is not replicated at that time,
+					// so the checkpoint ts and resolved ts should less than start ts.
 					ResolvedTs:   c.state.Info.StartTs - 1,
 					CheckpointTs: c.state.Info.StartTs - 1,
 					AdminJobType: model.AdminNone,

--- a/cdc/owner/ddl_puller.go
+++ b/cdc/owner/ddl_puller.go
@@ -72,10 +72,8 @@ func newDDLPuller(ctx cdcContext.Context, startTs uint64) (DDLPuller, error) {
 	}
 
 	return &ddlPullerImpl{
-		puller: plr,
-		// the puller will listen to change events from `startTs` (including `startTs`)
-		// `startTs - 1` is a valid resolvedTS, which means that all transactions before `startTs - 1` have been received (or don't need to be received)
-		resolvedTS: startTs - 1,
+		puller:     plr,
+		resolvedTS: startTs,
 		filter:     f,
 		cancel:     func() {},
 	}, nil

--- a/cdc/owner/ddl_puller_test.go
+++ b/cdc/owner/ddl_puller_test.go
@@ -126,10 +126,10 @@ func (s *ddlPullerSuite) TestPuller(c *check.C) {
 
 	// test initialize state
 	resolvedTs, ddl := p.FrontDDL()
-	c.Assert(resolvedTs, check.Equals, startTs-1)
+	c.Assert(resolvedTs, check.Equals, startTs)
 	c.Assert(ddl, check.IsNil)
 	resolvedTs, ddl = p.PopFrontDDL()
-	c.Assert(resolvedTs, check.Equals, startTs-1)
+	c.Assert(resolvedTs, check.Equals, startTs)
 	c.Assert(ddl, check.IsNil)
 
 	// test send resolvedTs

--- a/cdc/owner/gc_manager.go
+++ b/cdc/owner/gc_manager.go
@@ -54,7 +54,8 @@ func newGCManager() *gcManager {
 		gcSafepointUpdateInterval = time.Duration(val.(int) * int(time.Millisecond))
 	})
 	return &gcManager{
-		gcTTL: serverConfig.GcTTL,
+		lastSucceededTime: time.Now(),
+		gcTTL:             serverConfig.GcTTL,
 	}
 }
 

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -14,6 +14,7 @@
 package owner
 
 import (
+	"bytes"
 	"context"
 	"time"
 
@@ -146,12 +147,14 @@ func (s *ownerSuite) TestAdminJob(c *check.C) {
 	})
 	owner.TriggerRebalance("test-changefeed2")
 	owner.ManualSchedule("test-changefeed3", "test-caputre1", 10)
-	owner.WriteDebugInfo(nil)
+	var buf bytes.Buffer
+	owner.WriteDebugInfo(&buf)
 
 	// remove job.done, it's hard to check deep equals
 	jobs := owner.takeOnwerJobs()
 	for _, job := range jobs {
 		c.Assert(job.done, check.NotNil)
+		close(job.done)
 		job.done = nil
 	}
 	c.Assert(jobs, check.DeepEquals, []*ownerJob{
@@ -172,7 +175,7 @@ func (s *ownerSuite) TestAdminJob(c *check.C) {
 			tableID:         10,
 		}, {
 			tp:              ownerJobTypeDebugInfo,
-			debugInfoWriter: nil,
+			debugInfoWriter: &buf,
 		},
 	})
 	c.Assert(owner.takeOnwerJobs(), check.HasLen, 0)

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -171,8 +171,8 @@ func (s *ownerSuite) TestAdminJob(c *check.C) {
 			targetCaptureID: "test-caputre1",
 			tableID:         10,
 		}, {
-			tp:         ownerJobTypeDebugInfo,
-			httpWriter: nil,
+			tp:              ownerJobTypeDebugInfo,
+			debugInfoWriter: nil,
 		},
 	})
 	c.Assert(owner.takeOnwerJobs(), check.HasLen, 0)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
a capture implement, the capture manages and runs the owner and processor

the capture starts and runs the owner and processor, restart the owner and processor when they throw an error

#### why the capture_test.go is not exist?
the unit test of capture is a unit test framework for the hole capture(including the owner and the processor), the framework is WIP.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
