### PR TITLE
Backport asyncsink to old owner

### DIFF
--- a/cdc/async_sink.go
+++ b/cdc/async_sink.go
@@ -1,0 +1,184 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/cdc/sink"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/filter"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultErrChSize = 1024
+)
+
+// AsyncSink is a async sink design for owner
+// The EmitCheckpointTs and EmitDDLEvent is asynchronous function for now
+// Other functions are still synchronization
+type AsyncSink interface {
+	Initialize(ctx cdcContext.Context, tableInfo []*model.SimpleTableInfo) error
+	// EmitCheckpointTs emits the checkpoint Ts to downstream data source
+	// this function will return after recording the checkpointTs specified in memory immediately
+	// and the recorded checkpointTs will be sent and updated to downstream data source every second
+	EmitCheckpointTs(ctx cdcContext.Context, ts uint64)
+	// EmitDDLEvent emits DDL event asynchronously and return true if the DDL is executed
+	// the DDL event will be sent to another goroutine and execute to downstream
+	// the caller of this function can call again and again until a true returned
+	EmitDDLEvent(ctx cdcContext.Context, ddl *model.DDLEvent) (bool, error)
+	SinkSyncpoint(ctx cdcContext.Context, checkpointTs uint64) error
+	Close() error
+}
+
+type asyncSinkImpl struct {
+	sink           sink.Sink
+	syncpointStore sink.SyncpointStore
+
+	checkpointTs model.Ts
+
+	lastSyncPoint model.Ts
+
+	ddlCh         chan *model.DDLEvent
+	ddlFinishedTs model.Ts
+	ddlSentTs     model.Ts
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	errCh  chan error
+}
+
+func newAsyncSink(ctx cdcContext.Context) (AsyncSink, error) {
+	ctx, cancel := cdcContext.WithCancel(ctx)
+	changefeedID := ctx.ChangefeedVars().ID
+	changefeedInfo := ctx.ChangefeedVars().Info
+	filter, err := filter.NewFilter(changefeedInfo.Config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	errCh := make(chan error, defaultErrChSize)
+	s, err := sink.NewSink(ctx, changefeedID, changefeedInfo.SinkURI, filter, changefeedInfo.Config, changefeedInfo.Opts, errCh)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	asyncSink := &asyncSinkImpl{
+		sink:   s,
+		ddlCh:  make(chan *model.DDLEvent, 1),
+		errCh:  errCh,
+		cancel: cancel,
+	}
+
+	asyncSink.wg.Add(1)
+	go asyncSink.run(ctx)
+	return asyncSink, nil
+}
+
+func (s *asyncSinkImpl) Initialize(ctx cdcContext.Context, tableInfo []*model.SimpleTableInfo) error {
+	return s.sink.Initialize(ctx, tableInfo)
+}
+
+func (s *asyncSinkImpl) run(ctx cdcContext.Context) {
+	defer s.wg.Done()
+	// TODO make the tick duration configurable
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	var lastCheckpointTs model.Ts
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-s.errCh:
+			ctx.Throw(err)
+			return
+		case <-ticker.C:
+			checkpointTs := atomic.LoadUint64(&s.checkpointTs)
+			if checkpointTs == 0 || checkpointTs <= lastCheckpointTs {
+				continue
+			}
+			lastCheckpointTs = checkpointTs
+			if err := s.sink.EmitCheckpointTs(ctx, checkpointTs); err != nil {
+				ctx.Throw(errors.Trace(err))
+				return
+			}
+		case ddl := <-s.ddlCh:
+			err := s.sink.EmitDDLEvent(ctx, ddl)
+			failpoint.Inject("InjectChangefeedDDLError", func() {
+				err = cerror.ErrExecDDLFailed.GenWithStackByArgs()
+			})
+			if err == nil || cerror.ErrDDLEventIgnored.Equal(errors.Cause(err)) {
+				log.Info("Execute DDL succeeded", zap.String("changefeed", ctx.ChangefeedVars().ID), zap.Bool("ignored", err != nil), zap.Reflect("ddl", ddl))
+				atomic.StoreUint64(&s.ddlFinishedTs, ddl.CommitTs)
+			} else {
+				// If DDL executing failed, and the error can not be ignored, throw an error and pause the changefeed
+				log.Error("Execute DDL failed",
+					zap.String("ChangeFeedID", ctx.ChangefeedVars().ID),
+					zap.Error(err),
+					zap.Reflect("ddl", ddl))
+				ctx.Throw(errors.Trace(err))
+				return
+			}
+		}
+	}
+}
+
+func (s *asyncSinkImpl) EmitCheckpointTs(ctx cdcContext.Context, ts uint64) {
+	atomic.StoreUint64(&s.checkpointTs, ts)
+}
+
+func (s *asyncSinkImpl) EmitDDLEvent(ctx cdcContext.Context, ddl *model.DDLEvent) (bool, error) {
+	ddlFinishedTs := atomic.LoadUint64(&s.ddlFinishedTs)
+	if ddl.CommitTs <= ddlFinishedTs {
+		// the DDL event is executed successfully, and done is true
+		return true, nil
+	}
+	if ddl.CommitTs <= s.ddlSentTs {
+		// the DDL event is executing and not finished yes, return false
+		return false, nil
+	}
+	select {
+	case <-ctx.Done():
+		return false, errors.Trace(ctx.Err())
+	case s.ddlCh <- ddl:
+	}
+	s.ddlSentTs = ddl.CommitTs
+	return false, nil
+}
+
+func (s *asyncSinkImpl) SinkSyncpoint(ctx cdcContext.Context, checkpointTs uint64) error {
+	if checkpointTs == s.lastSyncPoint {
+		return nil
+	}
+	s.lastSyncPoint = checkpointTs
+	// TODO implement async sink syncpoint
+	return s.syncpointStore.SinkSyncpoint(ctx, ctx.ChangefeedVars().ID, checkpointTs)
+}
+
+func (s *asyncSinkImpl) Close() (err error) {
+	s.cancel()
+	err = s.sink.Close()
+	if s.syncpointStore != nil {
+		err = s.syncpointStore.Close()
+	}
+	s.wg.Wait()
+	return
+}

