### PR TITLE
redo-log: add basic framework for redo log manager and writer

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -249,6 +249,9 @@ func (info *ChangeFeedInfo) VerifyAndFix() error {
 	if info.Config.Scheduler == nil {
 		info.Config.Scheduler = defaultConfig.Scheduler
 	}
+	if info.Config.Consistent == nil {
+		info.Config.Consistent = defaultConfig.Consistent
+	}
 	return nil
 }
 

--- a/cdc/model/reactor_state_test.go
+++ b/cdc/model/reactor_state_test.go
@@ -63,7 +63,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/capture/6bbc01c8-0605-4f86-a0f9-b3119109b225",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","storage":"local"}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -88,6 +88,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 						Sink:             &config.SinkConfig{Protocol: "default"},
 						Cyclic:           &config.CyclicConfig{},
 						Scheduler:        &config.SchedulerConfig{Tp: "table-number", PollingTime: -1},
+						Consistent:       &config.ConsistentConfig{Level: "normal", Storage: "local"},
 					},
 				},
 				Status: &ChangeFeedStatus{CheckpointTs: 421980719742451713, ResolvedTs: 421980720003809281},
@@ -119,7 +120,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/capture/666777888",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","storage":"local"}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -148,6 +149,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 						Sink:             &config.SinkConfig{Protocol: "default"},
 						Cyclic:           &config.CyclicConfig{},
 						Scheduler:        &config.SchedulerConfig{Tp: "table-number", PollingTime: -1},
+						Consistent:       &config.ConsistentConfig{Level: "normal", Storage: "local"},
 					},
 				},
 				Status: &ChangeFeedStatus{CheckpointTs: 421980719742451713, ResolvedTs: 421980720003809281},
@@ -185,7 +187,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/task/workload/6bbc01c8-0605-4f86-a0f9-b3119109b225/test-fake",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","storage":"local"}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -215,6 +217,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 						Sink:             &config.SinkConfig{Protocol: "default"},
 						Cyclic:           &config.CyclicConfig{},
 						Scheduler:        &config.SchedulerConfig{Tp: "table-number", PollingTime: -1},
+						Consistent:       &config.ConsistentConfig{Level: "normal", Storage: "local"},
 					},
 				},
 				Status: &ChangeFeedStatus{CheckpointTs: 421980719742451713, ResolvedTs: 421980720003809281},
