### PR TITLE
new_collation: enable old_value

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -151,7 +151,8 @@ func NewMounter(schemaStorage SchemaStorage, workerNum int, enableOldValue bool)
 		schemaStorage:    schemaStorage,
 		rawRowChangedChs: chs,
 		workerNum:        workerNum,
-		//enableOldValue:   enableOldValue,
+		// TODO: this field enableOldValue is only temporarily set to true.
+		//  It needs to be changed according to the new_collation_enable field of mysql.tidb in the upstream cluster.
 		enableOldValue: true,
 	}
 }

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -151,7 +151,8 @@ func NewMounter(schemaStorage SchemaStorage, workerNum int, enableOldValue bool)
 		schemaStorage:    schemaStorage,
 		rawRowChangedChs: chs,
 		workerNum:        workerNum,
-		enableOldValue:   enableOldValue,
+		//enableOldValue:   enableOldValue,
+		enableOldValue: true,
 	}
 }
 
@@ -245,6 +246,7 @@ func (m *mounterImpl) unmarshalAndMountRowChanged(ctx context.Context, raw *mode
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	row, err := func() (*model.RowChangedEvent, error) {
 		if snap.IsIneligibleTableID(physicalTableID) {
 			log.Debug("skip the DML of ineligible table", zap.Uint64("ts", raw.CRTs), zap.Int64("tableID", physicalTableID))

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -119,13 +119,14 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 
 	lockresolver := txnutil.NewLockerResolver(p.kvStorage)
 
+	// TODO: this variable enableOldValue is only temporarily set to true.
+	//  It needs to be changed according to the new_collation_enable field of mysql.tidb in the upstream cluster.
 	enableOldValue := true
 	for _, span := range p.spans {
 		span := span
 
 		g.Go(func() error {
 			return p.kvCli.EventFeed(ctx, span, checkpointTs, enableOldValue, lockresolver, p, eventCh)
-			//return p.kvCli.EventFeed(ctx, span, checkpointTs, p.enableOldValue, lockresolver, p, eventCh)
 		})
 	}
 

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -118,11 +118,14 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 	eventCh := make(chan *model.RegionFeedEvent, defaultPullerEventChanSize)
 
 	lockresolver := txnutil.NewLockerResolver(p.kvStorage)
+
+	enableOldValue := true
 	for _, span := range p.spans {
 		span := span
 
 		g.Go(func() error {
-			return p.kvCli.EventFeed(ctx, span, checkpointTs, p.enableOldValue, lockresolver, p, eventCh)
+			return p.kvCli.EventFeed(ctx, span, checkpointTs, enableOldValue, lockresolver, p, eventCh)
+			//return p.kvCli.EventFeed(ctx, span, checkpointTs, p.enableOldValue, lockresolver, p, eventCh)
 		})
 	}
 

--- a/cdc/sink/manager.go
+++ b/cdc/sink/manager.go
@@ -15,6 +15,7 @@ package sink
 
 import (
 	"context"
+	"github.com/pingcap/ticdc/pkg/config"
 	"math"
 	"sort"
 	"sync"
@@ -230,6 +231,15 @@ func (b *bufferSink) run(ctx context.Context, errCh chan error) {
 				continue
 			}
 			start := time.Now()
+			for i := 0; i<len(e.rows); i++{
+				if !config.GetDefaultReplicaConfig().EnableOldValue{
+					if e.rows[i].Columns == nil && len(e.rows[i].PreColumns) == 2{
+						e.rows[i].PreColumns[1] = nil
+					}else{
+						e.rows[i].PreColumns = nil
+					}
+				}
+			}
 			err := b.Sink.EmitRowChangedEvents(ctx, e.rows...)
 			if err != nil {
 				if errors.Cause(err) != context.Canceled {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,7 +43,7 @@ func init() {
 
 var defaultReplicaConfig = &ReplicaConfig{
 	CaseSensitive:    true,
-	EnableOldValue:   false,
+	EnableOldValue:   true,
 	CheckGCSafePoint: true,
 	Filter: &FilterConfig{
 		Rules: []string{"*.*"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,7 +43,7 @@ func init() {
 
 var defaultReplicaConfig = &ReplicaConfig{
 	CaseSensitive:    true,
-	EnableOldValue:   true,
+	EnableOldValue:   false,
 	CheckGCSafePoint: true,
 	Filter: &FilterConfig{
 		Rules: []string{"*.*"},
@@ -161,8 +161,8 @@ type LogConfig struct {
 var defaultServerConfig = &ServerConfig{
 	Addr:          "127.0.0.1:8300",
 	AdvertiseAddr: "",
-	LogFile:       "",
-	LogLevel:      "info",
+	LogFile:       "./ticdc.log",
+	LogLevel:      "debug",
 	Log: &LogConfig{
 		File: &LogFileConfig{
 			MaxSize:    300,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
By setting enableOldValue to true, the data can be correctly synchronized when open NEW_COLLATION regardless of configuration.
This method is only a temporary solution.

### What is changed and how it works?
- set enableOldValue to true
- modify sink manager to remove excess data

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

- No release note
