### PR TITLE
async_sink: backport async sink to 5.0-branch old owner

### DIFF
--- a/cdc/async_sink.go
+++ b/cdc/async_sink.go
@@ -1,0 +1,197 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+// TODO: to remove this file once new owner is enabled.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/cdc/sink"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/filter"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultErrChSize = 1024
+)
+
+// AsyncSink is an async sink design for owner
+// The EmitCheckpointTs and EmitDDLEvent is asynchronous function for now
+// Other functions are still synchronization
+type AsyncSink interface {
+	Initialize(ctx cdcContext.Context, tableInfo []*model.SimpleTableInfo) error
+	// EmitCheckpointTs emits the checkpoint Ts to downstream data source
+	// this function will return after recording the checkpointTs specified in memory immediately
+	// and the recorded checkpointTs will be sent and updated to downstream data source every second
+	// return err here for the unit test TestOwnerCalcResolvedTs in owner_test
+	EmitCheckpointTs(ctx cdcContext.Context, ts uint64) error
+	// EmitDDLEvent emits DDL event asynchronously and return true if the DDL is executed
+	// the DDL event will be sent to another goroutine and execute to downstream
+	// the caller of this function can call again and again until a true returned
+	EmitDDLEvent(ctx cdcContext.Context, ddl *model.DDLEvent) (bool, error)
+	SinkSyncpoint(ctx cdcContext.Context, checkpointTs uint64) error
+	Close(ctx context.Context) error
+}
+
+type asyncSinkImpl struct {
+	sink           sink.Sink
+	syncpointStore sink.SyncpointStore
+
+	checkpointTs model.Ts
+
+	lastSyncPoint model.Ts
+
+	ddlCh         chan *model.DDLEvent
+	ddlFinishedTs model.Ts
+	ddlSentTs     model.Ts
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	errCh  chan error
+}
+
+func newAsyncSink(ctx cdcContext.Context) (AsyncSink, error) {
+	ctx, cancel := cdcContext.WithCancel(ctx)
+	changefeedID := ctx.ChangefeedVars().ID
+	changefeedInfo := ctx.ChangefeedVars().Info
+	filter, err := filter.NewFilter(changefeedInfo.Config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	errCh := make(chan error, defaultErrChSize)
+	s, err := sink.NewSink(ctx, changefeedID, changefeedInfo.SinkURI, filter, changefeedInfo.Config, changefeedInfo.Opts, errCh)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	asyncSink := &asyncSinkImpl{
+		sink:   s,
+		ddlCh:  make(chan *model.DDLEvent, 1),
+		errCh:  errCh,
+		cancel: cancel,
+	}
+
+	asyncSink.wg.Add(1)
+	go asyncSink.run(ctx)
+	return asyncSink, nil
+}
+
+func (s *asyncSinkImpl) Initialize(ctx cdcContext.Context, tableInfo []*model.SimpleTableInfo) error {
+	return s.sink.Initialize(ctx, tableInfo)
+}
+
+func (s *asyncSinkImpl) run(ctx cdcContext.Context) {
+	defer s.wg.Done()
+	// TODO make the tick duration configurable
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	var lastCheckpointTs model.Ts
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-s.errCh:
+			ctx.Throw(err)
+			return
+		case <-ticker.C:
+			checkpointTs := atomic.LoadUint64(&s.checkpointTs)
+			if checkpointTs == 0 || checkpointTs <= lastCheckpointTs {
+				continue
+			}
+			lastCheckpointTs = checkpointTs
+			if err := s.sink.EmitCheckpointTs(ctx, checkpointTs); err != nil {
+				ctx.Throw(errors.Trace(err))
+				return
+			}
+		case ddl := <-s.ddlCh:
+			err := s.sink.EmitDDLEvent(ctx, ddl)
+			failpoint.Inject("InjectChangefeedAsyncDDLError", func() {
+				err = cerror.ErrExecDDLFailed.GenWithStack("InjectChangefeedAsyncDDLError")
+			})
+			if err == nil || cerror.ErrDDLEventIgnored.Equal(err) {
+				log.Info("Execute DDL succeeded", zap.String("changefeed", ctx.ChangefeedVars().ID), zap.Bool("ignored", err != nil), zap.Reflect("ddl", ddl))
+				atomic.StoreUint64(&s.ddlFinishedTs, ddl.CommitTs)
+			} else {
+				// If DDL executing failed, and the error can not be ignored, throw an error and pause the changefeed
+				log.Error("Execute DDL failed",
+					zap.String("ChangeFeedID", ctx.ChangefeedVars().ID),
+					zap.Error(err),
+					zap.Reflect("ddl", ddl))
+				ctx.Throw(errors.Trace(err))
+				return
+			}
+		}
+	}
+}
+
+func (s *asyncSinkImpl) EmitCheckpointTs(ctx cdcContext.Context, ts uint64) error {
+	atomic.StoreUint64(&s.checkpointTs, ts)
+	return nil
+}
+
+func (s *asyncSinkImpl) EmitDDLEvent(ctx cdcContext.Context, ddl *model.DDLEvent) (bool, error) {
+	ddlFinishedTs := atomic.LoadUint64(&s.ddlFinishedTs)
+	failpoint.Inject("InjectChangefeedDDLBlock", func() {
+		if ctx.ChangefeedVars().ID == "changefeed-ddl-block" {
+			log.Info("step into failpoint")
+			// make the func EmitDDLEvent always return false
+			// tests/ddl_async will fail if ddl block the owner
+			ddlFinishedTs = ddl.CommitTs - 10
+			ddl.CommitTs = s.ddlSentTs - 10
+		}
+	})
+	if ddl.CommitTs <= ddlFinishedTs {
+		// the DDL event is executed successfully, and done is true
+		return true, nil
+	}
+	if ddl.CommitTs <= s.ddlSentTs {
+		// the DDL event is executing and not finished yes, return false
+		return false, nil
+	}
+	select {
+	case <-ctx.Done():
+		return false, errors.Trace(ctx.Err())
+	case s.ddlCh <- ddl:
+	}
+	s.ddlSentTs = ddl.CommitTs
+	return false, nil
+}
+
+func (s *asyncSinkImpl) SinkSyncpoint(ctx cdcContext.Context, checkpointTs uint64) error {
+	if checkpointTs == s.lastSyncPoint {
+		return nil
+	}
+	s.lastSyncPoint = checkpointTs
+	// TODO implement async sink syncpoint
+	return s.syncpointStore.SinkSyncpoint(ctx, ctx.ChangefeedVars().ID, checkpointTs)
+}
+
+func (s *asyncSinkImpl) Close(ctx context.Context) (err error) {
+	s.cancel()
+	err = s.sink.Close(ctx)
+	if s.syncpointStore != nil {
+		err = s.syncpointStore.Close()
+	}
+	s.wg.Wait()
+	return
+}

