### PR TITLE
etcd_worker: big txn

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -186,6 +186,11 @@ error = '''
 this patch should be excluded from the current etcd txn
 '''
 
+["CDC:ErrEtcdMockCrash"]
+error = '''
+used to mock a process crash while executing EtcdWorker. Internal use only
+'''
+
 ["CDC:ErrEtcdSessionDone"]
 error = '''
 the etcd session is done

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -199,6 +199,7 @@ var (
 	ErrEtcdSessionDone = errors.Normalize("the etcd session is done", errors.RFCCodeText("CDC:ErrEtcdSessionDone"))
 	// ErrReactorFinished is used by reactor to signal a **normal** exit.
 	ErrReactorFinished = errors.Normalize("the reactor has done its job and should no longer be executed", errors.RFCCodeText("CDC:ErrReactorFinished"))
+	ErrEtcdMockCrash   = errors.Normalize("used to mock a process crash while executing EtcdWorker. Internal use only", errors.RFCCodeText("CDC:ErrEtcdMockCrash"))
 	ErrLeaseTimeout    = errors.Normalize("owner lease timeout", errors.RFCCodeText("CDC:ErrLeaseTimeout"))
 	ErrLeaseExpired    = errors.Normalize("owner lease expired ", errors.RFCCodeText("CDC:ErrLeaseExpired"))
 

--- a/pkg/orchestrator/etcd_txn.go
+++ b/pkg/orchestrator/etcd_txn.go
@@ -1,0 +1,335 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"bytes"
+	"container/heap"
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/pingcap/failpoint"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/pkg/orchestrator/util"
+	"go.etcd.io/etcd/clientv3"
+	"go.uber.org/zap"
+)
+
+const (
+	txnStaleDuration = time.Second * 30
+)
+
+// EtcdWorkerTxn is the struct for Etcd metadata used to record individual
+// Etcd big transactions.
+type EtcdWorkerTxn struct {
+	StartPhysicalTs time.Time `json:"start_physical_ts"`
+	StartRevision   int64     `json:"start_revision"`
+	Committed       bool      `json:"committed"`
+
+	// for internal use only
+	txnRevision int64
+}
+
+// EtcdWorkerLock is the struct for Etcd metadata used to record locks used
+// to implement Etcd big transactions.
+type EtcdWorkerLock struct {
+	StartRevision int64 `json:"start_revision"`
+	OwnerID       int64 `json:"owner_id"`
+
+	// for internal use only
+	heapIndex    int
+	lockRevision int64
+}
+
+type txnObserver struct {
+	heap    lockHeap
+	lockMap map[util.EtcdKey]*EtcdWorkerLock
+	TxnMap  map[int64]*EtcdWorkerTxn
+	prefix  util.EtcdPrefix
+}
+
+func newTxnObserver(prefix util.EtcdPrefix) *txnObserver {
+	return &txnObserver{
+		heap:    make([]*EtcdWorkerLock, 0, 16),
+		lockMap: make(map[util.EtcdKey]*EtcdWorkerLock),
+		TxnMap:  make(map[int64]*EtcdWorkerTxn),
+		prefix:  prefix,
+	}
+}
+
+func (o *txnObserver) addLock(modifiedKey util.EtcdKey, lock *EtcdWorkerLock) {
+	heap.Push(&o.heap, lock)
+	o.lockMap[modifiedKey] = lock
+}
+
+func (o *txnObserver) deleteLock(modifiedKey util.EtcdKey) {
+	lock, ok := o.lockMap[modifiedKey]
+	if !ok {
+		log.Panic("Lock not found", zap.String("key", modifiedKey.String()))
+	}
+	heap.Remove(&o.heap, lock.heapIndex)
+	delete(o.lockMap, modifiedKey)
+}
+
+func (o *txnObserver) minLockRevision() int64 {
+	if o.heap.Len() == 0 {
+		return math.MaxInt64
+	}
+	return o.heap[0].StartRevision
+}
+
+func (o *txnObserver) upsertTxn(ownerID int64, txn *EtcdWorkerTxn) {
+	o.TxnMap[ownerID] = txn
+}
+
+func (o *txnObserver) deleteTxn(ownerID int64) {
+	if _, ok := o.TxnMap[ownerID]; !ok {
+		log.Panic("Txn not found", zap.Int64("owner-id", ownerID))
+	}
+
+	delete(o.TxnMap, ownerID)
+}
+
+func (o *txnObserver) cleanUpOrphanTxns(ctx context.Context, client *clientv3.Client) error {
+	txnMapClone := make(map[int64]*EtcdWorkerTxn, len(o.TxnMap))
+	for k, v := range o.TxnMap {
+		if time.Since(v.StartPhysicalTs) > time.Second*2 {
+			txnMapClone[k] = v
+		}
+	}
+
+	// Deletes non-orphan txns from txnMapClone
+	for _, lock := range o.lockMap {
+		delete(txnMapClone, lock.OwnerID)
+	}
+
+	// What remains now is the orphan txns.
+	for ownerID, txn := range txnMapClone {
+		log.Debug("Cleaning up orphan txn",
+			zap.Int64("owner-id", ownerID),
+			zap.Int64("revision", txn.txnRevision))
+
+		txnKey := txnKeyFromOwnerID(o.prefix, ownerID)
+		resp, err := client.Txn(ctx).
+			If(clientv3.Compare(clientv3.ModRevision(txnKey.String()), "<", txn.txnRevision+1)).
+			Then(clientv3.OpDelete(txnKey.String())).
+			Commit()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if resp.Succeeded {
+			log.Debug("Cleaned up orphan txn", zap.Int64("owner-id", ownerID))
+		} else {
+			log.Warn("Failed to clean up orphan txn", zap.Int64("owner-id", ownerID))
+		}
+	}
+
+	return nil
+}
+
+type cleanUpLockOp int
+
+const (
+	lockNoOp = cleanUpLockOp(iota)
+	lockOpRollBack
+	lockOpRollForward
+)
+
+func (o *txnObserver) cleanUpLocks(ctx context.Context, client *clientv3.Client) error {
+	forceCleanUp := false
+	failpoint.Inject("forceRollForwardByOthers", func() {
+		forceCleanUp = true
+	})
+	op := lockNoOp
+	for key, lock := range o.lockMap {
+		txn, ok := o.TxnMap[lock.OwnerID]
+		if !ok {
+			op = lockOpRollBack
+		} else if forceCleanUp || time.Since(txn.StartPhysicalTs) > txnStaleDuration {
+			if txn.Committed {
+				op = lockOpRollForward
+			} else if forceCleanUp {
+				// this is for unit testing only
+				op = lockOpRollBack
+			}
+		}
+
+		lockKey := lockKeyFromDataKey(o.prefix, key)
+		switch op {
+		case lockOpRollBack:
+			log.Debug("etcd big txn: lock rollback",
+				zap.String("lock-key", lockKey.String()),
+				zap.Int64("owner-id", lock.OwnerID))
+			resp, err := client.Get(ctx, key.String(), clientv3.WithRev(lock.StartRevision))
+			if err != nil {
+				return errors.Trace(err)
+			}
+			var oldValue []byte
+			if len(resp.Kvs) == 1 {
+				oldValue = resp.Kvs[0].Value
+			}
+
+			var op clientv3.Op
+			if oldValue != nil {
+				op = clientv3.OpPut(key.String(), string(oldValue))
+			} else {
+				op = clientv3.OpDelete(key.String())
+			}
+
+			txnResp, err := client.
+				Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(lockKey.String()), "<", lock.lockRevision+1),
+					clientv3.Compare(clientv3.ModRevision(key.String()), "<", lock.lockRevision+1)).
+				Then(op, clientv3.OpDelete(lockKey.String())).
+				Commit()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if !txnResp.Succeeded {
+				log.Warn("Failed to roll back etcd key", zap.String("key", key.String()))
+			}
+		case lockOpRollForward:
+			log.Debug("etcd big txn: lock roll-forward",
+				zap.String("lock-key", lockKey.String()),
+				zap.Int64("owner-id", lock.OwnerID))
+			txnResp, err := client.
+				Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(lockKey.String()), "<", lock.lockRevision+1)).
+				Then(clientv3.OpDelete(lockKey.String())).
+				Commit()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if !txnResp.Succeeded {
+				log.Warn("Failed to roll forward etcd key", zap.String("key", key.String()))
+			}
+		}
+	}
+
+	return nil
+}
+
+func lockKeyFromDataKey(prefix util.EtcdPrefix, dataKey util.EtcdKey) util.EtcdKey {
+	relKey := dataKey.RemovePrefix(&prefix)
+	return prefix.FullKey(util.NewEtcdRelKey(fmt.Sprintf("%s%s", etcdBigTxnLockPrefix, relKey.String())))
+}
+
+func txnKeyFromOwnerID(prefix util.EtcdPrefix, ownerID int64) util.EtcdKey {
+	return prefix.FullKey(util.NewEtcdRelKey(fmt.Sprintf("%s/%d", etcdBigTxnMetaPrefix, ownerID)))
+}
+
+type txnChangeSetEntry struct {
+	key util.EtcdKey
+	old []byte
+	new []byte
+}
+
+type txnChangeSet []*txnChangeSetEntry
+
+func newTxnChangeSet(changeSet map[util.EtcdKey][]byte, prevState map[util.EtcdKey][]byte) txnChangeSet {
+	var ret []*txnChangeSetEntry
+	for key, value := range changeSet {
+		prev := prevState[key]
+		ret = append(ret, &txnChangeSetEntry{
+			key: key,
+			old: prev,
+			new: value,
+		})
+	}
+	return ret
+}
+
+func (s txnChangeSet) sort() {
+	sort.Slice(s, func(i, j int) bool {
+		a := s[i].key.Bytes()
+		b := s[j].key.Bytes()
+		return bytes.Compare(a, b) == -1
+	})
+}
+
+func (s txnChangeSet) stats() (numEntries, numBytes int) {
+	numEntries = len(s)
+	for _, entry := range s {
+		numBytes += len(entry.new)
+	}
+	return
+}
+
+type bigTxnUndoLogEntry struct {
+	Key      util.EtcdKey
+	LockKey  util.EtcdKey
+	PreValue []byte
+	PostRev  int64
+	IsDelete bool
+}
+
+func (e *bigTxnUndoLogEntry) Ops() []clientv3.Op {
+	var ops []clientv3.Op
+	if e.PreValue != nil {
+		ops = append(ops, clientv3.OpPut(e.Key.String(), string(e.PreValue)))
+	} else {
+		ops = append(ops, clientv3.OpDelete(e.Key.String()))
+	}
+
+	ops = append(ops, clientv3.OpDelete(e.LockKey.String()))
+	return ops
+}
+
+func (e *bigTxnUndoLogEntry) Cmps() []clientv3.Cmp {
+	var cmps []clientv3.Cmp
+	if e.IsDelete {
+		cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(e.Key.String()), "=", 0))
+	} else {
+		cmps = append(cmps, clientv3.Compare(clientv3.ModRevision(e.Key.String()), "=", e.PostRev))
+	}
+
+	cmps = append(cmps, clientv3.Compare(clientv3.ModRevision(e.LockKey.String()), "=", e.PostRev))
+	return cmps
+}
+
+type lockHeap []*EtcdWorkerLock
+
+func (l lockHeap) Len() int {
+	return len(l)
+}
+
+func (l lockHeap) Less(i, j int) bool {
+	return l[i].StartRevision < l[j].StartRevision
+}
+
+func (l lockHeap) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+	l[i].heapIndex = i
+	l[j].heapIndex = j
+}
+
+func (l *lockHeap) Push(x interface{}) {
+	x.(*EtcdWorkerLock).heapIndex = len(*l)
+	*l = append(*l, x.(*EtcdWorkerLock))
+}
+
+func (l *lockHeap) Pop() interface{} {
+	old := *l
+	n := len(old)
+	x := old[n-1]
+	old[n-1] = nil
+	*l = old[0 : n-1]
+	x.heapIndex = -1
+	return x
+}

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -75,7 +75,7 @@ func NewEtcdWorker(client *etcd.Client, prefix string, reactor Reactor, initStat
 		prefix:      prefixNormalied,
 		barrierRev:  -1, // -1 indicates no barrier
 		txnManager:  newTxnObserver(prefixNormalied),
-		forceBigTxn: true, // for running CI only, TODO revert to false
+		forceBigTxn: false,
 	}, nil
 }
 

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2020 PingCAP, Inc.
+// Copyright 2021 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,14 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/etcd"
@@ -31,9 +36,10 @@ import (
 
 // EtcdWorker handles all interactions with Etcd
 type EtcdWorker struct {
-	client  *etcd.Client
-	reactor Reactor
-	state   ReactorState
+	client     *etcd.Client
+	reactor    Reactor
+	state      ReactorState
+	txnManager *txnObserver
 	// rawState is the local cache of the latest Etcd state.
 	rawState map[util.EtcdKey][]byte
 	// pendingUpdates stores updates initiated by the Reactor that have not yet been uploaded to Etcd.
@@ -45,6 +51,11 @@ type EtcdWorker struct {
 	barrierRev int64
 	// prefix is the scope of Etcd watch
 	prefix util.EtcdPrefix
+	// clientID is the unique ID for this client in this Etcd cluster.
+	clientID int64
+
+	// for testing only
+	forceBigTxn bool
 }
 
 type etcdUpdate struct {
@@ -55,17 +66,25 @@ type etcdUpdate struct {
 
 // NewEtcdWorker returns a new EtcdWorker
 func NewEtcdWorker(client *etcd.Client, prefix string, reactor Reactor, initState ReactorState) (*EtcdWorker, error) {
+	prefixNormalied := util.NormalizePrefix(prefix)
 	return &EtcdWorker{
-		client:     client,
-		reactor:    reactor,
-		state:      initState,
-		rawState:   make(map[util.EtcdKey][]byte),
-		prefix:     util.NormalizePrefix(prefix),
-		barrierRev: -1, // -1 indicates no barrier
+		client:      client,
+		reactor:     reactor,
+		state:       initState,
+		rawState:    make(map[util.EtcdKey][]byte),
+		prefix:      prefixNormalied,
+		barrierRev:  -1, // -1 indicates no barrier
+		txnManager:  newTxnObserver(prefixNormalied),
+		forceBigTxn: true, // for running CI only, TODO revert to false
 	}, nil
 }
 
-const etcdRequestProgressDuration = 2 * time.Second
+const (
+	etcdRequestProgressDuration = 2 * time.Second
+	etcdCleanUpBigTxnInterval   = 2 * time.Second
+	etcdBigTxnMetaPrefix        = "/meta-txn"
+	etcdBigTxnLockPrefix        = "/meta-lock"
+)
 
 // Run starts the EtcdWorker event loop.
 // A tick is generated either on a timer whose interval is timerInterval, or on an Etcd event.
@@ -73,6 +92,18 @@ const etcdRequestProgressDuration = 2 * time.Second
 // And the specified etcd session is nil-safty.
 func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session, timerInterval time.Duration) error {
 	defer worker.cleanUp()
+
+	if session == nil {
+		var err error
+		session, err = concurrency.NewSession(worker.client.Unwrap())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer func() {
+			_ = session.Close()
+		}()
+	}
+	worker.clientID = int64(session.Lease())
 
 	err := worker.syncRawState(ctx)
 	if err != nil {
@@ -98,7 +129,7 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 		sessionDone = make(chan struct{})
 	}
 	lastReceivedEventTime := time.Now()
-
+	lastCleanedUpStaleBigTxn := time.Now()
 	for {
 		var response clientv3.WatchResponse
 		select {
@@ -112,6 +143,18 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 				if err := worker.client.RequestProgress(ctx); err != nil {
 					log.Warn("failed to request progress for etcd watcher", zap.Error(err))
 				}
+			}
+			// Checking for orphan txns is not very costly so we can do it in every tick.
+			err = worker.txnManager.cleanUpOrphanTxns(ctx, worker.client.Unwrap())
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if time.Since(lastCleanedUpStaleBigTxn) > etcdCleanUpBigTxnInterval {
+				err := worker.txnManager.cleanUpLocks(ctx, worker.client.Unwrap())
+				if err != nil {
+					return errors.Trace(err)
+				}
+				lastCleanedUpStaleBigTxn = time.Now()
 			}
 		case response = <-watchCh:
 			// In this select case, we receive new events from Etcd, and call handleEvent if appropriate.
@@ -141,6 +184,17 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 			}
 		}
 
+		if worker.revision < worker.barrierRev {
+			// We hold off notifying the Reactor because barrierRev has not been reached.
+			// This usually happens when a committed write Txn has not been received by Watch.
+			continue
+		}
+
+		if worker.revision >= worker.txnManager.minLockRevision() {
+			log.Debug("waiting for big txn to finish", zap.Int("num-locks", len(worker.txnManager.lockMap)))
+			continue
+		}
+
 		if len(pendingPatches) > 0 {
 			// Here we have some patches yet to be uploaded to Etcd.
 			pendingPatches, err = worker.applyPatchGroups(ctx, pendingPatches)
@@ -154,11 +208,6 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 			if exiting {
 				// If exiting is true here, it means that the reactor returned `ErrReactorFinished` last tick, and all pending patches is applied.
 				return nil
-			}
-			if worker.revision < worker.barrierRev {
-				// We hold off notifying the Reactor because barrierRev has not been reached.
-				// This usually happens when a committed write Txn has not been received by Watch.
-				continue
 			}
 
 			// We are safe to update the ReactorState only if there is no pending patch.
@@ -180,26 +229,69 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 }
 
 func (worker *EtcdWorker) handleEvent(_ context.Context, event *clientv3.Event) error {
-	worker.pendingUpdates = append(worker.pendingUpdates, &etcdUpdate{
-		key:      util.NewEtcdKeyFromBytes(event.Kv.Key),
-		value:    event.Kv.Value,
-		revision: event.Kv.ModRevision,
-	})
+	txnPrefix := worker.prefix.String() + etcdBigTxnMetaPrefix
+	lockPrefix := worker.prefix.String() + etcdBigTxnLockPrefix
 
-	switch event.Type {
-	case mvccpb.PUT:
-		value := event.Kv.Value
-		if value == nil {
-			value = []byte{}
+	if strings.HasPrefix(string(event.Kv.Key), txnPrefix) {
+		ownerIDStr := strings.TrimPrefix(string(event.Kv.Key), txnPrefix+"/")
+		ownerID, err := strconv.Atoi(ownerIDStr)
+		if err != nil {
+			return errors.Trace(err)
 		}
-		worker.rawState[util.NewEtcdKeyFromBytes(event.Kv.Key)] = value
-	case mvccpb.DELETE:
-		delete(worker.rawState, util.NewEtcdKeyFromBytes(event.Kv.Key))
+
+		switch event.Type {
+		case mvccpb.DELETE:
+			worker.txnManager.deleteTxn(int64(ownerID))
+		case mvccpb.PUT:
+			var txn EtcdWorkerTxn
+			err := json.Unmarshal(event.Kv.Value, &txn)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			txn.txnRevision = event.Kv.ModRevision
+			worker.txnManager.upsertTxn(int64(ownerID), &txn)
+		}
+	} else if strings.HasPrefix(string(event.Kv.Key), lockPrefix) {
+		modifiedKeyStr := strings.TrimPrefix(string(event.Kv.Key), lockPrefix)
+		modifiedKey := worker.prefix.FullKey(util.NewEtcdRelKey(modifiedKeyStr))
+
+		switch event.Type {
+		case mvccpb.DELETE:
+			worker.txnManager.deleteLock(modifiedKey)
+		case mvccpb.PUT:
+			var lock EtcdWorkerLock
+			err := json.Unmarshal(event.Kv.Value, &lock)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			lock.lockRevision = event.Kv.ModRevision
+			worker.txnManager.addLock(modifiedKey, &lock)
+		}
+	} else {
+		worker.pendingUpdates = append(worker.pendingUpdates, &etcdUpdate{
+			key:      util.NewEtcdKeyFromBytes(event.Kv.Key),
+			value:    event.Kv.Value,
+			revision: event.Kv.ModRevision,
+		})
+
+		switch event.Type {
+		case mvccpb.PUT:
+			value := event.Kv.Value
+			if value == nil {
+				value = []byte{}
+			}
+			worker.rawState[util.NewEtcdKeyFromBytes(event.Kv.Key)] = value
+		case mvccpb.DELETE:
+			delete(worker.rawState, util.NewEtcdKeyFromBytes(event.Kv.Key))
+		}
 	}
 	return nil
 }
 
 func (worker *EtcdWorker) syncRawState(ctx context.Context) error {
+	txnPrefix := worker.prefix.String() + etcdBigTxnMetaPrefix
+	lockPrefix := worker.prefix.String() + etcdBigTxnLockPrefix
+
 	resp, err := worker.client.Get(ctx, worker.prefix.String(), clientv3.WithPrefix())
 	if err != nil {
 		return errors.Trace(err)
@@ -209,9 +301,37 @@ func (worker *EtcdWorker) syncRawState(ctx context.Context) error {
 	for _, kv := range resp.Kvs {
 		key := util.NewEtcdKeyFromBytes(kv.Key)
 		worker.rawState[key] = kv.Value
-		err := worker.state.Update(key, kv.Value, true)
-		if err != nil {
-			return errors.Trace(err)
+
+		if strings.HasPrefix(string(kv.Key), txnPrefix) {
+			ownerIDStr := strings.TrimPrefix(string(kv.Key), txnPrefix+"/")
+			ownerID, err := strconv.Atoi(ownerIDStr)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			var txn EtcdWorkerTxn
+			err = json.Unmarshal(kv.Value, &txn)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			txn.txnRevision = resp.Header.Revision
+			worker.txnManager.upsertTxn(int64(ownerID), &txn)
+		} else if strings.HasPrefix(string(kv.Key), lockPrefix) {
+			modifiedKeyStr := strings.TrimPrefix(string(kv.Key), lockPrefix)
+			modifiedKey := worker.prefix.FullKey(util.NewEtcdRelKey(modifiedKeyStr))
+
+			var lock EtcdWorkerLock
+			err := json.Unmarshal(kv.Value, &lock)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			lock.lockRevision = kv.ModRevision
+			worker.txnManager.addLock(modifiedKey, &lock)
+		} else {
+			err := worker.state.Update(key, kv.Value, true)
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 
@@ -242,6 +362,10 @@ func (worker *EtcdWorker) applyPatchGroups(ctx context.Context, patchGroups [][]
 }
 
 func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []DataPatch) error {
+	if len(patches) == 0 {
+		return nil
+	}
+
 	state := worker.cloneRawState()
 	changedSet := make(map[util.EtcdKey]struct{})
 	for _, patch := range patches {
@@ -253,6 +377,27 @@ func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []DataPatch)
 			return errors.Trace(err)
 		}
 	}
+
+	if len(changedSet) == 0 {
+		return nil
+	}
+
+	newKVMap := make(map[util.EtcdKey][]byte, len(changedSet))
+	for key := range changedSet {
+		newKVMap[key] = state[key]
+	}
+
+	changeSet := newTxnChangeSet(newKVMap, worker.rawState)
+	numEntries, numBytes := changeSet.stats()
+
+	useBigTxn := worker.forceBigTxn || numEntries > 128 || numBytes > 1024*512
+	failpoint.Inject("injectForceUseBigTxn", func() {
+		useBigTxn = true
+	})
+	if useBigTxn {
+		return worker.applyBigTxnPatches(ctx, changeSet)
+	}
+
 	cmps := make([]clientv3.Cmp, 0, len(changedSet))
 	ops := make([]clientv3.Op, 0, len(changedSet))
 	for key := range changedSet {
@@ -291,6 +436,168 @@ func (worker *EtcdWorker) applyPatches(ctx context.Context, patches []DataPatch)
 	return cerrors.ErrEtcdTryAgain.GenWithStackByArgs()
 }
 
+func (worker *EtcdWorker) applyBigTxnPatches(ctx context.Context, changeSet txnChangeSet) error {
+	newTxnKey := txnKeyFromOwnerID(worker.prefix, worker.clientID)
+	newTxn := &EtcdWorkerTxn{
+		StartPhysicalTs: time.Now(),
+		StartRevision:   worker.revision,
+		Committed:       false,
+	}
+	newTxnBytes, err := json.Marshal(newTxn)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	resp, err := worker.client.
+		Txn(ctx).
+		If(clientv3.Compare(clientv3.CreateRevision(newTxnKey.String()), "=", 0)).
+		Then(clientv3.OpPut(newTxnKey.String(), string(newTxnBytes), clientv3.WithLease(clientv3.LeaseID(worker.clientID)))).
+		Commit()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !resp.Succeeded {
+		log.Debug("Conflicting big txn by another EtcdWorker in the same process")
+		return cerrors.ErrEtcdTryAgain.FastGenByArgs()
+	}
+	needRemoveTxnKeyOnFailure := true
+	failpoint.Inject("etcdBigTxnFailAfterPutMeta", func() {
+		failpoint.Return(cerrors.ErrEtcdMockCrash.GenWithStackByArgs())
+	})
+	failpoint.Inject("etcdBigTxnPauseAfterPutMeta", func() {})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	txnRevision := resp.Header.Revision
+	defer func() {
+		if !needRemoveTxnKeyOnFailure {
+			return
+		}
+		resp, err := worker.client.Delete(ctx, newTxnKey.String())
+		if err != nil {
+			log.Warn("failed to clean up big txn entry", zap.Int64("owner-id", worker.clientID))
+			return
+		}
+		worker.barrierRev = resp.Header.Revision
+	}()
+
+	var undoLog []*bigTxnUndoLogEntry
+	defer func() {
+		for _, undoLogEntry := range undoLog {
+			resp, err := worker.client.Txn(ctx).If(undoLogEntry.Cmps()...).Then(undoLogEntry.Ops()...).Commit()
+			if err != nil {
+				log.Warn("Could not undo change", zap.Error(err))
+				return
+			}
+			if !resp.Succeeded {
+				log.Warn("Undo Txn failed", zap.Reflect("undo-log", undoLogEntry))
+			}
+		}
+	}()
+
+	changeSet.sort()
+
+	for _, change := range changeSet {
+		key := change.key
+		value := change.new
+		prev := change.old
+		var ops []clientv3.Op
+		if value != nil {
+			ops = append(ops, clientv3.OpPut(key.String(), string(value)))
+		} else {
+			ops = append(ops, clientv3.OpDelete(key.String()))
+		}
+
+		var cmp clientv3.Cmp
+		if prev != nil {
+			cmp = clientv3.Compare(clientv3.ModRevision(key.String()), "<", worker.revision+1)
+		} else {
+			cmp = clientv3.Compare(clientv3.ModRevision(key.String()), "=", 0)
+		}
+
+		lockKey := lockKeyFromDataKey(worker.prefix, key)
+		lock := &EtcdWorkerLock{
+			StartRevision: worker.revision,
+			OwnerID:       worker.clientID,
+		}
+		newLockBytes, err := json.Marshal(lock)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		ops = append(ops, clientv3.OpPut(lockKey.String(), string(newLockBytes)))
+
+		resp, err := worker.client.
+			Txn(ctx).
+			If(cmp, clientv3.Compare(clientv3.CreateRevision(lockKey.String()), "=", 0)).
+			Then(ops...).
+			Commit()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !resp.Succeeded {
+			return cerrors.ErrEtcdTryAgain.GenWithStackByArgs()
+		}
+		// Txn has been successfully committed
+		undoLog = append(undoLog, &bigTxnUndoLogEntry{
+			Key:      key,
+			LockKey:  lockKey,
+			PreValue: prev,
+			PostRev:  resp.Header.Revision,
+			IsDelete: value == nil,
+		})
+		failpoint.Inject("etcdBigTxnFailAfterPrewrite", func() {
+			failpoint.Return(cerrors.ErrEtcdMockCrash.GenWithStackByArgs())
+		})
+	}
+
+	failpoint.Inject("etcdBigTxnFailBeforeCommit", func() {
+		failpoint.Return(cerrors.ErrEtcdMockCrash.GenWithStackByArgs())
+	})
+	// Commit the Txn
+	newTxn.Committed = true
+	newTxnBytes, err = json.Marshal(newTxn)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	txnResp, err := worker.client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(newTxnKey.String()), "<", txnRevision+1)).
+		Then(clientv3.OpPut(newTxnKey.String(), string(newTxnBytes), clientv3.WithLease(clientv3.NoLease))).
+		Commit()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if txnResp.Succeeded {
+		log.Info("Committing big txn successful")
+		logEtcdChangeSet(changeSet, true)
+	} else {
+		log.Info("Failed to commit big txn", zap.Int64("owner-id", worker.clientID))
+		logEtcdChangeSet(changeSet, false)
+		return cerrors.ErrEtcdTryAgain.GenWithStackByArgs()
+	}
+
+	undoLog = nil
+
+	failpoint.Inject("etcdBigTxnFailAfterCommit", func() {
+		needRemoveTxnKeyOnFailure = false
+		failpoint.Return(cerrors.ErrEtcdMockCrash.GenWithStackByArgs())
+	})
+
+	// Clear the locks
+	for _, change := range changeSet {
+		key := change.key
+		relKey := key.RemovePrefix(&worker.prefix)
+		lockKey := worker.prefix.FullKey(util.NewEtcdRelKey(fmt.Sprintf("%s%s", etcdBigTxnLockPrefix, relKey.String())))
+		_, err := worker.client.Delete(ctx, lockKey.String())
+		if err != nil {
+			log.Warn("Could not clean lock", zap.Error(err))
+			needRemoveTxnKeyOnFailure = false
+		}
+	}
+
+	// txnKey will be deleted in the deferred function.
+	return nil
+}
+
 func (worker *EtcdWorker) applyUpdates() error {
 	for _, update := range worker.pendingUpdates {
 		err := worker.state.Update(update.key, update.value, false)
@@ -307,7 +614,8 @@ func logEtcdOps(ops []clientv3.Op, commited bool) {
 	if log.GetLevel() != zapcore.DebugLevel || len(ops) == 0 {
 		return
 	}
-	log.Debug("[etcd worker] ==========Update State to ETCD==========")
+	log.Debug("[etcd worker]" +
+		" ==========Update State to ETCD==========")
 	for _, op := range ops {
 		if op.IsDelete() {
 			log.Debug("[etcd worker] delete key", zap.ByteString("key", op.KeyBytes()))
@@ -316,6 +624,22 @@ func logEtcdOps(ops []clientv3.Op, commited bool) {
 		}
 	}
 	log.Debug("[etcd worker] ============State Commit=============", zap.Bool("committed", commited))
+}
+
+func logEtcdChangeSet(changeSet txnChangeSet, committed bool) {
+	if log.GetLevel() != zapcore.DebugLevel {
+		return
+	}
+	log.Debug("[etcd worker]" +
+		" ==========Update State to ETCD==========")
+	for _, change := range changeSet {
+		if change.new == nil {
+			log.Debug("[etcd worker] delete key", zap.ByteString("key", change.key.Bytes()))
+		} else {
+			log.Debug("[etcd worker] put key", zap.ByteString("key", change.key.Bytes()), zap.ByteString("value", change.new))
+		}
+	}
+	log.Debug("[etcd worker] ============State Commit=============", zap.Bool("committed", committed))
 }
 
 func (worker *EtcdWorker) cleanUp() {

--- a/pkg/orchestrator/etcd_worker_bank_test.go
+++ b/pkg/orchestrator/etcd_worker_bank_test.go
@@ -22,6 +22,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pingcap/failpoint"
+
+	"go.uber.org/zap/zapcore"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/log"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
@@ -121,6 +125,15 @@ func (b *bankReactor) Tick(ctx context.Context, state ReactorState) (nextState R
 
 func (s *etcdWorkerSuite) TestEtcdBank(c *check.C) {
 	defer testleak.AfterTest(c)()
+	c.Skip("skip bank for now")
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+
+	err := failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/injectForceUseBigTxn", "50%return(true)")
+	c.Assert(err, check.IsNil)
+	defer failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/injectForceUseBigTxn") //nolint:errcheck
+
 	totalAccountNumber := 25
 	workerNumber := 10
 	var wg sync.WaitGroup

--- a/pkg/orchestrator/etcd_worker_big_txn_test.go
+++ b/pkg/orchestrator/etcd_worker_big_txn_test.go
@@ -1,0 +1,481 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.etcd.io/etcd/clientv3/concurrency"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
+	cerrors "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/etcd"
+	"github.com/pingcap/ticdc/pkg/orchestrator/util"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"go.etcd.io/etcd/clientv3"
+	"go.uber.org/zap/zapcore"
+)
+
+var _ = check.SerialSuites(&etcdBigTxnSuite{})
+
+type etcdBigTxnSuite struct {
+}
+
+type bigTxnReactor struct {
+	state     *commonReactorState
+	tickCount int
+}
+
+const (
+	testBigTxnOpCount = 256
+)
+
+func (r *bigTxnReactor) Tick(ctx context.Context, state ReactorState) (nextState ReactorState, err error) {
+	r.state = state.(*commonReactorState)
+	if r.tickCount == 1 {
+		return r.state, cerrors.ErrReactorFinished.GenWithStackByArgs()
+	}
+	r.tickCount++
+	for i := 0; i < testBigTxnOpCount; i++ {
+		r.state.AppendPatch(util.NewEtcdKey(testEtcdKeyPrefix+"/big_txn/"+strconv.Itoa(i)), func(old []byte) (newValue []byte, changed bool, err error) {
+			return append(old, []byte("def")...), true, nil
+		})
+	}
+	return r.state, nil
+}
+
+func initKV(ctx context.Context, cli *etcd.Client) error {
+	for i := 0; i < testBigTxnOpCount; i++ {
+		_, err := cli.Put(ctx, testEtcdKeyPrefix+"/big_txn/"+strconv.Itoa(i), "abc")
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func assertNoLockRemains(ctx context.Context, cli *etcd.Client, c *check.C) {
+	resp, err := cli.Get(ctx, testEtcdKeyPrefix+"/big_txn"+etcdBigTxnLockPrefix, clientv3.WithPrefix())
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.Count, check.Equals, int64(0))
+
+	resp, err = cli.Get(ctx, testEtcdKeyPrefix+"/big_txn"+etcdBigTxnMetaPrefix, clientv3.WithPrefix())
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.Count, check.Equals, int64(0))
+}
+
+func assertRolledForward(ctx context.Context, cli *etcd.Client, c *check.C) {
+	for i := 0; i < testBigTxnOpCount; i++ {
+		resp, err := cli.Get(ctx, testEtcdKeyPrefix+"/big_txn/"+strconv.Itoa(i))
+		c.Assert(err, check.IsNil)
+		c.Assert(resp.Count, check.Equals, int64(1))
+		c.Assert(resp.Kvs[0].Value, check.BytesEquals, []byte("abcdef"))
+	}
+}
+
+func assertRolledBack(ctx context.Context, cli *etcd.Client, c *check.C) {
+	for i := 0; i < testBigTxnOpCount; i++ {
+		resp, err := cli.Get(ctx, testEtcdKeyPrefix+"/big_txn/"+strconv.Itoa(i))
+		c.Assert(err, check.IsNil)
+		c.Assert(resp.Count, check.Equals, int64(1))
+		c.Assert(resp.Kvs[0].Value, check.BytesEquals, []byte("abc"))
+	}
+}
+
+type noopReactor struct{}
+
+func (r *noopReactor) Tick(ctx context.Context, state ReactorState) (nextState ReactorState, err error) {
+	return state, nil
+}
+
+func mockCleanUpByOthers(ctx context.Context, cli *etcd.Client, c *check.C) {
+	defer cli.Unwrap().Close() //nolint:errcheck
+	err := failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/forceRollForwardByOthers", "return(true)")
+	c.Assert(err, check.IsNil)
+	defer failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/forceRollForwardByOthers") //nolint:errcheck
+
+	reactor, err := NewEtcdWorker(cli, testEtcdKeyPrefix+"/big_txn", &noopReactor{}, &commonReactorState{
+		state: map[string]string{},
+	})
+	c.Assert(err, check.IsNil)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*4)
+	defer cancel()
+	err = reactor.Run(ctx, nil, time.Millisecond*100)
+	c.Assert(err, check.ErrorMatches, ".*deadline.*")
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnBasic(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	err = reactor.Run(ctx, nil, time.Millisecond*100)
+	c.Assert(err, check.IsNil)
+
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledForward(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnErrorAfterPutMeta(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPutMeta", "return(true)")
+	c.Assert(err, check.IsNil)
+	defer failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPutMeta") //nolint:errcheck
+	err = reactor.Run(ctx, nil, time.Millisecond*100)
+	c.Assert(err, check.ErrorMatches, ".*ErrEtcdMockCrash.*")
+
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledBack(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnErrorAfterPrewrite(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPrewrite", "return(true)")
+	c.Assert(err, check.IsNil)
+	defer failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPrewrite") //nolint:errcheck
+	err = reactor.Run(ctx, nil, time.Millisecond*100)
+	c.Assert(err, check.ErrorMatches, ".*ErrEtcdMockCrash.*")
+
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledBack(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnErrorBeforeCommit(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailBeforeCommit", "return(true)")
+	c.Assert(err, check.IsNil)
+	defer failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailBeforeCommit") //nolint:errcheck
+	err = reactor.Run(ctx, nil, time.Millisecond*100)
+	c.Assert(err, check.ErrorMatches, ".*ErrEtcdMockCrash.*")
+
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledBack(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnErrorAfterCommit(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterCommit", "return(true)")
+	c.Assert(err, check.IsNil)
+	defer failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterCommit") //nolint:errcheck
+	err = reactor.Run(ctx, nil, time.Millisecond*100)
+	c.Assert(err, check.ErrorMatches, ".*ErrEtcdMockCrash.*")
+
+	mockCleanUpByOthers(ctx, newClient(), c)
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledForward(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnCrashAfterPutMeta(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	var wg sync.WaitGroup
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPutMeta", "1*pause")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPutMeta") //nolint:errcheck
+		wg.Wait()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := reactor.Run(ctx, nil, time.Millisecond*100)
+		c.Assert(err, check.ErrorMatches, ".*ErrEtcdMockCrash.*")
+	}()
+
+	time.Sleep(time.Second * 2)
+
+	mockCleanUpByOthers(ctx, newClient(), c)
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledBack(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnCrashAfterPrewrite(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	var wg sync.WaitGroup
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPrewrite", "1*pause")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailAfterPrewrite") //nolint:errcheck
+		wg.Wait()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := reactor.Run(ctx, nil, time.Millisecond*100)
+		c.Assert(err, check.ErrorMatches, ".*ErrEtcdMockCrash.*")
+	}()
+
+	time.Sleep(time.Second * 10)
+
+	mockCleanUpByOthers(ctx, newClient(), c)
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledBack(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnCrashBeforeCommit(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	initState := &commonReactorState{
+		state: make(map[string]string),
+	}
+	reactor, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, initState)
+	c.Assert(err, check.IsNil)
+
+	var wg sync.WaitGroup
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailBeforeCommit", "1*pause")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnFailBeforeCommit") //nolint:errcheck
+		wg.Wait()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := reactor.Run(ctx, nil, time.Millisecond*100)
+		c.Assert(err, check.ErrorMatches, ".*ErrEtcdMockCrash.*")
+	}()
+
+	time.Sleep(time.Second * 20)
+
+	mockCleanUpByOthers(ctx, newClient(), c)
+	assertNoLockRemains(ctx, cli, c)
+	assertRolledBack(ctx, cli, c)
+}
+
+func (s *etcdBigTxnSuite) TestBigTxnConflictWithSameClient(c *check.C) {
+	defer testleak.AfterTest(c)()
+	log.SetLevel(zapcore.DebugLevel)
+	defer log.SetLevel(zapcore.InfoLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	newClient, closer := setUpTest(c)
+	defer closer()
+
+	cli := newClient()
+	defer cli.Unwrap().Close()
+
+	err := initKV(ctx, cli)
+	c.Assert(err, check.IsNil)
+
+	prefix := testEtcdKeyPrefix + "/big_txn"
+	worker1, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, &commonReactorState{
+		state: make(map[string]string),
+	})
+	c.Assert(err, check.IsNil)
+
+	worker2, err := NewEtcdWorker(cli, prefix, &bigTxnReactor{}, &commonReactorState{
+		state: make(map[string]string),
+	})
+	c.Assert(err, check.IsNil)
+
+	err = failpoint.Enable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnPauseAfterPutMeta", "2*sleep(1000)")
+	c.Assert(err, check.IsNil)
+	defer failpoint.Disable("github.com/pingcap/ticdc/pkg/orchestrator/etcdBigTxnPauseAfterPutMeta") //nolint:errcheck
+
+	session, err := concurrency.NewSession(cli.Unwrap())
+	c.Assert(err, check.IsNil)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		err := worker1.Run(ctx, session, time.Millisecond*100)
+		c.Assert(err, check.IsNil)
+	}()
+
+	go func() {
+		defer wg.Done()
+		err := worker2.Run(ctx, session, time.Millisecond*100)
+		c.Assert(err, check.IsNil)
+	}()
+
+	wg.Wait()
+
+	assertNoLockRemains(ctx, cli, c)
+
+	for i := 0; i < testBigTxnOpCount; i++ {
+		resp, err := cli.Get(ctx, testEtcdKeyPrefix+"/big_txn/"+strconv.Itoa(i))
+		c.Assert(err, check.IsNil)
+		c.Assert(resp.Count, check.Equals, int64(1))
+		c.Assert(resp.Kvs[0].Value, check.BytesEquals, []byte("abcdefdef"))
+	}
+}

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -41,7 +41,9 @@ const (
 	totalTicksPerReactor = 1000
 )
 
-func Test(t *testing.T) { check.TestingT(t) }
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
 
 var _ = check.Suite(&etcdWorkerSuite{})
 
@@ -81,7 +83,7 @@ func (s *simpleReactor) Tick(_ context.Context, state ReactorState) (nextState R
 			}
 		}
 		if sum != expectedSum {
-			log.Panic("state is inconsistent", zap.Int("expected-sum", sum), zap.Int("actual-sum", s.state.sum))
+			log.Panic("state is inconsistent", zap.Int("expected-sum", expectedSum), zap.Int("actual-sum", sum))
 		}
 
 		s.state.SetSum(sum)
@@ -497,7 +499,7 @@ func (s *etcdWorkerSuite) TestCover(c *check.C) {
 		state: make(map[string]string),
 	})
 	c.Assert(err, check.IsNil)
-	err = reactor.Run(ctx, nil, 10*time.Millisecond)
+	err = reactor.Run(ctx, nil, 100*time.Millisecond)
 	c.Assert(err, check.IsNil)
 	resp, err := cli.Get(ctx, prefix+"/key1")
 	c.Assert(err, check.IsNil)

--- a/pkg/orchestrator/reactor_state_tester.go
+++ b/pkg/orchestrator/reactor_state_tester.go
@@ -16,8 +16,10 @@ package orchestrator
 import (
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/orchestrator/util"
+	"go.uber.org/zap"
 )
 
 // ReactorStateTester is a helper struct for unit-testing an implementer of ReactorState
@@ -105,7 +107,11 @@ RetryLoop:
 
 // MustApplyPatches calls ApplyPatches and must successfully
 func (t *ReactorStateTester) MustApplyPatches() {
-	t.c.Assert(t.ApplyPatches(), check.IsNil)
+	err := t.ApplyPatches()
+	if err != nil {
+		log.Error("error!", zap.Error(err))
+	}
+	t.c.Assert(err, check.IsNil)
 }
 
 // MustUpdate calls Update and must successfully

--- a/tests/processor_stop_delay_2/run.sh
+++ b/tests/processor_stop_delay_2/run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+TABLE_COUNT=3
+
+function check_position_removed() {
+    pd=$1
+    position=$(cdc cli unsafe show-metadata --pd=$pd | grep "position")
+    cdc cli unsafe show-metadata --pd=$pd
+    echo "AAposition: $position"
+    echo "AAposition: ${#position}"
+    if [[ ! "${#position}" -eq "0" ]]; then
+        echo "position: $position"
+        exit 1
+    fi
+}
+
+function check_changefeed_state() {
+    pd_addr=$1
+    changefeed_id=$2
+    expected=$3
+    state=$(cdc cli --pd=$pd_addr changefeed query -s -c $changefeed_id|jq -r ".state")
+    if [[ "$state" != "$expected" ]];then
+        echo "unexpected state $state, expected $expected"
+        exit 1
+    fi
+}
+
+export -f check_position_removed
+export -f check_changefeed_state
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+    TOPIC_NAME="ticdc-processor-stop-delay-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"
+    fi
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/ProcessorDDLPullerExitDelaying=sleep(2000);github.com/pingcap/ticdc/cdc/ProcessorUpdatePositionDelaying=sleep(2000)' # old processor
+    # this case should be skipped when new processor enabled
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
+    changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+    run_sql "CREATE DATABASE processor_stop_delay_2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table processor_stop_delay_2.t (id int primary key auto_increment, t datetime DEFAULT CURRENT_TIMESTAMP)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO processor_stop_delay_2.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    check_table_exists "processor_stop_delay_2.t" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    # pause changefeed first, and then resume the changefeed. The processor stop
+    # logic will be delayed by 10s, which is controlled by failpoint injection.
+    # The changefeed should be resumed and no data loss.
+    cdc cli changefeed pause --changefeed-id=$changefeed_id --pd=$pd_addr
+    ensure 10 check_position_removed $pd_addr
+    ensure 10 check_changefeed_state $pd_addr $changefeed_id "stopped"
+    run_sql "INSERT INTO processor_stop_delay_2.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr
+    run_sql "INSERT INTO processor_stop_delay_2.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    export GO_FAILPOINTS=''
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- A native Etcd transactions can only hold up to 128 operations. Even if the parameter can be adjusted, it would cause performance degradation in the whole Etcd cluster.
- We need Etcd transactions to make sure that the owner knows, at every instance, which tables are taken into consideration when each capture calculates its own checkpoint-ts, to prevent data loss.

### What is changed and how it works?
- Emulate transactions in EtcdWorker with a prewrite-commit protocol.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility


### Release note

- No release note

