### PR TITLE
cli: fix changefeed-id need to be limit max length 

### DIFF
--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -298,9 +298,6 @@ func (c CDCEtcdClient) GetCaptureLeases(ctx context.Context) (map[string]int64, 
 
 // CreateChangefeedInfo creates a change feed info into etcd and fails if it is already exists.
 func (c CDCEtcdClient) CreateChangefeedInfo(ctx context.Context, info *model.ChangeFeedInfo, changeFeedID string) error {
-	if err := model.ValidateChangefeedID(changeFeedID); err != nil {
-		return err
-	}
 	infoKey := GetEtcdKeyChangeFeedInfo(changeFeedID)
 	jobKey := GetEtcdKeyJob(changeFeedID)
 	value, err := info.Marshal()

--- a/cdc/kv/etcd_test.go
+++ b/cdc/kv/etcd_test.go
@@ -471,10 +471,7 @@ func (s *etcdSuite) TestCreateChangefeed(c *check.C) {
 		SinkURI: "root@tcp(127.0.0.1:3306)/mysql",
 	}
 
-	err := s.client.CreateChangefeedInfo(ctx, detail, "bad.id👻")
-	c.Assert(err, check.ErrorMatches, ".*bad changefeed id.*")
-
-	err = s.client.CreateChangefeedInfo(ctx, detail, "test-id")
+	err := s.client.CreateChangefeedInfo(ctx, detail, "test-id")
 	c.Assert(err, check.IsNil)
 
 	err = s.client.CreateChangefeedInfo(ctx, detail, "test-id")

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -90,13 +90,15 @@ type ChangeFeedInfo struct {
 	CreatorVersion    string        `json:"creator-version"`
 }
 
-var changeFeedIDRe *regexp.Regexp = regexp.MustCompile(`^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$`)
+const changeFeedIDMaxLen = 128
+
+var changeFeedIDRe = regexp.MustCompile(`^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$`)
 
 // ValidateChangefeedID returns true if the changefeed ID matches
-// the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$", eg, "simple-changefeed-task".
+// the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$", length no more than "changeFeedIDMaxLen", eg, "simple-changefeed-task".
 func ValidateChangefeedID(changefeedID string) error {
-	if !changeFeedIDRe.MatchString(changefeedID) {
-		return cerror.ErrInvalidChangefeedID.GenWithStackByArgs()
+	if !changeFeedIDRe.MatchString(changefeedID) || len(changefeedID) > changeFeedIDMaxLen {
+		return cerror.ErrInvalidChangefeedID.GenWithStackByArgs(changeFeedIDMaxLen)
 	}
 	return nil
 }

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -256,24 +256,80 @@ func (s *changefeedSuite) TestChangefeedInfoStringer(c *check.C) {
 
 func (s *changefeedSuite) TestValidateChangefeedID(c *check.C) {
 	defer testleak.AfterTest(c)()
-	validIDs := []string{
-		"test",
-		"1",
-		"9ff52aca-aea6-4022-8ec4-fbee3f2c7890",
-	}
-	for _, id := range validIDs {
-		err := ValidateChangefeedID(id)
-		c.Assert(err, check.IsNil)
-	}
 
-	invalidIDs := []string{
-		"",
-		"test_task",
-		"job$",
+	tests := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{
+			name:    "alphabet",
+			id:      "testTtTT",
+			wantErr: false,
+		},
+		{
+			name:    "number",
+			id:      "01131323",
+			wantErr: false,
+		},
+		{
+			name:    "mixed",
+			id:      "9ff52acaA-aea6-4022-8eVc4-fbee3fD2c7890",
+			wantErr: false,
+		},
+		{
+			name:    "len==128",
+			id:      "1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890123456789012345678901234567890",
+			wantErr: false,
+		},
+		{
+			name:    "empty string 1",
+			id:      "",
+			wantErr: true,
+		},
+		{
+			name:    "empty string 2",
+			id:      "   ",
+			wantErr: true,
+		},
+		{
+			name:    "test_task",
+			id:      "test_task ",
+			wantErr: true,
+		},
+		{
+			name:    "job$",
+			id:      "job$ ",
+			wantErr: true,
+		},
+		{
+			name:    "test-",
+			id:      "test-",
+			wantErr: true,
+		},
+		{
+			name:    "-",
+			id:      "-",
+			wantErr: true,
+		},
+		{
+			name:    "-sfsdfdf1",
+			id:      "-sfsdfdf1",
+			wantErr: true,
+		},
+		{
+			name:    "len==129",
+			id:      "1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-123456789012345678901234567890",
+			wantErr: true,
+		},
 	}
-	for _, id := range invalidIDs {
-		err := ValidateChangefeedID(id)
-		c.Assert(cerror.ErrInvalidChangefeedID.Equal(err), check.IsTrue)
+	for _, tt := range tests {
+		err := ValidateChangefeedID(tt.id)
+		if !tt.wantErr {
+			c.Assert(err, check.IsNil, check.Commentf("case:%s", tt.name))
+		} else {
+			c.Assert(cerror.ErrInvalidChangefeedID.Equal(err), check.IsTrue, check.Commentf("case:%s", tt.name))
+		}
 	}
 }
 

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -459,6 +459,10 @@ func newCreateChangefeedCommand() *cobra.Command {
 			if id == "" {
 				id = uuid.New().String()
 			}
+			// validate the changefeedID first
+			if err := model.ValidateChangefeedID(id); err != nil {
+				return err
+			}
 
 			_, captureInfos, err := cdcEtcdCli.GetCaptures(ctx)
 			if err != nil {

--- a/errors.toml
+++ b/errors.toml
@@ -313,7 +313,7 @@ invalid admin job type: %d
 
 ["CDC:ErrInvalidChangefeedID"]
 error = '''
-bad changefeed id, please match the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$", eg, "simple-changefeed-task"
+bad changefeed id, please match the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$, the length should no more than %d", eg, "simple-changefeed-task"
 '''
 
 ["CDC:ErrInvalidEtcdKey"]

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -129,7 +129,7 @@ var (
 	ErrDecodeRowToDatum      = errors.Normalize("decode row data to datum failed", errors.RFCCodeText("CDC:ErrDecodeRowToDatum"))
 	ErrMarshalFailed         = errors.Normalize("marshal failed", errors.RFCCodeText("CDC:ErrMarshalFailed"))
 	ErrUnmarshalFailed       = errors.Normalize("unmarshal failed", errors.RFCCodeText("CDC:ErrUnmarshalFailed"))
-	ErrInvalidChangefeedID   = errors.Normalize(`bad changefeed id, please match the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$", eg, "simple-changefeed-task"`, errors.RFCCodeText("CDC:ErrInvalidChangefeedID"))
+	ErrInvalidChangefeedID   = errors.Normalize(`bad changefeed id, please match the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$, the length should no more than %d", eg, "simple-changefeed-task"`, errors.RFCCodeText("CDC:ErrInvalidChangefeedID"))
 	ErrInvalidEtcdKey        = errors.Normalize("invalid key: %s", errors.RFCCodeText("CDC:ErrInvalidEtcdKey"))
 
 	// schema storage errors


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix `changefeed-id need to be limit max length` #1709

### What is changed and how it works?
add a limit check

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Add changfeed-id limit check

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
