### PR TITLE
pipeline: remove error log when runner is canceled

### DIFF
--- a/pkg/pipeline/runner.go
+++ b/pkg/pipeline/runner.go
@@ -14,6 +14,9 @@
 package pipeline
 
 import (
+	stdContext "context"
+
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/context"
 	"go.uber.org/zap"
@@ -47,7 +50,7 @@ func (r *nodeRunner) run(ctx context.Context) error {
 	defer close(r.outputCh)
 	defer func() {
 		err := r.node.Destroy(nodeCtx)
-		if err != nil {
+		if err != nil && errors.Cause(err) != stdContext.Canceled {
 			log.Error("found an error when stopping node", zap.String("node name", r.name), zap.Error(err))
 		}
 	}()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When a pipeline is canceled, runner logs quite a lot following error

```
[2021/08/12 22:51:27.155 +08:00] [ERROR] [runner.go:51] ["found an error when stopping node"] ["node name"=sink] [error="context canceled"]
```

### What is changed and how it works?

Don't log error when runner exits because of context canceled


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
