### PR TITLE
cli: make error message compatible with pd flag name when PD address  unreachable 

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -176,7 +176,7 @@ func newCliCommand() *cobra.Command {
 			})
 			if err != nil {
 				// PD embeds an etcd server.
-				return errors.Annotatef(err, "fail to open PD etcd client, pd-addr=\"%s\"", cliPdAddr)
+				return errors.Annotatef(err, "fail to open PD etcd client, pd=\"%s\"", cliPdAddr)
 			}
 			cdcEtcdCli = kv.NewCDCEtcdClient(defaultContext, etcdCli)
 			pdCli, err = pd.NewClientWithContext(


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Inaccurate error message for PD address #1893

### What is changed and how it works?
as the title said

### Check List <!--REMOVE the items that are not applicable-->



Related changes

 - Need to cherry-pick to the release branch

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