@@ -253,7 +256,7 @@ func (s *stateSuite) TestChangefeedStateUpdate(c *check.C) {
 				"/tidb/cdc/task/status/666777888/test1",
 			},
 			updateValue: []string{
-				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
+				`{"sink-uri":"blackhole://","opts":{},"create-time":"2020-02-02T00:00:00.000000+00:00","start-ts":421980685886554116,"target-ts":0,"admin-job-type":0,"sort-engine":"memory","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":false,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","storage":"local"}},"state":"normal","history":null,"error":null,"sync-point-enabled":false,"sync-point-interval":600000000000}`,
 				`{"resolved-ts":421980720003809281,"checkpoint-ts":421980719742451713,"admin-job-type":0}`,
 				`{"checkpoint-ts":421980720003809281,"resolved-ts":421980720003809281,"count":0,"error":null}`,
 				`{"tables":{"45":{"start-ts":421980685886554116,"mark-table-id":0}},"operation":null,"admin-job-type":0}`,
@@ -337,11 +340,12 @@ func (s *stateSuite) TestPatchInfo(c *check.C) {
 		SinkURI: "123",
 		Engine:  SortUnified,
 		Config: &config.ReplicaConfig{
-			Filter:    defaultConfig.Filter,
-			Mounter:   defaultConfig.Mounter,
-			Sink:      defaultConfig.Sink,
-			Cyclic:    defaultConfig.Cyclic,
-			Scheduler: defaultConfig.Scheduler,
+			Filter:     defaultConfig.Filter,
+			Mounter:    defaultConfig.Mounter,
+			Sink:       defaultConfig.Sink,
+			Cyclic:     defaultConfig.Cyclic,
+			Scheduler:  defaultConfig.Scheduler,
+			Consistent: defaultConfig.Consistent,
 		},
 	})
 	state.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {
@@ -354,11 +358,12 @@ func (s *stateSuite) TestPatchInfo(c *check.C) {
 		StartTs: 6,
 		Engine:  SortUnified,
 		Config: &config.ReplicaConfig{
-			Filter:    defaultConfig.Filter,
-			Mounter:   defaultConfig.Mounter,
-			Sink:      defaultConfig.Sink,
-			Cyclic:    defaultConfig.Cyclic,
-			Scheduler: defaultConfig.Scheduler,
+			Filter:     defaultConfig.Filter,
+			Mounter:    defaultConfig.Mounter,
+			Sink:       defaultConfig.Sink,
+			Cyclic:     defaultConfig.Cyclic,
+			Scheduler:  defaultConfig.Scheduler,
+			Consistent: defaultConfig.Consistent,
 		},
 	})
 	state.PatchInfo(func(info *ChangeFeedInfo) (*ChangeFeedInfo, bool, error) {

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	tablepipeline "github.com/pingcap/ticdc/cdc/processor/pipeline"
 	"github.com/pingcap/ticdc/cdc/puller"
+	"github.com/pingcap/ticdc/cdc/redo"
 	"github.com/pingcap/ticdc/cdc/sink"
 	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
@@ -62,6 +63,7 @@ type processor struct {
 	filter        *filter.Filter
 	mounter       entry.Mounter
 	sinkManager   *sink.Manager
+	redoManager   redo.LogManager
 
 	initialized bool
 	errCh       chan error
@@ -106,7 +108,10 @@ func newProcessor4Test(ctx cdcContext.Context,
 	createTablePipeline func(ctx cdcContext.Context, tableID model.TableID, replicaInfo *model.TableReplicaInfo) (tablepipeline.TablePipeline, error),
 ) *processor {
 	p := newProcessor(ctx)
-	p.lazyInit = func(ctx cdcContext.Context) error { return nil }
+	p.lazyInit = func(ctx cdcContext.Context) error {
+		p.redoManager = redo.NewDisabledManager()
+		return nil
+	}
 	p.createTablePipeline = createTablePipeline
 	return p
 }
@@ -287,6 +292,11 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 	}
 	checkpointTs := p.changefeed.Info.GetCheckpointTs(p.changefeed.Status)
 	p.sinkManager = sink.NewManager(stdCtx, s, errCh, checkpointTs)
+	redoManagerOpts := &redo.ManagerOptions{EnableBgRunner: true, ErrCh: errCh}
+	p.redoManager, err = redo.NewManager(stdCtx, p.changefeed.Info.Config.Consistent, redoManagerOpts)
+	if err != nil {
+		return err
+	}
 	p.initialized = true
 	log.Info("run processor", cdcContext.ZapFieldCapture(ctx), cdcContext.ZapFieldChangefeed(ctx))
 	return nil
@@ -376,9 +386,7 @@ func (p *processor) handleTableOperation(ctx cdcContext.Context) error {
 					operation.Done = true
 					return nil
 				})
-				table.Cancel()
-				table.Wait()
-				delete(p.tables, tableID)
+				p.removeTable(table, tableID)
 				log.Debug("Operation done signal received",
 					cdcContext.ZapFieldChangefeed(ctx),
 					zap.Int64("tableID", tableID),
@@ -545,9 +553,7 @@ func (p *processor) checkTablesNum(ctx cdcContext.Context) error {
 			// table will be removed by normal logic
 			continue
 		}
-		tablePipeline.Cancel()
-		tablePipeline.Wait()
-		delete(p.tables, tableID)
+		p.removeTable(tablePipeline, tableID)
 		log.Warn("the table was forcibly deleted", zap.Int64("tableID", tableID), zap.Any("taskStatus", taskStatus))
 	}
 	return nil
@@ -640,9 +646,7 @@ func (p *processor) addTable(ctx cdcContext.Context, tableID model.TableID, repl
 	if table, ok := p.tables[tableID]; ok {
 		if table.Status() == tablepipeline.TableStatusStopped {
 			log.Warn("The same table exists but is stopped. Cancel it and continue.", cdcContext.ZapFieldChangefeed(ctx), zap.Int64("ID", tableID))
-			table.Cancel()
-			table.Wait()
-			delete(p.tables, tableID)
+			p.removeTable(table, tableID)
 		} else {
 			log.Warn("Ignore existing table", cdcContext.ZapFieldChangefeed(ctx), zap.Int64("ID", tableID))
 			return nil
@@ -715,7 +719,7 @@ func (p *processor) createTablePipelineImpl(ctx cdcContext.Context, tableID mode
 		tableNameStr = tableName.QuoteString()
 	}
 
-	sink := p.sinkManager.CreateTableSink(tableID, replicaInfo.StartTs)
+	sink := p.sinkManager.CreateTableSink(tableID, replicaInfo.StartTs, p.redoManager)
 	table := tablepipeline.NewTablePipeline(
 		ctx,
 		p.mounter,
@@ -737,6 +741,10 @@ func (p *processor) createTablePipelineImpl(ctx cdcContext.Context, tableID mode
 			zap.Any("replicaInfo", replicaInfo))
 	}()
 
+	if p.redoManager.Enabled() {
+		p.redoManager.AddTable(tableID, replicaInfo.StartTs)
+	}
+
 	log.Info("Add table pipeline", zap.Int64("tableID", tableID),
 		cdcContext.ZapFieldChangefeed(ctx),
 		zap.String("name", table.Name()),
@@ -744,6 +752,15 @@ func (p *processor) createTablePipelineImpl(ctx cdcContext.Context, tableID mode
 		zap.Uint64("globalResolvedTs", p.changefeed.Status.ResolvedTs))
 
 	return table, nil
+}
+
+func (p *processor) removeTable(table tablepipeline.TablePipeline, tableID model.TableID) {
+	table.Cancel()
+	table.Wait()
+	delete(p.tables, tableID)
+	if p.redoManager.Enabled() {
+		p.redoManager.RemoveTable(tableID)
+	}
 }
 
 // doGCSchemaStorage trigger the schema storage GC

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -1,0 +1,254 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing pemissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/config"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"go.uber.org/zap"
+)
+
+var updateRtsInterval = time.Second
+
+type consistentLevelType string
+
+const (
+	consistentLevelNormal   consistentLevelType = "normal"
+	consistentLevelEventual consistentLevelType = "eventual"
+)
+
+type consistentStorage string
+
+const (
+	consistentStorageLocal     consistentStorage = "local"
+	consistentStorageS3        consistentStorage = "s3"
+	consistentStorageBlackhole consistentStorage = "blackhole"
+)
+
+// IsValidConsistentLevel checks whether a give consistent level is valid
+func IsValidConsistentLevel(level string) bool {
+	switch consistentLevelType(level) {
+	case consistentLevelNormal, consistentLevelEventual:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidConsistentStorage checks whether a give consistent storage is valid
+func IsValidConsistentStorage(storage string) bool {
+	switch consistentStorage(storage) {
+	case consistentStorageLocal, consistentStorageS3, consistentStorageBlackhole:
+		return true
+	default:
+		return false
+	}
+}
+
+// LogManager defines an interface that is used to manage redo log
+type LogManager interface {
+	// Enabled returns whether the log manager is enabled
+	Enabled() bool
+
+	// The following 5 APIs are called from processor only
+	EmitRowChangedEvents(ctx context.Context, tableID model.TableID, rows ...*model.RowChangedEvent) error
+	FlushLog(ctx context.Context, tableID model.TableID, resolvedTs uint64) error
+	AddTable(tableID model.TableID, startTs uint64)
+	RemoveTable(tableID model.TableID)
+	GetMinResolvedTs() uint64
+
+	// EmitDDLEvent and FlushResolvedAndCheckpointTs are called from owner only
+	EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
+	FlushResolvedAndCheckpointTs(ctx context.Context, resolvedTs, checkpointTs uint64) (err error)
+}
+
+// ManagerOptions defines options for redo log manager
+type ManagerOptions struct {
+	// whether to run background goroutine to fetch table resolved ts
+	EnableBgRunner bool
+	ErrCh          chan<- error
+}
+
+// ManagerImpl manages redo log writer, buffers un-persistent redo logs, calculates
+// redo log resolved ts. It implements LogManager interface.
+type ManagerImpl struct {
+	enabled       bool
+	level         consistentLevelType
+	storage       consistentStorage
+	writer        LogWriter
+	minResolvedTs uint64
+	tableIDs      []model.TableID
+	rtsMap        map[model.TableID]uint64
+	rtsMapMu      sync.RWMutex
+}
+
+// NewManager creates a new Manager
+func NewManager(ctx context.Context, cfg *config.ConsistentConfig, opts *ManagerOptions) (*ManagerImpl, error) {
+	// return a nil Manager if no consistent config or normal consistent level
+	if cfg == nil || consistentLevelType(cfg.Level) == consistentLevelNormal {
+		return &ManagerImpl{enabled: false}, nil
+	}
+	m := &ManagerImpl{
+		enabled: true,
+		level:   consistentLevelType(cfg.Level),
+		storage: consistentStorage(cfg.Storage),
+		rtsMap:  make(map[model.TableID]uint64),
+	}
+	switch m.storage {
+	case consistentStorageBlackhole:
+		m.writer = newBlackHoleStorage()
+	default:
+		return nil, cerror.ErrConsistentStorage.GenWithStackByArgs(m.storage)
+	}
+	if opts.EnableBgRunner {
+		go m.run(ctx, opts.ErrCh)
+	}
+	return m, nil
+}
+
+// NewDisabledManager returns a disabled log manger instance, used in test only
+func NewDisabledManager() *ManagerImpl {
+	return &ManagerImpl{enabled: false}
+}
+
+// Enabled returns whether this log manager is enabled
+func (m *ManagerImpl) Enabled() bool {
+	return m.enabled
+}
+
+// EmitRowChangedEvents converts RowChangedEvents to RedoLogs, and sends to redo log writer
+func (m *ManagerImpl) EmitRowChangedEvents(
+	ctx context.Context,
+	tableID model.TableID,
+	rows ...*model.RowChangedEvent,
+) error {
+	logs := make([]*RowRedoLog, 0, len(rows))
+	for _, row := range rows {
+		logs = append(logs, &RowRedoLog{Row: row, Index: row.IndexColumns})
+	}
+	_, err := m.writer.WriteLog(ctx, tableID, logs)
+	return err
+}
+
+// FlushLog emits resolved ts of a single table
+func (m *ManagerImpl) FlushLog(
+	ctx context.Context,
+	tableID model.TableID,
+	resolvedTs uint64,
+) error {
+	return m.writer.FlushLog(ctx, tableID, resolvedTs)
+}
+
+// EmitDDLEvent sends DDL event to redo log writer
+func (m *ManagerImpl) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
+	return m.writer.SendDDL(ctx, ddl)
+}
+
+// GetMinResolvedTs returns the minimum resolved ts of all tables in this redo log manager
+func (m *ManagerImpl) GetMinResolvedTs() uint64 {
+	return atomic.LoadUint64(&m.minResolvedTs)
+}
+
+// FlushResolvedAndCheckpointTs flushes resolved-ts and checkpoint-ts to redo log writer
+func (m *ManagerImpl) FlushResolvedAndCheckpointTs(ctx context.Context, resolvedTs, checkpointTs uint64) (err error) {
+	err = m.writer.EmitResolvedTs(ctx, resolvedTs)
+	if err != nil {
+		return
+	}
+	err = m.writer.EmitCheckpointTs(ctx, checkpointTs)
+	return
+}
+
+// AddTable adds a new table in redo log manager
+func (m *ManagerImpl) AddTable(tableID model.TableID, startTs uint64) {
+	m.rtsMapMu.Lock()
+	defer m.rtsMapMu.Unlock()
+	i := sort.Search(len(m.tableIDs), func(i int) bool {
+		return m.tableIDs[i] >= tableID
+	})
+	if i < len(m.tableIDs) && m.tableIDs[i] == tableID {
+		log.Warn("add duplicated table in redo log manager", zap.Int64("table-id", tableID))
+		return
+	}
+	if i == len(m.tableIDs) {
+		m.tableIDs = append(m.tableIDs, tableID)
+	} else {
+		m.tableIDs = append(m.tableIDs[:i+1], m.tableIDs[i:]...)
+		m.tableIDs[i] = tableID
+	}
+	m.rtsMap[tableID] = startTs
+}
+
+// RemoveTable removes a table from redo log manager
+func (m *ManagerImpl) RemoveTable(tableID model.TableID) {
+	m.rtsMapMu.Lock()
+	defer m.rtsMapMu.Unlock()
+	i := sort.Search(len(m.tableIDs), func(i int) bool {
+		return m.tableIDs[i] >= tableID
+	})
+	if i < len(m.tableIDs) && m.tableIDs[i] == tableID {
+		copy(m.tableIDs[i:], m.tableIDs[i+1:])
+		m.tableIDs = m.tableIDs[:len(m.tableIDs)-1]
+		delete(m.rtsMap, tableID)
+	} else {
+		log.Warn("remove a table not maintained in redo log manager", zap.Int64("table-id", tableID))
+	}
+	// TODO: send remove table command to redo log writer
+}
+
+// updatertsMap reads rtsMap from redo log writer and calculate the minimum
+// resolved ts of all maintaining tables.
+func (m *ManagerImpl) updateTableResolvedTs(ctx context.Context) error {
+	m.rtsMapMu.Lock()
+	defer m.rtsMapMu.Unlock()
+	rtsMap, err := m.writer.GetTableResolvedTs(ctx, m.tableIDs)
+	if err != nil {
+		return err
+	}
+	minResolvedTs := uint64(math.MaxUint64)
+	for tableID, rts := range rtsMap {
+		m.rtsMap[tableID] = rts
+		if rts < minResolvedTs {
+			minResolvedTs = rts
+		}
+	}
+	atomic.StoreUint64(&m.minResolvedTs, minResolvedTs)
+	return nil
+}
+
+func (m *ManagerImpl) run(ctx context.Context, errCh chan<- error) {
+	ticker := time.NewTicker(updateRtsInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			err := m.updateTableResolvedTs(ctx)
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}
+}

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -1,0 +1,174 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+func TestSuite(t *testing.T) { check.TestingT(t) }
+
+type logManagerSuite struct{}
+
+var _ = check.Suite(&logManagerSuite{})
+
+func (s *logManagerSuite) TestConsistentConfig(c *check.C) {
+	defer testleak.AfterTest(c)()
+	levelCases := []struct {
+		level string
+		valid bool
+	}{
+		{"normal", true},
+		{"eventual", true},
+		{"NORMAL", false},
+		{"", false},
+	}
+	for _, lc := range levelCases {
+		c.Assert(IsValidConsistentLevel(lc.level), check.Equals, lc.valid)
+	}
+
+	storageCases := []struct {
+		storage string
+		valid   bool
+	}{
+		{"local", true},
+		{"s3", true},
+		{"blackhole", true},
+		{"Local", false},
+		{"nfs", false},
+		{"", false},
+	}
+	for _, sc := range storageCases {
+		c.Assert(IsValidConsistentStorage(sc.storage), check.Equals, sc.valid)
+	}
+}
+
+func (s *logManagerSuite) TestLogManagerInProcessor(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	checkResovledTs := func(mgr LogManager, expectedRts uint64) {
+		time.Sleep(time.Millisecond*200 + updateRtsInterval)
+		resolvedTs := mgr.GetMinResolvedTs()
+		c.Assert(resolvedTs, check.Equals, expectedRts)
+	}
+
+	cfg := &config.ConsistentConfig{
+		Level:   string(consistentLevelEventual),
+		Storage: string(consistentStorageBlackhole),
+	}
+	errCh := make(chan error, 1)
+	opts := &ManagerOptions{
+		EnableBgRunner: true,
+		ErrCh:          errCh,
+	}
+	logMgr, err := NewManager(ctx, cfg, opts)
+	c.Assert(err, check.IsNil)
+
+	// check emit row changed events can move forward resolved ts
+	tables := []model.TableID{53, 55, 57, 59}
+	startTs := uint64(100)
+	for _, tableID := range tables {
+		logMgr.AddTable(tableID, startTs)
+	}
+	testCases := []struct {
+		tableID model.TableID
+		rows    []*model.RowChangedEvent
+	}{
+		{
+			tableID: 53,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 120, Table: &model.TableName{TableID: 53}},
+				{CommitTs: 125, Table: &model.TableName{TableID: 53}},
+				{CommitTs: 130, Table: &model.TableName{TableID: 53}},
+			},
+		},
+		{
+			tableID: 55,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 130, Table: &model.TableName{TableID: 55}},
+				{CommitTs: 135, Table: &model.TableName{TableID: 55}},
+			},
+		},
+		{
+			tableID: 57,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 130, Table: &model.TableName{TableID: 57}},
+			},
+		},
+		{
+			tableID: 59,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 128, Table: &model.TableName{TableID: 59}},
+				{CommitTs: 130, Table: &model.TableName{TableID: 59}},
+				{CommitTs: 133, Table: &model.TableName{TableID: 59}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		err := logMgr.EmitRowChangedEvents(ctx, tc.tableID, tc.rows...)
+		c.Assert(err, check.IsNil)
+	}
+	checkResovledTs(logMgr, uint64(130))
+
+	// check FlushLog can move forward the resolved ts when there is not row event.
+	flushResolvedTs := uint64(150)
+	for _, tableID := range tables {
+		err := logMgr.FlushLog(ctx, tableID, flushResolvedTs)
+		c.Assert(err, check.IsNil)
+	}
+	checkResovledTs(logMgr, flushResolvedTs)
+
+	// check remove table can work normally
+	removeTable := tables[len(tables)-1]
+	tables = tables[:len(tables)-1]
+	logMgr.RemoveTable(removeTable)
+	flushResolvedTs = uint64(200)
+	for _, tableID := range tables {
+		err := logMgr.FlushLog(ctx, tableID, flushResolvedTs)
+		c.Assert(err, check.IsNil)
+	}
+	checkResovledTs(logMgr, flushResolvedTs)
+}
+
+func (s *logManagerSuite) TestLogManagerInOwner(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &config.ConsistentConfig{
+		Level:   string(consistentLevelEventual),
+		Storage: string(consistentStorageBlackhole),
+	}
+	opts := &ManagerOptions{
+		EnableBgRunner: false,
+	}
+	logMgr, err := NewManager(ctx, cfg, opts)
+	c.Assert(err, check.IsNil)
+
+	ddl := &model.DDLEvent{StartTs: 100, CommitTs: 120, Query: "CREATE TABLE `TEST.T1`"}
+	err = logMgr.EmitDDLEvent(ctx, ddl)
+	c.Assert(err, check.IsNil)
+
+	err = logMgr.FlushResolvedAndCheckpointTs(ctx, 130 /*resolvedTs*/, 120 /*CheckPointTs*/)
+	c.Assert(err, check.IsNil)
+}

