### PR TITLE
pipeline: skip stack backtrace in hot path

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -100,6 +100,8 @@ func (p *Pipeline) driveRunner(ctx context.Context, previousRunner, runner runne
 	}
 }
 
+var pipelineTryAgainError error = cerror.ErrPipelineTryAgain.FastGenByArgs()
+
 // SendToFirstNode sends the message to the first node
 func (p *Pipeline) SendToFirstNode(msg *Message) error {
 	p.closeMu.Lock()
@@ -117,7 +119,7 @@ func (p *Pipeline) SendToFirstNode(msg *Message) error {
 	default:
 		// Do not call `GenWithStackByArgs` in the hot path,
 		// it consumes lots of CPU.
-		return cerror.ErrPipelineTryAgain
+		return pipelineTryAgainError
 	}
 	return nil
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -115,7 +115,9 @@ func (p *Pipeline) SendToFirstNode(msg *Message) error {
 	select {
 	case p.header <- msg:
 	default:
-		return cerror.ErrPipelineTryAgain.GenWithStackByArgs()
+		// Do not call `GenWithStackByArgs` in the hot path,
+		// it consumes lots of CPU.
+		return cerror.ErrPipelineTryAgain
 	}
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Save CPU by skipping stack backtrace.

![image](https://user-images.githubusercontent.com/2150711/127448262-ae5a90df-2305-41f8-985d-32f1b7de7b50.png)

### What is changed and how it works?

Skips stack backtrace.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
