### PR TITLE
pkg: fix retry getBackoffInMs panic when sleep overflowed

### DIFF
--- a/pkg/retry/retry_with_opt.go
+++ b/pkg/retry/retry_with_opt.go
@@ -88,7 +88,10 @@ func getBackoffInMs(backoffBaseInMs, backoffCapInMs, try float64) time.Duration 
 	if temp <= 0 {
 		temp = 1
 	}
-	sleep := temp + rand.Int63n(temp)
-	backOff := math.Min(backoffCapInMs, float64(rand.Int63n(sleep*3))+backoffBaseInMs)
+	sleep := (temp + rand.Int63n(temp)) * 3
+	if sleep <= 0 {
+		sleep = math.MaxInt64
+	}
+	backOff := math.Min(backoffCapInMs, float64(rand.Int63n(sleep))+backoffBaseInMs)
 	return time.Duration(backOff) * time.Millisecond
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix `sleep*3` overflowed in `getBackoffInMs`, detected by Test DoCornerCases fails https://github.com/pingcap/ticdc/issues/2273

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
