### PR TITLE
kv/client: add incremental scan region count limit

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -68,6 +68,9 @@ const (
 	// failed region will be reloaded via `BatchLoadRegionsWithKeyRange` API. So we
 	// don't need to force reload region any more.
 	regionScheduleReload = false
+
+	// defines the scan region limit for each table
+	regionScanLimitPerTable = 40
 )
 
 // time interval to force kv client to terminate gRPC stream and reconnect
@@ -92,6 +95,8 @@ var (
 	metricFeedDuplicateRequestCounter = eventFeedErrorCounter.WithLabelValues("DuplicateRequest")
 	metricFeedUnknownErrorCounter     = eventFeedErrorCounter.WithLabelValues("Unknown")
 	metricFeedRPCCtxUnavailable       = eventFeedErrorCounter.WithLabelValues("RPCCtxUnavailable")
+	metricStoreSendRequestErr         = eventFeedErrorCounter.WithLabelValues("SendRequestToStore")
+	metricConnectToStoreErr           = eventFeedErrorCounter.WithLabelValues("ConnectToStore")
 )
 
 var (
@@ -115,9 +120,13 @@ func newSingleRegionInfo(verID tikv.RegionVerID, span regionspan.ComparableSpan,
 // happens, kv client needs to recover region request from singleRegionInfo
 func (s *singleRegionInfo) partialClone() singleRegionInfo {
 	sri := singleRegionInfo{
-		verID: s.verID,
-		span:  s.span.Clone(),
-		ts:    s.ts,
+		verID:  s.verID,
+		span:   s.span.Clone(),
+		ts:     s.ts,
+		rpcCtx: &tikv.RPCContext{},
+	}
+	if s.rpcCtx != nil {
+		sri.rpcCtx.Addr = s.rpcCtx.Addr
 	}
 	return sri
 }
@@ -473,7 +482,7 @@ func (c *CDCClient) EventFeed(
 	isPullerInit PullerInitialization,
 	eventCh chan<- *model.RegionFeedEvent,
 ) error {
-	s := newEventFeedSession(c, c.regionCache, c.kvStorage, span,
+	s := newEventFeedSession(ctx, c, c.regionCache, c.kvStorage, span,
 		lockResolver, isPullerInit,
 		enableOldValue, ts, eventCh)
 	return s.eventFeed(ctx, ts)
@@ -503,6 +512,9 @@ type eventFeedSession struct {
 
 	// The channel to send the processed events.
 	eventCh chan<- *model.RegionFeedEvent
+	// The token based region router, it controls the uninitialzied regions with
+	// a given size limit.
+	regionRouter LimitRegionRouter
 	// The channel to put the region that will be sent requests.
 	regionCh chan singleRegionInfo
 	// The channel to notify that an error is happening, so that the error will be handled and the affected region
@@ -535,6 +547,7 @@ type rangeRequestTask struct {
 }
 
 func newEventFeedSession(
+	ctx context.Context,
 	client *CDCClient,
 	regionCache *tikv.RegionCache,
 	kvStorage tikv.Storage,
@@ -552,6 +565,7 @@ func newEventFeedSession(
 		kvStorage:         kvStorage,
 		totalSpan:         totalSpan,
 		eventCh:           eventCh,
+		regionRouter:      NewSizedRegionRouter(ctx, regionScanLimitPerTable),
 		regionCh:          make(chan singleRegionInfo, 16),
 		errCh:             make(chan regionErrorInfo, 16),
 		requestRangeCh:    make(chan rangeRequestTask, 16),
@@ -580,6 +594,10 @@ func (s *eventFeedSession) eventFeed(ctx context.Context, ts uint64) error {
 
 	g.Go(func() error {
 		return s.dispatchRequest(ctx, g)
+	})
+
+	g.Go(func() error {
+		return s.requestRegionToStore(ctx, g)
 	})
 
 	g.Go(func() error {
@@ -619,6 +637,10 @@ func (s *eventFeedSession) eventFeed(ctx context.Context, ts uint64) error {
 		}
 	})
 
+	g.Go(func() error {
+		return s.regionRouter.Run(ctx)
+	})
+
 	s.requestRangeCh <- rangeRequestTask{span: s.totalSpan, ts: ts}
 	s.rangeChSizeGauge.Inc()
 
@@ -648,7 +670,6 @@ func (s *eventFeedSession) scheduleRegionRequest(ctx context.Context, sri single
 				s.regionChSizeGauge.Inc()
 			case <-ctx.Done():
 			}
-
 		case regionspan.LockRangeStatusStale:
 			log.Info("request expired",
 				zap.Uint64("regionID", sri.verID.GetID()),
@@ -697,9 +718,12 @@ func (s *eventFeedSession) scheduleRegionRequest(ctx context.Context, sri single
 // onRegionFail handles a region's failure, which means, unlock the region's range and send the error to the errCh for
 // error handling. This function is non blocking even if error channel is full.
 // CAUTION: Note that this should only be called in a context that the region has locked it's range.
-func (s *eventFeedSession) onRegionFail(ctx context.Context, errorInfo regionErrorInfo) error {
+func (s *eventFeedSession) onRegionFail(ctx context.Context, errorInfo regionErrorInfo, revokeToken bool) error {
 	log.Debug("region failed", zap.Uint64("regionID", errorInfo.verID.GetID()), zap.Error(errorInfo.err))
 	s.rangeLock.UnlockRange(errorInfo.span.Start, errorInfo.span.End, errorInfo.verID.GetID(), errorInfo.verID.GetVer(), errorInfo.ts)
+	if revokeToken {
+		s.regionRouter.Release(errorInfo.rpcCtx.Addr)
+	}
 	select {
 	case s.errCh <- errorInfo:
 		s.errChSizeGauge.Inc()
@@ -715,6 +739,172 @@ func (s *eventFeedSession) onRegionFail(ctx context.Context, errorInfo regionErr
 	return nil
 }
 
+// requestRegionToStore gets singleRegionInfo from regionRouter, which is a token
+// based limitter, sends request to TiKV.
+// If the send request to TiKV returns error, fail the region with sendRequestToStoreErr
+// and kv client will redispatch the region.
+// If initialize gPRC stream with an error, fail the region with connectToStoreErr
+// and kv client will also redispatch the region.
+func (s *eventFeedSession) requestRegionToStore(
+	ctx context.Context,
+	g *errgroup.Group,
+) error {
+	// Stores pending regions info for each stream. After sending a new request, the region info wil be put to the map,
+	// and it will be loaded by the receiver thread when it receives the first response from that region. We need this
+	// to pass the region info to the receiver since the region info cannot be inferred from the response from TiKV.
+	storePendingRegions := make(map[string]*syncRegionFeedStateMap)
+
+	var sri singleRegionInfo
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.Trace(ctx.Err())
+		case sri = <-s.regionRouter.Chan():
+		}
+		requestID := allocID()
+
+		extraOp := kvrpcpb.ExtraOp_Noop
+		if s.enableOldValue {
+			extraOp = kvrpcpb.ExtraOp_ReadOldValue
+		}
+
+		rpcCtx := sri.rpcCtx
+		regionID := rpcCtx.Meta.GetId()
+		req := &cdcpb.ChangeDataRequest{
+			Header: &cdcpb.Header{
+				ClusterId:    s.client.clusterID,
+				TicdcVersion: version.ReleaseSemver(),
+			},
+			RegionId:     regionID,
+			RequestId:    requestID,
+			RegionEpoch:  rpcCtx.Meta.RegionEpoch,
+			CheckpointTs: sri.ts,
+			StartKey:     sri.span.Start,
+			EndKey:       sri.span.End,
+			ExtraOp:      extraOp,
+		}
+
+		failpoint.Inject("kvClientPendingRegionDelay", nil)
+
+		// each TiKV store has an independent pendingRegions.
+		var pendingRegions *syncRegionFeedStateMap
+
+		var err error
+		stream, ok := s.getStream(rpcCtx.Addr)
+		if ok {
+			var ok bool
+			pendingRegions, ok = storePendingRegions[rpcCtx.Addr]
+			if !ok {
+				// Should never happen
+				log.Panic("pending regions is not found for store", zap.String("store", rpcCtx.Addr))
+			}
+		} else {
+			// when a new stream is established, always create a new pending
+			// regions map, the old map will be used in old `receiveFromStream`
+			// and won't be deleted until that goroutine exits.
+			pendingRegions = newSyncRegionFeedStateMap()
+			storePendingRegions[rpcCtx.Addr] = pendingRegions
+			storeID := rpcCtx.Peer.GetStoreId()
+			log.Info("creating new stream to store to send request",
+				zap.Uint64("regionID", sri.verID.GetID()),
+				zap.Uint64("requestID", requestID),
+				zap.Uint64("storeID", storeID),
+				zap.String("addr", rpcCtx.Addr))
+			streamCtx, streamCancel := context.WithCancel(ctx)
+			_ = streamCancel // to avoid possible context leak warning from govet
+			stream, err = s.client.newStream(streamCtx, rpcCtx.Addr, storeID)
+			if err != nil {
+				// if get stream failed, maybe the store is down permanently, we should try to relocate the active store
+				log.Warn("get grpc stream client failed",
+					zap.Uint64("regionID", sri.verID.GetID()),
+					zap.Uint64("requestID", requestID),
+					zap.Uint64("storeID", storeID),
+					zap.String("error", err.Error()))
+				if cerror.ErrVersionIncompatible.Equal(err) {
+					// It often occurs on rolling update. Sleep 20s to reduce logs.
+					delay := 20 * time.Second
+					failpoint.Inject("kvClientDelayWhenIncompatible", func() {
+						delay = 100 * time.Millisecond
+					})
+					time.Sleep(delay)
+				}
+				bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
+				s.client.regionCache.OnSendFail(bo, rpcCtx, regionScheduleReload, err)
+				err = s.onRegionFail(ctx, regionErrorInfo{
+					singleRegionInfo: sri,
+					err:              &connectToStoreErr{},
+				}, false /* revokeToken */)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				continue
+			}
+			s.addStream(rpcCtx.Addr, stream, streamCancel)
+
+			limiter := s.client.getRegionLimiter(regionID)
+			g.Go(func() error {
+				if !s.enableKVClientV2 {
+					return s.receiveFromStream(ctx, g, rpcCtx.Addr, getStoreID(rpcCtx), stream, pendingRegions, limiter)
+				}
+				return s.receiveFromStreamV2(ctx, g, rpcCtx.Addr, getStoreID(rpcCtx), stream, pendingRegions, limiter)
+			})
+		}
+
+		state := newRegionFeedState(sri, requestID)
+		pendingRegions.insert(requestID, state)
+
+		logReq := log.Debug
+		if s.isPullerInit.IsInitialized() {
+			logReq = log.Info
+		}
+		logReq("start new request", zap.Reflect("request", req), zap.String("addr", rpcCtx.Addr))
+
+		err = stream.Send(req)
+
+		// If Send error, the receiver should have received error too or will receive error soon. So we doesn't need
+		// to do extra work here.
+		if err != nil {
+			log.Error("send request to stream failed",
+				zap.String("addr", rpcCtx.Addr),
+				zap.Uint64("storeID", getStoreID(rpcCtx)),
+				zap.Uint64("regionID", sri.verID.GetID()),
+				zap.Uint64("requestID", requestID),
+				zap.Error(err))
+			err1 := stream.CloseSend()
+			if err1 != nil {
+				log.Error("failed to close stream", zap.Error(err1))
+			}
+			// Delete the stream from the map so that the next time the store is accessed, the stream will be
+			// re-established.
+			s.deleteStream(rpcCtx.Addr)
+			// Delete `pendingRegions` from `storePendingRegions` so that the next time a region of this store is
+			// requested, it will create a new one. So if the `receiveFromStream` goroutine tries to stop all
+			// pending regions, the new pending regions that are requested after reconnecting won't be stopped
+			// incorrectly.
+			delete(storePendingRegions, rpcCtx.Addr)
+
+			// Remove the region from pendingRegions. If it's already removed, it should be already retried by
+			// `receiveFromStream`, so no need to retry here.
+			_, ok := pendingRegions.take(requestID)
+			if !ok {
+				continue
+			}
+
+			// Wait for a while and retry sending the request
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+			err = s.onRegionFail(ctx, regionErrorInfo{
+				singleRegionInfo: sri,
+				err:              &sendRequestToStoreErr{},
+			}, false /* revokeToken */)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		} else {
+			s.regionRouter.Acquire(rpcCtx.Addr)
+		}
+	}
+}
+
 // dispatchRequest manages a set of streams and dispatch event feed requests
 // to these streams. Streams to each store will be created on need. After
 // establishing new stream, a goroutine will be spawned to handle events from
@@ -726,12 +916,6 @@ func (s *eventFeedSession) dispatchRequest(
 	ctx context.Context,
 	g *errgroup.Group,
 ) error {
-	// Stores pending regions info for each stream. After sending a new request, the region info wil be put to the map,
-	// and it will be loaded by the receiver thread when it receives the first response from that region. We need this
-	// to pass the region info to the receiver since the region info cannot be inferred from the response from TiKV.
-	storePendingRegions := make(map[string]*syncRegionFeedStateMap)
-
-MainLoop:
 	for {
 		// Note that when a region is received from the channel, it's range has been already locked.
 		var sri singleRegionInfo
@@ -744,166 +928,28 @@ MainLoop:
 
 		log.Debug("dispatching region", zap.Uint64("regionID", sri.verID.GetID()))
 
-		// Loop for retrying in case the stream has disconnected.
-		// TODO: Should we break if retries and fails too many times?
-		for {
-			rpcCtx, err := s.getRPCContextForRegion(ctx, sri.verID)
+		rpcCtx, err := s.getRPCContextForRegion(ctx, sri.verID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if rpcCtx == nil {
+			// The region info is invalid. Retry the span.
+			log.Info("cannot get rpcCtx, retry span",
+				zap.Uint64("regionID", sri.verID.GetID()),
+				zap.Stringer("span", sri.span))
+			err = s.onRegionFail(ctx, regionErrorInfo{
+				singleRegionInfo: sri,
+				err: &rpcCtxUnavailableErr{
+					verID: sri.verID,
+				},
+			}, false /* revokeToken */)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if rpcCtx == nil {
-				// The region info is invalid. Retry the span.
-				log.Info("cannot get rpcCtx, retry span",
-					zap.Uint64("regionID", sri.verID.GetID()),
-					zap.Stringer("span", sri.span))
-				err = s.onRegionFail(ctx, regionErrorInfo{
-					singleRegionInfo: sri,
-					err: &rpcCtxUnavailableErr{
-						verID: sri.verID,
-					},
-				})
-				if err != nil {
-					return errors.Trace(err)
-				}
-				continue MainLoop
-			}
-			sri.rpcCtx = rpcCtx
-
-			requestID := allocID()
-
-			extraOp := kvrpcpb.ExtraOp_Noop
-			if s.enableOldValue {
-				extraOp = kvrpcpb.ExtraOp_ReadOldValue
-			}
-
-			regionID := rpcCtx.Meta.GetId()
-			req := &cdcpb.ChangeDataRequest{
-				Header: &cdcpb.Header{
-					ClusterId:    s.client.clusterID,
-					TicdcVersion: version.ReleaseSemver(),
-				},
-				RegionId:     regionID,
-				RequestId:    requestID,
-				RegionEpoch:  rpcCtx.Meta.RegionEpoch,
-				CheckpointTs: sri.ts,
-				StartKey:     sri.span.Start,
-				EndKey:       sri.span.End,
-				ExtraOp:      extraOp,
-			}
-
-			failpoint.Inject("kvClientPendingRegionDelay", nil)
-
-			// each TiKV store has an independent pendingRegions.
-			var pendingRegions *syncRegionFeedStateMap
-
-			stream, ok := s.getStream(rpcCtx.Addr)
-			if ok {
-				var ok bool
-				pendingRegions, ok = storePendingRegions[rpcCtx.Addr]
-				if !ok {
-					// Should never happen
-					log.Panic("pending regions is not found for store", zap.String("store", rpcCtx.Addr))
-				}
-			} else {
-				// when a new stream is established, always create a new pending
-				// regions map, the old map will be used in old `receiveFromStream`
-				// and won't be deleted until that goroutine exits.
-				pendingRegions = newSyncRegionFeedStateMap()
-				storePendingRegions[rpcCtx.Addr] = pendingRegions
-				storeID := rpcCtx.Peer.GetStoreId()
-				log.Info("creating new stream to store to send request",
-					zap.Uint64("regionID", sri.verID.GetID()),
-					zap.Uint64("requestID", requestID),
-					zap.Uint64("storeID", storeID),
-					zap.String("addr", rpcCtx.Addr))
-				streamCtx, streamCancel := context.WithCancel(ctx)
-				_ = streamCancel // to avoid possible context leak warning from govet
-				stream, err = s.client.newStream(streamCtx, rpcCtx.Addr, storeID)
-				if err != nil {
-					// if get stream failed, maybe the store is down permanently, we should try to relocate the active store
-					log.Warn("get grpc stream client failed",
-						zap.Uint64("regionID", sri.verID.GetID()),
-						zap.Uint64("requestID", requestID),
-						zap.Uint64("storeID", storeID),
-						zap.String("error", err.Error()))
-					if cerror.ErrVersionIncompatible.Equal(err) {
-						// It often occurs on rolling update. Sleep 20s to reduce logs.
-						delay := 20 * time.Second
-						failpoint.Inject("kvClientDelayWhenIncompatible", func() {
-							delay = 100 * time.Millisecond
-						})
-						time.Sleep(delay)
-					}
-					bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
-					s.client.regionCache.OnSendFail(bo, rpcCtx, regionScheduleReload, err)
-					continue
-				}
-				s.addStream(rpcCtx.Addr, stream, streamCancel)
-
-				limiter := s.client.getRegionLimiter(regionID)
-				g.Go(func() error {
-					if !s.enableKVClientV2 {
-						return s.receiveFromStream(ctx, g, rpcCtx.Addr, getStoreID(rpcCtx), stream, pendingRegions, limiter)
-					}
-					return s.receiveFromStreamV2(ctx, g, rpcCtx.Addr, getStoreID(rpcCtx), stream, pendingRegions, limiter)
-				})
-			}
-
-			state := newRegionFeedState(sri, requestID)
-			pendingRegions.insert(requestID, state)
-
-			logReq := log.Debug
-			if s.isPullerInit.IsInitialized() {
-				logReq = log.Info
-			}
-			logReq("start new request", zap.Reflect("request", req), zap.String("addr", rpcCtx.Addr))
-
-			err = stream.Send(req)
-
-			// If Send error, the receiver should have received error too or will receive error soon. So we doesn't need
-			// to do extra work here.
-			if err != nil {
-
-				log.Error("send request to stream failed",
-					zap.String("addr", rpcCtx.Addr),
-					zap.Uint64("storeID", getStoreID(rpcCtx)),
-					zap.Uint64("regionID", sri.verID.GetID()),
-					zap.Uint64("requestID", requestID),
-					zap.Error(err))
-				err1 := stream.CloseSend()
-				if err1 != nil {
-					log.Error("failed to close stream", zap.Error(err1))
-				}
-				// Delete the stream from the map so that the next time the store is accessed, the stream will be
-				// re-established.
-				s.deleteStream(rpcCtx.Addr)
-				// Delete `pendingRegions` from `storePendingRegions` so that the next time a region of this store is
-				// requested, it will create a new one. So if the `receiveFromStream` goroutine tries to stop all
-				// pending regions, the new pending regions that are requested after reconnecting won't be stopped
-				// incorrectly.
-				delete(storePendingRegions, rpcCtx.Addr)
-
-				// Remove the region from pendingRegions. If it's already removed, it should be already retried by
-				// `receiveFromStream`, so no need to retry here.
-				_, ok := pendingRegions.take(requestID)
-				if !ok {
-					break
-				}
-
-				// Wait for a while and retry sending the request
-				time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
-				// Break if ctx has been canceled.
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				default:
-				}
-
-				continue
-			}
-
-			break
+			continue
 		}
+		sri.rpcCtx = rpcCtx
+		s.regionRouter.AddRegion(sri)
 	}
 }
 
@@ -933,7 +979,8 @@ func (s *eventFeedSession) partialRegionFeed(
 	}()
 
 	ts := state.sri.ts
-	maxTs, err := s.singleEventFeed(ctx, state.sri.verID.GetID(), state.sri.span, state.sri.ts, receiver)
+	maxTs, err := s.singleEventFeed(ctx, state.sri.verID.GetID(), state.sri.span,
+		state.sri.ts, state.sri.rpcCtx.Addr, receiver)
 	log.Debug("singleEventFeed quit")
 
 	if err == nil || errors.Cause(err) == context.Canceled {
@@ -994,10 +1041,11 @@ func (s *eventFeedSession) partialRegionFeed(
 		}
 	}
 
+	revokeToken := !state.initialized
 	return s.onRegionFail(ctx, regionErrorInfo{
 		singleRegionInfo: state.sri,
 		err:              err,
-	})
+	}, revokeToken)
 }
 
 // divideAndSendEventFeedToRegions split up the input span into spans aligned
@@ -1114,6 +1162,10 @@ func (s *eventFeedSession) handleError(ctx context.Context, errInfo regionErrorI
 		metricFeedRPCCtxUnavailable.Inc()
 		s.scheduleDivideRegionAndRequest(ctx, errInfo.span, errInfo.ts)
 		return nil
+	case *connectToStoreErr:
+		metricConnectToStoreErr.Inc()
+	case *sendRequestToStoreErr:
+		metricStoreSendRequestErr.Inc()
 	default:
 		bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
 		if errInfo.rpcCtx.Meta != nil {
@@ -1157,7 +1209,7 @@ func (s *eventFeedSession) receiveFromStream(
 			err := s.onRegionFail(ctx, regionErrorInfo{
 				singleRegionInfo: state.sri,
 				err:              cerror.ErrPendingRegionCancel.GenWithStackByArgs(),
-			})
+			}, true /* revokeToken */)
 			if err != nil {
 				// The only possible is that the ctx is cancelled. Simply return.
 				return
@@ -1360,6 +1412,7 @@ func (s *eventFeedSession) singleEventFeed(
 	regionID uint64,
 	span regionspan.ComparableSpan,
 	startTs uint64,
+	storeAddr string,
 	receiverCh <-chan *regionEvent,
 ) (uint64, error) {
 	captureAddr := util.CaptureAddrFromCtx(ctx)
@@ -1500,12 +1553,13 @@ func (s *eventFeedSession) singleEventFeed(
 					switch entry.Type {
 					case cdcpb.Event_INITIALIZED:
 						if time.Since(startFeedTime) > 20*time.Second {
-							log.Warn("The time cost of initializing is too mush",
+							log.Warn("The time cost of initializing is too much",
 								zap.Duration("timeCost", time.Since(startFeedTime)),
 								zap.Uint64("regionID", regionID))
 						}
 						metricPullEventInitializedCounter.Inc()
 						initialized = true
+						s.regionRouter.Release(storeAddr)
 						cachedEvents := matcher.matchCachedRow()
 						for _, cachedEvent := range cachedEvents {
 							revent, err := assembleRowEvent(regionID, cachedEvent, s.enableOldValue)
@@ -1674,6 +1728,14 @@ func (e *rpcCtxUnavailableErr) Error() string {
 	return fmt.Sprintf("cannot get rpcCtx for region %v. ver:%v, confver:%v",
 		e.verID.GetID(), e.verID.GetVer(), e.verID.GetConfVer())
 }
+
+type connectToStoreErr struct{}
+
+func (e *connectToStoreErr) Error() string { return "connect to store error" }
+
+type sendRequestToStoreErr struct{}
+
+func (e *sendRequestToStoreErr) Error() string { return "send request to store error" }
 
 func getStoreID(rpcCtx *tikv.RPCContext) uint64 {
 	if rpcCtx != nil && rpcCtx.Peer != nil {

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -70,7 +70,7 @@ const (
 	regionScheduleReload = false
 
 	// defines the scan region limit for each table
-	regionScanLimitPerTable = 40
+	regionScanLimitPerTable = 6
 )
 
 // time interval to force kv client to terminate gRPC stream and reconnect

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -1479,7 +1479,7 @@ ReceiveLoop:
 	}
 }
 
-// TestStreamSendWithErrorNormal mainly tests the scenario that the `Recv` call
+// TestStreamRecvWithErrorNormal mainly tests the scenario that the `Recv` call
 // of a gPRC stream in kv client meets a **logical related** error, and kv client
 // logs the error and re-establish new request.
 func (s *etcdSuite) TestStreamRecvWithErrorNormal(c *check.C) {
@@ -1497,7 +1497,7 @@ func (s *etcdSuite) TestStreamRecvWithErrorNormal(c *check.C) {
 	s.testStreamRecvWithError(c, "1*return(\"injected stream recv error\")")
 }
 
-// TestStreamSendWithErrorIOEOF mainly tests the scenario that the `Recv` call
+// TestStreamRecvWithErrorIOEOF mainly tests the scenario that the `Recv` call
 // of a gPRC stream in kv client meets error io.EOF, and kv client logs the error
 // and re-establish new request
 func (s *etcdSuite) TestStreamRecvWithErrorIOEOF(c *check.C) {
@@ -2422,7 +2422,7 @@ func (s *clientSuite) TestSingleRegionInfoClone(c *check.C) {
 	c.Assert(sri.span.String(), check.Equals, "[61, 63)")
 	c.Assert(sri2.ts, check.Equals, uint64(2000))
 	c.Assert(sri2.span.String(), check.Equals, "[61, 62)")
-	c.Assert(sri2.rpcCtx, check.IsNil)
+	c.Assert(sri2.rpcCtx, check.DeepEquals, &tikv.RPCContext{})
 }
 
 // TestResolveLockNoCandidate tests the resolved ts manager can work normally

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -3138,7 +3138,9 @@ func (s *etcdSuite) TestConcurrentProcessRangeRequest(c *check.C) {
 	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
 	isPullInit := &mockPullerInit{}
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
-	eventCh := make(chan *model.RegionFeedEvent, 10)
+	// The buffer size of event channel must be large enough because in the test
+	// case we send events first, and then retrive all events from this channel.
+	eventCh := make(chan *model.RegionFeedEvent, 100)
 	wg.Add(1)
 	go func() {
 		err := cdcClient.EventFeed(ctx, regionspan.ComparableSpan{Start: []byte("a"), End: []byte("z")}, 100, false, lockresolver, isPullInit, eventCh)
@@ -3159,10 +3161,29 @@ func (s *etcdSuite) TestConcurrentProcessRangeRequest(c *check.C) {
 	}
 
 	// wait for all regions requested from cdc kv client
+	// Since there exists incremental scan limit in kv client, we must wait for
+	// the ready region and send initialized event.
+	sent := make(map[uint64]bool, regionNum)
 	err = retry.Run(time.Millisecond*200, 20, func() error {
 		count := 0
-		requestIDs.Range(func(_, _ interface{}) bool {
+		// send initialized event and a resolved ts event to each region
+		requestIDs.Range(func(key, value interface{}) bool {
 			count++
+			regionID := key.(uint64)
+			requestID := value.(uint64)
+			if _, ok := sent[regionID]; !ok {
+				initialized := mockInitializedEvent(regionID, requestID)
+				ch1 <- initialized
+				sent[regionID] = true
+				resolved := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
+					{
+						RegionId:  regionID,
+						RequestId: requestID,
+						Event:     &cdcpb.Event_ResolvedTs{ResolvedTs: 120},
+					},
+				}}
+				ch1 <- resolved
+			}
 			return true
 		})
 		if count == regionNum {
@@ -3171,23 +3192,6 @@ func (s *etcdSuite) TestConcurrentProcessRangeRequest(c *check.C) {
 		return errors.Errorf("region number %d is not as expected %d", count, regionNum)
 	})
 	c.Assert(err, check.IsNil)
-
-	// send initialized event and a resolved ts event to each region
-	requestIDs.Range(func(key, value interface{}) bool {
-		regionID := key.(uint64)
-		requestID := value.(uint64)
-		initialized := mockInitializedEvent(regionID, requestID)
-		ch1 <- initialized
-		resolved := &cdcpb.ChangeDataEvent{Events: []*cdcpb.Event{
-			{
-				RegionId:  regionID,
-				RequestId: requestID,
-				Event:     &cdcpb.Event_ResolvedTs{ResolvedTs: 120},
-			},
-		}}
-		ch1 <- resolved
-		return true
-	})
 
 	resolvedCount := 0
 checkEvent:

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -178,7 +178,7 @@ func (s *eventFeedSession) receiveFromStreamV2(
 			err := s.onRegionFail(ctx, regionErrorInfo{
 				singleRegionInfo: state.sri,
 				err:              cerror.ErrPendingRegionCancel.GenWithStackByArgs(),
-			})
+			}, false /* initialized */)
 			if err != nil {
 				// The only possible is that the ctx is cancelled. Simply return.
 				return

--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -67,6 +67,13 @@ var (
 			Name:      "channel_size",
 			Help:      "size of each channel in kv client",
 		}, []string{"id", "channel"})
+	clientRegionTokenSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "region_token",
+			Help:      "size of region token in kv client",
+		}, []string{"store", "table", "changefeed"})
 	batchResolvedEventSize = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "ticdc",
@@ -93,6 +100,7 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(pullEventCounter)
 	registry.MustRegister(sendEventCounter)
 	registry.MustRegister(clientChannelSize)
+	registry.MustRegister(clientRegionTokenSize)
 	registry.MustRegister(batchResolvedEventSize)
 	registry.MustRegister(etcdRequestCounter)
 }

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -199,10 +199,11 @@ func (w *regionWorker) handleSingleRegionError(ctx context.Context, err error, s
 		}
 	})
 
+	revokeToken := !state.initialized
 	return w.session.onRegionFail(ctx, regionErrorInfo{
 		singleRegionInfo: state.sri,
 		err:              err,
-	})
+	}, revokeToken)
 }
 
 func (w *regionWorker) checkUnInitRegions(ctx context.Context) error {
@@ -452,7 +453,7 @@ func (w *regionWorker) handleEventEntry(
 		switch entry.Type {
 		case cdcpb.Event_INITIALIZED:
 			if time.Since(state.startFeedTime) > 20*time.Second {
-				log.Warn("The time cost of initializing is too mush",
+				log.Warn("The time cost of initializing is too much",
 					zap.Duration("timeCost", time.Since(state.startFeedTime)),
 					zap.Uint64("regionID", regionID))
 			}
@@ -468,7 +469,7 @@ func (w *regionWorker) handleEventEntry(
 
 			metricPullEventInitializedCounter.Inc()
 			state.initialized = true
-
+			w.session.regionRouter.Release(state.sri.rpcCtx.Addr)
 			cachedEvents := state.matcher.matchCachedRow()
 			for _, cachedEvent := range cachedEvents {
 				revent, err := assembleRowEvent(regionID, cachedEvent, w.enableOldValue)
@@ -605,13 +606,14 @@ func (w *regionWorker) evictAllRegions(ctx context.Context) error {
 			if state.lastResolvedTs > singleRegionInfo.ts {
 				singleRegionInfo.ts = state.lastResolvedTs
 			}
+			revokeToken := !state.initialized
 			state.lock.Unlock()
 			err = w.session.onRegionFail(ctx, regionErrorInfo{
 				singleRegionInfo: singleRegionInfo,
 				err: &rpcCtxUnavailableErr{
 					verID: singleRegionInfo.verID,
 				},
-			})
+			}, revokeToken)
 			return err == nil
 		})
 	}

--- a/cdc/kv/token_region.go
+++ b/cdc/kv/token_region.go
@@ -1,0 +1,163 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// buffer size for ranged region consumer
+	regionRouterChanSize = 16
+	// sizedRegionRouter checks region buffer every 100ms
+	sizedRegionCheckInterval = 100 * time.Millisecond
+)
+
+// LimitRegionRouter defines an interface that can buffer singleRegionInfo
+// and provide token based consumption
+type LimitRegionRouter interface {
+	// Chan returns a singleRegionInfo channel that can be consumed from
+	Chan() <-chan singleRegionInfo
+	// AddRegion adds an singleRegionInfo to buffer, this function is thread-safe
+	AddRegion(task singleRegionInfo)
+	// Acquire acquires one token
+	Acquire(id string)
+	// Release gives back one token, this function is thread-safe
+	Release(id string)
+	// Run runs in background and does some logic work
+	Run(ctx context.Context) error
+}
+
+type srrMetrics struct {
+	changefeed string
+	table      string
+	tokens     map[string]prometheus.Gauge
+}
+
+func newSrrMetrics(ctx context.Context) *srrMetrics {
+	changefeed := util.ChangefeedIDFromCtx(ctx)
+	_, table := util.TableIDFromCtx(ctx)
+	return &srrMetrics{
+		changefeed: changefeed,
+		table:      table,
+		tokens:     make(map[string]prometheus.Gauge),
+	}
+}
+
+type sizedRegionRouter struct {
+	buffer    map[string][]singleRegionInfo
+	output    chan singleRegionInfo
+	lock      sync.Mutex
+	metrics   *srrMetrics
+	tokens    map[string]int
+	sizeLimit int
+}
+
+// NewSizedRegionRouter creates a new sizedRegionRouter
+func NewSizedRegionRouter(ctx context.Context, sizeLimit int) *sizedRegionRouter {
+	return &sizedRegionRouter{
+		buffer:    make(map[string][]singleRegionInfo),
+		output:    make(chan singleRegionInfo, regionRouterChanSize),
+		sizeLimit: sizeLimit,
+		tokens:    make(map[string]int),
+		metrics:   newSrrMetrics(ctx),
+	}
+}
+
+func (r *sizedRegionRouter) Chan() <-chan singleRegionInfo {
+	return r.output
+}
+
+func (r *sizedRegionRouter) AddRegion(sri singleRegionInfo) {
+	r.lock.Lock()
+	var id string
+	// if rpcCtx is not provided, use the default "" bucket
+	if sri.rpcCtx != nil {
+		id = sri.rpcCtx.Addr
+	}
+	if r.sizeLimit > r.tokens[id] && len(r.output) < regionRouterChanSize {
+		r.output <- sri
+	} else {
+		r.buffer[id] = append(r.buffer[id], sri)
+	}
+	r.lock.Unlock()
+}
+
+func (r *sizedRegionRouter) Acquire(id string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.tokens[id]++
+	if _, ok := r.metrics.tokens[id]; !ok {
+		r.metrics.tokens[id] = clientRegionTokenSize.WithLabelValues(id, r.metrics.table, r.metrics.changefeed)
+	}
+	r.metrics.tokens[id].Inc()
+}
+
+func (r *sizedRegionRouter) Release(id string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.tokens[id]--
+	if _, ok := r.metrics.tokens[id]; !ok {
+		r.metrics.tokens[id] = clientRegionTokenSize.WithLabelValues(id, r.metrics.table, r.metrics.changefeed)
+	}
+	r.metrics.tokens[id].Dec()
+}
+
+func (r *sizedRegionRouter) Run(ctx context.Context) error {
+	ticker := time.NewTicker(sizedRegionCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.Trace(ctx.Err())
+		case <-ticker.C:
+			r.lock.Lock()
+			for id, buf := range r.buffer {
+				available := r.sizeLimit - r.tokens[id]
+				// the tokens used could be more then size limit, since we have
+				// a sized channel as level1 cache
+				if available <= 0 {
+					continue
+				}
+				if available > len(buf) {
+					available = len(buf)
+				}
+				// to avoid deadlock because when consuming from the output channel.
+				// onRegionFail could decrease tokens, which requires lock protection.
+				if available > regionRouterChanSize-len(r.output) {
+					available = regionRouterChanSize - len(r.output)
+				}
+				if available == 0 {
+					continue
+				}
+				for i := 0; i < available; i++ {
+					select {
+					case <-ctx.Done():
+						r.lock.Unlock()
+						return errors.Trace(ctx.Err())
+					case r.output <- buf[i]:
+					}
+				}
+				r.buffer[id] = r.buffer[id][available:]
+			}
+			r.lock.Unlock()
+		}
+	}
+}

--- a/cdc/kv/token_region_test.go
+++ b/cdc/kv/token_region_test.go
@@ -1,0 +1,181 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"github.com/pingcap/tidb/store/tikv"
+	"golang.org/x/sync/errgroup"
+)
+
+type tokenRegionSuite struct {
+}
+
+var _ = check.Suite(&tokenRegionSuite{})
+
+func (s *tokenRegionSuite) TestRouter(c *check.C) {
+	defer testleak.AfterTest(c)()
+	store := "store-1"
+	limit := 10
+	r := NewSizedRegionRouter(context.Background(), limit)
+	for i := 0; i < limit; i++ {
+		r.AddRegion(singleRegionInfo{ts: uint64(i), rpcCtx: &tikv.RPCContext{Addr: store}})
+	}
+	regions := make([]singleRegionInfo, 0, limit)
+	// limit is less than regionScanLimitPerTable
+	for i := 0; i < limit; i++ {
+		select {
+		case sri := <-r.Chan():
+			c.Assert(sri.ts, check.Equals, uint64(i))
+			r.Acquire(store)
+			regions = append(regions, sri)
+		default:
+			c.Error("expect region info from router")
+		}
+	}
+	c.Assert(r.tokens[store], check.Equals, limit)
+	for range regions {
+		r.Release(store)
+	}
+	c.Assert(r.tokens[store], check.Equals, 0)
+}
+
+func (s *tokenRegionSuite) TestRouterWithFastConsumer(c *check.C) {
+	defer testleak.AfterTest(c)()
+	s.testRouterWithConsumer(c, func() {})
+}
+
+func (s *tokenRegionSuite) TestRouterWithSlowConsumer(c *check.C) {
+	defer testleak.AfterTest(c)()
+	s.testRouterWithConsumer(c, func() { time.Sleep(time.Millisecond * 15) })
+}
+
+func (s *tokenRegionSuite) testRouterWithConsumer(c *check.C, funcDoSth func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := "store-1"
+	limit := 20
+	r := NewSizedRegionRouter(context.Background(), limit)
+	for i := 0; i < limit*2; i++ {
+		r.AddRegion(singleRegionInfo{ts: uint64(i), rpcCtx: &tikv.RPCContext{Addr: store}})
+	}
+	received := uint64(0)
+	for i := 0; i < regionRouterChanSize; i++ {
+		<-r.Chan()
+		atomic.AddUint64(&received, 1)
+		r.Acquire(store)
+	}
+
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.Go(func() error {
+		return r.Run(ctx)
+	})
+
+	wg.Go(func() error {
+		for i := 0; i < regionRouterChanSize; i++ {
+			r.Release(store)
+		}
+		return nil
+	})
+
+	wg.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-r.Chan():
+				r.Acquire(store)
+				atomic.AddUint64(&received, 1)
+				r.Release(store)
+				funcDoSth()
+				if atomic.LoadUint64(&received) == uint64(limit*4) {
+					cancel()
+				}
+			}
+		}
+	})
+
+	for i := 0; i < limit*2; i++ {
+		r.AddRegion(singleRegionInfo{ts: uint64(i), rpcCtx: &tikv.RPCContext{Addr: store}})
+	}
+
+	err := wg.Wait()
+	c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+	c.Assert(r.tokens[store], check.Equals, 0)
+}
+
+func (s *tokenRegionSuite) TestRouterWithMultiStores(c *check.C) {
+	defer testleak.AfterTest(c)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	storeN := 10
+	stores := make([]string, 0, storeN)
+	for i := 0; i < storeN; i++ {
+		stores = append(stores, fmt.Sprintf("store-%d", i))
+	}
+	limit := 20
+	r := NewSizedRegionRouter(context.Background(), limit)
+
+	for _, store := range stores {
+		for j := 0; j < limit*5; j++ {
+			r.AddRegion(singleRegionInfo{ts: uint64(j), rpcCtx: &tikv.RPCContext{Addr: store}})
+		}
+	}
+	received := uint64(0)
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.Go(func() error {
+		return r.Run(ctx)
+	})
+
+	for _, store := range stores {
+		store := store
+		wg.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-r.Chan():
+					r.Acquire(store)
+					atomic.AddUint64(&received, 1)
+					r.Release(store)
+					if atomic.LoadUint64(&received) == uint64(limit*10) {
+						cancel()
+					}
+				}
+			}
+		})
+	}
+
+	for _, store := range stores {
+		for i := 0; i < limit*5; i++ {
+			r.AddRegion(singleRegionInfo{ts: uint64(i), rpcCtx: &tikv.RPCContext{Addr: store}})
+		}
+	}
+
+	err := wg.Wait()
+	c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+	for _, store := range stores {
+		c.Assert(r.tokens[store], check.Equals, 0)
+	}
+}

--- a/cdc/kv/token_region_test.go
+++ b/cdc/kv/token_region_test.go
@@ -138,7 +138,7 @@ func (s *tokenRegionSuite) TestRouterWithMultiStores(c *check.C) {
 	r := NewSizedRegionRouter(context.Background(), limit)
 
 	for _, store := range stores {
-		for j := 0; j < limit*5; j++ {
+		for j := 0; j < limit*2; j++ {
 			r.AddRegion(singleRegionInfo{ts: uint64(j), rpcCtx: &tikv.RPCContext{Addr: store}})
 		}
 	}
@@ -159,7 +159,7 @@ func (s *tokenRegionSuite) TestRouterWithMultiStores(c *check.C) {
 					r.Acquire(store)
 					atomic.AddUint64(&received, 1)
 					r.Release(store)
-					if atomic.LoadUint64(&received) == uint64(limit*10) {
+					if atomic.LoadUint64(&received) == uint64(limit*4*storeN) {
 						cancel()
 					}
 				}
@@ -168,7 +168,7 @@ func (s *tokenRegionSuite) TestRouterWithMultiStores(c *check.C) {
 	}
 
 	for _, store := range stores {
-		for i := 0; i < limit*5; i++ {
+		for i := 0; i < limit*2; i++ {
 			r.AddRegion(singleRegionInfo{ts: uint64(i), rpcCtx: &tikv.RPCContext{Addr: store}})
 		}
 	}

--- a/tests/move_table/conf/workload
+++ b/tests/move_table/conf/workload
@@ -1,5 +1,5 @@
 threadcount=10
-recordcount=60000
+recordcount=6000
 operationcount=0
 workload=core
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

cherry-pick #1899 into release-4.0, for test only

### What is changed and how it works?

cherry-pick #1899 into release-4.0, for test only

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release note

- Add concurrency limit to the region incremental scan in kv client.