### PR TITLE
table_pipeline: Fix blocking entire pipeline when DDL puller is lagging behind

### DIFF
--- a/cdc/processor/pipeline/mounter.go
+++ b/cdc/processor/pipeline/mounter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 PingCAP, Inc.
+// Copyright 2021 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cdc/processor/pipeline/mounter.go
+++ b/cdc/processor/pipeline/mounter.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	waitEventMountedBatchSize = 1024
-	maxNotificationsPerSecond = 20.0
+	waitEventMountedBatchSize = 32 * 1024
+	maxNotificationsPerSecond = 10.0
 )
 
 // mounterNode is now used to buffer unmounted events.

--- a/cdc/processor/pipeline/mounter.go
+++ b/cdc/processor/pipeline/mounter.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	waitEventMountedBatchSize = 128 * 1024
-	maxNotificationsPerSecond = 2.0
+	waitEventMountedBatchSize = 128 * 1024 // larger means less CPU overhead used by `select` but more memory overhead.
+	maxNotificationsPerSecond = 10.0       // larger means lower latency, but more CPU used by `select`.
 )
 
 // mounterNode is now used to buffer unmounted events.

--- a/cdc/processor/pipeline/mounter.go
+++ b/cdc/processor/pipeline/mounter.go
@@ -92,7 +92,7 @@ func (n *mounterNode) Init(ctx pipeline.NodeContext) error {
 						// handles PolymorphicEvents
 						event := msg.PolymorphicEvent
 						if event.RawKV.OpType != model.OpTypeResolved {
-							failpoint.Inject("mounterNodeWaitPreapre", func() {})
+							failpoint.Inject("MounterNodeWaitPrepare", func() {})
 							// only RowChangedEvents need mounting
 							err := event.WaitPrepare(stdCtx)
 							if err != nil {

--- a/cdc/processor/pipeline/mounter.go
+++ b/cdc/processor/pipeline/mounter.go
@@ -105,7 +105,9 @@ func (n *mounterNode) Init(ctx pipeline.NodeContext) error {
 // Receive receives the message from the previous node
 func (n *mounterNode) Receive(ctx pipeline.NodeContext) error {
 	msg := ctx.Message()
+	n.mu.Lock()
 	n.queue.PushBack(msg)
+	n.mu.Unlock()
 
 	if n.rl.Allow() {
 		n.notifier.Notify()

--- a/cdc/processor/pipeline/mounter.go
+++ b/cdc/processor/pipeline/mounter.go
@@ -19,9 +19,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/failpoint"
-
 	"github.com/edwingeng/deque"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/notify"
 	"github.com/pingcap/ticdc/pkg/pipeline"
@@ -65,9 +64,9 @@ func (n *mounterNode) Init(ctx pipeline.NodeContext) error {
 	if err != nil {
 		log.Panic("unexpected error", zap.Error(err))
 	}
-	defer receiver.Stop()
 
 	n.wg.Go(func() error {
+		defer receiver.Stop()
 		for {
 			select {
 			case <-stdCtx.Done():

--- a/cdc/processor/pipeline/mounter.go
+++ b/cdc/processor/pipeline/mounter.go
@@ -38,7 +38,7 @@ const (
 // TODO rename this node, or refactor the mounter to make it synchronous.
 type mounterNode struct {
 	mu    sync.Mutex
-	queue deque.Deque // we used Deque for better memory consumption and support for batching
+	queue deque.Deque // we use Deque for better memory consumption and support for batching
 
 	wg     errgroup.Group
 	cancel context.CancelFunc

--- a/cdc/processor/pipeline/mounter_test.go
+++ b/cdc/processor/pipeline/mounter_test.go
@@ -57,6 +57,11 @@ func (n *checkNode) Receive(ctx pipeline.NodeContext) error {
 	if n.count%100 == 0 {
 		log.Info("message received", zap.Int("count", n.count))
 	}
+
+	if n.count == basicsTestMessageCount/2 {
+		log.Info("sleeping for 5 seconds to simulate blocking")
+		time.Sleep(time.Second * 5)
+	}
 	n.count++
 	return nil
 }
@@ -137,7 +142,7 @@ func (s *mounterNodeSuite) TestMounterNodeBasics(c *check.C) {
 		log.Info("finished sending")
 	}()
 
-	wg.Add(2)
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		for {
@@ -153,4 +158,5 @@ func (s *mounterNodeSuite) TestMounterNodeBasics(c *check.C) {
 
 	p.Wait()
 	cancel()
+	wg.Wait()
 }

--- a/cdc/processor/pipeline/mounter_test.go
+++ b/cdc/processor/pipeline/mounter_test.go
@@ -1,0 +1,156 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/context"
+	"github.com/pingcap/ticdc/pkg/pipeline"
+	"github.com/pingcap/ticdc/pkg/retry"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"go.uber.org/zap"
+)
+
+type mounterNodeSuite struct{}
+
+var _ = check.Suite(&mounterNodeSuite{})
+
+type checkNode struct {
+	c        *check.C
+	count    int
+	expected int
+}
+
+func (n *checkNode) Init(ctx pipeline.NodeContext) error {
+	// do nothing
+	return nil
+}
+
+func (n *checkNode) Receive(ctx pipeline.NodeContext) error {
+	message := ctx.Message()
+	if message.Tp == pipeline.MessageTypePolymorphicEvent {
+		if message.PolymorphicEvent.RawKV.OpType == model.OpTypeResolved {
+			n.c.Assert(n.count, check.Equals, n.expected)
+			return errors.New("finished")
+		}
+		n.c.Assert(message.PolymorphicEvent.Row, check.NotNil)
+	}
+
+	if n.count%100 == 0 {
+		log.Info("message received", zap.Int("count", n.count))
+	}
+	n.count++
+	return nil
+}
+
+func (n *checkNode) Destroy(ctx pipeline.NodeContext) error {
+	return nil
+}
+
+const (
+	basicsTestMessageCount = 10000
+)
+
+func generateMockRawKV(ts uint64) *model.RawKVEntry {
+	return &model.RawKVEntry{
+		OpType:   model.OpTypePut,
+		Key:      []byte{},
+		Value:    []byte{},
+		OldValue: nil,
+		StartTs:  ts - 5,
+		CRTs:     ts,
+		RegionID: 0,
+	}
+}
+
+func (s *mounterNodeSuite) TestMounterNodeBasics(c *check.C) {
+	defer testleak.AfterTest(c)()
+
+	ctx, cancel := context.WithCancel(context.NewBackendContext4Test(false))
+	defer cancel()
+
+	ctx = context.WithErrorHandler(ctx, func(err error) error {
+		return nil
+	})
+	p := pipeline.NewPipeline(ctx, 0)
+	mounterNode := newMounterNode()
+	p.AppendNode(ctx, "mounter", mounterNode)
+
+	checkNode := &checkNode{
+		c:        c,
+		count:    0,
+		expected: basicsTestMessageCount,
+	}
+	p.AppendNode(ctx, "check", checkNode)
+
+	var sentCount int64
+	sendMsg := func(p *pipeline.Pipeline, msg *pipeline.Message) {
+		err := retry.Run(10*time.Millisecond, 100, func() error {
+			return p.SendToFirstNode(msg)
+		})
+		atomic.AddInt64(&sentCount, 1)
+		c.Assert(err, check.IsNil)
+	}
+
+	mockMounterInput := make(chan *model.PolymorphicEvent, 10240)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < basicsTestMessageCount; i++ {
+			var msg *pipeline.Message
+			if i%100 == 0 {
+				// generates a control message
+				msg = pipeline.TickMessage()
+			} else {
+				msg = pipeline.PolymorphicEventMessage(model.NewPolymorphicEvent(generateMockRawKV(uint64(i << 5))))
+				msg.PolymorphicEvent.SetUpFinishedChan()
+				select {
+				case <-ctx.Done():
+					return
+				case mockMounterInput <- msg.PolymorphicEvent:
+				}
+			}
+			sendMsg(p, msg)
+		}
+		msg := pipeline.PolymorphicEventMessage(model.NewResolvedPolymorphicEvent(0, (basicsTestMessageCount<<5)+1))
+		sendMsg(p, msg)
+		c.Assert(atomic.LoadInt64(&sentCount), check.Equals, int64(basicsTestMessageCount+1))
+		log.Info("finished sending")
+	}()
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-mockMounterInput:
+				event.Row = &model.RowChangedEvent{} // mocked row
+				event.PrepareFinished()
+			}
+		}
+	}()
+
+	p.Wait()
+	cancel()
+}

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -178,8 +178,8 @@ func NewTablePipeline(ctx cdcContext.Context,
 	flowController := common.NewTableFlowController(perTableMemoryQuota)
 	p := pipeline.NewPipeline(ctx, 500*time.Millisecond)
 	p.AppendNode(ctx, "puller", newPullerNode(limitter, tableID, replicaInfo, tableName))
-	p.AppendNode(ctx, "sorter", newSorterNode(tableName, tableID, flowController))
-	p.AppendNode(ctx, "mounter", newMounterNode(mounter))
+	p.AppendNode(ctx, "sorter", newSorterNode(tableName, tableID, flowController, mounter))
+	p.AppendNode(ctx, "mounter", newMounterNode())
 	config := ctx.ChangefeedVars().Info.Config
 	if config.Cyclic != nil && config.Cyclic.IsEnabled() {
 		p.AppendNode(ctx, "cyclic", newCyclicMarkNode(replicaInfo.MarkTableID))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- If DDL puller is behind, mounter could block the entire tablePipeline, causing deadlocks together with TiKV concurrency control or other components.

### What is changed and how it works?
- Events waiting to be mounted are buffered in a Deque, which has no explicit size limit (the flowController ensures there will be no OOM).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (WIP)

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note
