### PR TITLE
sorter: fix nil panic due to pool data race

### DIFF
--- a/cdc/puller/sorter/backend_pool_test.go
+++ b/cdc/puller/sorter/backend_pool_test.go
@@ -348,3 +348,21 @@ func (s *backendPoolSuite) TestGetMemoryPressureFailure(c *check.C) {
 		}
 	}
 }
+
+func (s *backendPoolSuite) TestGlobalPool(c *check.C) {
+	defer testleak.AfterTest(c)()
+
+	// terminateGlobalPool smoke testing to make sure calling it multiple times
+	// does not cause panic.
+	terminateGlobalPool()
+
+	setGlobalPool(func() *backEndPool {
+		dir := c.MkDir()
+		backEndPool, err := newBackEndPool(dir, "")
+		c.Assert(err, check.IsNil)
+		c.Assert(backEndPool, check.NotNil)
+		return backEndPool
+	})
+	terminateGlobalPool()
+	terminateGlobalPool()
+}

--- a/cdc/puller/sorter/file_backend_test.go
+++ b/cdc/puller/sorter/file_backend_test.go
@@ -46,7 +46,13 @@ func (s *fileBackendSuite) TestWrapIOError(c *check.C) {
 func (s *fileBackendSuite) TestNoSpace(c *check.C) {
 	defer testleak.AfterTest(c)()
 
+	dir := c.MkDir()
+	backEndPool, err := newBackEndPool(dir, "")
+	c.Assert(err, check.IsNil)
+	c.Assert(backEndPool, check.NotNil)
+
 	fb := &fileBackEnd{
+		pool:     backEndPool,
 		fileName: "/dev/full",
 		serde:    &msgPackGenSerde{},
 	}

--- a/cdc/puller/sorter/sorter_test.go
+++ b/cdc/puller/sorter/sorter_test.go
@@ -211,7 +211,7 @@ func testSorter(ctx context.Context, c *check.C, sorter puller.EventSorter, coun
 						panic("regressed")
 					}
 					lastTs = event.CRTs
-					counter += 1
+					counter++
 					if counter%10000 == 0 {
 						log.Debug("Messages received", zap.Int("counter", counter))
 					}
@@ -233,10 +233,8 @@ func (s *sorterSuite) TestSortDirConfigLocal(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer UnifiedSorterCleanUp()
 
-	poolMu.Lock()
 	// Clean up the back-end pool if one has been created
-	pool = nil
-	poolMu.Unlock()
+	terminateGlobalPool()
 
 	baseDir := c.MkDir()
 	dir := filepath.Join(baseDir, "sorter_local")
@@ -252,9 +250,7 @@ func (s *sorterSuite) TestSortDirConfigLocal(c *check.C) {
 		"0.0.0.0:0")
 	c.Assert(err, check.IsNil)
 
-	poolMu.Lock()
-	defer poolMu.Unlock()
-
+	pool := getGlobalPool()
 	c.Assert(pool, check.NotNil)
 	c.Assert(pool.dir, check.Equals, dir)
 }
@@ -263,10 +259,8 @@ func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
 	defer testleak.AfterTest(c)()
 	defer UnifiedSorterCleanUp()
 
-	poolMu.Lock()
 	// Clean up the back-end pool if one has been created
-	pool = nil
-	poolMu.Unlock()
+	terminateGlobalPool()
 
 	dir := c.MkDir()
 	// We expect the changefeed setting to take effect
@@ -279,9 +273,7 @@ func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
 		"0.0.0.0:0")
 	c.Assert(err, check.IsNil)
 
-	poolMu.Lock()
-	defer poolMu.Unlock()
-
+	pool := getGlobalPool()
 	c.Assert(pool, check.NotNil)
 	c.Assert(pool.dir, check.Equals, dir)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix nil panic due to pool data race

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x860 pc=0x227ac84]

goroutine 715841 [running]:
github.com/pingcap/ticdc/cdc/puller/sorter.(*backEndPool).dealloc(0x0, 0x2e5ced0, 0xc17bea42d0, 0x0, 0x0)
        github.com/pingcap/ticdc/cdc/puller/sorter/backend_pool.go:223 +0x464
github.com/pingcap/ticdc/cdc/puller/sorter.(*heapSorter).flush.func2(0x0, 0x0)
        github.com/pingcap/ticdc/cdc/puller/sorter/heap_sorter.go:158 +0x8f
github.com/pingcap/ticdc/cdc/puller/sorter.runMerger.func1.1(0xc21c131b00)
        github.com/pingcap/ticdc/cdc/puller/sorter/merger.go:77 +0x83
github.com/pingcap/ticdc/cdc/puller/sorter.runMerger.func1.2(0x2577440, 0xc21c131b00, 0x0, 0x0, 0xc1a52d3b01)
        github.com/pingcap/ticdc/cdc/puller/sorter/merger.go:98 +0x42
sync.(*Map).Range(0xc110b9a9c0, 0xc093e63c08)
        sync/map.go:345 +0x1dc
github.com/pingcap/ticdc/cdc/puller/sorter.runMerger.func1(0xc0ad7273c0, 0xc0142c7e60, 0xc110b9a9c0, 0xc0aedfc400)
        github.com/pingcap/ticdc/cdc/puller/sorter/merger.go:97 +0x125
github.com/pingcap/ticdc/cdc/puller/sorter.runMerger(0x2e6e4f0, 0xc0b8639fc0, 0x4, 0xc0142c7e60, 0xc0142c7da0, 0xc0ad7273c0, 0x2e24a80, 0xc00011e0b0)
        github.com/pingcap/ticdc/cdc/puller/sorter/merger.go:491 +0x9e7
github.com/pingcap/ticdc/cdc/puller/sorter.(*UnifiedSorter).Run.func5(0x0, 0x2)
        github.com/pingcap/ticdc/cdc/puller/sorter/unified_sorter.go:201 +0x5f
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0604fc900, 0xc0206d2200)
        golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
        golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9/errgroup/errgroup.go:54 +0x66
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x860 pc=0x227ac84]
```

Found at https://github.com/pingcap/ticdc/commit/95e35768211af34de94d3a935c04f34b2f80d239

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a panic due to data race when starting a new changefeed.
```
