### PR TITLE
replication: switch on new owner 5.0

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ import (
 const (
 	// NewReplicaImpl is true if we using new processor
 	// new owner should be also switched on after it implemented
-	NewReplicaImpl = false
+	NewReplicaImpl = true
 	// DefaultSortDir is the default value of sort-dir, it will be s sub directory of data-dir.
 	DefaultSortDir = "/tmp/sorter"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- We need to switch on the new owner/processor in 5.0

### What is changed and how it works?
- Switched on new owner/processor in 5.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- Enable new owner/processor
