### PR TITLE
redo: add manager, writer interface, add basic manager, blockhole writer

### DIFF
--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -1,0 +1,260 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing pemissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// ConsistentConfig represents replication consistency config for a changefeed
+// TODO: put ConsistentConfig to ticdc/pkg/config and make it configurable by changefeed
+type ConsistentConfig struct {
+	Level   string `toml:"level" json:"level"`
+	Storage string `toml:"storage" json:"storage"`
+}
+
+var updateRtsInterval = time.Second
+
+type consistentLevelType string
+
+const (
+	consistentLevelNormal   consistentLevelType = "normal"
+	consistentLevelEventual consistentLevelType = "eventual"
+)
+
+type consistentStorage string
+
+const (
+	consistentStorageLocal     consistentStorage = "local"
+	consistentStorageS3        consistentStorage = "s3"
+	consistentStorageBlackhole consistentStorage = "blackhole"
+)
+
+// IsValidConsistentLevel checks whether a give consistent level is valid
+func IsValidConsistentLevel(level string) bool {
+	switch consistentLevelType(level) {
+	case consistentLevelNormal, consistentLevelEventual:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidConsistentStorage checks whether a give consistent storage is valid
+func IsValidConsistentStorage(storage string) bool {
+	switch consistentStorage(storage) {
+	case consistentStorageLocal, consistentStorageS3, consistentStorageBlackhole:
+		return true
+	default:
+		return false
+	}
+}
+
+// LogManager defines an interface that is used to manage redo log
+type LogManager interface {
+	// Enabled returns whether the log manager is enabled
+	Enabled() bool
+
+	// The following 5 APIs are called from processor only
+	EmitRowChangedEvents(ctx context.Context, tableID model.TableID, rows ...*model.RowChangedEvent) error
+	FlushLog(ctx context.Context, tableID model.TableID, resolvedTs uint64) error
+	AddTable(tableID model.TableID, startTs uint64)
+	RemoveTable(tableID model.TableID)
+	GetMinResolvedTs() uint64
+
+	// EmitDDLEvent and FlushResolvedAndCheckpointTs are called from owner only
+	EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
+	FlushResolvedAndCheckpointTs(ctx context.Context, resolvedTs, checkpointTs uint64) (err error)
+}
+
+// ManagerOptions defines options for redo log manager
+type ManagerOptions struct {
+	// whether to run background goroutine to fetch table resolved ts
+	EnableBgRunner bool
+	ErrCh          chan<- error
+}
+
+// ManagerImpl manages redo log writer, buffers un-persistent redo logs, calculates
+// redo log resolved ts. It implements LogManager interface.
+type ManagerImpl struct {
+	enabled       bool
+	level         consistentLevelType
+	storage       consistentStorage
+	writer        LogWriter
+	minResolvedTs uint64
+	tableIDs      []model.TableID
+	rtsMap        map[model.TableID]uint64
+	rtsMapMu      sync.RWMutex
+}
+
+// NewManager creates a new Manager
+func NewManager(ctx context.Context, cfg *ConsistentConfig, opts *ManagerOptions) (*ManagerImpl, error) {
+	// return a nil Manager if no consistent config or normal consistent level
+	if cfg == nil || consistentLevelType(cfg.Level) == consistentLevelNormal {
+		return &ManagerImpl{enabled: false}, nil
+	}
+	m := &ManagerImpl{
+		enabled: true,
+		level:   consistentLevelType(cfg.Level),
+		storage: consistentStorage(cfg.Storage),
+		rtsMap:  make(map[model.TableID]uint64),
+	}
+	switch m.storage {
+	case consistentStorageBlackhole:
+		m.writer = newBlackHoleStorage()
+	default:
+		return nil, cerror.ErrConsistentStorage.GenWithStackByArgs(m.storage)
+	}
+	if opts.EnableBgRunner {
+		go m.run(ctx, opts.ErrCh)
+	}
+	return m, nil
+}
+
+// NewDisabledManager returns a disabled log manger instance, used in test only
+func NewDisabledManager() *ManagerImpl {
+	return &ManagerImpl{enabled: false}
+}
+
+// Enabled returns whether this log manager is enabled
+func (m *ManagerImpl) Enabled() bool {
+	return m.enabled
+}
+
+// EmitRowChangedEvents converts RowChangedEvents to RedoLogs, and sends to redo log writer
+func (m *ManagerImpl) EmitRowChangedEvents(
+	ctx context.Context,
+	tableID model.TableID,
+	rows ...*model.RowChangedEvent,
+) error {
+	logs := make([]*RowRedoLog, 0, len(rows))
+	for _, row := range rows {
+		logs = append(logs, &RowRedoLog{Row: row, Index: row.IndexColumns})
+	}
+	_, err := m.writer.WriteLog(ctx, tableID, logs)
+	return err
+}
+
+// FlushLog emits resolved ts of a single table
+func (m *ManagerImpl) FlushLog(
+	ctx context.Context,
+	tableID model.TableID,
+	resolvedTs uint64,
+) error {
+	return m.writer.FlushLog(ctx, tableID, resolvedTs)
+}
+
+// EmitDDLEvent sends DDL event to redo log writer
+func (m *ManagerImpl) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
+	return m.writer.SendDDL(ctx, ddl)
+}
+
+// GetMinResolvedTs returns the minimum resolved ts of all tables in this redo log manager
+func (m *ManagerImpl) GetMinResolvedTs() uint64 {
+	return atomic.LoadUint64(&m.minResolvedTs)
+}
+
+// FlushResolvedAndCheckpointTs flushes resolved-ts and checkpoint-ts to redo log writer
+func (m *ManagerImpl) FlushResolvedAndCheckpointTs(ctx context.Context, resolvedTs, checkpointTs uint64) (err error) {
+	err = m.writer.EmitResolvedTs(ctx, resolvedTs)
+	if err != nil {
+		return
+	}
+	err = m.writer.EmitCheckpointTs(ctx, checkpointTs)
+	return
+}
+
+// AddTable adds a new table in redo log manager
+func (m *ManagerImpl) AddTable(tableID model.TableID, startTs uint64) {
+	m.rtsMapMu.Lock()
+	defer m.rtsMapMu.Unlock()
+	i := sort.Search(len(m.tableIDs), func(i int) bool {
+		return m.tableIDs[i] >= tableID
+	})
+	if i < len(m.tableIDs) && m.tableIDs[i] == tableID {
+		log.Warn("add duplicated table in redo log manager", zap.Int64("table-id", tableID))
+		return
+	}
+	if i == len(m.tableIDs) {
+		m.tableIDs = append(m.tableIDs, tableID)
+	} else {
+		m.tableIDs = append(m.tableIDs[:i+1], m.tableIDs[i:]...)
+		m.tableIDs[i] = tableID
+	}
+	m.rtsMap[tableID] = startTs
+}
+
+// RemoveTable removes a table from redo log manager
+func (m *ManagerImpl) RemoveTable(tableID model.TableID) {
+	m.rtsMapMu.Lock()
+	defer m.rtsMapMu.Unlock()
+	i := sort.Search(len(m.tableIDs), func(i int) bool {
+		return m.tableIDs[i] >= tableID
+	})
+	if i < len(m.tableIDs) && m.tableIDs[i] == tableID {
+		copy(m.tableIDs[i:], m.tableIDs[i+1:])
+		m.tableIDs = m.tableIDs[:len(m.tableIDs)-1]
+		delete(m.rtsMap, tableID)
+	} else {
+		log.Warn("remove a table not maintained in redo log manager", zap.Int64("table-id", tableID))
+	}
+	// TODO: send remove table command to redo log writer
+}
+
+// updatertsMap reads rtsMap from redo log writer and calculate the minimum
+// resolved ts of all maintaining tables.
+func (m *ManagerImpl) updateTableResolvedTs(ctx context.Context) error {
+	m.rtsMapMu.Lock()
+	defer m.rtsMapMu.Unlock()
+	rtsMap, err := m.writer.GetTableResolvedTs(ctx, m.tableIDs)
+	if err != nil {
+		return err
+	}
+	minResolvedTs := uint64(math.MaxUint64)
+	for tableID, rts := range rtsMap {
+		m.rtsMap[tableID] = rts
+		if rts < minResolvedTs {
+			minResolvedTs = rts
+		}
+	}
+	atomic.StoreUint64(&m.minResolvedTs, minResolvedTs)
+	return nil
+}
+
+func (m *ManagerImpl) run(ctx context.Context, errCh chan<- error) {
+	ticker := time.NewTicker(updateRtsInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			err := m.updateTableResolvedTs(ctx)
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}
+}

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -1,0 +1,173 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+func TestSuite(t *testing.T) { check.TestingT(t) }
+
+type logManagerSuite struct{}
+
+var _ = check.Suite(&logManagerSuite{})
+
+func (s *logManagerSuite) TestConsistentConfig(c *check.C) {
+	defer testleak.AfterTest(c)()
+	levelCases := []struct {
+		level string
+		valid bool
+	}{
+		{"normal", true},
+		{"eventual", true},
+		{"NORMAL", false},
+		{"", false},
+	}
+	for _, lc := range levelCases {
+		c.Assert(IsValidConsistentLevel(lc.level), check.Equals, lc.valid)
+	}
+
+	storageCases := []struct {
+		storage string
+		valid   bool
+	}{
+		{"local", true},
+		{"s3", true},
+		{"blackhole", true},
+		{"Local", false},
+		{"nfs", false},
+		{"", false},
+	}
+	for _, sc := range storageCases {
+		c.Assert(IsValidConsistentStorage(sc.storage), check.Equals, sc.valid)
+	}
+}
+
+func (s *logManagerSuite) TestLogManagerInProcessor(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	checkResovledTs := func(mgr LogManager, expectedRts uint64) {
+		time.Sleep(time.Millisecond*200 + updateRtsInterval)
+		resolvedTs := mgr.GetMinResolvedTs()
+		c.Assert(resolvedTs, check.Equals, expectedRts)
+	}
+
+	cfg := &ConsistentConfig{
+		Level:   string(consistentLevelEventual),
+		Storage: string(consistentStorageBlackhole),
+	}
+	errCh := make(chan error, 1)
+	opts := &ManagerOptions{
+		EnableBgRunner: true,
+		ErrCh:          errCh,
+	}
+	logMgr, err := NewManager(ctx, cfg, opts)
+	c.Assert(err, check.IsNil)
+
+	// check emit row changed events can move forward resolved ts
+	tables := []model.TableID{53, 55, 57, 59}
+	startTs := uint64(100)
+	for _, tableID := range tables {
+		logMgr.AddTable(tableID, startTs)
+	}
+	testCases := []struct {
+		tableID model.TableID
+		rows    []*model.RowChangedEvent
+	}{
+		{
+			tableID: 53,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 120, Table: &model.TableName{TableID: 53}},
+				{CommitTs: 125, Table: &model.TableName{TableID: 53}},
+				{CommitTs: 130, Table: &model.TableName{TableID: 53}},
+			},
+		},
+		{
+			tableID: 55,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 130, Table: &model.TableName{TableID: 55}},
+				{CommitTs: 135, Table: &model.TableName{TableID: 55}},
+			},
+		},
+		{
+			tableID: 57,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 130, Table: &model.TableName{TableID: 57}},
+			},
+		},
+		{
+			tableID: 59,
+			rows: []*model.RowChangedEvent{
+				{CommitTs: 128, Table: &model.TableName{TableID: 59}},
+				{CommitTs: 130, Table: &model.TableName{TableID: 59}},
+				{CommitTs: 133, Table: &model.TableName{TableID: 59}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		err := logMgr.EmitRowChangedEvents(ctx, tc.tableID, tc.rows...)
+		c.Assert(err, check.IsNil)
+	}
+	checkResovledTs(logMgr, uint64(130))
+
+	// check FlushLog can move forward the resolved ts when there is not row event.
+	flushResolvedTs := uint64(150)
+	for _, tableID := range tables {
+		err := logMgr.FlushLog(ctx, tableID, flushResolvedTs)
+		c.Assert(err, check.IsNil)
+	}
+	checkResovledTs(logMgr, flushResolvedTs)
+
+	// check remove table can work normally
+	removeTable := tables[len(tables)-1]
+	tables = tables[:len(tables)-1]
+	logMgr.RemoveTable(removeTable)
+	flushResolvedTs = uint64(200)
+	for _, tableID := range tables {
+		err := logMgr.FlushLog(ctx, tableID, flushResolvedTs)
+		c.Assert(err, check.IsNil)
+	}
+	checkResovledTs(logMgr, flushResolvedTs)
+}
+
+func (s *logManagerSuite) TestLogManagerInOwner(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &ConsistentConfig{
+		Level:   string(consistentLevelEventual),
+		Storage: string(consistentStorageBlackhole),
+	}
+	opts := &ManagerOptions{
+		EnableBgRunner: false,
+	}
+	logMgr, err := NewManager(ctx, cfg, opts)
+	c.Assert(err, check.IsNil)
+
+	ddl := &model.DDLEvent{StartTs: 100, CommitTs: 120, Query: "CREATE TABLE `TEST.T1`"}
+	err = logMgr.EmitDDLEvent(ctx, ddl)
+	c.Assert(err, check.IsNil)
+
+	err = logMgr.FlushResolvedAndCheckpointTs(ctx, 130 /*resolvedTs*/, 120 /*CheckPointTs*/)
+	c.Assert(err, check.IsNil)
+}

--- a/cdc/redo/storage.go
+++ b/cdc/redo/storage.go
@@ -1,0 +1,45 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+
+	"github.com/pingcap/ticdc/cdc/model"
+)
+
+// RowRedoLog stores one RowChangedEvent and its index column
+type RowRedoLog struct {
+	Row *model.RowChangedEvent `json:"row"`
+	// Index is the IndexColumns field from model.RowChangedEvent, we need to persist
+	// this field in order to use it when consuming redo logs. Since this filed
+	// is not json encoded in model.RowChangedEvents, we store it separately here.
+	Index [][]int `json:"index"`
+}
+
+// LogWriter is a writer abstraction for redo log storage layer
+type LogWriter interface {
+	WriteLog(ctx context.Context, tableID model.TableID, log []*RowRedoLog) (resolvedTs uint64, err error)
+	// FlushLog sends resolved-ts from table pipeline to log writer, it is
+	// essential to flush when a table doesn't have any row change event for
+	// sometime, and the resolved ts of this table should be moved forward.
+	FlushLog(ctx context.Context, tableID model.TableID, resolvedTs uint64) error
+
+	// SendDDL, EmitCheckpointTs and EmitResolvedTs are called from owner only
+	SendDDL(ctx context.Context, ddl *model.DDLEvent) error
+	EmitCheckpointTs(ctx context.Context, checkpointTs uint64) error
+	EmitResolvedTs(ctx context.Context, resolvedTs uint64) error
+
+	GetTableResolvedTs(ctx context.Context, tableIDs []int64) (resolvedTsMap map[int64]uint64, err error)
+}

