### PR TITLE
owner: fix etcd error too many operations in txn request

### DIFF
--- a/cdc/model/reactor_state_test.go
+++ b/cdc/model/reactor_state_test.go
@@ -32,7 +32,7 @@ var _ = check.Suite(&stateSuite{})
 
 func (s *stateSuite) TestCheckCaptureAlive(c *check.C) {
 	defer testleak.AfterTest(c)()
-	state := NewGlobalState().(*GlobalReactorState)
+	state := NewChangefeedReactorState("test")
 	stateTester := orchestrator.NewReactorStateTester(c, state, nil)
 	state.CheckCaptureAlive("6bbc01c8-0605-4f86-a0f9-b3119109b225")
 	c.Assert(stateTester.ApplyPatches(), check.ErrorMatches, ".*[CDC:ErrLeaseExpired].*")

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -101,6 +101,7 @@ func (c *changefeed) Tick(ctx cdcContext.Context, state *model.ChangefeedReactor
 		c.errCh <- errors.Trace(err)
 		return nil
 	})
+	state.CheckCaptureAlive(ctx.GlobalVars().CaptureInfo.ID)
 	if err := c.tick(ctx, state, captures); err != nil {
 		log.Error("an error occurred in Owner", zap.String("changefeedID", c.state.ID), zap.Error(err))
 		var code string

--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -117,6 +117,7 @@ func createChangefeed4Test(ctx cdcContext.Context, c *check.C) (*changefeed, *mo
 		info = ctx.ChangefeedVars().Info
 		return info, true, nil
 	})
+	tester.MustUpdate("/tidb/cdc/capture/"+ctx.GlobalVars().CaptureInfo.ID, []byte(`{"id":"`+ctx.GlobalVars().CaptureInfo.ID+`","address":"127.0.0.1:8300"}`))
 	tester.MustApplyPatches()
 	captures := map[model.CaptureID]*model.CaptureInfo{ctx.GlobalVars().CaptureInfo.ID: ctx.GlobalVars().CaptureInfo}
 	return cf, state, captures, tester

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -106,7 +106,6 @@ func (o *Owner) Tick(stdCtx context.Context, rawState orchestrator.ReactorState)
 	ctx := stdCtx.(cdcContext.Context)
 	state := rawState.(*model.GlobalReactorState)
 	o.updateMetrics(state)
-	state.CheckCaptureAlive(ctx.GlobalVars().CaptureInfo.ID)
 	err = o.gcManager.updateGCSafePoint(ctx, state)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cdc/processor/manager.go
