### PR TITLE
cli: make error message compatible with pd flag name

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -195,7 +195,7 @@ func newCliCommand() *cobra.Command {
 					}),
 				))
 			if err != nil {
-				return errors.Annotatef(err, "fail to open PD client, pd-addr=\"%s\"", cliPdAddr)
+				return errors.Annotatef(err, "fail to open PD client, pd=\"%s\"", cliPdAddr)
 			}
 			ctx := defaultContext
 			errorTiKVIncompatible := true // Error if TiKV is incompatible.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/ticdc/issues/1893

### What is changed and how it works?

make error message compatible with pd flag name.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

None

Code changes

None

Side effects

None

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note