--- a/cdc/redo/storage.go
+++ b/cdc/redo/storage.go
@@ -1,0 +1,45 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+// RowRedoLog stores one RowChangedEvent and its index column
+type RowRedoLog struct {
+	Row *model.RowChangedEvent `json:"row"`
+	// Index is the IndexColumns field from model.RowChangedEvent, we need to persist
+	// this field in order to use it when consuming redo logs. Since this filed
+	// is not json encoded in model.RowChangedEvents, we store it separately here.
+	Index [][]int `json:"index"`
+}
+
+// LogWriter is a writer abstraction for redo log storage layer
+type LogWriter interface {
+	WriteLog(ctx context.Context, tableID model.TableID, log []*RowRedoLog) (resolvedTs uint64, err error)
+	// FlushLog sends resolved-ts from table pipeline to log writer, it is
+	// essential to flush when a table doesn't have any row change event for
+	// sometime, and the resolved ts of this table should be moved forward.
+	FlushLog(ctx context.Context, tableID model.TableID, resolvedTs uint64) error
+
+	// SendDDL, EmitCheckpointTs and EmitResolvedTs are called from owner only
+	SendDDL(ctx context.Context, ddl *model.DDLEvent) error
+	EmitCheckpointTs(ctx context.Context, checkpointTs uint64) error
+	EmitResolvedTs(ctx context.Context, resolvedTs uint64) error
+
+	GetTableResolvedTs(ctx context.Context, tableIDs []int64) (resolvedTsMap map[int64]uint64, err error)
+}

