### PR TITLE
owner: fix trying to replicate views by mistake

### DIFF
--- a/cdc/owner/scheduler.go
+++ b/cdc/owner/scheduler.go
@@ -164,6 +164,9 @@ func (s *scheduler) table2CaptureIndex() (map[model.TableID]model.CaptureID, err
 // dispatchToTargetCaptures sets the the TargetCapture of scheduler jobs
 // If the TargetCapture of a job is not set, it chooses a capture with the minimum workload and sets the TargetCapture to the capture.
 func (s *scheduler) dispatchToTargetCaptures(pendingJobs []*schedulerJob) {
+	if len(s.captures) == 0 {
+		log.Warn("No capture is found, delay dispatching", zap.Reflect("pending-jobs", pendingJobs))
+	}
 	workloads := make(map[model.CaptureID]uint64)
 
 	for captureID := range s.captures {
@@ -209,7 +212,7 @@ func (s *scheduler) dispatchToTargetCaptures(pendingJobs []*schedulerJob) {
 		}
 
 		if minCapture == "" {
-			log.Panic("Unreachable, no capture is found")
+			log.Panic("Unreachable, no capture is found", zap.Reflect("workload", workloads))
 		}
 		return minCapture
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- View are replicated by mistake, which results in undefined behavior because they are not real tables.

### What is changed and how it works?
- Filter out views in the owner.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix trying to replicate views by mistake
```
