### PR TITLE
owner: fix a changefeed can not removed when the changefeed status is not exist

### DIFF
--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -42,9 +42,6 @@ func (m *feedStateManager) Tick(state *model.ChangefeedReactorState) {
 			m.cleanUpInfos()
 		}
 	}()
-	if m.state.Status == nil {
-		return
-	}
 	if m.handleAdminJob() {
 		// `handleAdminJob` returns true means that some admin jobs are pending
 		// skip to the next tick until all the admin jobs is handled

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -41,6 +41,7 @@ func (s *feedStateManagerSuite) TestHandleJob(c *check.C) {
 		c.Assert(status, check.IsNil)
 		return &model.ChangeFeedStatus{}, true, nil
 	})
+	tester.MustApplyPatches()
 	manager.Tick(state)
 	tester.MustApplyPatches()
 	c.Assert(manager.ShouldRunning(), check.IsTrue)
@@ -138,6 +139,7 @@ func (s *feedStateManagerSuite) TestMarkFinished(c *check.C) {
 		c.Assert(status, check.IsNil)
 		return &model.ChangeFeedStatus{}, true, nil
 	})
+	tester.MustApplyPatches()
 	manager.Tick(state)
 	tester.MustApplyPatches()
 	c.Assert(manager.ShouldRunning(), check.IsTrue)
@@ -245,4 +247,39 @@ func (s *feedStateManagerSuite) TestHandleError(c *check.C) {
 	c.Assert(state.Info.State, check.Equals, model.StateError)
 	c.Assert(state.Info.AdminJobType, check.Equals, model.AdminStop)
 	c.Assert(state.Status.AdminJobType, check.Equals, model.AdminStop)
+}
+
+/*
+Key: /tidb/cdc/capture/40e04ab8-a488-47e3-bd07-8d82c40729a1, Value: {"id":"40e04ab8-a488-47e3-bd07-8d82c40729a1","address":"172.16.6.146:8300","version":"v5.0.0-master-dirty"}
+Key: /tidb/cdc/capture/d563bfc0-f406-4f34-bc7d-6dc2e35a44e5, Value: {"id":"d563bfc0-f406-4f34-bc7d-6dc2e35a44e5","address":"172.16.6.147:8300","version":"v5.0.0-master-dirty"}
+Key: /tidb/cdc/changefeed/info/oom-test-1, Value:
+{"sink-uri":"blackhole:///","opts":{},"create-time":"2021-06-05T00:44:15.065939487+08:00","start-ts":425381670108266496,"target-ts":0,"admin-job-type":1,"sort-engine":"unified","config":{"case-sensitive":true,"enable-old-value":true,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"failed","history":[060,260,460,661,860,],"error":{"addr":"172.16.6.147:8300","code":"CDC:ErrSnapshotLostByGC","message":"[CDC:ErrSnapshotLostByGC]fail to create or maintain changefeed due to snapshot loss caused by GC. checkpoint-ts 425381670108266496 is earlier than GC safepoint at 0"},"sync-point-enabled":false,"sync-point-interval":600000000000,"creator-version":"v5.0.0-master-dirty"}
+Key: /tidb/cdc/owner/156579d017f84a68, Value: d563bfc0-f406-4f34-bc7d-6dc2e35a44e5
+Key: /tidb/cdc/owner/156579d017f84a6e, Value: 40e04ab8-a488-47e3-bd07-8d82c40729a1
+*/
+
+func (s *feedStateManagerSuite) TestChangefeedStatusNotExist(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(true)
+	manager := new(feedStateManager)
+	state := model.NewChangefeedReactorState(ctx.ChangefeedVars().ID)
+	tester := orchestrator.NewReactorStateTester(c, state, map[string]string{
+		"/tidb/cdc/capture/d563bfc0-f406-4f34-bc7d-6dc2e35a44e5": `{"id":"d563bfc0-f406-4f34-bc7d-6dc2e35a44e5","address":"172.16.6.147:8300","version":"v5.0.0-master-dirty"}`,
+		"/tidb/cdc/changefeed/info/" + ctx.ChangefeedVars().ID:   `{"sink-uri":"blackhole:///","opts":{},"create-time":"2021-06-05T00:44:15.065939487+08:00","start-ts":425381670108266496,"target-ts":0,"admin-job-type":1,"sort-engine":"unified","config":{"case-sensitive":true,"enable-old-value":true,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"failed","history":[],"error":{"addr":"172.16.6.147:8300","code":"CDC:ErrSnapshotLostByGC","message":"[CDC:ErrSnapshotLostByGC]fail to create or maintain changefeed due to snapshot loss caused by GC. checkpoint-ts 425381670108266496 is earlier than GC safepoint at 0"},"sync-point-enabled":false,"sync-point-interval":600000000000,"creator-version":"v5.0.0-master-dirty"}`,
+		"/tidb/cdc/owner/156579d017f84a68":                       "d563bfc0-f406-4f34-bc7d-6dc2e35a44e5",
+	})
+	manager.Tick(state)
+	c.Assert(manager.ShouldRunning(), check.IsFalse)
+	tester.MustApplyPatches()
+
+	manager.PushAdminJob(&model.AdminJob{
+		CfID: ctx.ChangefeedVars().ID,
+		Type: model.AdminRemove,
+		Opts: &model.AdminJobOption{ForceRemove: true},
+	})
+	manager.Tick(state)
+	c.Assert(manager.ShouldRunning(), check.IsFalse)
+	tester.MustApplyPatches()
+	c.Assert(state.Info, check.IsNil)
+	c.Assert(state.Exist(), check.IsFalse)
 }

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -249,15 +249,6 @@ func (s *feedStateManagerSuite) TestHandleError(c *check.C) {
 	c.Assert(state.Status.AdminJobType, check.Equals, model.AdminStop)
 }
 