--- a/cdc/redo/storage_blackhole.go
+++ b/cdc/redo/storage_blackhole.go
@@ -1,0 +1,84 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	"go.uber.org/zap"
+)
+
+// blackholeStorage defines a blockhole storage, it receives events and persists
+// without any latency
+type blackholeStorage struct {
+	tableRtsMap  map[model.TableID]uint64
+	tableRtsMu   sync.RWMutex
+	resolvedTs   uint64
+	checkpointTs uint64
+}
+
+func newBlackHoleStorage() *blackholeStorage {
+	return &blackholeStorage{
+		tableRtsMap: make(map[model.TableID]uint64),
+	}
+}
+
+func (bs *blackholeStorage) WriteLog(ctx context.Context, tableID model.TableID, logs []*RowRedoLog) (resolvedTs uint64, err error) {
+	bs.tableRtsMu.Lock()
+	defer bs.tableRtsMu.Unlock()
+	if len(logs) == 0 {
+		return bs.tableRtsMap[tableID], nil
+	}
+	resolvedTs = bs.tableRtsMap[tableID]
+	current := logs[len(logs)-1].Row.CommitTs
+	bs.tableRtsMap[tableID] = current
+	log.Debug("write row redo logs", zap.Int("count", len(logs)),
+		zap.Uint64("resolvedTs", resolvedTs), zap.Uint64("current", current))
+	return
+}
+
+func (bs *blackholeStorage) FlushLog(ctx context.Context, tableID model.TableID, resolvedTs uint64) error {
+	bs.tableRtsMu.Lock()
+	defer bs.tableRtsMu.Unlock()
+	bs.tableRtsMap[tableID] = resolvedTs
+	return nil
+}
+
+func (bs *blackholeStorage) SendDDL(ctx context.Context, ddl *model.DDLEvent) error {
+	log.Debug("send ddl event", zap.Any("ddl", ddl))
+	return nil
+}
+
+func (bs *blackholeStorage) EmitResolvedTs(ctx context.Context, ts uint64) error {
+	bs.resolvedTs = ts
+	return nil
+}
+
+func (bs *blackholeStorage) EmitCheckpointTs(ctx context.Context, ts uint64) error {
+	bs.checkpointTs = ts
+	return nil
+}
+
+func (bs *blackholeStorage) GetTableResolvedTs(ctx context.Context, tableIDs []int64) (map[int64]uint64, error) {
+	bs.tableRtsMu.RLock()
+	defer bs.tableRtsMu.RUnlock()
+	rtsMap := make(map[int64]uint64, len(bs.tableRtsMap))
+	for _, tableID := range tableIDs {
+		rtsMap[tableID] = bs.tableRtsMap[tableID]
+	}
+	return rtsMap, nil
+}

