### PR TITLE
processor: cleanup some unnecessary error logs

### DIFF
--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -503,7 +503,9 @@ func (p *processor) sendError(err error) {
 	select {
 	case p.errCh <- err:
 	default:
-		log.Error("processor receives redundant error", zap.Error(err))
+		if errors.Cause(err) != context.Canceled {
+			log.Error("processor receives redundant error", zap.Error(err))
+		}
 	}
 }
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -96,7 +96,9 @@ func (p *Pipeline) driveRunner(ctx context.Context, previousRunner, runner runne
 	err := runner.run(ctx)
 	if err != nil {
 		ctx.Throw(err)
-		log.Error("found error when running the node", zap.String("name", runner.getName()), zap.Error(err))
+		if cerror.ErrTableProcessorStoppedSafely.NotEqual(err) {
+			log.Error("found error when running the node", zap.String("name", runner.getName()), zap.Error(err))
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Remove two unnecessary error logs:

```
[2021/08/02 22:03:33.331 +08:00] [ERROR] [pipeline.go:99] ["found error when running the node"] [name=sink] [error="[CDC:ErrTableProcessorStoppedSafely]table processor stopped safely"] [errorVerbose="[CDC:ErrTableProcessorStoppedSafely]table processor stopped safely\ngithub.com/pingcap/errors.AddStack\n\t/nfs/cache/mod/github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/errors.go:174\ngithub.com/pingcap/errors.(*Error).GenWithStackByArgs\n\t/nfs/cache/mod/github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/normalize.go:156\ngithub.com/pingcap/ticdc/cdc/processor/pipeline.(*sinkNode).flushSink.func1\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor/pipeline/sink.go:116\ngithub.com/pingcap/ticdc/cdc/processor/pipeline.(*sinkNode).flushSink\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor/pipeline/sink.go:126\ngithub.com/pingcap/ticdc/cdc/processor/pipeline.(*sinkNode).Receive\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/processor/pipeline/sink.go:308\ngithub.com/pingcap/ticdc/pkg/pipeline.(*nodeRunner).run\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/pkg/pipeline/runner.go:60\ngithub.com/pingcap/ticdc/pkg/pipeline.(*Pipeline).driveRunner\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/pkg/pipeline/pipeline.go:96\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371"]
```
and 

```
[2021/08/02 22:02:11.796 +08:00] [ERROR] [processor.go:506] ["processor receives redundant error"] [error="context canceled"] [errorVerbose="context canceled\ngithub.com/pingcap/errors.AddStack\n\t/nfs/cache/mod/github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/nfs/cache/mod/github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/juju_adaptor.go:15\ngithub.com/pingcap/ticdc/cdc/puller.(*pullerImpl).Run.func4\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/puller/puller.go:190\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/nfs/cache/mod/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9/errgroup/errgroup.go:57\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371"]
```

### What is changed and how it works?

Add error check

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
