### PR TITLE
processor: cancel all tables all at once

### DIFF
--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -777,6 +777,8 @@ func (p *processor) doGCSchemaStorage() error {
 func (p *processor) Close() error {
 	for _, tbl := range p.tables {
 		tbl.Cancel()
+	}
+	for _, tbl := range p.tables {
 		tbl.Wait()
 	}
 	p.cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- The processor cancels tables one by one, meaning that the next table is not cancelled until the first table has fully exited. This causes risks of deadlocking.

### What is changed and how it works?
- Cancel them all at once.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note

