### PR TITLE
version: prohibit operating TiCDC clusters across major and minor versions

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -196,6 +196,21 @@ func newCliCommand() *cobra.Command {
 				return errors.Annotatef(err, "fail to open PD client, pd=\"%s\"", cliPdAddr)
 			}
 			ctx := defaultContext
+			_, captureInfos, err := cdcEtcdCli.GetCaptures(ctx)
+			if err != nil {
+				return err
+			}
+			cdcClusterVer, err := version.GetTiCDCClusterVersion(captureInfos)
+			if err != nil {
+				return err
+			}
+			isUnknownVersion, err := version.CheckTiCDCClusterVersion(cdcClusterVer)
+			if err != nil {
+				return err
+			}
+			if isUnknownVersion {
+				return errors.NewNoStackError("TiCDC cluster is unknown, please start TiCDC cluster")
+			}
 			errorTiKVIncompatible := true // Error if TiKV is incompatible.
 			err = version.CheckClusterVersion(ctx, pdCli, pdEndpoints[0], credential, errorTiKVIncompatible)
 			if err != nil {

--- a/cmd/client_changefeed.go
+++ b/cmd/client_changefeed.go
@@ -242,7 +242,10 @@ func newQueryChangefeedCommand() *cobra.Command {
 	return command
 }
 
-func verifyChangefeedParameters(ctx context.Context, cmd *cobra.Command, isCreate bool, credential *security.Credential, captureInfos []*model.CaptureInfo) (*model.ChangeFeedInfo, error) {
+func verifyChangefeedParameters(
+	ctx context.Context, cmd *cobra.Command, isCreate bool,
+	credential *security.Credential, cdcClusterVer version.TiCDCClusterVersion,
+) (*model.ChangeFeedInfo, error) {
 	if isCreate {
 		if sinkURI == "" {
 			return nil, errors.New("Creating changefeed without a sink-uri")
@@ -263,10 +266,6 @@ func verifyChangefeedParameters(ctx context.Context, cmd *cobra.Command, isCreat
 		if err := verifyTargetTs(startTs, targetTs); err != nil {
 			return nil, err
 		}
-	}
-	cdcClusterVer, err := version.GetTiCDCClusterVersion(captureInfos)
-	if err != nil {
-		return nil, errors.Trace(err)
 	}
 	cfg := config.GetDefaultReplicaConfig()
 
@@ -474,7 +473,11 @@ func newCreateChangefeedCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			info, err := verifyChangefeedParameters(ctx, cmd, true /* isCreate */, getCredential(), captureInfos)
+			cdcClusterVer, err := version.GetTiCDCClusterVersion(captureInfos)
+			if err != nil {
+				return err
+			}
+			info, err := verifyChangefeedParameters(ctx, cmd, true /* isCreate */, getCredential(), cdcClusterVer)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Prohibit operating TiCDC clusters across major versions

### What is changed and how it works?

Add version check for both TiDB cluster and TiCDC cluster.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
tiup playground v5.1.0 --tiflash 0 --ticdc 1
cdc cli --pd http://127.0.0.1:2379 capture list // ok

tiup playground v5.0.3 --tiflash 0 --ticdc 1
cdc cli --pd http://127.0.0.1:2379 capture list // error "CDC:ErrVersionIncompatible"

tiup playground v4.0.14 --tiflash 0 --ticdc 1
cdc cli --pd http://127.0.0.1:2379 capture list // error "CDC:ErrVersionIncompatible"

// Or there is no TiCDC cluster
cdc cli --pd http://127.0.0.1:2379 capture list // error TiCDC cluster is unknown, please start TiCDC cluster
```

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Prohibit operating TiCDC clusters across major and minor versions
```
