### PR TITLE
kv/client: keep using kv client v1 in 5.0

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -86,7 +86,7 @@ var reconnectInterval = 60 * time.Minute
 // hard code switch
 // true: use kv client v2, which has a region worker for each stream
 // false: use kv client v1, which runs a goroutine for every single region
-var enableKVClientV2 = true
+var enableKVClientV2 = false
 
 type singleRegionInfo struct {
 	verID  tikv.RegionVerID

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1235,13 +1233,6 @@ func (s *etcdSuite) TestStreamSendWithError(c *check.C) {
 	expectedInitRegions := map[uint64]struct{}{regionID3: {}, regionID4: {}}
 	c.Assert(initRegions, check.DeepEquals, expectedInitRegions)
 
-	// a hack way to check the goroutine count of region worker is 1
-	buf := make([]byte, 1<<20)
-	stacklen := runtime.Stack(buf, true)
-	stack := string(buf[:stacklen])
-	c.Assert(strings.Count(stack, "resolveLock"), check.Equals, 1)
-	c.Assert(strings.Count(stack, "collectWorkpoolError"), check.Equals, 1)
-
 	cancel()
 }
 
@@ -1534,8 +1525,8 @@ func (s *etcdSuite) TestStreamRecvWithErrorNormal(c *check.C) {
 	}()
 
 	// test client v2
-	enableKVClientV2 = true
-	s.testStreamRecvWithError(c, "1*return(\"injected stream recv error\")")
+	// enableKVClientV2 = true
+	// s.testStreamRecvWithError(c, "1*return(\"injected stream recv error\")")
 
 	// test client v1
 	enableKVClientV2 = false
@@ -1554,8 +1545,8 @@ func (s *etcdSuite) TestStreamRecvWithErrorIOEOF(c *check.C) {
 	}()
 
 	// test client v2
-	enableKVClientV2 = true
-	s.testStreamRecvWithError(c, "1*return(\"EOF\")")
+	// enableKVClientV2 = true
+	// s.testStreamRecvWithError(c, "1*return(\"EOF\")")
 
 	// test client v1
 	enableKVClientV2 = false
@@ -2777,8 +2768,8 @@ func (s *etcdSuite) TestKVClientForceReconnect(c *check.C) {
 	enableKVClientV2 = false
 	s.testKVClientForceReconnect(c)
 
-	enableKVClientV2 = true
-	s.testKVClientForceReconnect(c)
+	// enableKVClientV2 = true
+	// s.testKVClientForceReconnect(c)
 }
 
 func (s *etcdSuite) testKVClientForceReconnect(c *check.C) {

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -1519,17 +1519,11 @@ ReceiveLoop:
 func (s *etcdSuite) TestStreamRecvWithErrorNormal(c *check.C) {
 	defer testleak.AfterTest(c)()
 
-	clientv2 := enableKVClientV2
-	defer func() {
-		enableKVClientV2 = clientv2
-	}()
-
 	// test client v2
 	// enableKVClientV2 = true
 	// s.testStreamRecvWithError(c, "1*return(\"injected stream recv error\")")
 
 	// test client v1
-	enableKVClientV2 = false
 	s.testStreamRecvWithError(c, "1*return(\"injected stream recv error\")")
 }
 
@@ -1539,17 +1533,11 @@ func (s *etcdSuite) TestStreamRecvWithErrorNormal(c *check.C) {
 func (s *etcdSuite) TestStreamRecvWithErrorIOEOF(c *check.C) {
 	defer testleak.AfterTest(c)()
 
-	clientv2 := enableKVClientV2
-	defer func() {
-		enableKVClientV2 = clientv2
-	}()
-
 	// test client v2
 	// enableKVClientV2 = true
 	// s.testStreamRecvWithError(c, "1*return(\"EOF\")")
 
 	// test client v1
-	enableKVClientV2 = false
 	s.testStreamRecvWithError(c, "1*return(\"EOF\")")
 }
 
@@ -2624,12 +2612,6 @@ func (s *etcdSuite) TestClientV1UnlockRangeReentrant(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer s.TearDownTest(c)
 
-	clientv2 := enableKVClientV2
-	enableKVClientV2 = false
-	defer func() {
-		enableKVClientV2 = clientv2
-	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := &sync.WaitGroup{}
 
@@ -2683,15 +2665,9 @@ func (s *etcdSuite) TestClientV1UnlockRangeReentrant(c *check.C) {
 
 // TestClientErrNoPendingRegion has the similar procedure with TestClientV1UnlockRangeReentrant
 // The difference is the delay injected point for region 2
-func (s *etcdSuite) TestClientErrNoPendingRegion(c *check.C) {
+func (s *etcdSuite) TestClientV1ErrNoPendingRegion(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer s.TearDownTest(c)
-
-	clientv2 := enableKVClientV2
-	enableKVClientV2 = false
-	defer func() {
-		enableKVClientV2 = clientv2
-	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := &sync.WaitGroup{}
@@ -2759,13 +2735,7 @@ func (s *etcdSuite) TestKVClientForceReconnect(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer s.TearDownTest(c)
 
-	clientv2 := enableKVClientV2
-	defer func() {
-		enableKVClientV2 = clientv2
-	}()
-
 	// test kv client v1
-	enableKVClientV2 = false
 	s.testKVClientForceReconnect(c)
 
 	// enableKVClientV2 = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Keep using kv client v1 in 5.0 release, only enable it in 5.1 release

### What is changed and how it works?

turn off switch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
### Release note

- No release note
