### PR TITLE
doc: change readme support Go version to Go >= 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ make
 $ make test
 ```
 
-Note that TiCDC supports building with Go version `Go >= 1.13`.
+Note that TiCDC supports building with Go version `Go >= 1.16`.
 
 When TiCDC is built successfully, you can find binary in the `bin` directory. Instructions for unit test and integration test can be found in [Running tests](tests/README.md).
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix readme Go version Go >= 1.16. we update to go 1.6.4 https://github.com/pingcap/ticdc/pull/1818, but ticdc is no longer compatible with go version >= 1.13 after  #2109

![image](https://user-images.githubusercontent.com/1741864/123362173-d7fc8180-d5a2-11eb-9d11-b1c8a4313b3e.png)

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code



Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

- No release note