--- a/cdc/redo/storage_blackhole.go
+++ b/cdc/redo/storage_blackhole.go
@@ -1,0 +1,84 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redo
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	"go.uber.org/zap"
+)
+
+// blackholeStorage defines a blockhole storage, it receives events and persists
+// without any latency
+type blackholeStorage struct {
+	tableRtsMap  map[model.TableID]uint64
+	tableRtsMu   sync.RWMutex
+	resolvedTs   uint64
+	checkpointTs uint64
+}
+
+func newBlackHoleStorage() *blackholeStorage {
+	return &blackholeStorage{
+		tableRtsMap: make(map[model.TableID]uint64),
+	}
+}
+
+func (bs *blackholeStorage) WriteLog(ctx context.Context, tableID model.TableID, logs []*RowRedoLog) (resolvedTs uint64, err error) {
+	bs.tableRtsMu.Lock()
+	defer bs.tableRtsMu.Unlock()
+	if len(logs) == 0 {
+		return bs.tableRtsMap[tableID], nil
+	}
+	resolvedTs = bs.tableRtsMap[tableID]
+	current := logs[len(logs)-1].Row.CommitTs
+	bs.tableRtsMap[tableID] = current
+	log.Debug("write row redo logs", zap.Int("count", len(logs)),
+		zap.Uint64("resolvedTs", resolvedTs), zap.Uint64("current", current))
+	return
+}
+
+func (bs *blackholeStorage) FlushLog(ctx context.Context, tableID model.TableID, resolvedTs uint64) error {
+	bs.tableRtsMu.Lock()
+	defer bs.tableRtsMu.Unlock()
+	bs.tableRtsMap[tableID] = resolvedTs
+	return nil
+}
+
+func (bs *blackholeStorage) SendDDL(ctx context.Context, ddl *model.DDLEvent) error {
+	log.Debug("send ddl event", zap.Any("ddl", ddl))
+	return nil
+}
+
+func (bs *blackholeStorage) EmitResolvedTs(ctx context.Context, ts uint64) error {
+	bs.resolvedTs = ts
+	return nil
+}
+
+func (bs *blackholeStorage) EmitCheckpointTs(ctx context.Context, ts uint64) error {
+	bs.checkpointTs = ts
+	return nil
+}
+
+func (bs *blackholeStorage) GetTableResolvedTs(ctx context.Context, tableIDs []int64) (map[int64]uint64, error) {
+	bs.tableRtsMu.RLock()
+	defer bs.tableRtsMu.RUnlock()
+	rtsMap := make(map[int64]uint64, len(bs.tableRtsMap))
+	for _, tableID := range tableIDs {
+		rtsMap[tableID] = bs.tableRtsMap[tableID]
+	}
+	return rtsMap, nil
+}

