### PR TITLE
refactor(cli): add client construction factory abstraction

### DIFF
--- a/pkg/cmd/context/context.go
+++ b/pkg/cmd/context/context.go
@@ -1,0 +1,28 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import "context"
+
+var defaultContext context.Context
+
+// SetDefaultContext sets the default context for command line usage.
+func SetDefaultContext(ctx context.Context) {
+	defaultContext = ctx
+}
+
+// GetDefaultContext returns the default context for command line usage.
+func GetDefaultContext() context.Context {
+	return defaultContext
+}

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -1,0 +1,102 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factory
+
+import (
+	"crypto/tls"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/pkg/security"
+	"github.com/spf13/cobra"
+	pd "github.com/tikv/pd/client"
+	"google.golang.org/grpc"
+)
+
+// Factory defines the client-side construction factory.
+type Factory interface {
+	ClientGetter
+	EtcdClient() (*kv.CDCEtcdClient, error)
+	PdClient() (pd.Client, error)
+}
+
+// ClientGetter defines the client getter.
+type ClientGetter interface {
+	ToTLSConfig() (*tls.Config, error)
+	ToGRPCDialOption() (grpc.DialOption, error)
+	GetPdAddr() string
+	GetCredential() *security.Credential
+}
+
+// ClientFlags specifies the parameters needed to construct the client.
+type ClientFlags struct {
+	cliPdAddr string
+	caPath    string
+	certPath  string
+	keyPath   string
+}
+
+var _ ClientGetter = &ClientFlags{}
+
+// ToTLSConfig returns the configuration of tls.
+func (c *ClientFlags) ToTLSConfig() (*tls.Config, error) {
+	credential := c.GetCredential()
+	tlsConfig, err := credential.ToTLSConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "fail to validate TLS settings")
+	}
+	return tlsConfig, nil
+}
+
+// ToGRPCDialOption returns the option of GRPC dial.
+func (c *ClientFlags) ToGRPCDialOption() (grpc.DialOption, error) {
+	credential := c.GetCredential()
+	grpcTLSOption, err := credential.ToGRPCDialOption()
+	if err != nil {
+		return nil, errors.Annotate(err, "fail to validate TLS settings")
+	}
+
+	return grpcTLSOption, nil
+}
+
+// GetPdAddr returns pd address.
+func (c *ClientFlags) GetPdAddr() string {
+	return c.cliPdAddr
+}
+
+// NewClientFlags creates new client flags.
+func NewClientFlags() *ClientFlags {
+	return &ClientFlags{}
+}
+
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to template printing to it.
+func (c *ClientFlags) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&c.cliPdAddr, "pd", "http://127.0.0.1:2379", "PD address, use ',' to separate multiple PDs")
+	cmd.PersistentFlags().StringVar(&c.caPath, "ca", "", "CA certificate path for TLS connection")
+	cmd.PersistentFlags().StringVar(&c.certPath, "cert", "", "Certificate path for TLS connection")
+	cmd.PersistentFlags().StringVar(&c.keyPath, "key", "", "Private key path for TLS connection")
+}
+
+// GetCredential returns credential.
+func (c *ClientFlags) GetCredential() *security.Credential {
+	var certAllowedCN []string
+
+	return &security.Credential{
+		CAPath:        c.caPath,
+		CertPath:      c.certPath,
+		KeyPath:       c.keyPath,
+		CertAllowedCN: certAllowedCN,
+	}
+}

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -37,15 +37,17 @@ type ClientGetter interface {
 	ToTLSConfig() (*tls.Config, error)
 	ToGRPCDialOption() (grpc.DialOption, error)
 	GetPdAddr() string
+	GetLogLevel() string
 	GetCredential() *security.Credential
 }
 
 // ClientFlags specifies the parameters needed to construct the client.
 type ClientFlags struct {
-	cliPdAddr string
-	caPath    string
-	certPath  string
-	keyPath   string
+	pdAddr   string
+	logLevel string
+	caPath   string
+	certPath string
+	keyPath  string
 }
 
 var _ ClientGetter = &ClientFlags{}
