### PR TITLE
puller,mounter,processor: always pull the old value internally

### DIFF
--- a/cdc/entry/codec.go
+++ b/cdc/entry/codec.go
@@ -31,7 +31,6 @@ import (
 var (
 	tablePrefix  = []byte{'t'}
 	recordPrefix = []byte("_r")
-	indexPrefix  = []byte("_i")
 	metaPrefix   = []byte("m")
 )
 
@@ -39,11 +38,9 @@ var (
 	intLen            = 8
 	tablePrefixLen    = len(tablePrefix)
 	recordPrefixLen   = len(recordPrefix)
-	indexPrefixLen    = len(indexPrefix)
 	metaPrefixLen     = len(metaPrefix)
 	prefixTableIDLen  = tablePrefixLen + intLen  /*tableID*/
 	prefixRecordIDLen = recordPrefixLen + intLen /*recordID*/
-	prefixIndexLen    = indexPrefixLen + intLen  /*indexID*/
 )
 
 // MetaType is for data structure meta/data flag.
@@ -116,22 +113,6 @@ func decodeRecordID(key []byte) (rest []byte, recordID int64, err error) {
 	rest, recordID, err = codec.DecodeInt(key)
 	if err != nil {
 		return nil, 0, cerror.WrapError(cerror.ErrCodecDecode, err)
-	}
-	return
-}
-
-func decodeIndexKey(key []byte) (indexID int64, indexValue []types.Datum, err error) {
-	if len(key) < prefixIndexLen || !bytes.HasPrefix(key, indexPrefix) {
-		return 0, nil, cerror.ErrInvalidRecordKey.GenWithStackByArgs(key)
-	}
-	key = key[indexPrefixLen:]
-	key, indexID, err = codec.DecodeInt(key)
-	if err != nil {
-		return 0, nil, cerror.WrapError(cerror.ErrCodecDecode, err)
-	}
-	indexValue, err = codec.Decode(key, 2)
-	if err != nil {
-		return 0, nil, cerror.WrapError(cerror.ErrCodecDecode, err)
 	}
 	return
 }

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -331,15 +331,6 @@ func datum2Column(tableInfo *model.TableInfo, datums map[int64]types.Datum, fill
 }
 
 func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntry, dataSize int64) (*model.RowChangedEvent, error) {
-	// if m.enableOldValue == true, go into this function
-	// if m.enableNewValue == false and row.Delete == false, go into this function
-	// if m.enableNewValue == false and row.Delete == true and use explict row id, go into this function
-	// only if m.enableNewValue == false and row.Delete == true and use implicit row id(_tidb_rowid), skip this function
-	useImplicitTiDBRowID := !tableInfo.PKIsHandle && !tableInfo.IsCommonHandle
-	if !m.enableOldValue && row.Delete && useImplicitTiDBRowID {
-		return nil, nil
-	}
-
 	var err error
 	// Decode previous columns.
 	var preCols []*model.Column

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -454,12 +454,28 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntr
 	var err error
 	// Decode previous columns.
 	var preCols []*model.Column
-	if row.PreRowExist {
+	// Since we now always use old value internally,
+	// we need to control the output(sink will use the PreColumns field to determine whether to output old value).
+	// Normally old value is output when only enableOldValue is on,
+	// but for the Delete event, when the old value feature is off,
+	// the HandleKey column needs to be included as well. So we need to do the following filtering.
+	if (row.PreRowExist && m.enableOldValue) || (row.PreRowExist && row.Delete) {
 		// FIXME(leoppro): using pre table info to mounter pre column datum
 		// the pre column and current column in one event may using different table info
 		preCols, err = datum2Column(tableInfo, row.PreRow, m.enableOldValue)
 		if err != nil {
 			return nil, errors.Trace(err)
+		}
+
+		// NOTICE: When the old Value feature is off,
+		// the Delete event only needs to keep the handle key column.
+		if row.Delete && !m.enableOldValue {
+			for i, _ := range preCols {
+				col := preCols[i]
+				if col.Flag.IsHandleKey() {
+					preCols[i] = nil
+				}
+			}
 		}
 	}
 

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -375,7 +375,8 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntr
 	}
 
 	var tableInfoVersion uint64
-	if row.Delete {
+	//
+	if row.Delete && !m.enableOldValue {
 		tableInfoVersion = 0
 	} else {
 		tableInfoVersion = tableInfo.TableInfoVersion

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -375,7 +375,7 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntr
 	}
 
 	var tableInfoVersion uint64
-	//
+	// Align with the old format if old value disabled.
 	if row.Delete && !m.enableOldValue {
 		tableInfoVersion = 0
 	} else {

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -16,7 +16,6 @@ package entry
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -62,66 +61,6 @@ type rowKVEntry struct {
 	// or row data that does not contain any Datum.
 	RowExist    bool
 	PreRowExist bool
-}
-
-type indexKVEntry struct {
-	baseKVEntry
-	IndexID    int64
-	IndexValue []types.Datum
-}
-
-func (idx *indexKVEntry) unflatten(tableInfo *model.TableInfo, tz *time.Location) error {
-	if tableInfo.ID != idx.PhysicalTableID {
-		isPartition := false
-		if pi := tableInfo.GetPartitionInfo(); pi != nil {
-			for _, p := range pi.Definitions {
-				if p.ID == idx.PhysicalTableID {
-					isPartition = true
-					break
-				}
-			}
-		}
-		if !isPartition {
-			return cerror.ErrWrongTableInfo.GenWithStackByArgs(tableInfo.ID, idx.PhysicalTableID)
-		}
-	}
-	index, exist := tableInfo.GetIndexInfo(idx.IndexID)
-	if !exist {
-		return cerror.ErrIndexKeyTableNotFound.GenWithStackByArgs(idx.IndexID)
-	}
-	if !isDistinct(index, idx.IndexValue) {
-		idx.RecordID = idx.baseKVEntry.RecordID
-		if idx.baseKVEntry.RecordID.IsInt() {
-			idx.IndexValue = idx.IndexValue[:len(idx.IndexValue)-1]
-		} else {
-			idx.IndexValue = idx.IndexValue[:len(idx.IndexValue)-idx.RecordID.NumCols()]
-		}
-	}
-	for i, v := range idx.IndexValue {
-		colOffset := index.Columns[i].Offset
-		fieldType := &tableInfo.Columns[colOffset].FieldType
-		datum, err := unflatten(v, fieldType, tz)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		idx.IndexValue[i] = datum
-	}
-	return nil
-}
-
-func isDistinct(index *timodel.IndexInfo, indexValue []types.Datum) bool {
-	if index.Primary {
-		return true
-	}
-	if index.Unique {
-		for _, value := range indexValue {
-			if value.IsNull() {
-				return false
-			}
-		}
-		return true
-	}
-	return false
 }
 
 // Mounter is used to parse SQL events from KV events
@@ -258,8 +197,7 @@ func (m *mounterImpl) unmarshalAndMountRowChanged(ctx context.Context, raw *mode
 			}
 			return nil, cerror.ErrSnapshotTableNotFound.GenWithStackByArgs(physicalTableID)
 		}
-		switch {
-		case bytes.HasPrefix(key, recordPrefix):
+		if bytes.HasPrefix(key, recordPrefix) {
 			rowKV, err := m.unmarshalRowKVEntry(tableInfo, raw.Key, raw.Value, raw.OldValue, baseInfo)
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -268,15 +206,6 @@ func (m *mounterImpl) unmarshalAndMountRowChanged(ctx context.Context, raw *mode
 				return nil, nil
 			}
 			return m.mountRowKVEntry(tableInfo, rowKV, raw.ApproximateSize())
-		case bytes.HasPrefix(key, indexPrefix):
-			indexKV, err := m.unmarshalIndexKVEntry(key, raw.Value, raw.OldValue, baseInfo)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if indexKV == nil {
-				return nil, nil
-			}
-			return m.mountIndexKVEntry(tableInfo, indexKV, raw.ApproximateSize())
 		}
 		return nil, nil
 	}()
@@ -328,46 +257,6 @@ func (m *mounterImpl) unmarshalRowKVEntry(tableInfo *model.TableInfo, rawKey []b
 		PreRow:      preRow,
 		RowExist:    rowExist,
 		PreRowExist: preRowExist,
-	}, nil
-}
-
-func (m *mounterImpl) unmarshalIndexKVEntry(restKey []byte, rawValue []byte, rawOldValue []byte, base baseKVEntry) (*indexKVEntry, error) {
-	// Skip set index KV.
-	// By default we cannot get the old value of a deleted row, then we must get the value of unique key
-	// or primary key for seeking the deleted row through its index key.
-	// After the old value was enabled, we can skip the index key.
-	if !base.Delete || m.enableOldValue {
-		return nil, nil
-	}
-
-	indexID, indexValue, err := decodeIndexKey(restKey)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var handle kv.Handle
-
-	if len(rawValue) == 8 {
-		// primary key or unique index
-		var recordID int64
-		buf := bytes.NewBuffer(rawValue)
-		err = binary.Read(buf, binary.BigEndian, &recordID)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		handle = kv.IntHandle(recordID)
-	} else if len(rawValue) > 0 && rawValue[0] == tablecodec.CommonHandleFlag {
-		handleLen := uint16(rawValue[1])<<8 + uint16(rawValue[2])
-		handleEndOff := 3 + handleLen
-		handle, err = kv.NewCommonHandle(rawValue[3:handleEndOff])
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	base.RecordID = handle
-	return &indexKVEntry{
-		baseKVEntry: base,
-		IndexID:     indexID,
-		IndexValue:  indexValue,
 	}, nil
 }
 
@@ -505,68 +394,6 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntr
 			IsPartition: tableInfo.GetPartitionInfo() != nil,
 		},
 		Columns:         cols,
-		PreColumns:      preCols,
-		IndexColumns:    tableInfo.IndexColumnsOffset,
-		ApproximateSize: dataSize,
-	}, nil
-}
-
-func (m *mounterImpl) mountIndexKVEntry(tableInfo *model.TableInfo, idx *indexKVEntry, dataSize int64) (*model.RowChangedEvent, error) {
-	// skip set index KV
-	if !idx.Delete || m.enableOldValue {
-		return nil, nil
-	}
-	// skip any index that is not the handle
-	if idx.IndexID != tableInfo.HandleIndexID {
-		return nil, nil
-	}
-
-	indexInfo, exist := tableInfo.GetIndexInfo(idx.IndexID)
-	if !exist {
-		log.Warn("index info not found", zap.Int64("indexID", idx.IndexID))
-		return nil, nil
-	}
-
-	if !tableInfo.IsIndexUnique(indexInfo) {
-		return nil, nil
-	}
-
-	err := idx.unflatten(tableInfo, m.tz)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	preCols := make([]*model.Column, len(tableInfo.RowColumnsOffset))
-	for i, idxCol := range indexInfo.Columns {
-		colInfo := tableInfo.Columns[idxCol.Offset]
-		value, warn, err := formatColVal(idx.IndexValue[i], colInfo.Tp)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if warn != "" {
-			log.Warn(warn, zap.String("table", tableInfo.TableName.String()), zap.String("column", colInfo.Name.String()))
-		}
-		preCols[tableInfo.RowColumnsOffset[colInfo.ID]] = &model.Column{
-			Name:  colInfo.Name.O,
-			Type:  colInfo.Tp,
-			Value: value,
-			Flag:  tableInfo.ColumnsFlag[colInfo.ID],
-		}
-	}
-	var intRowID int64
-	if idx.RecordID != nil && idx.RecordID.IsInt() {
-		intRowID = idx.RecordID.IntValue()
-	}
-	return &model.RowChangedEvent{
-		StartTs:  idx.StartTs,
-		CommitTs: idx.CRTs,
-		RowID:    intRowID,
-		Table: &model.TableName{
-			Schema:      tableInfo.TableName.Schema,
-			Table:       tableInfo.TableName.Table,
-			TableID:     idx.PhysicalTableID,
-			IsPartition: tableInfo.GetPartitionInfo() != nil,
-		},
 		PreColumns:      preCols,
 		IndexColumns:    tableInfo.IndexColumnsOffset,
 		ApproximateSize: dataSize,

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -472,7 +472,7 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntr
 		if row.Delete && !m.enableOldValue {
 			for i := range preCols {
 				col := preCols[i]
-				if col.Flag.IsHandleKey() {
+				if !col.Flag.IsHandleKey() {
 					preCols[i] = nil
 				}
 			}

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -470,7 +470,7 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntr
 		// NOTICE: When the old Value feature is off,
 		// the Delete event only needs to keep the handle key column.
 		if row.Delete && !m.enableOldValue {
-			for i, _ := range preCols {
+			for i := range preCols {
 				col := preCols[i]
 				if col.Flag.IsHandleKey() {
 					preCols[i] = nil

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -472,7 +472,7 @@ func (m *mounterImpl) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntr
 		if row.Delete && !m.enableOldValue {
 			for i := range preCols {
 				col := preCols[i]
-				if !col.Flag.IsHandleKey() {
+				if col != nil && !col.Flag.IsHandleKey() {
 					preCols[i] = nil
 				}
 			}

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -385,7 +385,7 @@ func walkTableSpanInStore(c *check.C, store tidbkv.Storage, tableID int64, f fun
 	txn, err := store.Begin()
 	c.Assert(err, check.IsNil)
 	defer txn.Rollback() //nolint:errcheck
-	tableSpan := regionspan.GetTableSpan(tableID, false)
+	tableSpan := regionspan.GetTableSpan(tableID)
 	kvIter, err := txn.Iter(tableSpan.Start, tableSpan.End)
 	c.Assert(err, check.IsNil)
 	defer kvIter.Close()

--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -83,16 +83,3 @@ func (e *PolymorphicEvent) WaitPrepare(ctx context.Context) error {
 	}
 	return nil
 }
-
-// Clone returns a deep-clone of the struct.
-func (e *PolymorphicEvent) Clone() *PolymorphicEvent {
-	clone := *e
-
-	row := *e.Row
-	clone.Row = &row
-
-	rowKV := *e.RawKV
-	clone.RawKV = &rowKV
-
-	return &clone
-}

--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -83,3 +83,16 @@ func (e *PolymorphicEvent) WaitPrepare(ctx context.Context) error {
 	}
 	return nil
 }
+
+// Clone returns a deep-clone of the struct.
+func (e *PolymorphicEvent) Clone() *PolymorphicEvent {
+	clone := *e
+
+	row := *e.Row
+	clone.Row = &row
+
+	rowKV := *e.RawKV
+	clone.RawKV = &rowKV
+
+	return &clone
+}

--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -143,6 +143,8 @@ func WrapTableInfo(schemaID int64, schemaName string, version uint64, info *mode
 	return ti
 }
 
+// TODO(hi-rustin): After we don't need to subscribe index update,
+// findHandleIndex may be not necessary any more.
 func (ti *TableInfo) findHandleIndex() {
 	if ti.HandleIndexID == HandleIndexPKIsHandle {
 		// pk is handle

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -811,8 +811,7 @@ func (p *oldProcessor) addTable(ctx context.Context, tableID int64, replicaInfo 
 
 	startPuller := func(tableID model.TableID, pResolvedTs *uint64, pCheckpointTs *uint64) sink.Sink {
 		// start table puller
-		enableOldValue := p.changefeed.Config.EnableOldValue
-		span := regionspan.GetTableSpan(tableID, enableOldValue)
+		span := regionspan.GetTableSpan(tableID, true)
 		kvStorage, err := util.KVStorageFromCtx(ctx)
 		if err != nil {
 			p.sendError(err)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -820,7 +820,7 @@ func (p *oldProcessor) addTable(ctx context.Context, tableID int64, replicaInfo 
 		}
 		plr := puller.NewPuller(ctx, p.pdCli, p.credential, kvStorage,
 			replicaInfo.StartTs, []regionspan.Span{span}, p.limitter,
-			enableOldValue)
+			true)
 		go func() {
 			err := plr.Run(ctx)
 			if errors.Cause(err) != context.Canceled {

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -811,7 +811,7 @@ func (p *oldProcessor) addTable(ctx context.Context, tableID int64, replicaInfo 
 
 	startPuller := func(tableID model.TableID, pResolvedTs *uint64, pCheckpointTs *uint64) sink.Sink {
 		// start table puller
-		span := regionspan.GetTableSpan(tableID, true)
+		span := regionspan.GetTableSpan(tableID)
 		kvStorage, err := util.KVStorageFromCtx(ctx)
 		if err != nil {
 			p.sendError(err)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -818,6 +818,8 @@ func (p *oldProcessor) addTable(ctx context.Context, tableID int64, replicaInfo 
 			p.sendError(err)
 			return nil
 		}
+		// NOTICE: always pull the old value internally
+		// See also: TODO(hi-rustin): add issue link here.
 		plr := puller.NewPuller(ctx, p.pdCli, p.credential, kvStorage,
 			replicaInfo.StartTs, []regionspan.Span{span}, p.limitter,
 			true)

--- a/cdc/processor/pipeline/puller.go
+++ b/cdc/processor/pipeline/puller.go
@@ -65,12 +65,11 @@ func (n *pullerNode) tableSpan(ctx cdcContext.Context) []regionspan.Span {
 func (n *pullerNode) Init(ctx pipeline.NodeContext) error {
 	metricTableResolvedTsGauge := tableResolvedTsGauge.WithLabelValues(ctx.ChangefeedVars().ID, ctx.GlobalVars().CaptureInfo.AdvertiseAddr, n.tableName)
 	globalConfig := config.GetGlobalServerConfig()
-	config := ctx.ChangefeedVars().Info.Config
 	ctxC, cancel := context.WithCancel(ctx)
 	ctxC = util.PutTableInfoInCtx(ctxC, n.tableID, n.tableName)
 	ctxC = util.PutChangefeedIDInCtx(ctxC, ctx.ChangefeedVars().ID)
 	plr := puller.NewPuller(ctxC, ctx.GlobalVars().PDClient, globalConfig.Security, ctx.GlobalVars().KVStorage,
-		n.replicaInfo.StartTs, n.tableSpan(ctx), n.limitter, config.EnableOldValue)
+		n.replicaInfo.StartTs, n.tableSpan(ctx), n.limitter, true)
 	n.wg.Go(func() error {
 		ctx.Throw(errors.Trace(plr.Run(ctxC)))
 		return nil

--- a/cdc/processor/pipeline/puller.go
+++ b/cdc/processor/pipeline/puller.go
@@ -68,6 +68,8 @@ func (n *pullerNode) Init(ctx pipeline.NodeContext) error {
 	ctxC, cancel := context.WithCancel(ctx)
 	ctxC = util.PutTableInfoInCtx(ctxC, n.tableID, n.tableName)
 	ctxC = util.PutChangefeedIDInCtx(ctxC, ctx.ChangefeedVars().ID)
+	// NOTICE: always pull the old value internally
+	// See also: TODO(hi-rustin): add issue link here.
 	plr := puller.NewPuller(ctxC, ctx.GlobalVars().PDClient, globalConfig.Security, ctx.GlobalVars().KVStorage,
 		n.replicaInfo.StartTs, n.tableSpan(ctx), n.limitter, true)
 	n.wg.Go(func() error {

--- a/cdc/processor/pipeline/puller.go
+++ b/cdc/processor/pipeline/puller.go
@@ -54,10 +54,10 @@ func (n *pullerNode) tableSpan(ctx cdcContext.Context) []regionspan.Span {
 	// start table puller
 	config := ctx.ChangefeedVars().Info.Config
 	spans := make([]regionspan.Span, 0, 4)
-	spans = append(spans, regionspan.GetTableSpan(n.tableID, true))
+	spans = append(spans, regionspan.GetTableSpan(n.tableID))
 
 	if config.Cyclic.IsEnabled() && n.replicaInfo.MarkTableID != 0 {
-		spans = append(spans, regionspan.GetTableSpan(n.replicaInfo.MarkTableID, true))
+		spans = append(spans, regionspan.GetTableSpan(n.replicaInfo.MarkTableID))
 	}
 	return spans
 }

--- a/cdc/processor/pipeline/puller.go
+++ b/cdc/processor/pipeline/puller.go
@@ -54,10 +54,10 @@ func (n *pullerNode) tableSpan(ctx cdcContext.Context) []regionspan.Span {
 	// start table puller
 	config := ctx.ChangefeedVars().Info.Config
 	spans := make([]regionspan.Span, 0, 4)
-	spans = append(spans, regionspan.GetTableSpan(n.tableID, config.EnableOldValue))
+	spans = append(spans, regionspan.GetTableSpan(n.tableID, true))
 
 	if config.Cyclic.IsEnabled() && n.replicaInfo.MarkTableID != 0 {
-		spans = append(spans, regionspan.GetTableSpan(n.replicaInfo.MarkTableID, config.EnableOldValue))
+		spans = append(spans, regionspan.GetTableSpan(n.replicaInfo.MarkTableID, true))
 	}
 	return spans
 }

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -142,6 +142,10 @@ func (n *sinkNode) flushSink(ctx pipeline.NodeContext, resolvedTs model.Ts) (err
 }
 
 func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicEvent) error {
+	if event == nil || event.Row == nil {
+		return nil
+	}
+
 	colLen := len(event.Row.Columns)
 	preColLen := len(event.Row.PreColumns)
 	config := ctx.ChangefeedVars().Info.Config

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -142,7 +142,57 @@ func (n *sinkNode) flushSink(ctx pipeline.NodeContext, resolvedTs model.Ts) (err
 }
 
 func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicEvent) error {
-	n.eventBuffer = append(n.eventBuffer, event)
+	colLen := len(event.Row.Columns)
+	preColLen := len(event.Row.PreColumns)
+
+	// This indicates that it is an update event,
+	// and after turning on old value internally by default,
+	// we need to handle the update event to be compatible with the old format.
+	if colLen != 0 && preColLen != 0 && colLen == preColLen {
+		config := ctx.ChangefeedVars().Info.Config
+		if config.EnableOldValue {
+			// TODO: Need to test if the behavior is correct.
+			n.eventBuffer = append(n.eventBuffer, event)
+		} else {
+			handleKeyCount := 0
+			equivalentHandleKeyCount := 0
+			for i := range event.Row.Columns {
+				if event.Row.Columns[i].Flag.IsHandleKey() && event.Row.PreColumns[i].Flag.IsHandleKey() {
+					handleKeyCount++
+					colValueString := model.ColumnValueString(event.Row.Columns[i].Value)
+					preColValueString := model.ColumnValueString(event.Row.PreColumns[i].Value)
+					if colValueString == preColValueString {
+						equivalentHandleKeyCount++
+					}
+				}
+			}
+			// If the handle key columns are not updated, PreColumns is directly ignored.
+			if handleKeyCount == equivalentHandleKeyCount {
+				event.Row.PreColumns = nil
+				n.eventBuffer = append(n.eventBuffer, event)
+			} else {
+				// If there is an update to handle key columns,
+				// we need to split the event into two events to be compatible with the old format.
+				deleteEvent := event.Clone()
+				deleteEvent.Row.Columns = nil
+				for i := range deleteEvent.Row.PreColumns {
+					// Only the handle key column is retained in the delete event.
+					if !deleteEvent.Row.PreColumns[i].Flag.IsHandleKey() {
+						deleteEvent.Row.PreColumns[i] = nil
+					}
+				}
+				deleteEvent.Row.TableInfoVersion = 0
+				n.eventBuffer = append(n.eventBuffer, deleteEvent)
+
+				replaceEvent := event.Clone()
+				replaceEvent.Row.PreColumns = nil
+				n.eventBuffer = append(n.eventBuffer, replaceEvent)
+			}
+		}
+	} else {
+		n.eventBuffer = append(n.eventBuffer, event)
+	}
+
 	if len(n.eventBuffer) >= defaultSyncResolvedBatch {
 		if err := n.flushRow2Sink(ctx); err != nil {
 			return errors.Trace(err)

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -193,15 +193,15 @@ func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicE
 			deleteEvent.Row.TableInfoVersion = 0
 			n.eventBuffer = append(n.eventBuffer, &deleteEvent)
 
-			replaceEvent := *event
-			replaceEventRow := *event.Row
-			replaceEventRowKV := *event.RawKV
-			replaceEvent.Row = &replaceEventRow
-			replaceEvent.RawKV = &replaceEventRowKV
+			insertEvent := *event
+			insertEventRow := *event.Row
+			insertEventRowKV := *event.RawKV
+			insertEvent.Row = &insertEventRow
+			insertEvent.RawKV = &insertEventRowKV
 
-			// NOTICE: clean up pre cols for replace event.
-			replaceEvent.Row.PreColumns = nil
-			n.eventBuffer = append(n.eventBuffer, &replaceEvent)
+			// NOTICE: clean up pre cols for insert event.
+			insertEvent.Row.PreColumns = nil
+			n.eventBuffer = append(n.eventBuffer, &insertEvent)
 		}
 	} else {
 		n.eventBuffer = append(n.eventBuffer, event)

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -147,8 +147,8 @@ func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicE
 	config := ctx.ChangefeedVars().Info.Config
 
 	// This indicates that it is an update event,
-	// and after turning on old value internally by default,
-	// we need to handle the update event to be compatible with the old format.
+	// and after enable old value internally by default(but disable in the configuration).
+	// We need to handle the update event to be compatible with the old format.
 	if !config.EnableOldValue && colLen != 0 && preColLen != 0 && colLen == preColLen {
 		handleKeyCount := 0
 		equivalentHandleKeyCount := 0
@@ -162,6 +162,7 @@ func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicE
 				}
 			}
 		}
+
 		// If the handle key columns are not updated, PreColumns is directly ignored.
 		if handleKeyCount == equivalentHandleKeyCount {
 			event.Row.PreColumns = nil
@@ -172,7 +173,7 @@ func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicE
 			deleteEvent := event.Clone()
 			deleteEvent.Row.Columns = nil
 			for i := range deleteEvent.Row.PreColumns {
-				// NOTICE: Only the handle key column is retained in the delete event.
+				// NOTICE: Only the handle key pre column is retained in the delete event.
 				if !deleteEvent.Row.PreColumns[i].Flag.IsHandleKey() {
 					deleteEvent.Row.PreColumns[i] = nil
 				}

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -172,15 +172,17 @@ func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicE
 			deleteEvent := event.Clone()
 			deleteEvent.Row.Columns = nil
 			for i := range deleteEvent.Row.PreColumns {
-				// Only the handle key column is retained in the delete event.
+				// NOTICE: Only the handle key column is retained in the delete event.
 				if !deleteEvent.Row.PreColumns[i].Flag.IsHandleKey() {
 					deleteEvent.Row.PreColumns[i] = nil
 				}
 			}
+			// Align with the old format if old value disabled.
 			deleteEvent.Row.TableInfoVersion = 0
 			n.eventBuffer = append(n.eventBuffer, deleteEvent)
 
 			replaceEvent := event.Clone()
+			// NOTICE: clean up pre cols for replace event.
 			replaceEvent.Row.PreColumns = nil
 			n.eventBuffer = append(n.eventBuffer, replaceEvent)
 		}

--- a/cdc/processor/pipeline/sink_test.go
+++ b/cdc/processor/pipeline/sink_test.go
@@ -244,3 +244,175 @@ func (s *outputSuite) TestManyTs(c *check.C) {
 	c.Assert(node.ResolvedTs(), check.Equals, uint64(2))
 	c.Assert(node.CheckpointTs(), check.Equals, uint64(2))
 }
+
+func (s *outputSuite) TestSplitUpdateEventWithEnableOldValue(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewContext(context.Background(), &cdcContext.GlobalVars{})
+	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
+		ID: "changefeed-id-test-split-update-event",
+		Info: &model.ChangeFeedInfo{
+			StartTs: oracle.GoTimeToTS(time.Now()),
+			Config:  config.GetDefaultReplicaConfig(),
+		},
+	})
+	sink := &mockSink{}
+	node := newSinkNode(sink, 0, 10, &mockFlowController{})
+	c.Assert(node.Init(pipeline.MockNodeContext4Test(ctx, nil, nil)), check.IsNil)
+
+	// nil row.
+	c.Assert(node.Receive(pipeline.MockNodeContext4Test(ctx,
+		pipeline.PolymorphicEventMessage(&model.PolymorphicEvent{CRTs: 1, RawKV: &model.RawKVEntry{OpType: model.OpTypePut}}), nil)), check.IsNil)
+	c.Assert(node.eventBuffer, check.HasLen, 0)
+
+	columns := []*model.Column{
+		{
+			Name:  "col1",
+			Flag:  model.BinaryFlag,
+			Value: "col1-value-updated",
+		},
+		{
+			Name:  "col2",
+			Flag:  model.HandleKeyFlag,
+			Value: "col2-value",
+		},
+	}
+	preColumns := []*model.Column{
+		{
+			Name:  "col1",
+			Flag:  model.BinaryFlag,
+			Value: "col1-value",
+		},
+		{
+			Name:  "col2",
+			Flag:  model.HandleKeyFlag,
+			Value: "col2-value",
+		},
+	}
+	c.Assert(node.Receive(pipeline.MockNodeContext4Test(
+		ctx,
+		pipeline.PolymorphicEventMessage(&model.PolymorphicEvent{
+			CRTs:  1,
+			RawKV: &model.RawKVEntry{OpType: model.OpTypePut},
+			Row:   &model.RowChangedEvent{CommitTs: 1, Columns: columns, PreColumns: preColumns},
+		}), nil)),
+		check.IsNil,
+	)
+	c.Assert(node.eventBuffer, check.HasLen, 1)
+	c.Assert(node.eventBuffer[0].Row.Columns, check.HasLen, 2)
+	c.Assert(node.eventBuffer[0].Row.PreColumns, check.HasLen, 2)
+}
+
+func (s *outputSuite) TestSplitUpdateEventWithDisableOldValue(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewContext(context.Background(), &cdcContext.GlobalVars{})
+	cfg := config.GetDefaultReplicaConfig()
+	cfg.EnableOldValue = false
+	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
+		ID: "changefeed-id-test-split-update-event",
+		Info: &model.ChangeFeedInfo{
+			StartTs: oracle.GoTimeToTS(time.Now()),
+			Config:  cfg,
+		},
+	})
+	sink := &mockSink{}
+	node := newSinkNode(sink, 0, 10, &mockFlowController{})
+	c.Assert(node.Init(pipeline.MockNodeContext4Test(ctx, nil, nil)), check.IsNil)
+
+	// nil row.
+	c.Assert(node.Receive(pipeline.MockNodeContext4Test(ctx,
+		pipeline.PolymorphicEventMessage(&model.PolymorphicEvent{CRTs: 1, RawKV: &model.RawKVEntry{OpType: model.OpTypePut}}), nil)), check.IsNil)
+	c.Assert(node.eventBuffer, check.HasLen, 0)
+
+	// No update to the handle key column.
+	columns := []*model.Column{
+		{
+			Name:  "col1",
+			Flag:  model.BinaryFlag,
+			Value: "col1-value-updated",
+		},
+		{
+			Name:  "col2",
+			Flag:  model.HandleKeyFlag,
+			Value: "col2-value",
+		},
+	}
+	preColumns := []*model.Column{
+		{
+			Name:  "col1",
+			Flag:  model.BinaryFlag,
+			Value: "col1-value",
+		},
+		{
+			Name:  "col2",
+			Flag:  model.HandleKeyFlag,
+			Value: "col2-value",
+		},
+	}
+
+	c.Assert(node.Receive(pipeline.MockNodeContext4Test(
+		ctx,
+		pipeline.PolymorphicEventMessage(&model.PolymorphicEvent{
+			CRTs:  1,
+			RawKV: &model.RawKVEntry{OpType: model.OpTypePut},
+			Row:   &model.RowChangedEvent{CommitTs: 1, Columns: columns, PreColumns: preColumns},
+		}), nil)),
+		check.IsNil,
+	)
+	c.Assert(node.eventBuffer, check.HasLen, 1)
+	c.Assert(node.eventBuffer[0].Row.Columns, check.HasLen, 2)
+	c.Assert(node.eventBuffer[0].Row.PreColumns, check.HasLen, 0)
+
+	// Cleanup.
+	node.eventBuffer = []*model.PolymorphicEvent{}
+	// Update to the handle key column.
+	columns = []*model.Column{
+		{
+			Name:  "col1",
+			Flag:  model.BinaryFlag,
+			Value: "col1-value-updated",
+		},
+		{
+			Name:  "col2",
+			Flag:  model.HandleKeyFlag,
+			Value: "col2-value-updated",
+		},
+	}
+	preColumns = []*model.Column{
+		{
+			Name:  "col1",
+			Flag:  model.BinaryFlag,
+			Value: "col1-value",
+		},
+		{
+			Name:  "col2",
+			Flag:  model.HandleKeyFlag,
+			Value: "col2-value",
+		},
+	}
+
+	c.Assert(node.Receive(pipeline.MockNodeContext4Test(
+		ctx,
+		pipeline.PolymorphicEventMessage(&model.PolymorphicEvent{
+			CRTs:  1,
+			RawKV: &model.RawKVEntry{OpType: model.OpTypePut},
+			Row:   &model.RowChangedEvent{CommitTs: 1, Columns: columns, PreColumns: preColumns},
+		}), nil)),
+		check.IsNil,
+	)
+	// Split an update event into a delete and an insert event.
+	c.Assert(node.eventBuffer, check.HasLen, 2)
+
+	deleteEventIndex := 0
+	c.Assert(node.eventBuffer[deleteEventIndex].Row.Columns, check.HasLen, 0)
+	c.Assert(node.eventBuffer[deleteEventIndex].Row.PreColumns, check.HasLen, 2)
+	nonHandleKeyColIndex := 0
+	handleKeyColIndex := 1
+	// NOTICE: When old value disabled, we only keep the handle key pre cols.
+	c.Assert(node.eventBuffer[deleteEventIndex].Row.PreColumns[nonHandleKeyColIndex], check.IsNil)
+	c.Assert(node.eventBuffer[deleteEventIndex].Row.PreColumns[handleKeyColIndex].Name, check.Equals, "col2")
+	c.Assert(node.eventBuffer[deleteEventIndex].Row.PreColumns[handleKeyColIndex].Flag.IsHandleKey(), check.IsTrue)
+
+	insertEventIndex := 1
+	c.Assert(node.eventBuffer[insertEventIndex].Row.Columns, check.HasLen, 2)
+	c.Assert(node.eventBuffer[insertEventIndex].Row.PreColumns, check.HasLen, 0)
+}

--- a/cdc/processor/pipeline/sink_test.go
+++ b/cdc/processor/pipeline/sink_test.go
@@ -245,7 +245,7 @@ func (s *outputSuite) TestManyTs(c *check.C) {
 	c.Assert(node.CheckpointTs(), check.Equals, uint64(2))
 }
 
-func (s *outputSuite) TestSplitUpdateEventWithEnableOldValue(c *check.C) {
+func (s *outputSuite) TestSplitUpdateEventWhenEnableOldValue(c *check.C) {
 	defer testleak.AfterTest(c)()
 	ctx := cdcContext.NewContext(context.Background(), &cdcContext.GlobalVars{})
 	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
@@ -302,7 +302,7 @@ func (s *outputSuite) TestSplitUpdateEventWithEnableOldValue(c *check.C) {
 	c.Assert(node.eventBuffer[0].Row.PreColumns, check.HasLen, 2)
 }
 
-func (s *outputSuite) TestSplitUpdateEventWithDisableOldValue(c *check.C) {
+func (s *outputSuite) TestSplitUpdateEventWhenDisableOldValue(c *check.C) {
 	defer testleak.AfterTest(c)()
 	ctx := cdcContext.NewContext(context.Background(), &cdcContext.GlobalVars{})
 	cfg := config.GetDefaultReplicaConfig()

--- a/cdc/processor/pipeline/sink_test.go
+++ b/cdc/processor/pipeline/sink_test.go
@@ -15,17 +15,17 @@ package pipeline
 
 import (
 	"context"
-	"github.com/pingcap/ticdc/pkg/config"
-	"github.com/tikv/client-go/v2/oracle"
 	"testing"
 	"time"
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/config"
 	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/pipeline"
 	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"github.com/tikv/client-go/v2/oracle"
 )
 
 func TestSuite(t *testing.T) {

--- a/pkg/regionspan/span.go
+++ b/pkg/regionspan/span.go
@@ -83,19 +83,14 @@ func hackSpan(originStart []byte, originEnd []byte) (start []byte, end []byte) {
 }
 
 // GetTableSpan returns the span to watch for the specified table
-func GetTableSpan(tableID int64, exceptIndexSpan bool) Span {
+func GetTableSpan(tableID int64) Span {
 	sep := byte('_')
 	recordMarker := byte('r')
 	tablePrefix := tablecodec.GenTablePrefix(tableID)
 	var start, end kv.Key
-	// ignore index keys if we don't need them
-	if exceptIndexSpan {
-		start = append(tablePrefix, sep, recordMarker)
-		end = append(tablePrefix, sep, recordMarker+1)
-	} else {
-		start = append(tablePrefix, sep)
-		end = append(tablePrefix, sep+1)
-	}
+	// ignore index keys.
+	start = append(tablePrefix, sep, recordMarker)
+	end = append(tablePrefix, sep, recordMarker+1)
 	return Span{
 		Start: start,
 		End:   end,

--- a/pkg/regionspan/span_test.go
+++ b/pkg/regionspan/span_test.go
@@ -104,6 +104,7 @@ func (s *spanSuite) TestIntersect(c *check.C) {
 }
 
 func (s *spanSuite) TestGetTableSpan(c *check.C) {
+	defer testleak.AfterTest(c)()
 	span := GetTableSpan(123)
 	c.Assert(span.Start, check.Less, span.End)
 	prefix := []byte(tablecodec.GenTableRecordPrefix(123))

--- a/pkg/regionspan/span_test.go
+++ b/pkg/regionspan/span_test.go
@@ -104,17 +104,9 @@ func (s *spanSuite) TestIntersect(c *check.C) {
 }
 
 func (s *spanSuite) TestGetTableSpan(c *check.C) {
-	defer testleak.AfterTest(c)()
-	span := GetTableSpan(123, false)
+	span := GetTableSpan(123)
 	c.Assert(span.Start, check.Less, span.End)
-	prefix := []byte(tablecodec.GenTablePrefix(123))
-	c.Assert(span.Start, check.Greater, prefix)
-	prefix[len(prefix)-1]++
-	c.Assert(span.End, check.Less, prefix)
-
-	span = GetTableSpan(123, true)
-	c.Assert(span.Start, check.Less, span.End)
-	prefix = []byte(tablecodec.GenTableRecordPrefix(123))
+	prefix := []byte(tablecodec.GenTableRecordPrefix(123))
 	c.Assert(span.Start, check.GreaterEqual, prefix)
 	prefix[len(prefix)-1]++
 	c.Assert(span.End, check.LessEqual, prefix)


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

ref: https://github.com/pingcap/ticdc/issues/2301

### What is changed and how it works?

ticdc  always pull the old value internally.

Because our `new collation` feature needs the `old value` to work properly. However, some users will not use old value, but may use new collation, so it needs to be configured by the user. (Users don't even know if they have new collation on)

To simplify this configuration and to make it easier for the user, we decided to:
1. always use old value **internally.**
2. the data output to the user needs to be in the correct format (without the old value configuration on, the old value cannot be output)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 
Code changes

 None

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch

### Release note

- puller,mounter,processor: always pull the old value internally
