### PR TITLE
makefile: bump release version to 5.2.0-master when built from master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ FAILPOINT_DISABLE := $$(find $(FAILPOINT_DIR) | xargs $(FAILPOINT) disable >/dev
 
 RELEASE_VERSION =
 ifeq ($(RELEASE_VERSION),)
-	RELEASE_VERSION := v5.0.0-master
+	RELEASE_VERSION := v5.2.0-master
 	release_version_regex := ^v5\..*$$
 	release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/v[0-9]\.[0-9]\..*$$"
 	ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -267,6 +267,10 @@ func (s *checkSuite) TestTiCDCClusterVersionFeaturesCompatible(c *check.C) {
 	c.Assert(ver.ShouldEnableUnifiedSorterByDefault(), check.Equals, true)
 	c.Assert(ver.ShouldEnableOldValueByDefault(), check.Equals, true)
 
+	ver = TiCDCClusterVersion{semver.New("5.2.0-master"), false}
+	c.Assert(ver.ShouldEnableUnifiedSorterByDefault(), check.Equals, true)
+	c.Assert(ver.ShouldEnableOldValueByDefault(), check.Equals, true)
+
 	c.Assert(TiCDCClusterVersionUnknown.ShouldEnableUnifiedSorterByDefault(), check.Equals, true)
 	c.Assert(TiCDCClusterVersionUnknown.ShouldEnableOldValueByDefault(), check.Equals, true)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- The next release version in TiCDC is `5.2.0`
- When creating a new changefeed with master cdc, we met `[2021/08/05 15:58:48.191 +08:00] [WARN] [client_changefeed.go:275] ["The TiCDC cluster is built from an older version, disabling old value by default."] [version=5.0.0-master]`

### What is changed and how it works?

Change default release version to `5.2.0-master` when built from master

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