@@ -73,7 +75,12 @@ func (c *ClientFlags) ToGRPCDialOption() (grpc.DialOption, error) {
 
 // GetPdAddr returns pd address.
 func (c *ClientFlags) GetPdAddr() string {
-	return c.cliPdAddr
+	return c.pdAddr
+}
+
+// GetLogLevel returns log level.
+func (c *ClientFlags) GetLogLevel() string {
+	return c.logLevel
 }
 
 // NewClientFlags creates new client flags.
@@ -84,10 +91,11 @@ func NewClientFlags() *ClientFlags {
 // AddFlags receives a *cobra.Command reference and binds
 // flags related to template printing to it.
 func (c *ClientFlags) AddFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&c.cliPdAddr, "pd", "http://127.0.0.1:2379", "PD address, use ',' to separate multiple PDs")
+	cmd.PersistentFlags().StringVar(&c.pdAddr, "pd", "http://127.0.0.1:2379", "PD address, use ',' to separate multiple PDs")
 	cmd.PersistentFlags().StringVar(&c.caPath, "ca", "", "CA certificate path for TLS connection")
 	cmd.PersistentFlags().StringVar(&c.certPath, "cert", "", "Certificate path for TLS connection")
 	cmd.PersistentFlags().StringVar(&c.keyPath, "key", "", "Private key path for TLS connection")
+	cmd.PersistentFlags().StringVar(&c.logLevel, "log-level", "warn", "log level (etc: debug|info|warn|error)")
 }
 
 // Validate makes sure provided values for ClientFlags are valid.
@@ -97,7 +105,7 @@ func (c *ClientFlags) Validate() error {
 		return errors.Annotate(err, "fail to validate TLS settings")
 	}
 
-	if err := util.VerifyPdEndpoint(c.cliPdAddr, tlsConfig != nil); err != nil {
+	if err := util.VerifyPdEndpoint(c.pdAddr, tlsConfig != nil); err != nil {
 		return errors.Annotate(err, "fail to validate PD endpoint")
 	}
 

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/cdc/kv"
+	"github.com/pingcap/ticdc/pkg/cmd/util"
 	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/spf13/cobra"
 	pd "github.com/tikv/pd/client"
@@ -87,6 +88,20 @@ func (c *ClientFlags) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&c.caPath, "ca", "", "CA certificate path for TLS connection")
 	cmd.PersistentFlags().StringVar(&c.certPath, "cert", "", "Certificate path for TLS connection")
 	cmd.PersistentFlags().StringVar(&c.keyPath, "key", "", "Private key path for TLS connection")
+}
+
+// Validate makes sure provided values for ClientFlags are valid.
+func (c *ClientFlags) Validate() error {
+	tlsConfig, err := c.ToTLSConfig()
+	if err != nil {
+		return errors.Annotate(err, "fail to validate TLS settings")
+	}
+
+	if err := util.VerifyPdEndpoint(c.cliPdAddr, tlsConfig != nil); err != nil {
+		return errors.Annotate(err, "fail to validate PD endpoint")
+	}
+
+	return nil
 }
 
 // GetCredential returns credential.

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -139,6 +139,8 @@ func (f factoryImpl) PdClient() (pd.Client, error) {
 		return nil, errors.Annotatef(err, "fail to open PD client, pd=\"%s\"", pdAddr)
 	}
 
+	// TODO: we need to check all pd endpoint and make sure they belong to the same cluster.
+	// See also: https://github.com/pingcap/ticdc/pull/2341#discussion_r673021305.
 	err = version.CheckClusterVersion(ctx, pdClient, pdEndpoints[0], credential, true)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -1,0 +1,148 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factory
