### PR TITLE
cmd/root: Add a check to check whether the cli parameter contains non-ascii code

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/pingcap/ticdc/pkg/httputil"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,9 @@
 package cmd
 
 import (
-	"os"
-
+	"github.com/pingcap/ticdc/pkg/httputil"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var rootCmd = &cobra.Command{
@@ -29,6 +29,15 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	// Outputs cmd.Print to stdout.
 	rootCmd.SetOut(os.Stdout)
+	args := os.Args[1:]
+
+	for _, arg := range args {
+		if httputil.IsContainNonASCII(arg) {
+			rootCmd.Printf("Please input ASCII char only, the arg: %s contain Non-ASCII char.\n", arg)
+			os.Exit(1)
+		}
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		rootCmd.Println(err)
 		os.Exit(1)

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -14,9 +14,10 @@
 package httputil
 
 import (
+	"net/http"
+
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/security"
-	"net/http"
 )
 
 // Client wraps an HTTP client and support TLS requests.

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -14,10 +14,9 @@
 package httputil
 
 import (
-	"net/http"
-
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/security"
+	"net/http"
 )
 
 // Client wraps an HTTP client and support TLS requests.
@@ -61,4 +60,14 @@ func IsFiltered(whiteList string, feedState model.FeedState) bool {
 		}
 	}
 	return whiteList == string(feedState)
+}
+
+// IsContainNonASCII return true if a string contain non-ascii char
+func IsContainNonASCII(s string) bool {
+	for _, r := range s {
+		if r < 0 || r > 127 {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Add a check to check whether the parameter contains non-ascii code

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2303  

### What is changed and how it works?
Add a check to check whether the parameter contains non-ascii code


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
![2021721-14330](https://user-images.githubusercontent.com/20351731/126439130-d5ba1e8a-8e25-49fc-a09b-31f21a1c71f0.png)

Code changes

 - None

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note