### PR TITLE
owner: fix gc safepoint larger by one

### DIFF
--- a/cdc/owner/gc_manager.go
+++ b/cdc/owner/gc_manager.go
@@ -131,7 +131,7 @@ func (m *gcManager) currentTimeFromPDCached(ctx cdcContext.Context) (time.Time, 
 }
 
 func (m *gcManager) checkStaleCheckpointTs(ctx cdcContext.Context, checkpointTs model.Ts) error {
-	gcSafepointUpperBound := checkpointTs-1
+	gcSafepointUpperBound := checkpointTs - 1
 	if m.isTiCDCBlockGC {
 		pdTime, err := m.currentTimeFromPDCached(ctx)
 		if err != nil {

--- a/cdc/owner/gc_manager.go
+++ b/cdc/owner/gc_manager.go
@@ -81,7 +81,7 @@ func (m *gcManager) updateGCSafePoint(ctx cdcContext.Context, state *model.Globa
 		default:
 			continue
 		}
-		checkpointTs := cfState.Info.GetCheckpointTs(cfState.Status)
+		checkpointTs := cfState.Info.GetCheckpointTs(cfState.Status) - 1
 		if minCheckpointTs > checkpointTs {
 			minCheckpointTs = checkpointTs
 		}
@@ -139,7 +139,7 @@ func (m *gcManager) checkStaleCheckpointTs(ctx cdcContext.Context, checkpointTs 
 		}
 	} else {
 		// if `isTiCDCBlockGC` is false, it means there is another service gc point less than the min checkpoint ts.
-		if checkpointTs < m.lastSafePointTs {
+		if checkpointTs-1 < m.lastSafePointTs {
 			return cerror.ErrSnapshotLostByGC.GenWithStackByArgs(checkpointTs, m.lastSafePointTs)
 		}
 	}

--- a/cdc/owner/gc_manager_test.go
+++ b/cdc/owner/gc_manager_test.go
@@ -117,7 +117,7 @@ func (s *gcManagerSuite) TestUpdateGCSafePoint(c *check.C) {
 	mockPDClient.updateServiceGCSafePointFunc = func(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 		c.Assert(serviceID, check.Equals, CDCServiceSafePointID)
 		c.Assert(ttl, check.Equals, gcManager.gcTTL)
-		c.Assert(safePoint, check.Equals, uint64(20))
+		c.Assert(safePoint, check.Equals, uint64(19))
 		return 0, nil
 	}
 	err = gcManager.updateGCSafePoint(ctx, state)

--- a/cdc/owner/schema.go
+++ b/cdc/owner/schema.go
@@ -65,7 +65,7 @@ func newSchemaWrap4Owner(kvStorage tidbkv.Storage, startTs model.Ts, config *con
 // AllPhysicalTables returns the table IDs of all tables and partition tables.
 func (s *schemaWrap4Owner) AllPhysicalTables() []model.TableID {
 	if s.allPhysicalTablesCache != nil {
-		return s.allPhysicalTablesCachegc_safe_point
+		return s.allPhysicalTablesCache
 	}
 	tables := s.schemaSnapshot.Tables()
 	s.allPhysicalTablesCache = make([]model.TableID, 0, len(tables))

--- a/cdc/owner/schema.go
+++ b/cdc/owner/schema.go
@@ -65,7 +65,7 @@ func newSchemaWrap4Owner(kvStorage tidbkv.Storage, startTs model.Ts, config *con
 // AllPhysicalTables returns the table IDs of all tables and partition tables.
 func (s *schemaWrap4Owner) AllPhysicalTables() []model.TableID {
 	if s.allPhysicalTablesCache != nil {
-		return s.allPhysicalTablesCache
+		return s.allPhysicalTablesCachegc_safe_point
 	}
 	tables := s.schemaSnapshot.Tables()
 	s.allPhysicalTablesCache = make([]model.TableID, 0, len(tables))

--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -16,7 +16,7 @@ function get_safepoint() {
     echo $safe_point
 }
 
-function get_clear_gc_worker_safepoint() {
+function clear_gc_worker_safepoint() {
     pd_addr=$1
     pd_cluster_id=$2
     ETCDCTL_API=3 etcdctl --endpoints=$pd_addr del /pd/$pd_cluster_id/gc/safe_point/service/ticdc

--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -93,7 +93,7 @@ function run() {
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
 
-    get_clear_gc_worker_safepoint $pd_addr $pd_cluster_id
+    clear_gc_worker_safepoint $pd_addr $pd_cluster_id
 
     run_sql "CREATE DATABASE gc_safepoint;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     run_sql "CREATE table gc_safepoint.simple(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}

--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -129,8 +129,6 @@ function run() {
     cdc cli changefeed remove --changefeed-id=$changefeed_id2 --pd=$pd_addr
     ensure $MAX_RETRIES check_safepoint_cleared $pd_addr $pd_cluster_id
 
-
-
     cleanup_process $CDC_BINARY
 }
 

--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -16,6 +16,12 @@ function get_safepoint() {
     echo $safe_point
 }
 
+function get_clear_gc_worker_safepoint() {
+    pd_addr=$1
+    pd_cluster_id=$2
+    ETCDCTL_API=3 etcdctl --endpoints=$pd_addr del /pd/$pd_cluster_id/gc/safe_point/service/ticdc
+}
+
 function check_safepoint_cleared() {
     pd_addr=$1
     pd_cluster_id=$2
@@ -67,6 +73,7 @@ export -f check_safepoint_forward
 export -f check_safepoint_cleared
 export -f check_safepoint_equal
 export -f check_changefeed_state
+export -f get_clear_gc_worker_safepoint
 
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR
@@ -85,6 +92,8 @@ function run() {
     export GO_FAILPOINTS='github.com/pingcap/ticdc/cdc/owner/InjectGcSafepointUpdateInterval=return(500)' # new owner
     run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
     changefeed_id=$(cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" 2>&1|tail -n2|head -n1|awk '{print $2}')
+
+    get_clear_gc_worker_safepoint $pd_addr $pd_cluster_id
 
     run_sql "CREATE DATABASE gc_safepoint;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
     run_sql "CREATE table gc_safepoint.simple(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
@@ -119,6 +128,8 @@ function run() {
     # remove all changefeeds, the safe_point will be cleared
     cdc cli changefeed remove --changefeed-id=$changefeed_id2 --pd=$pd_addr
     ensure $MAX_RETRIES check_safepoint_cleared $pd_addr $pd_cluster_id
+
+
 
     cleanup_process $CDC_BINARY
 }

--- a/tests/gc_safepoint/run.sh
+++ b/tests/gc_safepoint/run.sh
@@ -73,7 +73,7 @@ export -f check_safepoint_forward
 export -f check_safepoint_cleared
 export -f check_safepoint_equal
 export -f check_changefeed_state
-export -f get_clear_gc_worker_safepoint
+export -f clear_gc_worker_safepoint
 
 function run() {
     rm -rf $WORK_DIR && mkdir -p $WORK_DIR


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Since #2626 GC safepoint should be calculated from `checkpointTs - 1` instead of `checkpointTs`.

### What is changed and how it works?
- Subtract one from GC safepoint.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has persistent data change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
