### PR TITLE
sink: fix concurrent map access in sink manager

### DIFF
--- a/cdc/sink/manager.go
+++ b/cdc/sink/manager.go
@@ -58,6 +58,8 @@ func NewManager(ctx context.Context, backendSink Sink, errCh chan error, checkpo
 
 // CreateTableSink creates a table sink
 func (m *Manager) CreateTableSink(tableID model.TableID, checkpointTs model.Ts) Sink {
+	m.tableSinksMu.Lock()
+	defer m.tableSinksMu.Unlock()
 	if _, exist := m.tableSinks[tableID]; exist {
 		log.Panic("the table sink already exists", zap.Uint64("tableID", uint64(tableID)))
 	}
@@ -67,8 +69,6 @@ func (m *Manager) CreateTableSink(tableID model.TableID, checkpointTs model.Ts) 
 		buffer:    make([]*model.RowChangedEvent, 0, 128),
 		emittedTs: checkpointTs,
 	}
-	m.tableSinksMu.Lock()
-	defer m.tableSinksMu.Unlock()
 	m.tableSinks[tableID] = sink
 	return sink
 }

--- a/cdc/sink/manager_test.go
+++ b/cdc/sink/manager_test.go
@@ -100,7 +100,6 @@ func (s *managerSuite) TestManagerRandom(c *check.C) {
 		}()
 	}
 	wg.Wait()
-	wg = sync.WaitGroup{}
 	for i := 0; i < goroutineNum; i++ {
 		i := i
 		tableSink := tableSinks[i]

--- a/cdc/sink/manager_test.go
+++ b/cdc/sink/manager_test.go
@@ -92,8 +92,15 @@ func (s *managerSuite) TestManagerRandom(c *check.C) {
 	var wg sync.WaitGroup
 	tableSinks := make([]Sink, goroutineNum)
 	for i := 0; i < goroutineNum; i++ {
-		tableSinks[i] = manager.CreateTableSink(model.TableID(i), 0)
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tableSinks[i] = manager.CreateTableSink(model.TableID(i), 0)
+		}()
 	}
+	wg.Wait()
+	wg = sync.WaitGroup{}
 	for i := 0; i < goroutineNum; i++ {
 		i := i
 		tableSink := tableSinks[i]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- There is an unsynchronized access to a shared map, which can cause runtime panic.

### What is changed and how it works?
- Lock it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note

- Fix minor runtime panic risk
