### PR TITLE
sorter: add close check to AddEntry

### DIFF
--- a/cdc/puller/sorter/sorter_test.go
+++ b/cdc/puller/sorter/sorter_test.go
@@ -465,3 +465,33 @@ func (s *sorterSuite) TestSorterErrorReportCorrect(c *check.C) {
 	case <-finishedCh:
 	}
 }
+
+func (s *sorterSuite) TestSortClosedAddEntry(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer UnifiedSorterCleanUp()
+
+	sorter, err := NewUnifiedSorter("/tmp/sorter",
+		"test-cf",
+		"test",
+		0,
+		"0.0.0.0:0")
+	c.Assert(err, check.IsNil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+	err = sorter.Run(ctx)
+	c.Assert(err, check.ErrorMatches, ".*deadline.*")
+
+	ctx1, cancel1 := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel1()
+	for i := 0; i < 10000; i++ {
+		sorter.AddEntry(ctx1, model.NewPolymorphicEvent(generateMockRawKV(uint64(i))))
+	}
+
+	select {
+	case <-ctx1.Done():
+		c.Fatal("TestSortClosedAddEntry timed out")
+	default:
+	}
+	cancel1()
+}

--- a/cdc/puller/sorter/unified_sorter.go
+++ b/cdc/puller/sorter/unified_sorter.go
@@ -41,6 +41,8 @@ type UnifiedSorter struct {
 	dir         string
 	pool        *backEndPool
 	metricsInfo *metricsInfo
+
+	closeCh chan struct{}
 }
 
 type metricsInfo struct {
@@ -116,6 +118,7 @@ func NewUnifiedSorter(
 			tableID:      tableID,
 			captureAddr:  captureAddr,
 		},
+		closeCh: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -136,6 +139,8 @@ func (s *UnifiedSorter) Run(ctx context.Context) error {
 	failpoint.Inject("sorterDebug", func() {
 		log.Info("sorterDebug: Running Unified Sorter in debug mode")
 	})
+
+	defer close(s.closeCh)
 
 	finish := util.MonitorCancelLatency(ctx, "Unified Sorter")
 	defer finish()
@@ -265,6 +270,7 @@ func (s *UnifiedSorter) AddEntry(ctx context.Context, entry *model.PolymorphicEv
 	select {
 	case <-ctx.Done():
 		return
+	case <-s.closeCh:
 	case s.inputCh <- entry:
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Cancelling Unified Sorter's `Run` does not cancel `AddEntry`. This can cause unexpected channel congestion.

### What is changed and how it works?
- Added close detection in `AddEntry`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note