+
+import (
+	"crypto/tls"
+	"strings"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc/kv"
+	cmdconetxt "github.com/pingcap/ticdc/pkg/cmd/context"
+	"github.com/pingcap/ticdc/pkg/security"
+	"github.com/pingcap/ticdc/pkg/version"
+	pd "github.com/tikv/pd/client"
+	"go.etcd.io/etcd/clientv3"
+	etcdlogutil "go.etcd.io/etcd/pkg/logutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+)
+
+type factoryImpl struct {
+	clientGetter ClientGetter
+}
+
+// NewFactory creates a client build factory.
+func NewFactory(clientGetter ClientGetter) Factory {
+	if clientGetter == nil {
+		panic("attempt to instantiate factory with nil clientGetter")
+	}
+	f := &factoryImpl{
+		clientGetter: clientGetter,
+	}
+
+	return f
+}
+
+func (f *factoryImpl) ToTLSConfig() (*tls.Config, error) {
+	return f.clientGetter.ToTLSConfig()
+}
+
+func (f *factoryImpl) ToGRPCDialOption() (grpc.DialOption, error) {
+	return f.clientGetter.ToGRPCDialOption()
+}
+
+func (f *factoryImpl) GetPdAddr() string {
+	return f.clientGetter.GetPdAddr()
+}
+
+func (f *factoryImpl) GetCredential() *security.Credential {
+	return f.clientGetter.GetCredential()
+}
+
+func (f *factoryImpl) EtcdClient() (*kv.CDCEtcdClient, error) {
+	ctx := cmdconetxt.GetDefaultContext()
+
+	tlsConfig, err := f.ToTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+	grpcTLSOption, err := f.ToGRPCDialOption()
+	if err != nil {
+		return nil, err
+	}
+
+	logConfig := etcdlogutil.DefaultZapLoggerConfig
+	logConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
+	pdEndpoints := strings.Split(f.GetPdAddr(), ",")
+
+	etcdClient, err := clientv3.New(clientv3.Config{
+		Context:     ctx,
+		Endpoints:   pdEndpoints,
+		TLS:         tlsConfig,
+		LogConfig:   &logConfig,
+		DialTimeout: 30 * time.Second,
+		DialOptions: []grpc.DialOption{
+			grpcTLSOption,
+			grpc.WithBlock(),
+			grpc.WithConnectParams(grpc.ConnectParams{
+				Backoff: backoff.Config{
+					BaseDelay:  time.Second,
+					Multiplier: 1.1,
+					Jitter:     0.1,
+					MaxDelay:   3 * time.Second,
+				},
+				MinConnectTimeout: 3 * time.Second,
+			}),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	client := kv.NewCDCEtcdClient(ctx, etcdClient)
+	return &client, nil
+}
+
+func (f factoryImpl) PdClient() (pd.Client, error) {
+	ctx := cmdconetxt.GetDefaultContext()
+
+	credential := f.GetCredential()
+	grpcTLSOption, err := f.ToGRPCDialOption()
+	if err != nil {
+		return nil, err
+	}
+
+	pdAddr := f.GetPdAddr()
+	pdEndpoints := strings.Split(pdAddr, ",")
+
+	pdClient, err := pd.NewClientWithContext(
+		ctx, pdEndpoints, credential.PDSecurityOption(),
+		pd.WithGRPCDialOptions(
+			grpcTLSOption,
+			grpc.WithBlock(),
+			grpc.WithConnectParams(grpc.ConnectParams{
+				Backoff: backoff.Config{
+					BaseDelay:  time.Second,
+					Multiplier: 1.1,
+					Jitter:     0.1,
+					MaxDelay:   3 * time.Second,
+				},
+				MinConnectTimeout: 3 * time.Second,
+			}),
+		))
+	if err != nil {
+		return nil, errors.Annotatef(err, "fail to open PD client, pd=\"%s\"", pdAddr)
+	}
+
+	err = version.CheckClusterVersion(ctx, pdClient, pdEndpoints[0], credential, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return pdClient, nil
+}

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -86,6 +86,8 @@ func (f *factoryImpl) EtcdClient() (*kv.CDCEtcdClient, error) {
 		TLS:         tlsConfig,
 		LogConfig:   &logConfig,
 		DialTimeout: 30 * time.Second,
+		// TODO(hi-rustin): add gRPC metrics to Options.
+		// See also: https://github.com/pingcap/ticdc/pull/2341#discussion_r673018537.
 		DialOptions: []grpc.DialOption{
 			grpcTLSOption,
 			grpc.WithBlock(),
@@ -122,6 +124,8 @@ func (f factoryImpl) PdClient() (pd.Client, error) {
 
 	pdClient, err := pd.NewClientWithContext(
 		ctx, pdEndpoints, credential.PDSecurityOption(),
+		// TODO(hi-rustin): add gRPC metrics to Options.
+		// See also: https://github.com/pingcap/ticdc/pull/2341#discussion_r673032407.
 		pd.WithGRPCDialOptions(
 			grpcTLSOption,
 			grpc.WithBlock(),

--- a/pkg/cmd/util/helper.go
+++ b/pkg/cmd/util/helper.go
@@ -1,0 +1,49 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"net/url"
+
+	"github.com/pingcap/errors"
+)
+
+// Endpoint schemes.
+const (
+	HTTP  = "http"
+	HTTPS = "https"
+)
+
+// VerifyPdEndpoint verifies whether the pd endpoint is a valid http or https URL.
+// The certificate is required when using https.
+func VerifyPdEndpoint(pdEndpoint string, useTLS bool) error {
+	u, err := url.Parse(pdEndpoint)
+	if err != nil {
+		return errors.Annotate(err, "parse PD endpoint")
+	}
+	if (u.Scheme != HTTP && u.Scheme != HTTPS) || u.Host == "" {
+		return errors.New("PD endpoint should be a valid http or https URL")
+	}
+
+	if useTLS {
+		if u.Scheme == HTTP {
+			return errors.New("PD endpoint scheme should be https")
+		}
+	} else {
+		if u.Scheme == HTTPS {
+			return errors.New("PD endpoint scheme is https, please provide certificate")
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/util/helper_test.go
+++ b/pkg/cmd/util/helper_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+func TestSuite(t *testing.T) { check.TestingT(t) }
+
+type utilsSuite struct{}
+
+var _ = check.Suite(&utilsSuite{})
+
+func (s *utilsSuite) TestVerifyPdEndpoint(c *check.C) {
+	defer testleak.AfterTest(c)()
+	// empty URL.
+	url := ""
+	c.Assert(VerifyPdEndpoint(url, false), check.ErrorMatches, ".*PD endpoint should be a valid http or https URL.*")
+
+	// invalid URL.
+	url = "\n hi"
+	c.Assert(VerifyPdEndpoint(url, false), check.ErrorMatches, ".*invalid control character in URL.*")
+
+	// http URL without host.
+	url = "http://"
+	c.Assert(VerifyPdEndpoint(url, false), check.ErrorMatches, ".*PD endpoint should be a valid http or https URL.*")
+
+	// https URL without host.
+	url = "https://"
+	c.Assert(VerifyPdEndpoint(url, false), check.ErrorMatches, ".*PD endpoint should be a valid http or https URL.*")
+
+	// postgres scheme.
+	url = "postgres://postgres@localhost/cargo_registry"
+	c.Assert(VerifyPdEndpoint(url, false), check.ErrorMatches, ".*PD endpoint should be a valid http or https URL.*")
+
+	// https scheme without TLS.
+	url = "https://aa"
+	c.Assert(VerifyPdEndpoint(url, false), check.ErrorMatches, ".*PD endpoint scheme is https, please provide certificate.*")
+
+	// http scheme with TLS.
+	url = "http://aa"
+	c.Assert(VerifyPdEndpoint(url, true), check.ErrorMatches, ".*PD endpoint scheme should be https.*")
+
+	// valid http URL.
+	c.Assert(VerifyPdEndpoint("http://aa", false), check.IsNil)
+
+	// valid https URL with TLS.
+	c.Assert(VerifyPdEndpoint("https://aa", true), check.IsNil)
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

part of https://github.com/pingcap/ticdc/issues/2168

cc: https://github.com/pingcap/ticdc/issues/2199

split from https://github.com/pingcap/ticdc/pull/2262
### What is changed and how it works?

add client construction factory abstraction.

1. abstract the client constructor code that we originally put in the cli initialization
2. abstract the interface and have a struct (subsequently used as the cli's global flags binding) implement it, var _ ClientGetter = &ClientFlags{}, so that in effect the constructor implementation becomes the global flags of our original cli.
3. Putting our original global context into a new package


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 None

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 None

Related changes

 None

### Release note

- No release note


/cc @amyangfei  @overvenus 
