### PR TITLE
[DNM] capture: make capture info register & unregister atomic.

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -92,7 +92,7 @@ func (c *Capture) reset() error {
 	c.processorManager = c.newProcessorManager()
 	if c.session != nil {
 		if err := c.session.Close(); err != nil {
-			log.Warn("close etcd session failed", zap.Error(err))
+			return errors.Annotate(cerror.WrapError(cerror.ErrNewCaptureFailed, err), "close exist capture session")
 		}
 	}
 	sess, err := concurrency.NewSession(c.etcdClient.Client.Unwrap(),
@@ -128,6 +128,7 @@ func (c *Capture) Run(ctx context.Context) error {
 		}
 		err = c.reset()
 		if err != nil {
+			log.Error("reset capture failed", zap.Error(err))
 			return errors.Trace(err)
 		}
 		err = c.run(ctx)

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -320,7 +320,7 @@ func (c *Capture) resign(ctx cdcContext.Context) error {
 
 // register the capture information in etcd
 func (c *Capture) register(ctx cdcContext.Context) error {
-	if !atomic.CompareAndSwapInt32(&c.infoRegistered, 0, 1) {
+	if atomic.LoadInt32(&c.infoRegistered) == 1 {
 		// capture info already registered
 		return cerror.WrapError(cerror.ErrCaptureRegister, errors.New("capture info already registered"))
 	}
@@ -328,6 +328,7 @@ func (c *Capture) register(ctx cdcContext.Context) error {
 	if err != nil {
 		return cerror.WrapError(cerror.ErrCaptureRegister, err)
 	}
+	atomic.StoreInt32(&c.infoRegistered, 1)
 	return nil
 }
 

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -333,12 +333,13 @@ func (c *Capture) register(ctx cdcContext.Context) error {
 
 // unregister the capture info in etcd
 func (c *Capture) unregister(ctx cdcContext.Context) error {
-	if !atomic.CompareAndSwapInt32(&c.infoRegistered, 1, 0) {
+	if atomic.LoadInt32(&c.infoRegistered) == 0 {
 		return cerror.WrapError(cerror.ErrCaptureRegister, errors.New("capture info is not registered"))
 	}
 	if err := ctx.GlobalVars().EtcdClient.DeleteCaptureInfo(ctx, c.info.ID); err != nil {
 		return cerror.WrapError(cerror.ErrCaptureRegister, err)
 	}
+	atomic.StoreInt32(&c.infoRegistered, 0)
 	return nil
 }
 

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -46,8 +46,8 @@ type Capture struct {
 	captureMu sync.Mutex
 
 	// make sure that only one capture's info registered into etcd
-	infoRegistered bool
-	info           *model.CaptureInfo
+	// infoRegistered bool
+	info *model.CaptureInfo
 
 	ownerMu          sync.Mutex
 	owner            *owner.Owner
@@ -323,27 +323,27 @@ func (c *Capture) resign(ctx cdcContext.Context) error {
 
 // register the capture information in etcd
 func (c *Capture) register(ctx cdcContext.Context) error {
-	if c.infoRegistered {
-		// capture info already registered
-		return cerror.WrapError(cerror.ErrCaptureRegister, errors.New("capture info already registered"))
-	}
+	// if c.infoRegistered {
+	// 	// capture info already registered
+	// 	return cerror.WrapError(cerror.ErrCaptureRegister, errors.New("capture info already registered"))
+	// }
 	err := ctx.GlobalVars().EtcdClient.PutCaptureInfo(ctx, c.info, c.session.Lease())
 	if err != nil {
 		return cerror.WrapError(cerror.ErrCaptureRegister, err)
 	}
-	c.infoRegistered = true
+	// c.infoRegistered = true
 	return nil
 }
 
 // unregister the capture info in etcd
 func (c *Capture) unregister(ctx cdcContext.Context) error {
-	if !c.infoRegistered {
-		return cerror.WrapError(cerror.ErrCaptureRegister, errors.New("capture info is not registered"))
-	}
+	// if !c.infoRegistered {
+	// 	return cerror.WrapError(cerror.ErrCaptureRegister, errors.New("capture info is not registered"))
+	// }
 	if err := ctx.GlobalVars().EtcdClient.DeleteCaptureInfo(ctx, c.info.ID); err != nil {
 		return cerror.WrapError(cerror.ErrCaptureRegister, err)
 	}
-	c.infoRegistered = false
+	// c.infoRegistered = false
 	return nil
 }
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -151,6 +151,12 @@ func WithCancel(ctx Context) (Context, context.CancelFunc) {
 	return WithStd(ctx, stdCtx), cancel
 }
 
+// WithTimeout returns a Context with the timeout and cancel function
+func WithTimeout(ctx Context, timeout time.Duration) (Context, context.CancelFunc) {
+	stdCtx, cancel := context.WithTimeout(ctx, timeout)
+	return WithStd(ctx, stdCtx), cancel
+}
+
 type throwContext struct {
 	Context
 	f func(error) error


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #2388

### What is changed and how it works?

* add an atomic variable to control the register and unregister capture info into etcd.
* fix some lint and typo when wql

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

Side effects

Related changes

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with `None`.
```
None