--- a/cdc/async_sink_test.go
+++ b/cdc/async_sink_test.go
@@ -1,0 +1,196 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/config"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/retry"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+var _ = check.Suite(&asyncSinkSuite{})
+
+type asyncSinkSuite struct {
+}
+
+type mockSink struct {
+	sink.Sink
+	initTableInfo []*model.SimpleTableInfo
+	checkpointTs  model.Ts
+	ddl           *model.DDLEvent
+	ddlMu         sync.Mutex
+	ddlError      error
+}
+
+func (m *mockSink) Initialize(ctx context.Context, tableInfo []*model.SimpleTableInfo) error {
+	m.initTableInfo = tableInfo
+	return nil
+}
+
+func (m *mockSink) EmitCheckpointTs(ctx context.Context, ts uint64) error {
+	atomic.StoreUint64(&m.checkpointTs, ts)
+	return nil
+}
+
+func (m *mockSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
+	m.ddlMu.Lock()
+	defer m.ddlMu.Unlock()
+	time.Sleep(1 * time.Second)
+	m.ddl = ddl
+	return m.ddlError
+}
+
+func (m *mockSink) Close() error {
+	return nil
+}
+
+func (m *mockSink) GetDDL() *model.DDLEvent {
+	m.ddlMu.Lock()
+	defer m.ddlMu.Unlock()
+	return m.ddl
+}
+
+func newAsyncSink4Test(ctx cdcContext.Context, c *check.C) (cdcContext.Context, AsyncSink, *mockSink) {
+	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
+		ID:   "test-changefeed",
+		Info: &model.ChangeFeedInfo{SinkURI: "blackhole://", Config: config.GetDefaultReplicaConfig()},
+	})
+	sink, err := newAsyncSink(ctx)
+	c.Assert(err, check.IsNil)
+	mockSink := &mockSink{}
+	sink.(*asyncSinkImpl).sink = mockSink
+	return ctx, sink, mockSink
+}
+
+func (s *asyncSinkSuite) TestInitialize(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	ctx, sink, mockSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close()
+	tableInfos := []*model.SimpleTableInfo{{Schema: "test"}}
+	err := sink.Initialize(ctx, tableInfos)
+	c.Assert(err, check.IsNil)
+	c.Assert(tableInfos, check.DeepEquals, mockSink.initTableInfo)
+}
+
+func (s *asyncSinkSuite) TestCheckpoint(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	ctx, sink, mSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close()
+
+	waitCheckpointGrowingUp := func(m *mockSink, targetTs model.Ts) error {
+		return retry.Run(100*time.Millisecond, 30, func() error {
+			if targetTs != atomic.LoadUint64(&m.checkpointTs) {
+				return errors.New("targetTs!=checkpointTs")
+			}
+			return nil
+		})
+	}
+	sink.EmitCheckpointTs(ctx, 1)
+	c.Assert(waitCheckpointGrowingUp(mSink, 1), check.IsNil)
+	sink.EmitCheckpointTs(ctx, 10)
+	c.Assert(waitCheckpointGrowingUp(mSink, 10), check.IsNil)
+}
+
+func (s *asyncSinkSuite) TestExecDDL(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	ctx, sink, mSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close()
+	ddl1 := &model.DDLEvent{CommitTs: 1}
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl1)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl1)
+			break
+		}
+	}
+	ddl2 := &model.DDLEvent{CommitTs: 2}
+	ddl3 := &model.DDLEvent{CommitTs: 3}
+	_, err := sink.EmitDDLEvent(ctx, ddl2)
+	c.Assert(err, check.IsNil)
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl2)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl2)
+			break
+		}
+	}
+	_, err = sink.EmitDDLEvent(ctx, ddl3)
+	c.Assert(err, check.IsNil)
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl3)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl3)
+			break
+		}
+	}
+}
+
+func (s *asyncSinkSuite) TestExecDDLError(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	var resultErr error
+	var resultErrMu sync.Mutex
+	getResultErr := func() error {
+		resultErrMu.Lock()
+		defer resultErrMu.Unlock()
+		return resultErr
+	}
+	ctx = cdcContext.WithErrorHandler(ctx, func(err error) error {
+		resultErrMu.Lock()
+		defer resultErrMu.Unlock()
+		resultErr = err
+		return nil
+	})
+	ctx, sink, mSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close()
+	mSink.ddlError = cerror.ErrDDLEventIgnored.GenWithStackByArgs()
+	ddl1 := &model.DDLEvent{CommitTs: 1}
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl1)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl1)
+			break
+		}
+	}
+	c.Assert(getResultErr(), check.IsNil)
+	mSink.ddlError = cerror.ErrExecDDLFailed.GenWithStackByArgs()
+	ddl2 := &model.DDLEvent{CommitTs: 2}
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl2)
+		c.Assert(err, check.IsNil)
+		if done || getResultErr() != nil {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl2)
+			break
+		}
+	}
+	c.Assert(cerror.ErrExecDDLFailed.Equal(errors.Cause(getResultErr())), check.IsTrue)
+}

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -16,7 +16,6 @@ package cdc
 import (
 	"context"
 	"fmt"
-	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"math"
 	"sync"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/filter"

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -72,6 +72,24 @@ func (o *ownership) inc() {
 	}
 }
 
