### PR TITLE
http: enable all sub paths matching in pprof

### DIFF
--- a/cdc/http_router.go
+++ b/cdc/http_router.go
@@ -84,6 +84,7 @@ func newRouter(capture2 *capture.Capture) *gin.Engine {
 	pprofGroup := router.Group("/debug/pprof")
 	{
 		pprofGroup.GET("", gin.WrapF(pprof.Index))
+		pprofGroup.GET("/:any", gin.WrapF(pprof.Index))
 		pprofGroup.GET("/cmdline", gin.WrapF(pprof.Cmdline))
 		pprofGroup.GET("/profile", gin.WrapF(pprof.Profile))
 		pprofGroup.GET("/symbol", gin.WrapF(pprof.Symbol))

--- a/cdc/http_status_test.go
+++ b/cdc/http_status_test.go
@@ -77,12 +77,18 @@ func (s *httpStatusSuite) TestHTTPStatus(c *check.C) {
 }
 
 func testPprof(c *check.C) {
-	resp, err := http.Get(fmt.Sprintf("http://%s/debug/pprof/cmdline", advertiseAddr4Test))
-	c.Assert(err, check.IsNil)
-	defer resp.Body.Close()
-	c.Assert(resp.StatusCode, check.Equals, 200)
-	_, err = ioutil.ReadAll(resp.Body)
-	c.Assert(err, check.IsNil)
+	testValidPprof := func(uri string) {
+		resp, err := http.Get(uri)
+		c.Assert(err, check.IsNil)
+		defer resp.Body.Close()
+		c.Assert(resp.StatusCode, check.Equals, 200)
+		_, err = ioutil.ReadAll(resp.Body)
+		c.Assert(err, check.IsNil)
+	}
+	testValidPprof(fmt.Sprintf("http://%s/debug/pprof", advertiseAddr4Test))
+	testValidPprof(fmt.Sprintf("http://%s/debug/pprof/cmdline", advertiseAddr4Test))
+	testValidPprof(fmt.Sprintf("http://%s/debug/pprof/mutex", advertiseAddr4Test))
+	testValidPprof(fmt.Sprintf("http://%s/debug/pprof/heap?debug=1", advertiseAddr4Test))
 }
 
 func testReisgnOwner(c *check.C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix some pprof requests (`/debug/pprof/xxx`) return 404

```
➜  curl http://172.16.6.135:8301/debug/pprof/goroutine\?debug=1
404 page not found%
```

### What is changed and how it works?

Should match path `/debug/pprof/:any` and handled by `pprof.Index`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
