### PR TITLE
kv/client: add global grpc connection pool

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -120,7 +120,7 @@ func NewCapture(
 		Version:       version.ReleaseVersion,
 	}
 	processorManager := processor.NewManager()
-	grpcPool := kv.NewGrpcPoolImpl(credential)
+	grpcPool := kv.NewGrpcPoolImpl(stdCtx, credential)
 	log.Info("creating capture", zap.String("capture-id", id), util.ZapFieldCapture(stdCtx))
 
 	c = &Capture{

--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -29,7 +29,6 @@ import (
 	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/orchestrator"
-	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/pkg/version"
 	tidbkv "github.com/pingcap/tidb/kv"
@@ -49,7 +48,7 @@ type Capture struct {
 	etcdClient kv.CDCEtcdClient
 	pdCli      pd.Client
 	kvStorage  tidbkv.Storage
-	credential *security.Credential
+	grpcPool   kv.GrpcPool
 
 	processorManager *processor.Manager
 
@@ -121,12 +120,13 @@ func NewCapture(
 		Version:       version.ReleaseVersion,
 	}
 	processorManager := processor.NewManager()
+	grpcPool := kv.NewGrpcPoolImpl(credential)
 	log.Info("creating capture", zap.String("capture-id", id), util.ZapFieldCapture(stdCtx))
 
 	c = &Capture{
 		processors:       make(map[string]*oldProcessor),
 		etcdClient:       cli,
-		credential:       credential,
+		grpcPool:         grpcPool,
 		session:          sess,
 		election:         elec,
 		info:             info,
@@ -310,7 +310,7 @@ func (c *Capture) assignTask(ctx context.Context, task *Task) (*oldProcessor, er
 		zap.String("changefeed", task.ChangeFeedID))
 	conf := config.GetGlobalServerConfig()
 	p, err := runProcessorImpl(
-		ctx, c.pdCli, c.credential, c.session, *cf, task.ChangeFeedID, *c.info, task.CheckpointTS, time.Duration(conf.ProcessorFlushInterval))
+		ctx, c.pdCli, c.grpcPool, c.session, *cf, task.ChangeFeedID, *c.info, task.CheckpointTS, time.Duration(conf.ProcessorFlushInterval))
 	if err != nil {
 		log.Error("run processor failed",
 			zap.String("changefeed", task.ChangeFeedID),

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -57,6 +57,7 @@ type Capture struct {
 	pdClient   pd.Client
 	kvStorage  tidbkv.Storage
 	etcdClient *kv.CDCEtcdClient
+	grpcPool   kv.GrpcPool
 
 	cancel context.CancelFunc
 
@@ -66,10 +67,12 @@ type Capture struct {
 
 // NewCapture returns a new Capture instance
 func NewCapture(pdClient pd.Client, kvStorage tidbkv.Storage, etcdClient *kv.CDCEtcdClient) *Capture {
+	grpcPool := kv.NewGrpcPoolImpl(config.GetGlobalServerConfig().Security)
 	return &Capture{
 		pdClient:   pdClient,
 		kvStorage:  kvStorage,
 		etcdClient: etcdClient,
+		grpcPool:   grpcPool,
 		cancel:     func() {},
 
 		newProcessorManager: processor.NewManager,
@@ -145,6 +148,7 @@ func (c *Capture) run(stdCtx context.Context) error {
 		KVStorage:   c.kvStorage,
 		CaptureInfo: c.info,
 		EtcdClient:  c.etcdClient,
+		GrpcPool:    c.grpcPool,
 	})
 	err := c.register(ctx)
 	if err != nil {

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -346,6 +346,9 @@ func (c *Capture) AsyncClose() {
 	if c.processorManager != nil {
 		c.processorManager.AsyncClose()
 	}
+	if c.grpcPool != nil {
+		c.grpcPool.Close()
+	}
 }
 
 // WriteDebugInfo writes the debug info into writer.

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -78,7 +78,7 @@ func NewCapture(pdClient pd.Client, kvStorage tidbkv.Storage, etcdClient *kv.CDC
 	}
 }
 
-func (c *Capture) reset() error {
+func (c *Capture) reset(ctx context.Context) error {
 	c.captureMu.Lock()
 	defer c.captureMu.Unlock()
 	conf := config.GetGlobalServerConfig()
@@ -101,7 +101,7 @@ func (c *Capture) reset() error {
 	if c.grpcPool != nil {
 		c.grpcPool.Close()
 	}
-	c.grpcPool = kv.NewGrpcPoolImpl(conf.Security)
+	c.grpcPool = kv.NewGrpcPoolImpl(ctx, conf.Security)
 	log.Info("init capture", zap.String("capture-id", c.info.ID), zap.String("capture-addr", c.info.AdvertiseAddr))
 	return nil
 }
@@ -126,7 +126,7 @@ func (c *Capture) Run(ctx context.Context) error {
 			}
 			return errors.Trace(err)
 		}
-		err = c.reset()
+		err = c.reset(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cdc/capture_test.go
+++ b/cdc/capture_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/etcd"
-	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/pkg/util/testleak"
 	pd "github.com/tikv/pd/client"
@@ -121,7 +120,7 @@ func (s *captureSuite) TestCaptureSessionDoneDuringHandleTask(c *check.C) {
 	}()
 	runProcessorBackup := runProcessorImpl
 	runProcessorImpl = func(
-		ctx context.Context, _ pd.Client, _ *security.Credential,
+		ctx context.Context, _ pd.Client, grpcPool kv.GrpcPool,
 		session *concurrency.Session, info model.ChangeFeedInfo, changefeedID string,
 		captureInfo model.CaptureInfo, checkpointTs uint64, flushCheckpointInterval time.Duration,
 	) (*oldProcessor, error) {

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -260,7 +260,7 @@ func (rl *regionEventFeedLimiters) getLimiter(regionID uint64) *rate.Limiter {
 	return limiter
 }
 
-// grpcStream stores an EventFeed stream and pointer to the underlying gRPC connection
+// eventFeedStream stores an EventFeed stream and pointer to the underlying gRPC connection
 type eventFeedStream struct {
 	client cdcpb.ChangeData_EventFeedClient
 	conn   *sharedConn
@@ -346,7 +346,7 @@ func (c *CDCClient) newStream(ctx context.Context, addr string, storeID uint64) 
 				c.grpcPool.ReleaseConn(conn, addr)
 			}
 		}()
-		conn, err = c.grpcPool.GetConn(ctx, addr)
+		conn, err = c.grpcPool.GetConn(addr)
 		if err != nil {
 			log.Info("get connection to store failed, retry later", zap.String("addr", addr), zap.Error(err))
 			return

--- a/cdc/kv/client_bench_test.go
+++ b/cdc/kv/client_bench_test.go
@@ -188,7 +188,7 @@ func prepareBenchMultiStore(b *testing.B, storeNum, regionNum int) (
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 1000000)
@@ -278,7 +278,7 @@ func prepareBench(b *testing.B, regionNum int) (
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 1000000)

--- a/cdc/kv/client_bench_test.go
+++ b/cdc/kv/client_bench_test.go
@@ -188,7 +188,9 @@ func prepareBenchMultiStore(b *testing.B, storeNum, regionNum int) (
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 1000000)
 	wg.Add(1)
 	go func() {
@@ -276,7 +278,9 @@ func prepareBench(b *testing.B, regionNum int) (
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 1000000)
 	wg.Add(1)
 	go func() {

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -73,7 +73,9 @@ func (s *clientSuite) TestNewClose(c *check.C) {
 	pdCli := mocktikv.NewPDClient(cluster)
 	defer pdCli.Close() //nolint:errcheck
 
-	cli := NewCDCClient(context.Background(), pdCli, nil, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cli := NewCDCClient(context.Background(), pdCli, nil, grpcPool)
 	err := cli.Close()
 	c.Assert(err, check.IsNil)
 }
@@ -332,7 +334,9 @@ func (s *etcdSuite) TestConnectOfflineTiKV(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(context.Background(), pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(context.Background(), pdClient, kvStorage, grpcPool)
 	defer cdcClient.Close() //nolint:errcheck
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
@@ -422,7 +426,9 @@ func (s *etcdSuite) TestRecvLargeMessageSize(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -518,7 +524,9 @@ func (s *etcdSuite) TestHandleError(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -673,7 +681,9 @@ func (s *etcdSuite) TestCompatibilityWithSameConn(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	var wg2 sync.WaitGroup
 	wg2.Add(1)
@@ -733,7 +743,9 @@ func (s *etcdSuite) testHandleFeedEvent(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -1180,7 +1192,9 @@ func (s *etcdSuite) TestStreamSendWithError(c *check.C) {
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -1290,7 +1304,9 @@ func (s *etcdSuite) testStreamRecvWithError(c *check.C, failpointStr string) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 40)
 	wg.Add(1)
 	go func() {
@@ -1417,7 +1433,9 @@ func (s *etcdSuite) TestStreamRecvWithErrorAndResolvedGoBack(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -1645,7 +1663,9 @@ func (s *etcdSuite) TestIncompatibleTiKV(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -1686,27 +1706,6 @@ func (s *etcdSuite) TestIncompatibleTiKV(c *check.C) {
 	cancel()
 }
 
-// Use etcdSuite for some special reasons, the embed etcd uses zap as the only candidate
-// logger and in the logger initializtion it also initializes the grpclog/loggerv2, which
-// is not a thread-safe operation and it must be called before any gRPC functions
-// ref: https://github.com/grpc/grpc-go/blob/master/grpclog/loggerv2.go#L67-L72
-func (s *etcdSuite) TestConnArray(c *check.C) {
-	defer testleak.AfterTest(c)()
-	defer s.TearDownTest(c)
-	addr := "127.0.0.1:2379"
-	ca, err := newConnArray(context.TODO(), 2, addr, &security.Credential{})
-	c.Assert(err, check.IsNil)
-
-	conn1 := ca.Get()
-	conn2 := ca.Get()
-	c.Assert(conn1, check.Not(check.Equals), conn2)
-
-	conn3 := ca.Get()
-	c.Assert(conn1, check.Equals, conn3)
-
-	ca.Close()
-}
-
 // TestPendingRegionError tests kv client should return an error when receiving
 // a new subscription (the first event of specific region) but the corresponding
 // region is not found in pending regions.
@@ -1739,7 +1738,9 @@ func (s *etcdSuite) TestNoPendingRegionError(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	var wg2 sync.WaitGroup
 	if enableKVClientV2 {
@@ -1829,7 +1830,9 @@ func (s *etcdSuite) TestDropStaleRequest(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -1936,7 +1939,9 @@ func (s *etcdSuite) TestResolveLock(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -2033,7 +2038,9 @@ func (s *etcdSuite) testEventCommitTsFallback(c *check.C, events []*cdcpb.Change
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	var clientWg sync.WaitGroup
 	clientWg.Add(1)
@@ -2179,7 +2186,9 @@ func (s *etcdSuite) testEventAfterFeedStop(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -2355,7 +2364,9 @@ func (s *etcdSuite) TestOutOfRegionRangeEvent(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -2583,7 +2594,9 @@ func (s *etcdSuite) TestResolveLockNoCandidate(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -2675,7 +2688,9 @@ func (s *etcdSuite) TestFailRegionReentrant(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -2760,7 +2775,9 @@ func (s *etcdSuite) TestClientV1UnlockRangeReentrant(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -2834,7 +2851,9 @@ func (s *etcdSuite) testClientErrNoPendingRegion(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -2908,7 +2927,9 @@ func (s *etcdSuite) testKVClientForceReconnect(c *check.C) {
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -3065,7 +3086,9 @@ func (s *etcdSuite) TestConcurrentProcessRangeRequest(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 100)
 	wg.Add(1)
 	go func() {
@@ -3179,7 +3202,9 @@ func (s *etcdSuite) TestEvTimeUpdate(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {
@@ -3300,7 +3325,9 @@ func (s *etcdSuite) TestRegionWorkerExitWhenIsIdle(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
 	wg.Add(1)
 	go func() {

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -73,7 +73,7 @@ func (s *clientSuite) TestNewClose(c *check.C) {
 	pdCli := mocktikv.NewPDClient(cluster)
 	defer pdCli.Close() //nolint:errcheck
 
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(context.Background(), &security.Credential{})
 	defer grpcPool.Close()
 	cli := NewCDCClient(context.Background(), pdCli, nil, grpcPool)
 	err := cli.Close()
@@ -334,7 +334,7 @@ func (s *etcdSuite) TestConnectOfflineTiKV(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(context.Background(), pdClient, kvStorage, grpcPool)
 	defer cdcClient.Close() //nolint:errcheck
@@ -426,7 +426,7 @@ func (s *etcdSuite) TestRecvLargeMessageSize(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -524,7 +524,7 @@ func (s *etcdSuite) TestHandleError(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -681,7 +681,7 @@ func (s *etcdSuite) TestCompatibilityWithSameConn(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -743,7 +743,7 @@ func (s *etcdSuite) testHandleFeedEvent(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -1192,7 +1192,7 @@ func (s *etcdSuite) TestStreamSendWithError(c *check.C) {
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -1304,7 +1304,7 @@ func (s *etcdSuite) testStreamRecvWithError(c *check.C, failpointStr string) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 40)
@@ -1433,7 +1433,7 @@ func (s *etcdSuite) TestStreamRecvWithErrorAndResolvedGoBack(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -1663,7 +1663,7 @@ func (s *etcdSuite) TestIncompatibleTiKV(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -1738,7 +1738,7 @@ func (s *etcdSuite) TestNoPendingRegionError(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -1830,7 +1830,7 @@ func (s *etcdSuite) TestDropStaleRequest(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -1939,7 +1939,7 @@ func (s *etcdSuite) TestResolveLock(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2038,7 +2038,7 @@ func (s *etcdSuite) testEventCommitTsFallback(c *check.C, events []*cdcpb.Change
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2186,7 +2186,7 @@ func (s *etcdSuite) testEventAfterFeedStop(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2364,7 +2364,7 @@ func (s *etcdSuite) TestOutOfRegionRangeEvent(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2594,7 +2594,7 @@ func (s *etcdSuite) TestResolveLockNoCandidate(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2688,7 +2688,7 @@ func (s *etcdSuite) TestFailRegionReentrant(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage.(tikv.Storage))
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage.(tikv.Storage), grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2775,7 +2775,7 @@ func (s *etcdSuite) TestClientV1UnlockRangeReentrant(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2851,7 +2851,7 @@ func (s *etcdSuite) testClientErrNoPendingRegion(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -2927,7 +2927,7 @@ func (s *etcdSuite) testKVClientForceReconnect(c *check.C) {
 
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -3086,7 +3086,7 @@ func (s *etcdSuite) TestConcurrentProcessRangeRequest(c *check.C) {
 	}()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 100)
@@ -3202,7 +3202,7 @@ func (s *etcdSuite) TestEvTimeUpdate(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)
@@ -3325,7 +3325,7 @@ func (s *etcdSuite) TestRegionWorkerExitWhenIsIdle(c *check.C) {
 	baseAllocatedID := currentRequestID()
 	lockresolver := txnutil.NewLockerResolver(kvStorage)
 	isPullInit := &mockPullerInit{}
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	cdcClient := NewCDCClient(ctx, pdClient, kvStorage, grpcPool)
 	eventCh := make(chan model.RegionFeedEvent, 10)

--- a/cdc/kv/grpc_pool.go
+++ b/cdc/kv/grpc_pool.go
@@ -29,7 +29,7 @@ type sharedConn struct {
 // reference of the shared connection
 type GrpcPool interface {
 	// GetConn returns an available gRPC ClientConn
-	GetConn(ctx context.Context, target string) (*sharedConn, error)
+	GetConn(target string) (*sharedConn, error)
 
 	// ReleaseConn is called when a gRPC stream is released
 	ReleaseConn(sc *sharedConn, target string)

--- a/cdc/kv/grpc_pool.go
+++ b/cdc/kv/grpc_pool.go
@@ -29,10 +29,13 @@ type sharedConn struct {
 // reference of the shared connection
 type GrpcPool interface {
 	// GetConn returns an available gRPC ClientConn
-	GetConn(ctx context.Context, target string, tableID int64) (*sharedConn, error)
+	GetConn(ctx context.Context, target string) (*sharedConn, error)
 
 	// ReleaseConn is called when a gRPC stream is released
-	ReleaseConn(sc *sharedConn, target string, tableID int64)
+	ReleaseConn(sc *sharedConn, target string)
+
+	// Recycle recycles idle connections periodically
+	RecycleConn(ctx context.Context)
 
 	// Close tears down all ClientConns maintained in pool
 	Close()

--- a/cdc/kv/grpc_pool.go
+++ b/cdc/kv/grpc_pool.go
@@ -1,0 +1,39 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+type sharedConn struct {
+	*grpc.ClientConn
+	active int64
+}
+
+// GrpcPool defines an interface that can serve as a gPRC connection pool.
+// It provides API to get a shared connection from pool and API to decrease usage
+// reference of the shared connection
+type GrpcPool interface {
+	// GetConn returns an available gRPC ClientConn
+	GetConn(ctx context.Context, target string, tableID int64) (*sharedConn, error)
+
+	// ReleaseConn is called when a gRPC stream is released
+	ReleaseConn(sc *sharedConn, target string, tableID int64)
+
+	// Close tears down all ClientConns maintained in pool
+	Close()
+}

--- a/cdc/kv/grpc_pool_impl.go
+++ b/cdc/kv/grpc_pool_impl.go
@@ -178,8 +178,11 @@ type GrpcPoolImpl struct {
 	// bucketConns maps from TiKV store address to a connArray, which stores a
 	// a slice of gRPC connections.
 	bucketConns map[string]*connArray
-	credential  *security.Credential
-	ctx         context.Context
+
+	credential *security.Credential
+
+	// lifecycles of all gPRC connections are bounded to this context
+	ctx context.Context
 }
 
 // NewGrpcPoolImpl creates a new GrpcPoolImpl instance

--- a/cdc/kv/grpc_pool_impl.go
+++ b/cdc/kv/grpc_pool_impl.go
@@ -156,7 +156,10 @@ func (ca *connArray) recycle() (empty bool) {
 	}
 	// erasing truncated values
 	for j := i; j < len(ca.conns); j++ {
-		ca.conns[i] = nil
+		// tear down this grpc.ClientConn, we don't use it anymore, the returned
+		// not-nil error can be ignored
+		ca.conns[j].Close() //nolint:errcheck
+		ca.conns[j] = nil
 	}
 	ca.conns = ca.conns[:i]
 	return len(ca.conns) == 0

--- a/cdc/kv/grpc_pool_impl.go
+++ b/cdc/kv/grpc_pool_impl.go
@@ -179,24 +179,26 @@ type GrpcPoolImpl struct {
 	// a slice of gRPC connections.
 	bucketConns map[string]*connArray
 	credential  *security.Credential
+	ctx         context.Context
 }
 
 // NewGrpcPoolImpl creates a new GrpcPoolImpl instance
-func NewGrpcPoolImpl(credential *security.Credential) *GrpcPoolImpl {
+func NewGrpcPoolImpl(ctx context.Context, credential *security.Credential) *GrpcPoolImpl {
 	return &GrpcPoolImpl{
 		credential:  credential,
 		bucketConns: make(map[string]*connArray),
+		ctx:         ctx,
 	}
 }
 
 // GetConn implements GrpcPool.GetConn
-func (pool *GrpcPoolImpl) GetConn(ctx context.Context, addr string) (*sharedConn, error) {
+func (pool *GrpcPoolImpl) GetConn(addr string) (*sharedConn, error) {
 	pool.poolMu.Lock()
 	defer pool.poolMu.Unlock()
 	if _, ok := pool.bucketConns[addr]; !ok {
 		pool.bucketConns[addr] = newConnArray(addr)
 	}
-	return pool.bucketConns[addr].getNext(ctx, pool.credential)
+	return pool.bucketConns[addr].getNext(pool.ctx, pool.credential)
 }
 
 // ReleaseConn implements GrpcPool.ReleaseConn

--- a/cdc/kv/grpc_pool_impl.go
+++ b/cdc/kv/grpc_pool_impl.go
@@ -1,0 +1,213 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pingcap/log"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/security"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	gbackoff "google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	defaultConnBucket = 8
+	defaultCapacity   = 1000
+)
+
+// connArray is an array of sharedConn
+type connArray struct {
+	// target is TiKV storage address
+	target string
+	mu     sync.Mutex
+	conns  []*sharedConn
+	// next is used for fetching sharedConn in a round robin way
+	next int
+}
+
+func newConnArray(target string) *connArray {
+	return &connArray{target: target}
+}
+
+// resize increases conn array size by `size` parameter
+func (ca *connArray) resize(ctx context.Context, credential *security.Credential, size int) error {
+	conns := make([]*sharedConn, 0, size)
+	for i := 0; i < size; i++ {
+		conn, err := createClientConn(ctx, credential, ca.target)
+		if err != nil {
+			return err
+		}
+		conns = append(conns, &sharedConn{ClientConn: conn, active: 0})
+	}
+	ca.conns = append(ca.conns, conns...)
+	return nil
+}
+
+func createClientConn(ctx context.Context, credential *security.Credential, target string) (*grpc.ClientConn, error) {
+	grpcTLSOption, err := credential.ToGRPCDialOption()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+
+	conn, err := grpc.DialContext(
+		ctx,
+		target,
+		grpcTLSOption,
+		grpc.WithInitialWindowSize(grpcInitialWindowSize),
+		grpc.WithInitialConnWindowSize(grpcInitialConnWindowSize),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcMaxCallRecvMsgSize)),
+		grpc.WithUnaryInterceptor(grpcMetrics.UnaryClientInterceptor()),
+		grpc.WithStreamInterceptor(grpcMetrics.StreamClientInterceptor()),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: gbackoff.Config{
+				BaseDelay:  time.Second,
+				Multiplier: 1.1,
+				Jitter:     0.1,
+				MaxDelay:   3 * time.Second,
+			},
+			MinConnectTimeout: 3 * time.Second,
+		}),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second,
+			Timeout:             3 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	)
+	cancel()
+
+	if err != nil {
+		err2 := conn.Close()
+		if err2 != nil {
+			log.Warn("close grpc conn", zap.Error(err2))
+		}
+		return nil, cerror.WrapError(cerror.ErrGRPCDialFailed, err)
+	}
+	return conn, nil
+}
+
+// getNext gets next available sharedConn, if all conns are not available, scale
+// the connArray to double size.
+func (ca *connArray) getNext(ctx context.Context, credential *security.Credential) (*sharedConn, error) {
+	ca.mu.Lock()
+	defer ca.mu.Unlock()
+
+	if len(ca.conns) == 0 {
+		err := ca.resize(ctx, credential, 2)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for current := ca.next; current < ca.next+len(ca.conns); current++ {
+		conn := ca.conns[current%len(ca.conns)]
+		if conn.active < defaultCapacity {
+			conn.active++
+			ca.next = (current + 1) % len(ca.conns)
+			return conn, nil
+		}
+	}
+
+	current := len(ca.conns)
+	// if there is no available conn, increase connArray size by 2.
+	err := ca.resize(ctx, credential, 2)
+	if err != nil {
+		return nil, err
+	}
+	ca.conns[current].active++
+	ca.next = current + 1
+	return ca.conns[current], nil
+}
+
+// close tears down all ClientConns maintained in connArray
+func (ca *connArray) close() {
+	ca.mu.Lock()
+	defer ca.mu.Unlock()
+	for _, conn := range ca.conns {
+		// tear down this grpc.ClientConn, we don't use it anymore, the returned
+		// not-nil error can be ignored
+		conn.Close() //nolint:errcheck
+	}
+}
+
+func getBucket(tableID int64) int {
+	// plus defaultConnBucket in case of tableID = -1
+	return int(tableID+defaultConnBucket) % defaultConnBucket
+}
+
+// GrpcPoolImpl implement GrpcPool interface
+type GrpcPoolImpl struct {
+	poolMu sync.RWMutex
+	// bucketConns maps from TiKV store address to a slice of connArray, we call
+	// it connArray bucket.
+	// Each table will be mapped to a determinated bucket and GetConn will only
+	// return gRPC connections within this bucket, which means regions from the
+	// same table tend to use the same gRPC connection.
+	bucketConns map[string][]*connArray
+	credential  *security.Credential
+}
+
+// NewGrpcPoolImpl creates a new GrpcPoolImpl instance
+func NewGrpcPoolImpl(credential *security.Credential) *GrpcPoolImpl {
+	return &GrpcPoolImpl{
+		credential:  credential,
+		bucketConns: make(map[string][]*connArray),
+	}
+}
+
+// GetConn implements GrpcPool.GetConn
+func (pool *GrpcPoolImpl) GetConn(ctx context.Context, addr string, tableID int64) (*sharedConn, error) {
+	pool.poolMu.Lock()
+	defer pool.poolMu.Unlock()
+	if _, ok := pool.bucketConns[addr]; !ok {
+		bucketConn := make([]*connArray, 0, defaultConnBucket)
+		for i := 0; i < defaultConnBucket; i++ {
+			bucketConn = append(bucketConn, newConnArray(addr))
+		}
+		pool.bucketConns[addr] = bucketConn
+	}
+	index := getBucket(tableID)
+	return pool.bucketConns[addr][index].getNext(ctx, pool.credential)
+}
+
+// ReleaseConn implements GrpcPool.ReleaseConn
+func (pool *GrpcPoolImpl) ReleaseConn(sc *sharedConn, addr string, tableID int64) {
+	pool.poolMu.RLock()
+	defer pool.poolMu.RUnlock()
+	if bucket, ok := pool.bucketConns[addr]; !ok {
+		log.Warn("resource is not found in grpc pool", zap.String("addr", addr))
+	} else {
+		index := getBucket(tableID)
+		array := bucket[index]
+		array.mu.Lock()
+		sc.active--
+		array.mu.Unlock()
+	}
+}
+
+// Close implements GrpcPool.Close
+func (pool *GrpcPoolImpl) Close() {
+	pool.poolMu.Lock()
+	defer pool.poolMu.Unlock()
+	for _, bucket := range pool.bucketConns {
+		for _, ca := range bucket {
+			ca.close()
+		}
+	}
+}

--- a/cdc/kv/grpc_pool_impl.go
+++ b/cdc/kv/grpc_pool_impl.go
@@ -152,13 +152,14 @@ func (ca *connArray) recycle() (empty bool) {
 		if conn.active > 0 {
 			ca.conns[i] = conn
 			i++
+		} else {
+			// tear down this grpc.ClientConn, we don't use it anymore, the returned
+			// not-nil error can be ignored
+			conn.Close() //nolint:errcheck
 		}
 	}
 	// erasing truncated values
 	for j := i; j < len(ca.conns); j++ {
-		// tear down this grpc.ClientConn, we don't use it anymore, the returned
-		// not-nil error can be ignored
-		ca.conns[j].Close() //nolint:errcheck
 		ca.conns[j] = nil
 	}
 	ca.conns = ca.conns[:i]

--- a/cdc/kv/grpc_pool_impl_test.go
+++ b/cdc/kv/grpc_pool_impl_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/pkg/security"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+// Use etcdSuite for some special reasons, the embed etcd uses zap as the only candidate
+// logger and in the logger initializtion it also initializes the grpclog/loggerv2, which
+// is not a thread-safe operation and it must be called before any gRPC functions
+// ref: https://github.com/grpc/grpc-go/blob/master/grpclog/loggerv2.go#L67-L72
+func (s *etcdSuite) TestConnArray(c *check.C) {
+	defer testleak.AfterTest(c)()
+	defer s.TearDownTest(c)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool := NewGrpcPoolImpl(&security.Credential{})
+	defer pool.Close()
+	addr := "127.0.0.1:20161"
+	tableID := int64(53)
+	conn, err := pool.GetConn(ctx, addr, tableID)
+	c.Assert(err, check.IsNil)
+	c.Assert(conn.active, check.Equals, int64(1))
+	pool.ReleaseConn(conn, addr, tableID)
+	c.Assert(conn.active, check.Equals, int64(0))
+
+	lastConn := conn
+	// First defaultCapacity*2 connections will use initial two connections.
+	for i := 0; i < defaultCapacity*2; i++ {
+		conn, err := pool.GetConn(ctx, addr, tableID)
+		c.Assert(err, check.IsNil)
+		c.Assert(lastConn.ClientConn, check.Not(check.Equals), conn.ClientConn)
+		c.Assert(conn.active, check.Equals, int64(i)/2+1)
+		lastConn = conn
+	}
+	// The following defaultCapacity*2 connections will trigger resize of connection array.
+	for i := 0; i < defaultCapacity*2; i++ {
+		conn, err := pool.GetConn(ctx, addr, tableID)
+		c.Assert(err, check.IsNil)
+		c.Assert(lastConn.ClientConn, check.Not(check.Equals), conn.ClientConn)
+		c.Assert(conn.active, check.Equals, int64(i)/2+1)
+		lastConn = conn
+	}
+}

--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -98,7 +98,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: "ticdc",
 			Subsystem: "kvclient",
-			Name:      "stream_count",
+			Name:      "grpc_stream_count",
 			Help:      "active stream count of each gRPC connection",
 		}, []string{"store"})
 )

--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -115,6 +115,7 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(clientRegionTokenSize)
 	registry.MustRegister(batchResolvedEventSize)
 	registry.MustRegister(etcdRequestCounter)
+	registry.MustRegister(grpcPoolStreamGauge)
 
 	// Register client metrics to registry.
 	registry.MustRegister(grpcMetrics)

--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -94,6 +94,13 @@ var (
 			Name:      "request_count",
 			Help:      "request counter of etcd operation",
 		}, []string{"type", "capture"})
+	grpcPoolStreamGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "stream_count",
+			Help:      "active stream count of each gRPC connection",
+		}, []string{"store"})
 )
 
 // InitMetrics registers all metrics in the kv package

--- a/cdc/kv/testing.go
+++ b/cdc/kv/testing.go
@@ -145,7 +145,8 @@ func (*mockPullerInit) IsInitialized() bool {
 // TestSplit try split on every region, and test can get value event from
 // every region after split.
 func TestSplit(t require.TestingT, pdCli pd.Client, storage tikv.Storage, kvStore kv.Storage) {
-	cli := NewCDCClient(context.Background(), pdCli, storage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	cli := NewCDCClient(context.Background(), pdCli, storage, grpcPool)
 	defer cli.Close()
 
 	eventCh := make(chan model.RegionFeedEvent, 1<<20)
@@ -234,7 +235,8 @@ func mustDeleteKey(t require.TestingT, storage kv.Storage, key []byte) {
 
 // TestGetKVSimple test simple KV operations
 func TestGetKVSimple(t require.TestingT, pdCli pd.Client, storage tikv.Storage, kvStore kv.Storage) {
-	cli := NewCDCClient(context.Background(), pdCli, storage, &security.Credential{})
+	grpcPool := NewGrpcPoolImpl(&security.Credential{})
+	cli := NewCDCClient(context.Background(), pdCli, storage, grpcPool)
 	defer cli.Close()
 
 	checker := newEventChecker(t)

--- a/cdc/kv/testing.go
+++ b/cdc/kv/testing.go
@@ -145,13 +145,13 @@ func (*mockPullerInit) IsInitialized() bool {
 // TestSplit try split on every region, and test can get value event from
 // every region after split.
 func TestSplit(t require.TestingT, pdCli pd.Client, storage tikv.Storage, kvStore kv.Storage) {
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
-	cli := NewCDCClient(context.Background(), pdCli, storage, grpcPool)
-	defer cli.Close()
-
 	eventCh := make(chan model.RegionFeedEvent, 1<<20)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
+	cli := NewCDCClient(context.Background(), pdCli, storage, grpcPool)
+	defer cli.Close()
 
 	startTS := mustGetTimestamp(t, storage)
 
@@ -235,13 +235,13 @@ func mustDeleteKey(t require.TestingT, storage kv.Storage, key []byte) {
 
 // TestGetKVSimple test simple KV operations
 func TestGetKVSimple(t require.TestingT, pdCli pd.Client, storage tikv.Storage, kvStore kv.Storage) {
-	grpcPool := NewGrpcPoolImpl(&security.Credential{})
-	cli := NewCDCClient(context.Background(), pdCli, storage, grpcPool)
-	defer cli.Close()
-
 	checker := newEventChecker(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	grpcPool := NewGrpcPoolImpl(ctx, &security.Credential{})
+	cli := NewCDCClient(context.Background(), pdCli, storage, grpcPool)
+	defer cli.Close()
 
 	startTS := mustGetTimestamp(t, storage)
 	lockresolver := txnutil.NewLockerResolver(storage)

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/notify"
 	"github.com/pingcap/ticdc/pkg/scheduler"
-	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
@@ -117,7 +116,7 @@ type Owner struct {
 	l sync.RWMutex
 
 	pdEndpoints []string
-	credential  *security.Credential
+	grpcPool    kv.GrpcPool
 	pdClient    pd.Client
 	etcdClient  kv.CDCEtcdClient
 
@@ -156,7 +155,7 @@ const (
 func NewOwner(
 	ctx context.Context,
 	pdClient pd.Client,
-	credential *security.Credential,
+	grpcPool kv.GrpcPool,
 	sess *concurrency.Session,
 	gcTTL int64,
 	flushChangefeedInterval time.Duration,
@@ -172,7 +171,7 @@ func NewOwner(
 		done:                    make(chan struct{}),
 		session:                 sess,
 		pdClient:                pdClient,
-		credential:              credential,
+		grpcPool:                grpcPool,
 		changeFeeds:             make(map[model.ChangeFeedID]*changeFeed),
 		failInitFeeds:           make(map[model.ChangeFeedID]struct{}),
 		stoppedFeeds:            make(map[model.ChangeFeedID]*model.ChangeFeedStatus),
@@ -331,7 +330,7 @@ func (o *Owner) newChangeFeed(
 		return nil, errors.Trace(err)
 	}
 
-	ddlHandler := newDDLHandler(o.pdClient, o.credential, kvStore, checkpointTs)
+	ddlHandler := newDDLHandler(o.pdClient, o.grpcPool, kvStore, checkpointTs)
 	defer func() {
 		if resultErr != nil {
 			ddlHandler.Close()

--- a/cdc/owner/ddl_puller.go
+++ b/cdc/owner/ddl_puller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller"
-	"github.com/pingcap/ticdc/pkg/config"
 	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/regionspan"
@@ -58,7 +57,6 @@ type ddlPullerImpl struct {
 
 func newDDLPuller(ctx cdcContext.Context, startTs uint64) (DDLPuller, error) {
 	pdCli := ctx.GlobalVars().PDClient
-	conf := config.GetGlobalServerConfig()
 	f, err := filter.NewFilter(ctx.ChangefeedVars().Info.Config)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -67,7 +65,7 @@ func newDDLPuller(ctx cdcContext.Context, startTs uint64) (DDLPuller, error) {
 	kvStorage := ctx.GlobalVars().KVStorage
 	// kvStorage can be nil only in the test
 	if kvStorage != nil {
-		plr = puller.NewPuller(ctx, pdCli, conf.Security, kvStorage, startTs,
+		plr = puller.NewPuller(ctx, pdCli, ctx.GlobalVars().GrpcPool, kvStorage, startTs,
 			[]regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}, false)
 	}
 

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -22,10 +22,10 @@ import (
 	"github.com/pingcap/errors"
 	timodel "github.com/pingcap/parser/model"
 	"github.com/pingcap/ticdc/cdc/entry"
+	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller"
 	"github.com/pingcap/ticdc/pkg/regionspan"
-	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/util"
 	pd "github.com/tikv/pd/client"
 	"golang.org/x/sync/errgroup"
@@ -42,10 +42,10 @@ type ddlHandler struct {
 	cancel func()
 }
 
-func newDDLHandler(pdCli pd.Client, credential *security.Credential, kvStorage tidbkv.Storage, checkpointTS uint64) *ddlHandler {
+func newDDLHandler(pdCli pd.Client, grpcPool kv.GrpcPool, kvStorage tidbkv.Storage, checkpointTS uint64) *ddlHandler {
 	// TODO: context should be passed from outter caller
 	ctx, cancel := context.WithCancel(context.Background())
-	plr := puller.NewPuller(ctx, pdCli, credential, kvStorage, checkpointTS, []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}, false)
+	plr := puller.NewPuller(ctx, pdCli, grpcPool, kvStorage, checkpointTS, []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}, false)
 	h := &ddlHandler{
 		puller: plr,
 		cancel: cancel,

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -914,7 +914,9 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	err = capture.Campaign(ctx)
 	c.Assert(err, check.IsNil)
 
-	owner, err := NewOwner(ctx, nil, &security.Credential{}, capture.session, cdcGCSafePointTTL4Test, time.Millisecond*200)
+	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	owner, err := NewOwner(ctx, nil, grpcPool, capture.session, cdcGCSafePointTTL4Test, time.Millisecond*200)
 	c.Assert(err, check.IsNil)
 
 	sampleCF.etcdCli = owner.etcdClient
@@ -1215,8 +1217,10 @@ func (s *ownerSuite) TestWatchCampaignKey(c *check.C) {
 	err = capture.Campaign(ctx)
 	c.Assert(err, check.IsNil)
 
+	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
 	ctx1, cancel1 := context.WithCancel(ctx)
-	owner, err := NewOwner(ctx1, nil, &security.Credential{}, capture.session,
+	owner, err := NewOwner(ctx1, nil, grpcPool, capture.session,
 		cdcGCSafePointTTL4Test, time.Millisecond*200)
 	c.Assert(err, check.IsNil)
 
@@ -1297,7 +1301,9 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 	for _, c := range captureList {
 		captures[c.ID] = c
 	}
-	owner, err := NewOwner(ctx, nil, &security.Credential{}, capture.session,
+	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	owner, err := NewOwner(ctx, nil, grpcPool, capture.session,
 		cdcGCSafePointTTL4Test, time.Millisecond*200)
 	c.Assert(err, check.IsNil)
 	// It is better to update changefeed information by `loadChangeFeeds`, however
@@ -1355,7 +1361,9 @@ func (s *ownerSuite) TestWatchFeedChange(c *check.C) {
 	ctx = util.PutCaptureAddrInCtx(ctx, addr)
 	capture, err := NewCapture(ctx, []string{s.clientURL.String()}, nil, nil)
 	c.Assert(err, check.IsNil)
-	owner, err := NewOwner(ctx, nil, &security.Credential{}, capture.session,
+	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	owner, err := NewOwner(ctx, nil, grpcPool, capture.session,
 		cdcGCSafePointTTL4Test, time.Millisecond*200)
 	c.Assert(err, check.IsNil)
 

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -914,7 +914,7 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	err = capture.Campaign(ctx)
 	c.Assert(err, check.IsNil)
 
-	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := kv.NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	owner, err := NewOwner(ctx, nil, grpcPool, capture.session, cdcGCSafePointTTL4Test, time.Millisecond*200)
 	c.Assert(err, check.IsNil)
@@ -1217,7 +1217,7 @@ func (s *ownerSuite) TestWatchCampaignKey(c *check.C) {
 	err = capture.Campaign(ctx)
 	c.Assert(err, check.IsNil)
 
-	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := kv.NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	ctx1, cancel1 := context.WithCancel(ctx)
 	owner, err := NewOwner(ctx1, nil, grpcPool, capture.session,
@@ -1301,7 +1301,7 @@ func (s *ownerSuite) TestCleanUpStaleTasks(c *check.C) {
 	for _, c := range captureList {
 		captures[c.ID] = c
 	}
-	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := kv.NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	owner, err := NewOwner(ctx, nil, grpcPool, capture.session,
 		cdcGCSafePointTTL4Test, time.Millisecond*200)
@@ -1361,7 +1361,7 @@ func (s *ownerSuite) TestWatchFeedChange(c *check.C) {
 	ctx = util.PutCaptureAddrInCtx(ctx, addr)
 	capture, err := NewCapture(ctx, []string{s.clientURL.String()}, nil, nil)
 	c.Assert(err, check.IsNil)
-	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := kv.NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	owner, err := NewOwner(ctx, nil, grpcPool, capture.session,
 		cdcGCSafePointTTL4Test, time.Millisecond*200)

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -38,7 +38,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/notify"
 	"github.com/pingcap/ticdc/pkg/regionspan"
 	"github.com/pingcap/ticdc/pkg/retry"
-	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/util"
 	tidbkv "github.com/pingcap/tidb/kv"
 	"github.com/tikv/client-go/v2/oracle"
@@ -65,10 +64,10 @@ type oldProcessor struct {
 	changefeed   model.ChangeFeedInfo
 	stopped      int32
 
-	pdCli      pd.Client
-	credential *security.Credential
-	etcdCli    kv.CDCEtcdClient
-	session    *concurrency.Session
+	pdCli    pd.Client
+	etcdCli  kv.CDCEtcdClient
+	grpcPool kv.GrpcPool
+	session  *concurrency.Session
 
 	sinkManager *sink.Manager
 
@@ -142,7 +141,7 @@ func (t *tableInfo) loadCheckpointTs() uint64 {
 func newProcessor(
 	ctx context.Context,
 	pdCli pd.Client,
-	credential *security.Credential,
+	grpcPool kv.GrpcPool,
 	session *concurrency.Session,
 	changefeed model.ChangeFeedInfo,
 	sinkManager *sink.Manager,
@@ -162,7 +161,7 @@ func newProcessor(
 		return nil, errors.Trace(err)
 	}
 	ddlspans := []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}
-	ddlPuller := puller.NewPuller(ctx, pdCli, credential, kvStorage, checkpointTs, ddlspans, false)
+	ddlPuller := puller.NewPuller(ctx, pdCli, grpcPool, kvStorage, checkpointTs, ddlspans, false)
 	filter, err := filter.NewFilter(changefeed.Config)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -190,7 +189,7 @@ func newProcessor(
 		changefeedID:  changefeedID,
 		changefeed:    changefeed,
 		pdCli:         pdCli,
-		credential:    credential,
+		grpcPool:      grpcPool,
 		etcdCli:       cdcEtcdCli,
 		session:       session,
 		sinkManager:   sinkManager,
@@ -819,7 +818,7 @@ func (p *oldProcessor) addTable(ctx context.Context, tableID int64, replicaInfo 
 		}
 		// NOTICE: always pull the old value internally
 		// See also: TODO(hi-rustin): add issue link here.
-		plr := puller.NewPuller(ctx, p.pdCli, p.credential, kvStorage,
+		plr := puller.NewPuller(ctx, p.pdCli, p.grpcPool, kvStorage,
 			replicaInfo.StartTs, []regionspan.Span{span},
 			true)
 		go func() {
@@ -1203,7 +1202,7 @@ var runProcessorImpl = runProcessor
 func runProcessor(
 	ctx context.Context,
 	pdCli pd.Client,
-	credential *security.Credential,
+	grpcPool kv.GrpcPool,
 	session *concurrency.Session,
 	info model.ChangeFeedInfo,
 	changefeedID string,
@@ -1232,7 +1231,7 @@ func runProcessor(
 		return nil, errors.Trace(err)
 	}
 	sinkManager := sink.NewManager(ctx, s, errCh, checkpointTs)
-	processor, err := newProcessor(ctx, pdCli, credential, session, info, sinkManager,
+	processor, err := newProcessor(ctx, pdCli, grpcPool, session, info, sinkManager,
 		changefeedID, captureInfo, checkpointTs, errCh, flushCheckpointInterval)
 	if err != nil {
 		cancel()

--- a/cdc/processor/pipeline/puller.go
+++ b/cdc/processor/pipeline/puller.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller"
-	"github.com/pingcap/ticdc/pkg/config"
 	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"github.com/pingcap/ticdc/pkg/pipeline"
 	"github.com/pingcap/ticdc/pkg/regionspan"
@@ -60,13 +59,12 @@ func (n *pullerNode) tableSpan(ctx cdcContext.Context) []regionspan.Span {
 
 func (n *pullerNode) Init(ctx pipeline.NodeContext) error {
 	metricTableResolvedTsGauge := tableResolvedTsGauge.WithLabelValues(ctx.ChangefeedVars().ID, ctx.GlobalVars().CaptureInfo.AdvertiseAddr, n.tableName)
-	globalConfig := config.GetGlobalServerConfig()
 	ctxC, cancel := context.WithCancel(ctx)
 	ctxC = util.PutTableInfoInCtx(ctxC, n.tableID, n.tableName)
 	ctxC = util.PutChangefeedIDInCtx(ctxC, ctx.ChangefeedVars().ID)
 	// NOTICE: always pull the old value internally
 	// See also: TODO(hi-rustin): add issue link here.
-	plr := puller.NewPuller(ctxC, ctx.GlobalVars().PDClient, globalConfig.Security, ctx.GlobalVars().KVStorage,
+	plr := puller.NewPuller(ctxC, ctx.GlobalVars().PDClient, ctx.GlobalVars().GrpcPool, ctx.GlobalVars().KVStorage,
 		n.replicaInfo.StartTs, n.tableSpan(ctx), true)
 	n.wg.Go(func() error {
 		ctx.Throw(errors.Trace(plr.Run(ctxC)))

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -31,7 +31,6 @@ import (
 	tablepipeline "github.com/pingcap/ticdc/cdc/processor/pipeline"
 	"github.com/pingcap/ticdc/cdc/puller"
 	"github.com/pingcap/ticdc/cdc/sink"
-	"github.com/pingcap/ticdc/pkg/config"
 	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
@@ -441,11 +440,10 @@ func (p *processor) createAndDriveSchemaStorage(ctx cdcContext.Context) (entry.S
 	kvStorage := ctx.GlobalVars().KVStorage
 	ddlspans := []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}
 	checkpointTs := p.changefeed.Info.GetCheckpointTs(p.changefeed.Status)
-	conf := config.GetGlobalServerConfig()
 	ddlPuller := puller.NewPuller(
 		ctx,
 		ctx.GlobalVars().PDClient,
-		conf.Security,
+		ctx.GlobalVars().GrpcPool,
 		ctx.GlobalVars().KVStorage,
 		checkpointTs, ddlspans, false)
 	meta, err := kv.GetSnapshotMeta(kvStorage, checkpointTs)

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/puller/frontier"
 	"github.com/pingcap/ticdc/pkg/regionspan"
-	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/txnutil"
 	"github.com/pingcap/ticdc/pkg/util"
 	tidbkv "github.com/pingcap/tidb/kv"
@@ -52,7 +51,6 @@ type Puller interface {
 type pullerImpl struct {
 	pdCli          pd.Client
 	kvCli          kv.CDCKVClient
-	credential     *security.Credential
 	kvStorage      tikv.Storage
 	checkpointTs   uint64
 	spans          []regionspan.ComparableSpan
@@ -68,7 +66,7 @@ type pullerImpl struct {
 func NewPuller(
 	ctx context.Context,
 	pdCli pd.Client,
-	credential *security.Credential,
+	grpcPool kv.GrpcPool,
 	kvStorage tidbkv.Storage,
 	checkpointTs uint64,
 	spans []regionspan.Span,
@@ -86,11 +84,10 @@ func NewPuller(
 	// the initial ts for frontier to 0. Once the puller level resolved ts
 	// initialized, the ts should advance to a non-zero value.
 	tsTracker := frontier.NewFrontier(0, comparableSpans...)
-	kvCli := kv.NewCDCKVClient(ctx, pdCli, tikvStorage, credential)
+	kvCli := kv.NewCDCKVClient(ctx, pdCli, tikvStorage, grpcPool)
 	p := &pullerImpl{
 		pdCli:          pdCli,
 		kvCli:          kvCli,
-		credential:     credential,
 		kvStorage:      tikvStorage,
 		checkpointTs:   checkpointTs,
 		spans:          comparableSpans,

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -62,7 +62,7 @@ func newMockCDCKVClient(
 	ctx context.Context,
 	pd pd.Client,
 	kvStorage tikv.Storage,
-	credential *security.Credential,
+	grpcPool kv.GrpcPool,
 ) kv.CDCKVClient {
 	return &mockCDCKVClient{
 		expectations: make(chan model.RegionFeedEvent, 1024),
@@ -123,7 +123,9 @@ func (s *pullerSuite) newPullerForTest(
 		kv.NewCDCKVClient = backupNewCDCKVClient
 	}()
 	pdCli := &mockPdClientForPullerTest{clusterID: uint64(1)}
-	plr := NewPuller(ctx, pdCli, nil /* credential */, store, checkpointTs, spans, enableOldValue)
+	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	defer grpcPool.Close()
+	plr := NewPuller(ctx, pdCli, grpcPool, store, checkpointTs, spans, enableOldValue)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -123,7 +123,7 @@ func (s *pullerSuite) newPullerForTest(
 		kv.NewCDCKVClient = backupNewCDCKVClient
 	}()
 	pdCli := &mockPdClientForPullerTest{clusterID: uint64(1)}
-	grpcPool := kv.NewGrpcPoolImpl(&security.Credential{})
+	grpcPool := kv.NewGrpcPoolImpl(ctx, &security.Credential{})
 	defer grpcPool.Close()
 	plr := NewPuller(ctx, pdCli, grpcPool, store, checkpointTs, spans, enableOldValue)
 	wg.Add(1)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -37,6 +37,7 @@ type GlobalVars struct {
 	KVStorage   tidbkv.Storage
 	CaptureInfo *model.CaptureInfo
 	EtcdClient  *kv.CDCEtcdClient
+	GrpcPool    kv.GrpcPool
 }
 
 // ChangefeedVars contains some vars which can be used anywhere in a pipeline


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add global gRPC connection pool in cdc server.

### What is changed and how it works?

- The gRPC pool is shared by all kv clients in a `capture`, the pool is created before a `capture` starts running and destroyed after a `capture` suicides or exits.
- The gPRC pool maintains a bucket of gPRC connections for each TiKV store, the bucket is increased in a lazy way.
- The gPRC pool provides a builtin recycle method, which is used to collect idle connections periodically.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Add a global gRPC connection pool and share gRPC connections among kv clients.
```