+type minGCSafePointCacheEntry struct {
+	ts          model.Ts
+	lastUpdated time.Time
+}
+
+func (o *Owner) getMinGCSafePointCache(ctx context.Context) model.Ts {
+	if time.Now().After(o.minGCSafePointCache.lastUpdated.Add(MinGCSafePointCacheUpdateInterval)) {
+		physicalTs, logicalTs, err := o.pdClient.GetTS(ctx)
+		if err != nil {
+			log.Warn("Fail to update minGCSafePointCache.", zap.Error(err))
+			return o.minGCSafePointCache.ts
+		}
+		o.minGCSafePointCache.ts = oracle.ComposeTS(physicalTs-(o.gcTTL*1000), logicalTs)
+		o.minGCSafePointCache.lastUpdated = time.Now()
+	}
+	return o.minGCSafePointCache.ts
+}
+
 // Owner manages the cdc cluster
 type Owner struct {
 	done        chan struct{}
@@ -107,6 +125,8 @@ type Owner struct {
 	gcTTL int64
 	// last update gc safepoint time. zero time means has not updated or cleared
 	gcSafepointLastUpdate time.Time
+	// stores the ts obtained from PD and is updated every MinGCSafePointCacheUpdateInterval.
+	minGCSafePointCache minGCSafePointCacheEntry
 	// record last time that flushes all changefeeds' replication status
 	lastFlushChangefeeds    time.Time
 	flushChangefeedInterval time.Duration
@@ -118,6 +138,8 @@ const (
 	CDCServiceSafePointID = "ticdc"
 	// GCSafepointUpdateInterval is the minimual interval that CDC can update gc safepoint
 	GCSafepointUpdateInterval = time.Duration(2 * time.Second)
+	// MinGCSafePointCacheUpdateInterval is the interval that update minGCSafePointCache
+	MinGCSafePointCacheUpdateInterval = time.Second * 2
 )
 
 // NewOwner creates a new Owner instance
@@ -715,13 +737,26 @@ func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 		return nil
 	}
 
-	minCheckpointTs := uint64(math.MaxUint64)
+	staleChangeFeeds := make(map[model.ChangeFeedID]*model.ChangeFeedStatus, len(o.changeFeeds))
+	gcSafePoint := uint64(math.MaxUint64)
+
+	// get the lower bound of gcSafePoint
+	minGCSafePoint := o.getMinGCSafePointCache(ctx)
+
 	if len(o.changeFeeds) > 0 {
 		snapshot := make(map[model.ChangeFeedID]*model.ChangeFeedStatus, len(o.changeFeeds))
 		for id, changefeed := range o.changeFeeds {
 			snapshot[id] = changefeed.status
-			if changefeed.appliedCheckpointTs < minCheckpointTs {
-				minCheckpointTs = changefeed.appliedCheckpointTs
+			if changefeed.status.CheckpointTs < gcSafePoint {
+				gcSafePoint = changefeed.status.CheckpointTs
+			}
+			// If changefeed's appliedCheckpoinTs < minGCSafePoint, it means this changefeed is stagnant.
+			// They are collected into this map, and then handleStaleChangeFeed() is called to deal with these stagnant changefeed.
+			// A changefeed will not enter the map twice, because in run(),
+			// handleAdminJob() will always be executed before flushChangeFeedInfos(),
+			// ensuring that the previous changefeed in staleChangeFeeds has been stopped and removed from o.changeFeeds.
+			if changefeed.status.CheckpointTs < minGCSafePoint {
+				staleChangeFeeds[id] = changefeed.status
 			}
 
 			phyTs := oracle.ExtractPhysical(changefeed.status.CheckpointTs)
@@ -741,13 +776,28 @@ func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 			o.lastFlushChangefeeds = time.Now()
 		}
 	}
+
 	for _, status := range o.stoppedFeeds {
-		if status.CheckpointTs < minCheckpointTs {
-			minCheckpointTs = status.CheckpointTs
+		// If a stopped changefeed's CheckpoinTs < minGCSafePoint, means this changefeed is stagnant.
+		// It should never be resumed. This part of the logic is in newChangeFeed()
+		// So here we can skip it.
+		if status.CheckpointTs < minGCSafePoint {
+			continue
+		}
+
+		if status.CheckpointTs < gcSafePoint {
+			gcSafePoint = status.CheckpointTs
 		}
 	}
+
+	// handle stagnant changefeed collected above
+	err := o.handleStaleChangeFeed(ctx, staleChangeFeeds, minGCSafePoint)
+	if err != nil {
+		log.Warn("failed to handleStaleChangeFeed ", zap.Error(err))
+	}
+
 	if time.Since(o.gcSafepointLastUpdate) > GCSafepointUpdateInterval {
-		actual, err := o.pdClient.UpdateServiceGCSafePoint(ctx, CDCServiceSafePointID, o.gcTTL, minCheckpointTs)
+		actual, err := o.pdClient.UpdateServiceGCSafePoint(ctx, CDCServiceSafePointID, o.gcTTL, gcSafePoint)
 		if err != nil {
 			sinceLastUpdate := time.Since(o.gcSafepointLastUpdate)
 			log.Warn("failed to update service safe point", zap.Error(err),
@@ -764,9 +814,9 @@ func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 			actual = uint64(val.(int))
 		})
 
-		if actual > minCheckpointTs {
+		if actual > gcSafePoint {
 			// UpdateServiceGCSafePoint has failed.
-			log.Warn("updating an outdated service safe point", zap.Uint64("checkpoint-ts", minCheckpointTs), zap.Uint64("actual-safepoint", actual))
+			log.Warn("updating an outdated service safe point", zap.Uint64("checkpoint-ts", gcSafePoint), zap.Uint64("actual-safepoint", actual))
 
 			for cfID, cf := range o.changeFeeds {
 				if cf.status.CheckpointTs < actual {
@@ -871,6 +921,7 @@ func (o *Owner) dispatchJob(ctx context.Context, job model.AdminJob) error {
 	// For `AdminResume`, we remove stopped feed in changefeed initialization phase.
 	// For `AdminRemove`, we need to update stoppedFeeds when removing a stopped changefeed.
 	if job.Type == model.AdminStop {
+		log.Debug("put changfeed into stoppedFeeds queue", zap.String("changefeed", job.CfID))
 		o.stoppedFeeds[job.CfID] = cf.status
 	}
 	for captureID := range cf.taskStatus {
@@ -1622,4 +1673,29 @@ func (o *Owner) startCaptureWatcher(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// handle the StaleChangeFeed
+// By setting the AdminJob type to AdminStop and the Error code to indicate that the changefeed is stagnant.
+func (o *Owner) handleStaleChangeFeed(ctx context.Context, staleChangeFeeds map[model.ChangeFeedID]*model.ChangeFeedStatus, minGCSafePoint uint64) error {
+	for id, status := range staleChangeFeeds {
+		message := cerror.ErrSnapshotLostByGC.GenWithStackByArgs(status.CheckpointTs, minGCSafePoint).Error()
+		log.Warn("changefeed checkpoint is lagging too much, so it will be stopped.", zap.String("changefeed", id), zap.String("Error message", message))
+		runningError := &model.RunningError{
+			Addr:    util.CaptureAddrFromCtx(ctx),
+			Code:    string(cerror.ErrSnapshotLostByGC.RFCCode()), // changfeed is stagnant
+			Message: message,
+		}
+
+		err := o.EnqueueJob(model.AdminJob{
+			CfID:  id,
+			Type:  model.AdminStop,
+			Error: runningError,
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+		delete(staleChangeFeeds, id)
+	}
+	return nil
 }

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -16,13 +16,14 @@ package cdc
 import (
 	"context"
 	"fmt"
-	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"io"
 	"math"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -245,7 +245,7 @@ func (s *ownerSuite) TestOwnerHandleStaleChangeFeed(c *check.C) {
 	}
 
 	session, err := concurrency.NewSession(s.client.Client.Unwrap(),
-		concurrency.WithTTL(config.GetDefaultServerConfig().CaptureSessionTTL))
+		concurrency.WithTTL(defaultCaptureSessionTTL))
 	c.Assert(err, check.IsNil)
 
 	mockOwner := Owner{

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/util/testleak"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	pd "github.com/tikv/pd/client"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
@@ -89,6 +90,16 @@ type mockPDClient struct {
 	invokeCounter     int
 	mockSafePointLost bool
 	mockPDFailure     bool
+}
+
+func (m *mockPDClient) GetTS(ctx context.Context) (int64, int64, error) {
+	if m.mockPDFailure {
+		return 0, 0, errors.New("injected PD failure")
+	}
+	if m.mockSafePointLost {
+		return 0, 0, nil
+	}
+	return oracle.GetPhysical(time.Now()), 0, nil
 }
 
 func (m *mockPDClient) UpdateServiceGCSafePoint(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
@@ -173,12 +184,114 @@ func (s *ownerSuite) TestOwnerFlushChangeFeedInfosFailed(c *check.C) {
 	s.TearDownTest(c)
 }
 
+// Test whether the owner handles the stagnant task correctly, so that it can't block the update of gcSafePoint.
+// If a changefeed is put into the stop queue due to stagnation, it can no longer affect the update of gcSafePoint.
+// So we just need to test whether the stagnant changefeed is put into the stop queue.
+func (s *ownerSuite) TestOwnerHandleStaleChangeFeed(c *check.C) {
+	defer testleak.AfterTest(c)()
+	mockPDCli := &mockPDClient{}
+	changeFeeds := map[model.ChangeFeedID]*changeFeed{
+		"test_change_feed_1": {
+			info:    &model.ChangeFeedInfo{State: model.StateNormal},
+			etcdCli: s.client,
+			status: &model.ChangeFeedStatus{
+				CheckpointTs: 1000,
+			},
+			targetTs: 2000,
+			ddlState: model.ChangeFeedSyncDML,
+			taskStatus: model.ProcessorsInfos{
+				"capture_1": {},
+				"capture_2": {},
+			},
+			taskPositions: map[string]*model.TaskPosition{
+				"capture_1": {},
+				"capture_2": {},
+			},
+		},
+		"test_change_feed_2": {
+			info:    &model.ChangeFeedInfo{State: model.StateNormal},
+			etcdCli: s.client,
+			status: &model.ChangeFeedStatus{
+				CheckpointTs: oracle.EncodeTSO(oracle.GetPhysical(time.Now())),
+			},
+			targetTs: 2000,
+			ddlState: model.ChangeFeedSyncDML,
+			taskStatus: model.ProcessorsInfos{
+				"capture_1": {},
+				"capture_2": {},
+			},
+			taskPositions: map[string]*model.TaskPosition{
+				"capture_1": {},
+				"capture_2": {},
+			},
+		},
+		"test_change_feed_3": {
+			info:    &model.ChangeFeedInfo{State: model.StateNormal},
+			etcdCli: s.client,
+			status: &model.ChangeFeedStatus{
+				CheckpointTs: 0,
+			},
+			targetTs: 2000,
+			ddlState: model.ChangeFeedSyncDML,
+			taskStatus: model.ProcessorsInfos{
+				"capture_1": {},
+				"capture_2": {},
+			},
+			taskPositions: map[string]*model.TaskPosition{
+				"capture_1": {},
+				"capture_2": {},
+			},
+		},
+	}
+
+	session, err := concurrency.NewSession(s.client.Client.Unwrap(),
+		concurrency.WithTTL(config.GetDefaultServerConfig().CaptureSessionTTL))
+	c.Assert(err, check.IsNil)
+
+	mockOwner := Owner{
+		session:                 session,
+		pdClient:                mockPDCli,
+		etcdClient:              s.client,
+		lastFlushChangefeeds:    time.Now(),
+		flushChangefeedInterval: 1 * time.Hour,
+		// gcSafepointLastUpdate:   time.Now(),
+		gcTTL:               6, // 6 seconds
+		changeFeeds:         changeFeeds,
+		cfRWriter:           s.client,
+		stoppedFeeds:        make(map[model.ChangeFeedID]*model.ChangeFeedStatus),
+		minGCSafePointCache: minGCSafePointCacheEntry{},
+	}
+
+	time.Sleep(3 * time.Second)
+	err = mockOwner.flushChangeFeedInfos(s.ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(mockPDCli.invokeCounter, check.Equals, 1)
+
+	err = mockOwner.handleAdminJob(s.ctx)
+	c.Assert(err, check.IsNil)
+	err = mockOwner.handleAdminJob(s.ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(mockOwner.stoppedFeeds["test_change_feed_1"], check.NotNil)
+	c.Assert(mockOwner.stoppedFeeds["test_change_feed_3"], check.NotNil)
+	c.Assert(mockOwner.changeFeeds["test_change_feed_2"].info.State, check.Equals, model.StateNormal)
+
+	time.Sleep(6 * time.Second)
+	err = mockOwner.flushChangeFeedInfos(s.ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(mockPDCli.invokeCounter, check.Equals, 2)
+
+	err = mockOwner.handleAdminJob(s.ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(mockOwner.stoppedFeeds["test_change_feed_2"], check.NotNil)
+
+	s.TearDownTest(c)
+}
+
 func (s *ownerSuite) TestOwnerUploadGCSafePointOutdated(c *check.C) {
 	defer testleak.AfterTest(c)()
 	mockPDCli := &mockPDClient{
 		mockSafePointLost: true,
 	}
-
 	changeFeeds := map[model.ChangeFeedID]*changeFeed{
 		"test_change_feed_1": {
 			info:    &model.ChangeFeedInfo{State: model.StateNormal},
@@ -219,6 +332,7 @@ func (s *ownerSuite) TestOwnerUploadGCSafePointOutdated(c *check.C) {
 	session, err := concurrency.NewSession(s.client.Client.Unwrap(),
 		concurrency.WithTTL(defaultCaptureSessionTTL))
 	c.Assert(err, check.IsNil)
+
 	mockOwner := Owner{
 		pdClient:                mockPDCli,
 		session:                 session,
@@ -228,6 +342,7 @@ func (s *ownerSuite) TestOwnerUploadGCSafePointOutdated(c *check.C) {
 		changeFeeds:             changeFeeds,
 		cfRWriter:               s.client,
 		stoppedFeeds:            make(map[model.ChangeFeedID]*model.ChangeFeedStatus),
+		minGCSafePointCache:     minGCSafePointCacheEntry{},
 	}
 
 	err = mockOwner.flushChangeFeedInfos(s.ctx)

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -33,6 +32,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/config"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/filter"
@@ -726,10 +726,10 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	defer cancel0()
 	cctx, cancel := context.WithCancel(ctx)
 	errg, _ := errgroup.WithContext(cctx)
-
+	replicaConf := config.GetDefaultReplicaConfig()
 	sampleCF := &changeFeed{
 		id:       cfID,
-		info:     &model.ChangeFeedInfo{},
+		info:     &model.ChangeFeedInfo{Config: replicaConf, SinkURI: "blackhole://"},
 		status:   &model.ChangeFeedStatus{},
 		ddlState: model.ChangeFeedSyncDML,
 		taskStatus: model.ProcessorsInfos{

--- a/errors.toml
+++ b/errors.toml
@@ -651,6 +651,11 @@ error = '''
 sink uri invalid
 '''
 
+["CDC:ErrSnapshotLostByGC"]
+error = '''
+fail to create or maintain changefeed due to snapshot loss caused by GC. checkpoint-ts %d is earlier than GC safepoint at %d
+'''
+
 ["CDC:ErrSnapshotSchemaExists"]
 error = '''
 schema %s(%d) already exists

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -15,7 +15,9 @@ package context
 
 import (
 	"context"
+	"github.com/pingcap/ticdc/cdc/model"
 	"log"
+	"time"
 
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/pkg/config"
@@ -33,20 +35,30 @@ type Vars struct {
 	Config        *config.ReplicaConfig
 }
 
+// ChangefeedVars contains some vars which can be used anywhere in a pipeline
+// the lifecycle of vars in the ChangefeedVars should be aligned with the changefeed.
+// All field in Vars should be READ-ONLY and THREAD-SAFE
+type ChangefeedVars struct {
+	ID   model.ChangeFeedID
+	Info *model.ChangeFeedInfo
+}
+
 // Context contains Vars(), Done(), Throw(error) and StdContext() context.Context
 // Context is used to instead of standard context
 type Context interface {
-
+	context.Context
 	// Vars return the `Vars` store by the root context created by `NewContext`
 	// Note that the `Vars` should be READ-ONLY and THREAD-SAFE
 	// The root node and all its children node share one pointer of `Vars`
 	// So any modification of `Vars` will cause all other family nodes to change.
 	Vars() *Vars
 
-	// Done return a channel which will be closed in the following cases:
-	// - the `cancel()` returned from `WithCancel` is called.
-	// - the `stdCtx` specified in `NewContext` is done.
-	Done() <-chan struct{}
+	// ChangefeedVars return the `ChangefeedVars` store by the context created by `WithChangefeedVars`
+	// Note that the `ChangefeedVars` should be READ-ONLY and THREAD-SAFE
+	// The root node and all its children node share one pointer of `ChangefeedVars`
+	// So any modification of `ChangefeedVars` will cause all other family nodes to change.
+	// ChangefeedVars could be return nil when the `ChangefeedVars` is not set by `WithChangefeedVars`
+	ChangefeedVars() *ChangefeedVars
 
 	// Throw an error to parents nodes
 	// we can using `WatchThrow` to listen the errors thrown by children nodes
@@ -75,6 +87,10 @@ func (ctx *rootContext) Vars() *Vars {
 	return ctx.vars
 }
 
+func (ctx *rootContext) ChangefeedVars() *ChangefeedVars {
+	return nil
+}
+
 func (ctx *rootContext) Throw(err error) {
 	if err == nil {
 		return
@@ -83,9 +99,38 @@ func (ctx *rootContext) Throw(err error) {
 	log.Panic("an error has escaped, please report a bug", zap.Error(err))
 }
 
+// WithChangefeedVars return a Context with the `ChangefeedVars`
+func WithChangefeedVars(ctx Context, changefeedVars *ChangefeedVars) Context {
+	return &changefeedVarsContext{
+		Context:        ctx,
+		changefeedVars: changefeedVars,
+	}
+}
+
+type changefeedVarsContext struct {
+	Context
+	changefeedVars *ChangefeedVars
+}
+
+func (ctx *changefeedVarsContext) ChangefeedVars() *ChangefeedVars {
+	return ctx.changefeedVars
+}
+
 type stdContext struct {
 	stdCtx context.Context
 	Context
+}
+
+func (ctx *stdContext) Deadline() (deadline time.Time, ok bool) {
+	return ctx.stdCtx.Deadline()
+}
+
+func (ctx *stdContext) Err() error {
+	return ctx.stdCtx.Err()
+}
+
+func (ctx *stdContext) Value(key interface{}) interface{} {
+	return ctx.stdCtx.Value(key)
 }
 
 func (ctx *stdContext) Done() <-chan struct{} {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -178,7 +178,7 @@ var (
 	ErrServiceSafepointLost         = errors.Normalize("service safepoint lost. current safepoint is %d, please remove all changefeed(s) whose checkpoints are behind the current safepoint", errors.RFCCodeText("CDC:ErrServiceSafepointLost"))
 	ErrUpdateServiceSafepointFailed = errors.Normalize("updating service safepoint failed", errors.RFCCodeText("CDC:ErrUpdateServiceSafepointFailed"))
 	ErrStartTsBeforeGC              = errors.Normalize("fail to create changefeed because start-ts %d is earlier than GC safepoint at %d", errors.RFCCodeText("CDC:ErrStartTsBeforeGC"))
-
+	ErrSnapshotLostByGC             = errors.Normalize("fail to create or maintain changefeed due to snapshot loss caused by GC. checkpoint-ts %d is earlier than GC safepoint at %d", errors.RFCCodeText("CDC:ErrSnapshotLostByGC"))
 	// EtcdWorker related errors. Internal use only.
 	// ErrEtcdTryAgain is used by a PatchFunc to force a transaction abort.
 	ErrEtcdTryAgain = errors.Normalize("the etcd txn should be aborted and retried immediately", errors.RFCCodeText("CDC:ErrEtcdTryAgain"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#2295 
### What is changed and how it works?

- [x] Back port `asyncSink` to the old owner
- [x] Make old owner's DDL execution asynchronous (in `changefeed.go`)
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
