### PR TITLE
*: reduce memory consumption by reducing channel sizes

### DIFF
--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -45,7 +45,7 @@ var (
 	// other components in TiCDC, including worker pool task chan size, mounter
 	// chan size etc.
 	// TODO: unified channel buffer mechanism
-	regionWorkerInputChanSize = 12800
+	regionWorkerInputChanSize = 128
 	regionWorkerLowWatermark  = int(float64(regionWorkerInputChanSize) * 0.2)
 	regionWorkerHighWatermark = int(float64(regionWorkerInputChanSize) * 0.7)
 )

--- a/pkg/workerpool/pool_impl.go
+++ b/pkg/workerpool/pool_impl.go
@@ -260,7 +260,7 @@ type worker struct {
 
 func newWorker() *worker {
 	return &worker{
-		taskCh:         make(chan *task, 128000),
+		taskCh:         make(chan *task, 128),
 		handles:        make(map[*defaultEventHandle]struct{}),
 		handleCancelCh: make(chan struct{}), // this channel must be unbuffered, i.e. blocking
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- TiCDC can OOM frequently on machines with memory less than 16GB.

### What is changed and how it works?
- Decreased the channel sizes in two places.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test 

Side effects

 - Possible performance regression


Related changes

 - Need to cherry-pick to the release branch

### Release note

- Reduce unnecessary memory consumption