### PR TITLE
puller: ignore fallen back resolved ts

### DIFF
--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -160,12 +160,17 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 	lastResolvedTs := p.checkpointTs
 	g.Go(func() error {
 		output := func(raw *model.RawKVEntry) error {
+			// even after https://github.com/pingcap/ticdc/pull/2038, kv client
+			// could still miss region change notification, which lead to resolved
+			// ts update missing, however resolved ts fallback here can be ignored
+			// here.
 			if raw.CRTs < p.resolvedTs || (raw.CRTs == p.resolvedTs && raw.OpType != model.OpTypeResolved) {
-				log.Panic("The CRTs must be greater than the resolvedTs",
+				log.Warn("The CRTs is fallen back in pulelr",
 					zap.Reflect("row", raw),
 					zap.Uint64("CRTs", raw.CRTs),
 					zap.Uint64("resolvedTs", p.resolvedTs),
 					zap.Int64("tableID", tableID))
+				return nil
 			}
 			select {
 			case <-ctx.Done():

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -161,9 +161,10 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 	g.Go(func() error {
 		output := func(raw *model.RawKVEntry) error {
 			// even after https://github.com/pingcap/ticdc/pull/2038, kv client
-			// could still miss region change notification, which lead to resolved
-			// ts update missing, however resolved ts fallback here can be ignored
-			// here.
+			// could still miss region change notification, which leads to resolved
+			// ts update missing in puller, however resolved ts fallback here can
+			// be ignored since no late data is received and the guarantee of
+			// resolved ts is not broken.
 			if raw.CRTs < p.resolvedTs || (raw.CRTs == p.resolvedTs && raw.OpType != model.OpTypeResolved) {
 				log.Warn("The CRTs is fallen back in pulelr",
 					zap.Reflect("row", raw),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This is an addition fix after #2038 

In #2038, kv client tries to send `resolved ts` to puller after a region information is loaded from PD and dispatched in kv client. However, in extreme scenario, `BatchLoadRegionsWithKeyRange` could still miss some regions of intermediate states. 

### What is changed and how it works?

In the #2038 scenario, the fallen back resolved doesn't make any sense, because the `resovled-ts` in puller only guarantees **no late data**, but doesn't guarantee **no repeated data**. We have the same behavior in kv client when processing the resovled ts fallen back from TiKV, ref: https://github.com/pingcap/ticdc/blob/43c40f9d368a5f85beaf05080c3f11135648faa5/cdc/kv/client.go#L1473-L1480

- late data: It is **the first time** that a row changed event is received, and its `commit-ts` is smaller than `resolved-ts`. 
- repeated data: It is **not the first time** that a row changed event is received, and its `commit-ts` is smaller than `resolved-ts`.

TODO, we should add more tests in span frontier module, and make sure the correctness. Some possible tasks:
- Support more fine-grained region forward strategy, to avoid non-essential resolved ts fallen back
- Add more robust and correctness tests for span frontier module

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- No release note
