### PR TITLE
kv/client: send resovled ts in advance when region is locked

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -947,6 +947,8 @@ func (s *eventFeedSession) dispatchRequest(
 		//    receives the first kv event from TiKV, the region could split or
 		//    merge in advance, which should cause the change of resolved ts
 		//    distribution in puller, so this resolved ts event is needed.
+		// After this resolved ts event is sent, we don't need to send one more
+		// resolved ts event when the region starts to work.
 		resolvedEv := &model.RegionFeedEvent{
 			RegionID: sri.verID.GetID(),
 			Resolved: &model.ResolvedSpan{

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1495,18 +1495,6 @@ func (s *eventFeedSession) singleEventFeed(
 		return nil
 	}
 
-	select {
-	case s.eventCh <- &model.RegionFeedEvent{
-		RegionID: regionID,
-		Resolved: &model.ResolvedSpan{
-			Span:       span,
-			ResolvedTs: startTs,
-		},
-	}:
-	case <-ctx.Done():
-		err = errors.Trace(ctx.Err())
-		return
-	}
 	resolveLockInterval := 20 * time.Second
 	failpoint.Inject("kvClientResolveLockInterval", func(val failpoint.Value) {
 		resolveLockInterval = time.Duration(val.(int)) * time.Second

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -939,6 +939,27 @@ func (s *eventFeedSession) dispatchRequest(
 
 		log.Debug("dispatching region", zap.Uint64("regionID", sri.verID.GetID()))
 
+		// Send a resolved ts to event channel first, for two reasons:
+		// 1. Since we have locked the region range, and have maintained correct
+		//    checkpoint ts for the range, it is safe to report the resolved ts
+		//    to puller at this moment.
+		// 2. Before the kv client gets region rpcCtx, sends request to TiKV and
+		//    receives the first kv event from TiKV, the region could split or
+		//    merge in advance, which should cause the change of resolved ts
+		//    distribution in puller, so this resolved ts event is needed.
+		resolvedEv := &model.RegionFeedEvent{
+			RegionID: sri.verID.GetID(),
+			Resolved: &model.ResolvedSpan{
+				Span:       sri.span,
+				ResolvedTs: sri.ts,
+			},
+		}
+		select {
+		case s.eventCh <- resolvedEv:
+		case <-ctx.Done():
+			return errors.Trace(ctx.Err())
+		}
+
 		rpcCtx, err := s.getRPCContextForRegion(ctx, sri.verID)
 		if err != nil {
 			return errors.Trace(err)

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/cdcpb"
 	"github.com/pingcap/log"
-	"github.com/pingcap/ticdc/cdc/model"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.uber.org/zap"
@@ -94,19 +93,6 @@ func (s *eventFeedSession) sendRegionChangeEventV2(
 
 		state.start()
 		worker.setRegionState(event.RegionId, state)
-
-		// send resolved event when starting a single event feed
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case s.eventCh <- &model.RegionFeedEvent{
-			RegionID: state.sri.verID.GetID(),
-			Resolved: &model.ResolvedSpan{
-				Span:       state.sri.span,
-				ResolvedTs: state.sri.ts,
-			},
-		}:
-		}
 	} else if state.isStopped() {
 		log.Warn("drop event due to region feed stopped",
 			zap.Uint64("regionID", event.RegionId),

--- a/cdc/puller/frontier/frontier_test.go
+++ b/cdc/puller/frontier/frontier_test.go
@@ -193,7 +193,7 @@ func (s *spanFrontierSuite) TestSpanFrontierFallback(c *check.C) {
 
 	// [A, B) [B, C) [C, D) [D, E)
 	// 20     10     10     20
-	// [B, C) does not forward, because of merge into [A, B) immediately
+	// [B, C) does not forward, because of merge into [A, C) immediately
 	f.Forward(spCD, 20)
 	c.Assert(f.Frontier(), check.Equals, uint64(20))
 	// the frontier stoes [A, B) and [B, C) but they are not correct exactly

--- a/cdc/puller/frontier/frontier_test.go
+++ b/cdc/puller/frontier/frontier_test.go
@@ -163,6 +163,48 @@ func (s *spanFrontierSuite) TestSpanFrontier(c *check.C) {
 	checkFrontier(c, f)
 }
 
+func (s *spanFrontierSuite) TestSpanFrontierFallback(c *check.C) {
+	defer testleak.AfterTest(c)()
+	keyA := []byte("a")
+	keyB := []byte("b")
+	keyC := []byte("c")
+	keyD := []byte("d")
+	keyE := []byte("e")
+
+	spAB := regionspan.ComparableSpan{Start: keyA, End: keyB}
+	spBC := regionspan.ComparableSpan{Start: keyB, End: keyC}
+	spCD := regionspan.ComparableSpan{Start: keyC, End: keyD}
+	spDE := regionspan.ComparableSpan{Start: keyD, End: keyE}
+
+	f := NewFrontier(20, spAB).(*spanFrontier)
+	f.Forward(spBC, 20)
+	f.Forward(spCD, 10)
+	f.Forward(spDE, 20)
+
+	// [A, B) [B, C) [C, D) [D, E)
+	// 20     20     10     20
+	c.Assert(f.Frontier(), check.Equals, uint64(10))
+	c.Assert(f.String(), check.Equals, `[a @ 20] [b @ 20] [c @ 10] [d @ 20] [e @ Max] `)
+	checkFrontier(c, f)
+
+	// [A, B) [B, D) [D, E)
+	// 20     10     10
+	// [B, D) does not forward, because of split to [B, C) and [C, D) immediately
+
+	// [A, B) [B, C) [C, D) [D, E)
+	// 20     10     10     20
+	// [B, C) does not forward, because of merge into [A, B) immediately
+	f.Forward(spCD, 20)
+	c.Assert(f.Frontier(), check.Equals, uint64(20))
+	// the frontier stoes [A, B) and [B, C) but they are not correct exactly
+	c.Assert(f.String(), check.Equals, `[a @ 20] [b @ 20] [c @ 20] [d @ 20] [e @ Max] `)
+	checkFrontier(c, f)
+
+	// Bump, here we meet resolved ts fall back, where 10 is less than f.Frontier()
+	// But there is no data loss actually.
+	// f.Forward(spAC, 10)
+}
+
 func (s *spanFrontierSuite) TestMinMax(c *check.C) {
 	defer testleak.AfterTest(c)()
 	var keyMin []byte


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

A workaround fix for #1576 

Since the region can merge and split at any given time, we have found one possible scenario that can cause panic in #1576, as following

- A, B, C, D, E are region range key.
- In the first line each range represents a region range, such as [A, B) represents range from A to B.
- The second line represents the resolved-ts maintained in puller frontier.

```
1. 
[A, B) [B, C) [C, D) [D, E)
20     20     10     20

2. [B, C) [C, D) merged into [B, D). But [B, D) does not forward, because of split to [B, C) and [C, D) immediately
[A, B) [B, D) [D, E)
20     10     20

3. [B, D) split to [B, C) and [C, D). [B, C) does not forward, because of merge into [A, B) immediately
[A, B) [B, C) [C, D) [D, E)
20     10     10     20

4.  Bump, here we meet resolved ts fall back, where 10 is less than the resolved ts (20) in puller. But there is no data loss actually.
region [A, C) starts from resolved-ts=10
```

### What is changed and how it works?

- Send a resolved ts to event channel first, for two reasons:
   1. Since we have locked the region range, and have maintained correct
   checkpoint ts for the range, it is safe to report the resolved ts
   to puller at this moment.
   2. Before the kv client gets region rpcCtx, sends request to TiKV and
   receives the first kv event from TiKV, the region could split or
   merge in advance, which should cause the change of resolved ts
   distribution in puller, so this resolved ts event is needed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix a bug that could cause cdc server panic because of the late calculation of resolved ts 
