### PR TITLE
Update TicdcEventDecoderTest.java

### DIFF
--- a/demo/java/src/test/java/com/pingcap/ticdc/cdc/TicdcEventDecoderTest.java
+++ b/demo/java/src/test/java/com/pingcap/ticdc/cdc/TicdcEventDecoderTest.java
@@ -69,7 +69,8 @@ public class TicdcEventDecoderTest {
         Assert.assertNotNull(keyFiles);
         Assert.assertNotNull(valueFiles);
         Assert.assertEquals(keyFiles.length, valueFiles.length);
-
+        Arrays.sort(keyFiles);
+        Arrays.sort(valueFiles);
         for (int i = 0; i < keyFiles.length; i++) {
             File kf = keyFiles[i];
             byte[] kafkaMessageKey = Files.readAllBytes(kf.toPath());


### PR DESCRIPTION
When I get the code from Github and run this Test code,it goes wrong, I find UnixFileSystem.list() not return filenames ordered so fix it.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```