### PR TITLE
kv/client: change some error log to warn log

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -874,7 +874,7 @@ func (s *eventFeedSession) requestRegionToStore(
 		// If Send error, the receiver should have received error too or will receive error soon. So we doesn't need
 		// to do extra work here.
 		if err != nil {
-			log.Error("send request to stream failed",
+			log.Warn("send request to stream failed",
 				zap.String("addr", rpcCtx.Addr),
 				zap.Uint64("storeID", getStoreID(rpcCtx)),
 				zap.Uint64("regionID", sri.verID.GetID()),
@@ -882,7 +882,7 @@ func (s *eventFeedSession) requestRegionToStore(
 				zap.Error(err))
 			err1 := stream.CloseSend()
 			if err1 != nil {
-				log.Error("failed to close stream", zap.Error(err1))
+				log.Warn("failed to close stream", zap.Error(err1))
 			}
 			// Delete the stream from the map so that the next time the store is accessed, the stream will be
 			// re-established.
@@ -1270,7 +1270,7 @@ func (s *eventFeedSession) receiveFromStream(
 					zap.Uint64("storeID", storeID),
 				)
 			} else {
-				log.Error(
+				log.Warn(
 					"failed to receive from stream",
 					zap.String("addr", addr),
 					zap.Uint64("storeID", storeID),

--- a/cdc/kv/client_v2.go
+++ b/cdc/kv/client_v2.go
@@ -217,7 +217,7 @@ func (s *eventFeedSession) receiveFromStreamV2(
 					zap.Uint64("storeID", storeID),
 				)
 			} else {
-				log.Error(
+				log.Warn(
 					"failed to receive from stream",
 					zap.String("addr", addr),
 					zap.Uint64("storeID", storeID),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In kv client, gRPC stream read or send error is retriable, use warn log when these scenarios happen

### What is changed and how it works?

Use warn log when meet gRPC stream error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
