### PR TITLE
kv/client: don't resolve lock immediately after a region is initialized

### DIFF
--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -249,6 +249,9 @@ func (w *regionWorker) handleSingleRegionError(ctx context.Context, err error, s
 }
 
 func (w *regionWorker) resolveLock(ctx context.Context) error {
+	// tikv resolved update interval is 1s, use half of the resolck lock interval
+	// as lock penalty.
+	resolveLockPenalty := 10
 	resolveLockInterval := 20 * time.Second
 	failpoint.Inject("kvClientResolveLockInterval", func(val failpoint.Value) {
 		resolveLockInterval = time.Duration(val.(int)) * time.Second
@@ -303,6 +306,17 @@ func (w *regionWorker) resolveLock(ctx context.Context) error {
 						log.Warn("kv client reconnect triggered",
 							zap.Duration("duration", sinceLastResolvedTs), zap.Duration("since last event", sinceLastResolvedTs))
 						return errReconnect
+					}
+					// Only resolve lock if the resovled-ts keeps unchanged for
+					// more than resolveLockPenalty times.
+					if rts.ts.penalty < resolveLockPenalty {
+						if lastResolvedTs > rts.ts.resolvedTs {
+							rts.ts.resolvedTs = lastResolvedTs
+							rts.ts.eventTime = time.Now()
+							rts.ts.penalty = 0
+						}
+						w.rtsManager.Upsert(rts)
+						continue
 					}
 					log.Warn("region not receiving resolved event from tikv or resolved ts is not pushing for too long time, try to resolve lock",
 						zap.Uint64("regionID", rts.regionID),
@@ -586,13 +600,6 @@ func (w *regionWorker) handleEventEntry(
 			}
 			w.metrics.metricPullEventInitializedCounter.Inc()
 
-			select {
-			case w.rtsUpdateCh <- &regionTsInfo{regionID: regionID, ts: newResolvedTsItem(state.sri.ts)}:
-			default:
-				// rtsUpdateCh block often means too many regions are suffering
-				// lock resolve, the kv client status is not very healthy.
-				log.Warn("region is not upsert into rts manager", zap.Uint64("region-id", regionID))
-			}
 			state.initialized = true
 			w.session.regionRouter.Release(state.sri.rpcCtx.Addr)
 			cachedEvents := state.matcher.matchCachedRow()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #2188

### What is changed and how it works?

Introduce a penalty mechanism
- If TiCDC keeps receiving unchanged resolved-ts, increase the penalty. 
- If TiCDC receives a new resolved ts, reset the penalty to zero
- Only resolve ts if the penalty is larger than threshold


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Don't resolve lock immediately after a region is initialized.
