### PR TITLE
sorter: use tmp dir to stable tests

### DIFF
--- a/cdc/puller/sorter/backend_pool_test.go
+++ b/cdc/puller/sorter/backend_pool_test.go
@@ -35,7 +35,7 @@ var _ = check.SerialSuites(&backendPoolSuite{})
 func (s *backendPoolSuite) TestBasicFunction(c *check.C) {
 	defer testleak.AfterTest(c)()
 
-	dataDir := "/tmp/cdc_data"
+	dataDir := c.MkDir()
 	err := os.MkdirAll(dataDir, 0o755)
 	c.Assert(err, check.IsNil)
 

--- a/cdc/puller/sorter/sorter_test.go
+++ b/cdc/puller/sorter/sorter_test.go
@@ -62,7 +62,7 @@ func (s *sorterSuite) TestSorterBasic(c *check.C) {
 	defer UnifiedSorterCleanUp()
 
 	conf := config.GetDefaultServerConfig()
-	conf.DataDir = "/tmp/cdc_data"
+	conf.DataDir = c.MkDir()
 	sortDir := filepath.Join(conf.DataDir, config.DefaultSortDir)
 	conf.Sorter = &config.SorterConfig{
 		NumConcurrentWorker:    8,
@@ -90,7 +90,7 @@ func (s *sorterSuite) TestSorterCancel(c *check.C) {
 	defer UnifiedSorterCleanUp()
 
 	conf := config.GetDefaultServerConfig()
-	conf.DataDir = "/tmp/cdc_data"
+	conf.DataDir = c.MkDir()
 	sortDir := filepath.Join(conf.DataDir, config.DefaultSortDir)
 	conf.Sorter = &config.SorterConfig{
 		NumConcurrentWorker:    8,
@@ -238,12 +238,14 @@ func (s *sorterSuite) TestSortDirConfigLocal(c *check.C) {
 	pool = nil
 	poolMu.Unlock()
 
-	err := os.MkdirAll("/tmp/sorter_local", 0o755)
+	baseDir := c.MkDir()
+	dir := filepath.Join(baseDir, "sorter_local")
+	err := os.MkdirAll(dir, 0o755)
 	c.Assert(err, check.IsNil)
 	// We expect the local setting to override the changefeed setting
-	config.GetGlobalServerConfig().Sorter.SortDir = "/tmp/sorter_local"
+	config.GetGlobalServerConfig().Sorter.SortDir = dir
 
-	_, err = NewUnifiedSorter("/tmp/sorter", /* the changefeed setting */
+	_, err = NewUnifiedSorter(filepath.Join(baseDir, "sorter"), /* the changefeed setting */
 		"test-cf",
 		"test",
 		0,
@@ -254,7 +256,7 @@ func (s *sorterSuite) TestSortDirConfigLocal(c *check.C) {
 	defer poolMu.Unlock()
 
 	c.Assert(pool, check.NotNil)
-	c.Assert(pool.dir, check.Equals, "/tmp/sorter_local")
+	c.Assert(pool.dir, check.Equals, dir)
 }
 
 func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
@@ -266,12 +268,11 @@ func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
 	pool = nil
 	poolMu.Unlock()
 
-	err := os.MkdirAll("/tmp/sorter", 0o755)
-	c.Assert(err, check.IsNil)
+	dir := c.MkDir()
 	// We expect the changefeed setting to take effect
 	config.GetGlobalServerConfig().Sorter.SortDir = ""
 
-	_, err = NewUnifiedSorter("/tmp/sorter", /* the changefeed setting */
+	_, err := NewUnifiedSorter(dir, /* the changefeed setting */
 		"test-cf",
 		"test",
 		0,
@@ -282,7 +283,7 @@ func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
 	defer poolMu.Unlock()
 
 	c.Assert(pool, check.NotNil)
-	c.Assert(pool.dir, check.Equals, "/tmp/sorter")
+	c.Assert(pool.dir, check.Equals, dir)
 }
 
 // TestSorterCancelRestart tests the situation where the Unified Sorter is repeatedly canceled and
@@ -292,7 +293,7 @@ func (s *sorterSuite) TestSorterCancelRestart(c *check.C) {
 	defer UnifiedSorterCleanUp()
 
 	conf := config.GetDefaultServerConfig()
-	conf.DataDir = "/tmp/cdc_data"
+	conf.DataDir = c.MkDir()
 	sortDir := filepath.Join(conf.DataDir, config.DefaultSortDir)
 	conf.Sorter = &config.SorterConfig{
 		NumConcurrentWorker:    8,
@@ -336,7 +337,7 @@ func (s *sorterSuite) TestSorterIOError(c *check.C) {
 	defer UnifiedSorterCleanUp()
 
 	conf := config.GetDefaultServerConfig()
-	conf.DataDir = "/tmp/cdc_data"
+	conf.DataDir = c.MkDir()
 	sortDir := filepath.Join(conf.DataDir, config.DefaultSortDir)
 	conf.Sorter = &config.SorterConfig{
 		NumConcurrentWorker:    8,
@@ -413,7 +414,7 @@ func (s *sorterSuite) TestSorterErrorReportCorrect(c *check.C) {
 	defer log.SetLevel(zapcore.InfoLevel)
 
 	conf := config.GetDefaultServerConfig()
-	conf.DataDir = "/tmp/cdc_data"
+	conf.DataDir = c.MkDir()
 	sortDir := filepath.Join(conf.DataDir, config.DefaultSortDir)
 	conf.Sorter = &config.SorterConfig{
 		NumConcurrentWorker:    8,
@@ -465,7 +466,7 @@ func (s *sorterSuite) TestSortClosedAddEntry(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer UnifiedSorterCleanUp()
 
-	sorter, err := NewUnifiedSorter("/tmp/sorter",
+	sorter, err := NewUnifiedSorter(c.MkDir(),
 		"test-cf",
 		"test",
 		0,


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Use dedicated tmp dir to avoid locked error and stable tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
