### PR TITLE
changefeed: filter out the temporary table schema change

### DIFF
--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -174,6 +174,10 @@ func (c *changeFeed) dropSchema(schemaID model.SchemaID, targetTs model.Ts) {
 }
 
 func (c *changeFeed) addTable(tblInfo *model.TableInfo, targetTs model.Ts) {
+	// Ignore temporary table.
+	if tblInfo.TempTableType != TempTableNone {
+		return
+	}
 	if c.filter.ShouldIgnoreTable(tblInfo.TableName.Schema, tblInfo.TableName.Table) {
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/kvproto v0.0.0-20210429093846-65f54a202d7e
 	github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4
-	github.com/pingcap/parser v0.0.0-20210427084954-8e8ed7927bde
+	github.com/pingcap/parser v0.0.0-20210602030610-10b704ade769
 	github.com/pingcap/tidb v1.1.0-beta.0.20210508083641-8ed1d9d4a798
 	github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible
 	github.com/prometheus/client_golang v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,8 @@ github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4 h1:ERrF0fTuIOnwfGbt71J
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/parser v0.0.0-20210427084954-8e8ed7927bde h1:CcGOCE3kr8aYBy6rRcWWldidL1X5smQxV79nlnzOk+o=
 github.com/pingcap/parser v0.0.0-20210427084954-8e8ed7927bde/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
+github.com/pingcap/parser v0.0.0-20210602030610-10b704ade769 h1:rS9DRDbiBegKsLNbz0s1T/d/RY+RGqZVLMuHahWwGis=
+github.com/pingcap/parser v0.0.0-20210602030610-10b704ade769/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3 h1:A9KL9R+lWSVPH8IqUuH1QSTRJ5FGoY1bT2IcfPKsWD8=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We are implementing [temporary table](https://github.com/pingcap/tidb/blob/master/docs/design/2021-04-20-temporary-table.md) 

Write on the temporary table do not generate any key-value to TiKV,
but for the global temporary table, the table meta data is generated.

Our local temporary table will be MySQL compatible.
Our global temporary table is an extension of MySQL, so it's not supposed to sync to a MySQL downstream.
This extension should make the CDC processing fail.

### What is changed and how it works?

Filter the create global temporary table DDL changes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Seems the integration test environment is so ... complex.
This is just one line change, could we skip the test?

Side effects

 - Breaking backward compatibility

Update the parser, the `model.Table` is updated, this should not affect the compatibility because the lack of the field would be set the default value 

### Release note

- No release note