--- a/cdc/async_sink_test.go
+++ b/cdc/async_sink_test.go
@@ -1,0 +1,202 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/cdc/model"
+	"github.com/pingcap/ticdc/cdc/sink"
+	"github.com/pingcap/ticdc/pkg/config"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/retry"
+	"github.com/pingcap/ticdc/pkg/util/testleak"
+)
+
+var _ = check.Suite(&asyncSinkSuite{})
+
+type asyncSinkSuite struct {
+}
+
+type mockAsyncSink struct {
+	sink.Sink
+	initTableInfo []*model.SimpleTableInfo
+	checkpointTs  model.Ts
+	ddl           *model.DDLEvent
+	ddlMu         sync.Mutex
+	ddlError      error
+}
+
+func (m *mockAsyncSink) Initialize(ctx context.Context, tableInfo []*model.SimpleTableInfo) error {
+	m.initTableInfo = tableInfo
+	return nil
+}
+
+func (m *mockAsyncSink) EmitCheckpointTs(ctx context.Context, ts uint64) error {
+	atomic.StoreUint64(&m.checkpointTs, ts)
+	return nil
+}
+
+func (m *mockAsyncSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
+	m.ddlMu.Lock()
+	defer m.ddlMu.Unlock()
+	time.Sleep(1 * time.Second)
+	m.ddl = ddl
+	return m.ddlError
+}
+
+func (m *mockAsyncSink) Close(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockAsyncSink) Barrier(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockAsyncSink) GetDDL() *model.DDLEvent {
+	m.ddlMu.Lock()
+	defer m.ddlMu.Unlock()
+	return m.ddl
+}
+
+func newAsyncSink4Test(ctx cdcContext.Context, c *check.C) (cdcContext.Context, AsyncSink, *mockAsyncSink) {
+	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
+		ID:   "test-changefeed",
+		Info: &model.ChangeFeedInfo{SinkURI: "blackhole://", Config: config.GetDefaultReplicaConfig()},
+	})
+	sink, err := newAsyncSink(ctx)
+	c.Assert(err, check.IsNil)
+	mockAsyncSink := &mockAsyncSink{}
+	sink.(*asyncSinkImpl).sink = mockAsyncSink
+	return ctx, sink, mockAsyncSink
+}
+
+func (s *asyncSinkSuite) TestInitialize(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	ctx, sink, mockAsyncSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close(ctx)
+	tableInfos := []*model.SimpleTableInfo{{Schema: "test"}}
+	err := sink.Initialize(ctx, tableInfos)
+	c.Assert(err, check.IsNil)
+	c.Assert(tableInfos, check.DeepEquals, mockAsyncSink.initTableInfo)
+}
+
+func (s *asyncSinkSuite) TestCheckpoint(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	ctx, sink, mSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close(ctx)
+
+	waitCheckpointGrowingUp := func(m *mockAsyncSink, targetTs model.Ts) error {
+		return retry.Run(100*time.Millisecond, 30, func() error {
+			if targetTs != atomic.LoadUint64(&m.checkpointTs) {
+				return errors.New("targetTs!=checkpointTs")
+			}
+			return nil
+		})
+	}
+	err := sink.EmitCheckpointTs(ctx, 1)
+	c.Assert(err, check.IsNil)
+	c.Assert(waitCheckpointGrowingUp(mSink, 1), check.IsNil)
+	err = sink.EmitCheckpointTs(ctx, 10)
+	c.Assert(err, check.IsNil)
+	c.Assert(waitCheckpointGrowingUp(mSink, 10), check.IsNil)
+}
+
+func (s *asyncSinkSuite) TestExecDDL(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	ctx, sink, mSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close(ctx)
+	ddl1 := &model.DDLEvent{CommitTs: 1}
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl1)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl1)
+			break
+		}
+	}
+	ddl2 := &model.DDLEvent{CommitTs: 2}
+	ddl3 := &model.DDLEvent{CommitTs: 3}
+	_, err := sink.EmitDDLEvent(ctx, ddl2)
+	c.Assert(err, check.IsNil)
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl2)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl2)
+			break
+		}
+	}
+	_, err = sink.EmitDDLEvent(ctx, ddl3)
+	c.Assert(err, check.IsNil)
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl3)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl3)
+			break
+		}
+	}
+}
+
+func (s *asyncSinkSuite) TestExecDDLError(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := cdcContext.NewBackendContext4Test(false)
+	var resultErr error
+	var resultErrMu sync.Mutex
+	getResultErr := func() error {
+		resultErrMu.Lock()
+		defer resultErrMu.Unlock()
+		return resultErr
+	}
+	ctx = cdcContext.WithErrorHandler(ctx, func(err error) error {
+		resultErrMu.Lock()
+		defer resultErrMu.Unlock()
+		resultErr = err
+		return nil
+	})
+	ctx, sink, mSink := newAsyncSink4Test(ctx, c)
+	defer sink.Close(ctx)
+	mSink.ddlError = cerror.ErrDDLEventIgnored.GenWithStackByArgs()
+	ddl1 := &model.DDLEvent{CommitTs: 1}
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl1)
+		c.Assert(err, check.IsNil)
+		if done {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl1)
+			break
+		}
+	}
+	c.Assert(getResultErr(), check.IsNil)
+	mSink.ddlError = cerror.ErrExecDDLFailed.GenWithStackByArgs()
+	ddl2 := &model.DDLEvent{CommitTs: 2}
+	for {
+		done, err := sink.EmitDDLEvent(ctx, ddl2)
+		c.Assert(err, check.IsNil)
+		if done || getResultErr() != nil {
+			c.Assert(mSink.GetDDL(), check.DeepEquals, ddl2)
+			break
+		}
+	}
+	c.Assert(cerror.ErrExecDDLFailed.Equal(errors.Cause(getResultErr())), check.IsTrue)
+}

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -16,6 +16,7 @@ package cdc
 import (
 	"context"
 	"fmt"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"math"
 	"sync"
 	"time"
@@ -107,7 +108,7 @@ type changeFeed struct {
 	taskStatus       model.ProcessorsInfos
 	taskPositions    map[model.CaptureID]*model.TaskPosition
 	filter           *filter.Filter
-	sink             sink.Sink
+	sink             AsyncSink
 	scheduler        scheduler.Scheduler
 
 	cyclicEnabled bool
@@ -116,6 +117,9 @@ type changeFeed struct {
 	ddlResolvedTs uint64
 	ddlJobHistory []*timodel.Job
 	ddlExecutedTs uint64
+	// ddlEventCache is not nil when the changefeed is executing a DDL event asynchronously
+	// After the DDL event has been executed, ddlEventCache will be set to nil.
+	ddlEventCache *model.DDLEvent
 
 	schemas map[model.SchemaID]tableIDMap
 	tables  map[model.TableID]model.TableName
@@ -132,6 +136,8 @@ type changeFeed struct {
 	etcdCli kv.CDCEtcdClient
 	leaseID clientv3.LeaseID
 
+	// cdcCtx for all
+	cdcCtx cdcContext.Context
 	// context cancel function for all internal goroutines
 	cancel context.CancelFunc
 }
@@ -641,7 +647,22 @@ func (c *changeFeed) applyJob(job *timodel.Job) (skip bool, err error) {
 // handleDDL check if we can change the status to be `ChangeFeedExecDDL` and execute the DDL asynchronously
 // if the status is in ChangeFeedWaitToExecDDL.
 // After executing the DDL successfully, the status will be changed to be ChangeFeedSyncDML.
-func (c *changeFeed) handleDDL(ctx context.Context) error {
+func (c *changeFeed) handleDDL() error {
+	// async ddl
+	if c.ddlState == model.ChangeFeedExecDDL && c.ddlEventCache != nil {
+		done, err := c.sink.EmitDDLEvent(c.cdcCtx, c.ddlEventCache)
+		if err != nil {
+			return cerror.ErrExecDDLFailed.GenWithStackByArgs()
+		}
+		if done {
+			c.ddlExecutedTs = c.ddlJobHistory[0].BinlogInfo.FinishedTS
+			c.ddlJobHistory = c.ddlJobHistory[1:]
+			c.ddlState = model.ChangeFeedSyncDML
+			c.ddlEventCache = nil
+		}
+		return nil
+	}
+
 	if c.ddlState != model.ChangeFeedWaitToExecDDL {
 		return nil
 	}
@@ -706,10 +727,10 @@ func (c *changeFeed) handleDDL(ctx context.Context) error {
 		c.ddlJobHistory = c.ddlJobHistory[1:]
 		c.ddlExecutedTs = todoDDLJob.BinlogInfo.FinishedTS
 		c.ddlState = model.ChangeFeedSyncDML
+		c.ddlEventCache = nil
 		return nil
 	}
 
-	executed := false
 	if !c.cyclicEnabled || c.info.Config.Cyclic.SyncDDL {
 		failpoint.Inject("InjectChangefeedDDLError", func() {
 			failpoint.Return(cerror.ErrExecDDLFailed.GenWithStackByArgs())
@@ -717,28 +738,23 @@ func (c *changeFeed) handleDDL(ctx context.Context) error {
 
 		ddlEvent.Query = binloginfo.AddSpecialComment(ddlEvent.Query)
 		log.Debug("DDL processed to make special features mysql-compatible", zap.String("query", ddlEvent.Query))
-		err = c.sink.EmitDDLEvent(ctx, ddlEvent)
+		c.ddlEventCache = ddlEvent
+		done, err := c.sink.EmitDDLEvent(c.cdcCtx, c.ddlEventCache)
 		// If DDL executing failed, pause the changefeed and print log, rather
 		// than return an error and break the running of this owner.
 		if err != nil {
-			if cerror.ErrDDLEventIgnored.NotEqual(err) {
-				c.ddlState = model.ChangeFeedDDLExecuteFailed
-				log.Error("Execute DDL failed",
-					zap.String("ChangeFeedID", c.id),
-					zap.Error(err),
-					zap.Reflect("ddlJob", todoDDLJob))
-				return cerror.ErrExecDDLFailed.GenWithStackByArgs()
-			}
-		} else {
-			executed = true
+			return cerror.ErrExecDDLFailed.GenWithStackByArgs()
 		}
-	}
-	if executed {
-		log.Info("Execute DDL succeeded", zap.String("changefeed", c.id), zap.Reflect("ddlJob", todoDDLJob))
-	} else {
-		log.Info("Execute DDL ignored", zap.String("changefeed", c.id), zap.Reflect("ddlJob", todoDDLJob))
-	}
+		if done {
+			c.ddlJobHistory = c.ddlJobHistory[1:]
+			c.ddlExecutedTs = todoDDLJob.BinlogInfo.FinishedTS
+			c.ddlState = model.ChangeFeedSyncDML
+			c.ddlEventCache = nil
+		}
+		return nil
 
+	}
+	log.Info("Execute DDL ignored", zap.String("changefeed", c.id), zap.Reflect("ddlJob", todoDDLJob))
 	c.ddlJobHistory = c.ddlJobHistory[1:]
 	c.ddlExecutedTs = todoDDLJob.BinlogInfo.FinishedTS
 	c.ddlState = model.ChangeFeedSyncDML
@@ -790,7 +806,7 @@ func (c *changeFeed) handleSyncPoint(ctx context.Context) error {
 }
 
 // calcResolvedTs update every changefeed's resolve ts and checkpoint ts.
-func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
+func (c *changeFeed) calcResolvedTs() error {
 	if c.ddlState != model.ChangeFeedSyncDML && c.ddlState != model.ChangeFeedWaitToExecDDL {
 		log.Debug("skip update resolved ts", zap.String("ddlState", c.ddlState.String()))
 		return nil
@@ -937,9 +953,9 @@ func (c *changeFeed) calcResolvedTs(ctx context.Context) error {
 			failpoint.Inject("InjectEmitCheckpointTsError", func() {
 				failpoint.Return(cerror.ErrEmitCheckpointTsFailed.GenWithStackByArgs())
 			})
-			err := c.sink.EmitCheckpointTs(ctx, minCheckpointTs)
+			err := c.sink.EmitCheckpointTs(c.cdcCtx, minCheckpointTs)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		}
 		tsUpdated = true

--- a/cdc/changefeed.go
+++ b/cdc/changefeed.go
@@ -16,7 +16,6 @@ package cdc
 import (
 	"context"
 	"fmt"
-	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"math"
 	"sync"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/filter"

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/cdc/sink"
 	"github.com/pingcap/ticdc/pkg/config"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/filter"
@@ -352,6 +353,7 @@ func (o *Owner) newChangeFeed(
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
+	cdcCtx := cdcContext.NewContext(ctx, &cdcContext.GlobalVars{})
 	defer func() {
 		if resultErr != nil {
 			cancel()
@@ -428,17 +430,22 @@ func (o *Owner) newChangeFeed(
 		}
 
 	}
-	errCh := make(chan error, 1)
-
-	primarySink, err := sink.NewSink(ctx, id, info.SinkURI, filter, info.Config, info.Opts, errCh)
+	cdcCtx = cdcContext.WithChangefeedVars(cdcCtx, &cdcContext.ChangefeedVars{
+		ID:   id,
+		Info: info,
+	})
+	errCh := make(chan error, defaultErrChSize)
+	cdcCtx = cdcContext.WithErrorHandler(cdcCtx, func(err error) error {
+		errCh <- errors.Trace(err)
+		return nil
+	})
+	asyncSink, err := newAsyncSink(cdcCtx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	defer func() {
-		if resultErr != nil && primarySink != nil {
-			// The Close of backend sink here doesn't use context, it is ok to pass
-			// a canceled context here.
-			primarySink.Close(ctx)
+		if resultErr != nil && asyncSink != nil {
+			asyncSink.Close(ctx)
 		}
 	}()
 	go func() {
@@ -450,12 +457,28 @@ func (o *Owner) newChangeFeed(
 		}
 		if err != nil && errors.Cause(err) != context.Canceled {
 			log.Error("error on running changefeed", zap.Error(err), zap.String("changefeed", id))
+			// asyncSink error, stop the changefeed
+			var code string
+			if terror, ok := err.(*errors.Error); ok {
+				code = string(terror.RFCCode())
+			} else {
+				code = string(cerror.ErrExecDDLFailed.RFCCode())
+			}
+			_ = o.EnqueueJob(model.AdminJob{
+				CfID: cf.id,
+				Type: model.AdminStop,
+				Error: &model.RunningError{
+					Addr:    util.CaptureAddrFromCtx(ctx),
+					Code:    code,
+					Message: err.Error(),
+				},
+			})
 		} else {
 			log.Info("changefeed exited", zap.String("changfeed", id))
 		}
 	}()
 
-	err = primarySink.Initialize(ctx, sinkTableInfo)
+	err = asyncSink.Initialize(cdcCtx, sinkTableInfo)
 	if err != nil {
 		log.Error("error on running owner", zap.Error(err))
 	}
@@ -497,9 +520,10 @@ func (o *Owner) newChangeFeed(
 		etcdCli:             o.etcdClient,
 		leaseID:             o.session.Lease(),
 		filter:              filter,
-		sink:                primarySink,
+		sink:                asyncSink,
 		cyclicEnabled:       info.Config.Cyclic.IsEnabled(),
 		lastRebalanceTime:   time.Now(),
+		cdcCtx:              cdcCtx,
 		cancel:              cancel,
 	}
 	return cf, nil
@@ -853,7 +877,7 @@ func (o *Owner) flushChangeFeedInfos(ctx context.Context) error {
 // calcResolvedTs call calcResolvedTs of every changefeeds
 func (o *Owner) calcResolvedTs(ctx context.Context) error {
 	for id, cf := range o.changeFeeds {
-		if err := cf.calcResolvedTs(ctx); err != nil {
+		if err := cf.calcResolvedTs(); err != nil {
 			log.Error("fail to calculate checkpoint ts, so it will be stopped", zap.String("changefeed", cf.id), zap.Error(err))
 			// error may cause by sink.EmitCheckpointTs`, just stop the changefeed at the moment
 			// todo: make the method mentioned above more robust.
@@ -885,7 +909,7 @@ func (o *Owner) calcResolvedTs(ctx context.Context) error {
 // handleDDL call handleDDL of every changefeeds
 func (o *Owner) handleDDL(ctx context.Context) error {
 	for _, cf := range o.changeFeeds {
-		err := cf.handleDDL(ctx)
+		err := cf.handleDDL()
 		if err != nil {
 			var code string
 			if terror, ok := err.(*errors.Error); ok {

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -129,7 +129,7 @@ type mockSink struct {
 	checkpointError error
 }
 
-func (m *mockSink) EmitCheckpointTs(ctx context.Context, ts uint64) error {
+func (m *mockSink) EmitCheckpointTs(ctx cdcContext.Context, ts uint64) error {
 	m.checkpointMu.Lock()
 	defer m.checkpointMu.Unlock()
 	atomic.StoreUint64(&m.checkpointTs, ts)

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/pingcap/ticdc/cdc/entry"
 	"github.com/pingcap/ticdc/cdc/kv"
 	"github.com/pingcap/ticdc/cdc/model"
-	"github.com/pingcap/ticdc/cdc/sink"
 	"github.com/pingcap/ticdc/pkg/config"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/filter"
@@ -122,7 +122,7 @@ func (m *mockPDClient) UpdateServiceGCSafePoint(ctx context.Context, serviceID s
 }
 
 type mockSink struct {
-	sink.Sink
+	AsyncSink
 	checkpointTs model.Ts
 
 	checkpointMu    sync.Mutex
@@ -195,6 +195,9 @@ func (s *ownerSuite) TestOwnerCalcResolvedTs(c *check.C) {
 	}
 
 	err = mockOwner.calcResolvedTs(s.ctx)
+	c.Assert(err, check.IsNil)
+
+	err = mockOwner.handleDDL(s.ctx)
 	c.Assert(err, check.IsNil)
 
 	err = mockOwner.handleAdminJob(s.ctx)
@@ -881,12 +884,10 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 	errg, _ := errgroup.WithContext(cctx)
 
 	replicaConf := config.GetDefaultReplicaConfig()
-	f, err := filter.NewFilter(replicaConf)
-	c.Assert(err, check.IsNil)
 
 	sampleCF := &changeFeed{
 		id:       cfID,
-		info:     &model.ChangeFeedInfo{},
+		info:     &model.ChangeFeedInfo{Config: replicaConf, SinkURI: "blackhole://"},
 		status:   &model.ChangeFeedStatus{},
 		ddlState: model.ChangeFeedSyncDML,
 		taskStatus: model.ProcessorsInfos{
@@ -903,8 +904,13 @@ func (s *ownerSuite) TestHandleAdmin(c *check.C) {
 		},
 		cancel: cancel,
 	}
-	errCh := make(chan error, 1)
-	sink, err := sink.NewSink(ctx, cfID, "blackhole://", f, replicaConf, map[string]string{}, errCh)
+	// new asyncSink
+	cdcCtx := cdcContext.NewContext(ctx, &cdcContext.GlobalVars{})
+	cdcCtx = cdcContext.WithChangefeedVars(cdcCtx, &cdcContext.ChangefeedVars{
+		ID:   cfID,
+		Info: sampleCF.info,
+	})
+	sink, err := newAsyncSink(cdcCtx)
 	c.Assert(err, check.IsNil)
 	defer sink.Close(cctx) //nolint:errcheck
 	sampleCF.sink = sink

--- a/tests/changefeed_error/run.sh
+++ b/tests/changefeed_error/run.sh
@@ -151,6 +151,18 @@ function run() {
     export GO_FAILPOINTS=''
     cleanup_process $CDC_BINARY
 
+    # changefeed Async DDL error case
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/InjectChangefeedAsyncDDLError=return(true)'
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    changefeedid_0=$(cdc cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+
+    run_sql "CREATE table changefeed_error.AsyncDDLERROR(id int primary key, val int);"
+    ensure $MAX_RETRIES check_changefeed_mark_stopped http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_0} "[CDC:ErrExecDDLFailed]InjectChangefeedAsyncDDLError"
+
+
+    cdc cli changefeed remove -c $changefeedid_0
+    cleanup_process $CDC_BINARY
+
     # owner DDL error case
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/InjectChangefeedDDLError=return(true)'
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY

--- a/tests/cyclic_abc/run.sh
+++ b/tests/cyclic_abc/run.sh
@@ -98,21 +98,21 @@ function run() {
         --cert-allowed-cn "client" # The common name of client.pem
 
     run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/?safe-mode=false" \
+        --sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/?safe-mode=true" \
         --pd "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" \
         --cyclic-replica-id 1 \
         --cyclic-filter-replica-ids 2 \
         --cyclic-sync-ddl true
 
     run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${TLS_TIDB_HOST}:${TLS_TIDB_PORT}/?safe-mode=false&ssl-ca=${TLS_DIR}/ca.pem&ssl-cert=${TLS_DIR}/server.pem?ssl-key=${TLS_DIR}/server-key.pem" \
+        --sink-uri="mysql://root@${TLS_TIDB_HOST}:${TLS_TIDB_PORT}/?safe-mode=true&ssl-ca=${TLS_DIR}/ca.pem&ssl-cert=${TLS_DIR}/server.pem?ssl-key=${TLS_DIR}/server-key.pem" \
         --pd "http://${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
         --cyclic-replica-id 2 \
         --cyclic-filter-replica-ids 3 \
         --cyclic-sync-ddl true
 
     run_cdc_cli changefeed create --start-ts=$start_ts \
-        --sink-uri="mysql://root@${UP_TIDB_HOST}:${UP_TIDB_PORT}/?safe-mode=false" \
+        --sink-uri="mysql://root@${UP_TIDB_HOST}:${UP_TIDB_PORT}/?safe-mode=true" \
         --pd "https://${TLS_PD_HOST}:${TLS_PD_PORT}" \
         --changefeed-id "tls-changefeed" \
         --ca=$TLS_DIR/ca.pem \

--- a/tests/ddl_async/conf/block_cf_config.toml
+++ b/tests/ddl_async/conf/block_cf_config.toml
@@ -1,0 +1,5 @@
+# changefeed config
+
+[filter]
+# 过滤器规则
+rules = ['ddl_async.ddl_block*']

--- a/tests/ddl_async/conf/diff_config.toml
+++ b/tests/ddl_async/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+schema = "ddl_async"
+tables = ["many_cols1","many_cols2","many_cols3","many_cols4","many_cols5","finish_mark"]
+
+[[source-db]]
+host = "127.0.0.1"
+port = 4000
+user = "root"
+password = ""
+instance-id = "source-1"
+
+[target-db]
+host = "127.0.0.1"
+port = 3306
+user = "root"
+password = ""

--- a/tests/ddl_async/conf/normal_cf_config.toml
+++ b/tests/ddl_async/conf/normal_cf_config.toml
@@ -1,0 +1,5 @@
+# changefeed config
+
+[filter]
+# 过滤器规则
+rules = ['ddl_async.many*','ddl_async.finish_mark']

--- a/tests/ddl_async/data/prepare.sql
+++ b/tests/ddl_async/data/prepare.sql
@@ -1,0 +1,70 @@
+drop database if exists `ddl_async`;
+create database `ddl_async`;
+use `ddl_async`;
+
+CREATE TABLE ddl_block1 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE ddl_block1 DROP COLUMN col0;
+INSERT INTO ddl_block1 (val) VALUES (1);
+
+CREATE TABLE ddl_block2 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE ddl_block2 DROP COLUMN col0;
+INSERT INTO ddl_block2 (val) VALUES (1);
+
+CREATE TABLE ddl_block3 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE ddl_block3 DROP COLUMN col0;
+INSERT INTO ddl_block3 (val) VALUES (1);
+
+
+CREATE TABLE many_cols1 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE many_cols1 DROP COLUMN col0;
+INSERT INTO many_cols1 (val) VALUES (1);
+
+CREATE TABLE many_cols2 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE many_cols2 DROP COLUMN col0;
+INSERT INTO many_cols2 (val) VALUES (1);
+
+CREATE TABLE many_cols3 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE many_cols3 DROP COLUMN col0;
+INSERT INTO many_cols3 (val) VALUES (1);
+
+CREATE TABLE many_cols4 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE many_cols4 DROP COLUMN col0;
+INSERT INTO many_cols4 (val) VALUES (1);
+
+CREATE TABLE many_cols5 (
+                            id INT AUTO_INCREMENT PRIMARY KEY,
+                            val INT DEFAULT 0,
+                            col0 INT NOT NULL
+);
+ALTER TABLE many_cols5 DROP COLUMN col0;
+INSERT INTO many_cols5 (val) VALUES (1);
+
+CREATE TABLE finish_mark(a int primary key)

--- a/tests/ddl_async/run.sh
+++ b/tests/ddl_async/run.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+SINK_URI="mysql://root@127.0.0.1:3306/"
+
+function check_ts_forward() {
+    changefeedid=$1
+    rts1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."resolved-ts"')
+    checkpoint1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."checkpoint-ts"')
+    sleep 1
+    rts2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."resolved-ts"')
+    checkpoint2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."checkpoint-ts"')
+    if [[ "$rts1" != "null" ]] && [[ "$rts1" != "0" ]]; then
+        if [[  "$rts1" -ne "$rts2" ]] || [[ "$checkpoint1" -ne "$checkpoint2" ]]; then
+            echo "changefeed is working normally rts: ${rts1}->${rts2} checkpoint: ${checkpoint1}->${checkpoint2}"
+            return
+        fi
+    fi
+    exit 1
+}
+
+function check_ts_block() {
+    changefeedid=$1
+    rts1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."resolved-ts"')
+    checkpoint1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."checkpoint-ts"')
+    sleep 1
+    rts2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."resolved-ts"')
+    checkpoint2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1|jq '.status."checkpoint-ts"')
+
+    echo "changefeed is blocking rts: ${rts1}->${rts2} checkpoint: ${checkpoint1}->${checkpoint2}"
+
+    if [[ "$rts1" != "null" ]] && [[ "$rts1" != "0" ]]; then
+        if [[  "$rts1" -eq "$rts2" ]] || [[ "$checkpoint1" -eq "$checkpoint2" ]]; then
+            echo "changefeed is blocking rts: ${rts1}->${rts2} checkpoint: ${checkpoint1}->${checkpoint2}"
+            return
+        fi
+    fi
+    exit 1
+}
+
+export -f check_ts_forward
+export -f check_ts_block
+
+function run() {
+      # don't test kafka in this case
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      return
+    fi
+
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+    start_tidb_cluster --workdir $WORK_DIR
+
+    cd $WORK_DIR
+
+    # record tso before we create tables to skip the system table DDLs
+    start_ts=$(run_cdc_cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
+
+    run_sql_file $CUR/data/prepare.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/InjectChangefeedDDLBlock=1*return(true)'
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+    # normal changefeed
+    run_cdc_cli changefeed create -c="changefeed-ddl-normal" --start-ts=$start_ts --sink-uri="$SINK_URI" --config="$CUR/conf/normal_cf_config.toml"
+    # ddl blocked changefeed
+    run_cdc_cli changefeed create -c="changefeed-ddl-block" --start-ts=$start_ts --sink-uri="blackhole://" --config="$CUR/conf/block_cf_config.toml"
+    # write ddl
+
+    ensure 5 check_ts_forward "changefeed-ddl-normal"
+    ensure 15 check_ts_block "changefeed-ddl-block"
+
+    check_table_exists ddl_async.finish_mark ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/ddl_reentrant/run.sh
+++ b/tests/ddl_reentrant/run.sh
@@ -103,7 +103,7 @@ function ddl_test() {
 
     echo $ddl > ${WORK_DIR}/ddl_temp.sql
     ensure 10 check_ddl_executed "${WORK_DIR}/cdc.log" "${WORK_DIR}/ddl_temp.sql" true
-    ddl_start_ts=$(grep "Execute DDL succeeded" ${WORK_DIR}/cdc.log|tail -n 1|grep -oE '"start_ts\\":[0-9]{18}'|awk -F: '{print $(NF)}')
+    ddl_start_ts=$(grep "Execute DDL succeeded" ${WORK_DIR}/cdc.log|tail -n 1|grep -oE '"StartTs\\":[0-9]{18}'|awk -F: '{print $(NF)}')
     cdc cli changefeed remove --changefeed-id=${changefeedid}
     changefeedid=$(cdc cli changefeed create --no-confirm --start-ts=${ddl_start_ts} --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
     echo "create new changefeed ${changefeedid} from ${ddl_start_ts}"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2295 

### What is changed and how it works?
Backport async sink to old owner and old changefeed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Side effects

 - Possible performance regression
 - Increased code complexity

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
This PR make the old owner handle DDL in Async mode.
```
