### PR TITLE
kvclient: Fix grpc pool error handling

### DIFF
--- a/cdc/kv/grpc_pool_impl.go
+++ b/cdc/kv/grpc_pool_impl.go
@@ -74,6 +74,7 @@ func createClientConn(ctx context.Context, credential *security.Credential, targ
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
 
 	conn, err := grpc.DialContext(
 		ctx,
@@ -99,13 +100,7 @@ func createClientConn(ctx context.Context, credential *security.Credential, targ
 			PermitWithoutStream: true,
 		}),
 	)
-	cancel()
-
 	if err != nil {
-		err2 := conn.Close()
-		if err2 != nil {
-			log.Warn("close grpc conn", zap.Error(err2))
-		}
 		return nil, cerror.WrapError(cerror.ErrGRPCDialFailed, err)
 	}
 	return conn, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Improper error handling in grpc pool can cause nil pointer dereference.

### What is changed and how it works?
- No need to close connection if `Dial` has returned error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