--- a/cdc/sink/manager.go
+++ b/cdc/sink/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/cdc/redo"
 	"github.com/pingcap/ticdc/pkg/util"
 	"go.uber.org/zap"
 )
@@ -56,17 +57,18 @@ func NewManager(ctx context.Context, backendSink Sink, errCh chan error, checkpo
 }
 
 // CreateTableSink creates a table sink
-func (m *Manager) CreateTableSink(tableID model.TableID, checkpointTs model.Ts) Sink {
+func (m *Manager) CreateTableSink(tableID model.TableID, checkpointTs model.Ts, redoManager redo.LogManager) Sink {
 	m.tableSinksMu.Lock()
 	defer m.tableSinksMu.Unlock()
 	if _, exist := m.tableSinks[tableID]; exist {
 		log.Panic("the table sink already exists", zap.Uint64("tableID", uint64(tableID)))
 	}
 	sink := &tableSink{
-		tableID:   tableID,
-		manager:   m,
-		buffer:    make([]*model.RowChangedEvent, 0, 128),
-		emittedTs: checkpointTs,
+		tableID:     tableID,
+		manager:     m,
+		buffer:      make([]*model.RowChangedEvent, 0, 128),
+		emittedTs:   checkpointTs,
+		redoManager: redoManager,
 	}
 	m.tableSinks[tableID] = sink
 	return sink
@@ -85,9 +87,9 @@ func (m *Manager) getMinEmittedTs() model.Ts {
 	}
 	minTs := model.Ts(math.MaxUint64)
 	for _, tableSink := range m.tableSinks {
-		emittedTs := tableSink.getEmittedTs()
-		if minTs > emittedTs {
-			minTs = emittedTs
+		resolvedTs := tableSink.getResolvedTs()
+		if minTs > resolvedTs {
+			minTs = resolvedTs
 		}
 	}
 	return minTs
@@ -132,7 +134,8 @@ type tableSink struct {
 	manager *Manager
 	buffer  []*model.RowChangedEvent
 	// emittedTs means all of events which of commitTs less than or equal to emittedTs is sent to backendSink
-	emittedTs model.Ts
+	emittedTs   model.Ts
+	redoManager redo.LogManager
 }
 
 func (t *tableSink) Initialize(ctx context.Context, tableInfo []*model.SimpleTableInfo) error {
@@ -142,6 +145,9 @@ func (t *tableSink) Initialize(ctx context.Context, tableInfo []*model.SimpleTab
 
 func (t *tableSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowChangedEvent) error {
 	t.buffer = append(t.buffer, rows...)
+	if t.redoManager.Enabled() {
+		return t.redoManager.EmitRowChangedEvents(ctx, t.tableID, rows...)
+	}
 	return nil
 }
 
@@ -150,11 +156,20 @@ func (t *tableSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 	return nil
 }
 
+// FlushRowChangedEvents flushes sorted rows to sink manager, note the resolvedTs
+// is required to be no more than global resolvedTs, table barrierTs and table
+// redo log watermarkTs.
 func (t *tableSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error) {
 	i := sort.Search(len(t.buffer), func(i int) bool {
 		return t.buffer[i].CommitTs > resolvedTs
 	})
 	if i == 0 {
+		if t.redoManager.Enabled() {
+			err := t.redoManager.FlushLog(ctx, t.tableID, resolvedTs)
+			if err != nil {
+				return t.manager.getCheckpointTs(), err
+			}
+		}
 		atomic.StoreUint64(&t.emittedTs, resolvedTs)
 		return t.manager.flushBackendSink(ctx)
 	}
@@ -166,11 +181,27 @@ func (t *tableSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64
 		return t.manager.getCheckpointTs(), errors.Trace(err)
 	}
 	atomic.StoreUint64(&t.emittedTs, resolvedTs)
+	if t.redoManager.Enabled() {
+		err := t.redoManager.FlushLog(ctx, t.tableID, resolvedTs)
+		if err != nil {
+			return t.manager.getCheckpointTs(), err
+		}
+	}
 	return t.manager.flushBackendSink(ctx)
 }
 
-func (t *tableSink) getEmittedTs() uint64 {
-	return atomic.LoadUint64(&t.emittedTs)
+// getResolvedTs returns resolved ts, which means all events before resolved ts
+// have been sent to sink manager, if redo log is enabled, it also means all events
+// before resolved ts have been persisted to redo log storage.
+func (t *tableSink) getResolvedTs() uint64 {
+	ts := atomic.LoadUint64(&t.emittedTs)
+	if t.redoManager.Enabled() {
+		redoResolvedTs := t.redoManager.GetMinResolvedTs()
+		if redoResolvedTs < ts {
+			ts = redoResolvedTs
+		}
+	}
+	return ts
 }
 
 func (t *tableSink) EmitCheckpointTs(ctx context.Context, ts uint64) error {

--- a/errors.toml
+++ b/errors.toml
@@ -146,6 +146,16 @@ error = '''
 codec decode error
 '''
 
+["CDC:ErrConsistentLevel"]
+error = '''
+consistent level (%s) not support
+'''
+
+["CDC:ErrConsistentStorage"]
+error = '''
+consistent storage (%s) not support
+'''
+
 ["CDC:ErrCraftCodecInvalidData"]
 error = '''
 craft codec invalid data

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,21 +61,26 @@ var defaultReplicaConfig = &ReplicaConfig{
 		Tp:          "table-number",
 		PollingTime: -1,
 	},
+	Consistent: &ConsistentConfig{
+		Level:   "normal",
+		Storage: "local",
+	},
 }
 
 // ReplicaConfig represents some addition replication config for a changefeed
 type ReplicaConfig replicaConfig
 
 type replicaConfig struct {
-	CaseSensitive    bool             `toml:"case-sensitive" json:"case-sensitive"`
-	EnableOldValue   bool             `toml:"enable-old-value" json:"enable-old-value"`
-	ForceReplicate   bool             `toml:"force-replicate" json:"force-replicate"`
-	CheckGCSafePoint bool             `toml:"check-gc-safe-point" json:"check-gc-safe-point"`
-	Filter           *FilterConfig    `toml:"filter" json:"filter"`
-	Mounter          *MounterConfig   `toml:"mounter" json:"mounter"`
-	Sink             *SinkConfig      `toml:"sink" json:"sink"`
-	Cyclic           *CyclicConfig    `toml:"cyclic-replication" json:"cyclic-replication"`
-	Scheduler        *SchedulerConfig `toml:"scheduler" json:"scheduler"`
+	CaseSensitive    bool              `toml:"case-sensitive" json:"case-sensitive"`
+	EnableOldValue   bool              `toml:"enable-old-value" json:"enable-old-value"`
+	ForceReplicate   bool              `toml:"force-replicate" json:"force-replicate"`
+	CheckGCSafePoint bool              `toml:"check-gc-safe-point" json:"check-gc-safe-point"`
+	Filter           *FilterConfig     `toml:"filter" json:"filter"`
+	Mounter          *MounterConfig    `toml:"mounter" json:"mounter"`
+	Sink             *SinkConfig       `toml:"sink" json:"sink"`
+	Cyclic           *CyclicConfig     `toml:"cyclic-replication" json:"cyclic-replication"`
+	Scheduler        *SchedulerConfig  `toml:"scheduler" json:"scheduler"`
+	Consistent       *ConsistentConfig `toml:"consistent" json:"consistent"`
 }
 
 // Marshal returns the json marshal format of a ReplicationConfig

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -35,9 +35,9 @@ func (s *replicaConfigSuite) TestMarshal(c *check.C) {
 	conf.Mounter.WorkerNum = 3
 	b, err := conf.Marshal()
 	c.Assert(err, check.IsNil)
-	c.Assert(b, check.Equals, `{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}}`)
+	c.Assert(b, check.Equals, `{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","storage":"local"}}`)
 	conf2 := new(ReplicaConfig)
-	err = conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}}`))
+	err = conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","storage":"local"}}`))
 	c.Assert(err, check.IsNil)
 	c.Assert(conf2, check.DeepEquals, conf)
 }
@@ -58,7 +58,7 @@ func (s *replicaConfigSuite) TestClone(c *check.C) {
 func (s *replicaConfigSuite) TestOutDated(c *check.C) {
 	defer testleak.AfterTest(c)()
 	conf2 := new(ReplicaConfig)
-	err := conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":3},"sink":{"dispatch-rules":[{"db-name":"a","tbl-name":"b","rule":"r1"},{"db-name":"a","tbl-name":"c","rule":"r2"},{"db-name":"a","tbl-name":"d","rule":"r2"}],"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1}}`))
+	err := conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":3},"sink":{"dispatch-rules":[{"db-name":"a","tbl-name":"b","rule":"r1"},{"db-name":"a","tbl-name":"c","rule":"r2"},{"db-name":"a","tbl-name":"d","rule":"r2"}],"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","storage":"local"}}`))
 	c.Assert(err, check.IsNil)
 
 	conf := GetDefaultReplicaConfig()

--- a/pkg/config/consistent.go
+++ b/pkg/config/consistent.go
@@ -1,0 +1,20 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// ConsistentConfig represents replication consistency config for a changefeed
+type ConsistentConfig struct {
+	Level   string `toml:"level" json:"level"`
+	Storage string `toml:"storage" json:"storage"`
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -110,6 +110,10 @@ var (
 	ErrSinkInvalidConfig         = errors.Normalize("sink config invalid", errors.RFCCodeText("CDC:ErrSinkInvalidConfig"))
 	ErrCraftCodecInvalidData     = errors.Normalize("craft codec invalid data", errors.RFCCodeText("CDC:ErrCraftCodecInvalidData"))
 
+	// redo log related errors
+	ErrConsistentLevel   = errors.Normalize("consistent level (%s) not support", errors.RFCCodeText("CDC:ErrConsistentLevel"))
+	ErrConsistentStorage = errors.Normalize("consistent storage (%s) not support", errors.RFCCodeText("CDC:ErrConsistentStorage"))
+
 	// utilities related errors
 	ErrToTLSConfigFailed         = errors.Normalize("generate tls config failed", errors.RFCCodeText("CDC:ErrToTLSConfigFailed"))
 	ErrCheckClusterVersionFromPD = errors.Normalize("failed to request PD", errors.RFCCodeText("CDC:ErrCheckClusterVersionFromPD"))

--- a/tests/consistent_replicate_blackhole/conf/changefeed.toml
+++ b/tests/consistent_replicate_blackhole/conf/changefeed.toml
@@ -1,0 +1,3 @@
+[consistent]
+level = "eventual"
+storage = "blackhole"

--- a/tests/consistent_replicate_blackhole/conf/diff_config.toml
+++ b/tests/consistent_replicate_blackhole/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "consistent_replicate_blackhole"
+    tables = ["~usertable.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/consistent_replicate_blackhole/conf/workload
+++ b/tests/consistent_replicate_blackhole/conf/workload
@@ -1,0 +1,13 @@
+threadcount=10
+recordcount=1000
+operationcount=0
+workload=core
+
+readallfields=true
+
+readproportion=0
+updateproportion=0
+scanproportion=0
+insertproportion=0
+
+requestdistribution=uniform

--- a/tests/consistent_replicate_blackhole/run.sh
+++ b/tests/consistent_replicate_blackhole/run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+    start_tidb_cluster --workdir $WORK_DIR
+
+    cd $WORK_DIR
+
+    start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
+    run_sql "CREATE DATABASE consistent_replicate_blackhole;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=consistent_replicate_blackhole
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+
+    TOPIC_NAME="ticdc-sink-retry-test-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&max-message-bytes=102400&kafka-version=${KAFKA_VERSION}";;
+        *) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    sort_dir="$WORK_DIR/consistent_replicate_blackhole_cache"
+    mkdir $sort_dir
+    run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --config="$CUR/conf/changefeed.toml"
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"
+    fi
+
+    run_sql "CREATE table consistent_replicate_blackhole.check1(id int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_table_exists "consistent_replicate_blackhole.USERTABLE" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_table_exists "consistent_replicate_blackhole.check1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    run_sql "truncate table consistent_replicate_blackhole.USERTABLE" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+    run_sql "CREATE table consistent_replicate_blackhole.check2(id int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_table_exists "consistent_replicate_blackhole.check2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=consistent_replicate_blackhole
+    run_sql "CREATE table consistent_replicate_blackhole.check3(id int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_table_exists "consistent_replicate_blackhole.check3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    run_sql "create table consistent_replicate_blackhole.USERTABLE2 like consistent_replicate_blackhole.USERTABLE" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "insert into consistent_replicate_blackhole.USERTABLE2 select * from consistent_replicate_blackhole.USERTABLE" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "create table consistent_replicate_blackhole.check4(id int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    check_table_exists "consistent_replicate_blackhole.USERTABLE2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_table_exists "consistent_replicate_blackhole.check4" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR adds basic logic for #2351 to complete subtasks 4-2, 5-1 and 5-2, and implements the following workflows.

- Add interface of redo log writer and basic redo log manager.
- Add necessary changefeed config, currently it is simple, containing consistent level and consistent storage.
- Implement basic watermark mechanism, adding `RedoLogTs` in each table sink.
- Add a mock blackhole redo log writer and verify the replication can run normally with consistent replication feature enabled.

There still exists some remaining works, including

   - [ ] Add admin command, such as remove a table from redo log writer
   - [ ] Better interface abstraction
   - [x] Unit test for new code

### What is changed and how it works?

   As described in PR description

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