--- a/errors.toml
+++ b/errors.toml
@@ -146,6 +146,16 @@ error = '''
 codec decode error
 '''
 
+["CDC:ErrConsistentLevel"]
+error = '''
+consistent level (%s) not support
+'''
+
+["CDC:ErrConsistentStorage"]
+error = '''
+consistent storage (%s) not support
+'''
+
 ["CDC:ErrCraftCodecInvalidData"]
 error = '''
 craft codec invalid data

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -110,6 +110,10 @@ var (
 	ErrSinkInvalidConfig         = errors.Normalize("sink config invalid", errors.RFCCodeText("CDC:ErrSinkInvalidConfig"))
 	ErrCraftCodecInvalidData     = errors.Normalize("craft codec invalid data", errors.RFCCodeText("CDC:ErrCraftCodecInvalidData"))
 
+	// redo log related errors
+	ErrConsistentLevel   = errors.Normalize("consistent level (%s) not support", errors.RFCCodeText("CDC:ErrConsistentLevel"))
+	ErrConsistentStorage = errors.Normalize("consistent storage (%s) not support", errors.RFCCodeText("CDC:ErrConsistentStorage"))
+
 	// utilities related errors
 	ErrToTLSConfigFailed         = errors.Normalize("generate tls config failed", errors.RFCCodeText("CDC:ErrToTLSConfigFailed"))
 	ErrCheckClusterVersionFromPD = errors.Normalize("failed to request PD", errors.RFCCodeText("CDC:ErrCheckClusterVersionFromPD"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

A subtask from https://github.com/pingcap/ticdc/issues/2351, this PR closes task-1

1.  Add basic interface definition.
2. Integration redo log writer with TiCDC table sink.
3. Add resolved ts management and integrate it into TiCDC replication logic.

### What is changed and how it works?

- Defines the interface of redo log manager and redo log writer
- Add a simple redo log manager, maintaining resolved ts of redo log writer of each table.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