-/*
-Key: /tidb/cdc/capture/40e04ab8-a488-47e3-bd07-8d82c40729a1, Value: {"id":"40e04ab8-a488-47e3-bd07-8d82c40729a1","address":"172.16.6.146:8300","version":"v5.0.0-master-dirty"}
-Key: /tidb/cdc/capture/d563bfc0-f406-4f34-bc7d-6dc2e35a44e5, Value: {"id":"d563bfc0-f406-4f34-bc7d-6dc2e35a44e5","address":"172.16.6.147:8300","version":"v5.0.0-master-dirty"}
-Key: /tidb/cdc/changefeed/info/oom-test-1, Value:
-{"sink-uri":"blackhole:///","opts":{},"create-time":"2021-06-05T00:44:15.065939487+08:00","start-ts":425381670108266496,"target-ts":0,"admin-job-type":1,"sort-engine":"unified","config":{"case-sensitive":true,"enable-old-value":true,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"failed","history":[060,260,460,661,860,],"error":{"addr":"172.16.6.147:8300","code":"CDC:ErrSnapshotLostByGC","message":"[CDC:ErrSnapshotLostByGC]fail to create or maintain changefeed due to snapshot loss caused by GC. checkpoint-ts 425381670108266496 is earlier than GC safepoint at 0"},"sync-point-enabled":false,"sync-point-interval":600000000000,"creator-version":"v5.0.0-master-dirty"}
-Key: /tidb/cdc/owner/156579d017f84a68, Value: d563bfc0-f406-4f34-bc7d-6dc2e35a44e5
-Key: /tidb/cdc/owner/156579d017f84a6e, Value: 40e04ab8-a488-47e3-bd07-8d82c40729a1
-*/
-
 func (s *feedStateManagerSuite) TestChangefeedStatusNotExist(c *check.C) {
 	defer testleak.AfterTest(c)()
 	ctx := cdcContext.NewBackendContext4Test(true)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
 fix a changefeed can not removed when the changefeed status is not exist


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