+++ b/cdc/processor/manager.go
@@ -79,7 +79,6 @@ func NewManager4Test(
 func (m *Manager) Tick(stdCtx context.Context, state orchestrator.ReactorState) (nextState orchestrator.ReactorState, err error) {
 	ctx := stdCtx.(cdcContext.Context)
 	globalState := state.(*model.GlobalReactorState)
-	globalState.CheckCaptureAlive(ctx.GlobalVars().CaptureInfo.ID)
 	if err := m.handleCommand(); err != nil {
 		return state, err
 	}

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -119,6 +119,7 @@ func newProcessor4Test(ctx cdcContext.Context,
 // The main logic of processor is in this function, including the calculation of many kinds of ts, maintain table pipeline, error handling, etc.
 func (p *processor) Tick(ctx cdcContext.Context, state *model.ChangefeedReactorState) (orchestrator.ReactorState, error) {
 	p.changefeed = state
+	state.CheckCaptureAlive(ctx.GlobalVars().CaptureInfo.ID)
 	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
 		ID:   state.ID,
 		Info: state.Info,

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -47,6 +47,7 @@ func initProcessor4Test(ctx cdcContext.Context, c *check.C) (*processor, *orches
 	})
 	p.changefeed = model.NewChangefeedReactorState(ctx.ChangefeedVars().ID)
 	return p, orchestrator.NewReactorStateTester(c, p.changefeed, map[string]string{
+		"/tidb/cdc/capture/" + ctx.GlobalVars().CaptureInfo.ID:                                     `{"id":"` + ctx.GlobalVars().CaptureInfo.ID + `","address":"127.0.0.1:8300"}`,
 		"/tidb/cdc/changefeed/info/" + ctx.ChangefeedVars().ID:                                     `{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":0,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":".","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 		"/tidb/cdc/job/" + ctx.ChangefeedVars().ID:                                                 `{"resolved-ts":0,"checkpoint-ts":0,"admin-job-type":0}`,
 		"/tidb/cdc/task/status/" + ctx.GlobalVars().CaptureInfo.ID + "/" + ctx.ChangefeedVars().ID: `{"tables":{},"operation":null,"admin-job-type":0}`,

--- a/pkg/orchestrator/etcd_worker_bank_test.go
+++ b/pkg/orchestrator/etcd_worker_bank_test.go
@@ -33,7 +33,7 @@ import (
 type bankReactorState struct {
 	c            *check.C
 	account      []int
-	pendingPatch []DataPatch
+	pendingPatch [][]DataPatch
 	index        int
 	notFirstTick bool
 }
@@ -47,7 +47,7 @@ func (b *bankReactorState) Update(key util.EtcdKey, value []byte, isInit bool) e
 	return nil
 }
 
-func (b *bankReactorState) GetPatches() []DataPatch {
+func (b *bankReactorState) GetPatches() [][]DataPatch {
 	pendingPatches := b.pendingPatch
 	b.pendingPatch = nil
 	return pendingPatches
@@ -70,8 +70,8 @@ func (b *bankReactorState) atoi(value string) int {
 	return i
 }
 
-func (b *bankReactorState) patchAccount(index int, fn func(int) int) {
-	b.pendingPatch = append(b.pendingPatch, &SingleDataPatch{
+func (b *bankReactorState) patchAccount(index int, fn func(int) int) DataPatch {
+	return &SingleDataPatch{
 		Key: util.NewEtcdKey(fmt.Sprintf("%s%d", bankTestPrefix, index)),
 		Func: func(old []byte) (newValue []byte, changed bool, err error) {
 			oldMoney := b.atoi(string(old))
@@ -82,7 +82,7 @@ func (b *bankReactorState) patchAccount(index int, fn func(int) int) {
 			log.Debug("change money", zap.Int("account", index), zap.Int("from", oldMoney), zap.Int("to", newMoney))
 			return []byte(strconv.Itoa(newMoney)), true, nil
 		},
-	})
+	}
 }
 
 func (b *bankReactorState) TransferRandomly(transferNumber int) {
@@ -90,11 +90,13 @@ func (b *bankReactorState) TransferRandomly(transferNumber int) {
 		accountA := rand.Intn(len(b.account))
 		accountB := rand.Intn(len(b.account))
 		transferMoney := rand.Intn(100)
-		b.patchAccount(accountA, func(money int) int {
-			return money - transferMoney
-		})
-		b.patchAccount(accountB, func(money int) int {
-			return money + transferMoney
+		b.pendingPatch = append(b.pendingPatch, []DataPatch{
+			b.patchAccount(accountA, func(money int) int {
+				return money - transferMoney
+			}),
+			b.patchAccount(accountB, func(money int) int {
+				return money + transferMoney
+			}),
 		})
 		log.Debug("transfer money", zap.Int("accountA", accountA), zap.Int("accountB", accountB), zap.Int("money", transferMoney))
 	}

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -191,10 +191,10 @@ func (s *simpleReactorState) Update(key util.EtcdKey, value []byte, isInit bool)
 	return nil
 }
 
-func (s *simpleReactorState) GetPatches() []DataPatch {
+func (s *simpleReactorState) GetPatches() [][]DataPatch {
 	ret := s.patches
 	s.patches = nil
-	return ret
+	return [][]DataPatch{ret}
 }
 
 func setUpTest(c *check.C) (func() *etcd.Client, func()) {
@@ -293,8 +293,8 @@ func (s *intReactorState) Update(key util.EtcdKey, value []byte, isInit bool) er
 	return nil
 }
 
-func (s *intReactorState) GetPatches() []DataPatch {
-	return []DataPatch{}
+func (s *intReactorState) GetPatches() [][]DataPatch {
+	return [][]DataPatch{}
 }
 
 type linearizabilityReactor struct {
@@ -378,10 +378,10 @@ func (s *commonReactorState) AppendPatch(key util.EtcdKey, fun func(old []byte) 
 	})
 }
 
-func (s *commonReactorState) GetPatches() []DataPatch {
+func (s *commonReactorState) GetPatches() [][]DataPatch {
 	pendingPatches := s.pendingPatches
 	s.pendingPatches = nil
-	return pendingPatches
+	return [][]DataPatch{pendingPatches}
 }
 
 type finishedReactor struct {

--- a/pkg/orchestrator/interfaces.go
+++ b/pkg/orchestrator/interfaces.go
@@ -35,9 +35,10 @@ type ReactorState interface {
 	// Update is called by EtcdWorker to notify the Reactor of a latest change to the Etcd state.
 	Update(key util.EtcdKey, value []byte, isInit bool) error
 
-	// GetPatches is called by EtcdWorker, and should return a slice of data patches that represents the changes
+	// GetPatches is called by EtcdWorker, and should return many slices of data patches that represents the changes
 	// that a Reactor wants to apply to Etcd.
-	GetPatches() []DataPatch
+	// a slice of DataPatch will be committed as one ETCD txn
+	GetPatches() [][]DataPatch
 }
 
 // SingleDataPatch represents an update to a given Etcd key

--- a/pkg/orchestrator/reactor_state_tester.go
+++ b/pkg/orchestrator/reactor_state_tester.go
@@ -60,7 +60,17 @@ func (t *ReactorStateTester) Update(key string, value []byte) error {
 
 // ApplyPatches calls the GetPatches method on the ReactorState and apply the changes to the mocked kv-store.
 func (t *ReactorStateTester) ApplyPatches() error {
-	patches := t.state.GetPatches()
+	patchGroups := t.state.GetPatches()
+	for _, patches := range patchGroups {
+		err := t.applyPatches(patches)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *ReactorStateTester) applyPatches(patches []DataPatch) error {
 RetryLoop:
 	for {
 		tmpKVEntries := make(map[util.EtcdKey][]byte)

--- a/testing_utils/cdc_state_checker/state.go
+++ b/testing_utils/cdc_state_checker/state.go
@@ -227,6 +227,6 @@ func (s *cdcReactorState) Update(key util.EtcdKey, value []byte, isInit bool) er
 	return nil
 }
 
-func (s *cdcReactorState) GetPatches() []orchestrator.DataPatch {
+func (s *cdcReactorState) GetPatches() [][]orchestrator.DataPatch {
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix `etcdserver: too many operations in txn request`:

before this PR, all operations of etcd key in a tick is committed as one txn, and the operations are generated by multiple changefeeds.
after this PR, the operations of one changefeed will be committed as one txn, and all operations of etcd key in a tick will be committed as more than one txn.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

-->
- No release note
