### PR TITLE
sink: clean up useless WaitPrepare call

### DIFF
--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -17,16 +17,15 @@ import (
 	"context"
 )
 
-// PolymorphicEvent describes a event can be in multiple states
+// PolymorphicEvent describes an event can be in multiple states
 type PolymorphicEvent struct {
 	StartTs uint64
 	// Commit or resolved TS
 	CRTs uint64
 
-	RawKV     *RawKVEntry
-	Row       *RowChangedEvent
-	ReplicaID uint64
-	finished  chan struct{}
+	RawKV    *RawKVEntry
+	Row      *RowChangedEvent
+	finished chan struct{}
 }
 
 // NewPolymorphicEvent creates a new PolymorphicEvent with a raw KV

--- a/cdc/processor/pipeline/cyclic_mark.go
+++ b/cdc/processor/pipeline/cyclic_mark.go
@@ -23,15 +23,16 @@ import (
 	"go.uber.org/zap"
 )
 
-// cyclicMarkNode match the mark rows and normal rows, set the ReplicaID of normal rows and filter the mark rows
-// and filter the normal rows by the FilterReplicaID config item.
+// cyclicMarkNode match the mark row events and normal row events.
+// Set the ReplicaID of normal row events and filter the mark row events
+// and filter the normal row events by the FilterReplicaID config item.
 type cyclicMarkNode struct {
 	localReplicaID  uint64
 	filterReplicaID map[uint64]struct{}
 	markTableID     model.TableID
 
-	// startTs -> rows
-	rowsUnknownReplicaID map[model.Ts][]*model.PolymorphicEvent
+	// startTs -> events
+	unknownReplicaIDEvents map[model.Ts][]*model.PolymorphicEvent
 	// startTs -> replicaID
 	currentReplicaIDs map[model.Ts]uint64
 	currentCommitTs   uint64
@@ -39,9 +40,9 @@ type cyclicMarkNode struct {
 
 func newCyclicMarkNode(markTableID model.TableID) pipeline.Node {
 	return &cyclicMarkNode{
-		markTableID:          markTableID,
-		rowsUnknownReplicaID: make(map[model.Ts][]*model.PolymorphicEvent),
-		currentReplicaIDs:    make(map[model.Ts]uint64),
+		markTableID:            markTableID,
+		unknownReplicaIDEvents: make(map[model.Ts][]*model.PolymorphicEvent),
+		currentReplicaIDs:      make(map[model.Ts]uint64),
 	}
 }
 
@@ -56,12 +57,13 @@ func (n *cyclicMarkNode) Init(ctx pipeline.NodeContext) error {
 	return nil
 }
 
-// Receive receives the message from the previous node
+// Receive receives the message from the previous node.
 // In the previous nodes(puller node and sorter node),
-// the change logs of mark table and normal table are listen by one puller,
-// and sorted by one sorter. So, this node will receive a commitTs-ordered stream which include the mark rows and normal rows.
-// Under the above conditions, we need to cache at most one transaction's rows to matching rows.
-// For every row event, Receive function flushes every the last transaction's rows, and adds the mark row or normal row into the cache.
+// the change logs of mark table and normal table are listen by one puller, and sorted by one sorter.
+// So, this node will receive a commitTs-ordered stream which include the mark row events and normal row events.
+// Under the above conditions, we need to cache at most one transaction's row events to matching row events.
+// For every row event, Receive function flushes every the last transaction's row events,
+// and adds the mark row event or normal row event into the cache.
 func (n *cyclicMarkNode) Receive(ctx pipeline.NodeContext) error {
 	msg := ctx.Message()
 	switch msg.Tp {
@@ -77,9 +79,9 @@ func (n *cyclicMarkNode) Receive(ctx pipeline.NodeContext) error {
 			return errors.Trace(err)
 		}
 		if tableID == n.markTableID {
-			n.appendMarkRow(ctx, event)
+			n.appendMarkRowEvent(ctx, event)
 		} else {
-			n.appendNormalRow(ctx, event)
+			n.appendNormalRowEvent(ctx, event)
 		}
 		return nil
 	}
@@ -87,23 +89,23 @@ func (n *cyclicMarkNode) Receive(ctx pipeline.NodeContext) error {
 	return nil
 }
 
-// appendNormalRow adds the normal row into the cache
-func (n *cyclicMarkNode) appendNormalRow(ctx pipeline.NodeContext, event *model.PolymorphicEvent) {
+// appendNormalRowEvent adds the normal row into the cache.
+func (n *cyclicMarkNode) appendNormalRowEvent(ctx pipeline.NodeContext, event *model.PolymorphicEvent) {
 	if event.CRTs != n.currentCommitTs {
 		log.Panic("the CommitTs of the received event is not equal to the currentCommitTs, please report a bug", zap.Reflect("event", event), zap.Uint64("currentCommitTs", n.currentCommitTs))
 	}
 	if replicaID, exist := n.currentReplicaIDs[event.StartTs]; exist {
 		// we already know the replicaID of this startTs, it means that the mark row of this startTs is already in cached.
 		event.ReplicaID = replicaID
-		n.sendNormalRowToNextNode(ctx, event.ReplicaID, event)
+		n.sendNormalRowEventToNextNode(ctx, event.ReplicaID, event)
 		return
 	}
-	// for all normal rows which we don't know the replicaID for now. we cache them in rowsUnknownReplicaID.
-	n.rowsUnknownReplicaID[event.StartTs] = append(n.rowsUnknownReplicaID[event.StartTs], event)
+	// for all normal row events which we don't know the replicaID for now. we cache them in unknownReplicaIDEvents.
+	n.unknownReplicaIDEvents[event.StartTs] = append(n.unknownReplicaIDEvents[event.StartTs], event)
 }
 
-// appendMarkRow adds the mark row into the cache
-func (n *cyclicMarkNode) appendMarkRow(ctx pipeline.NodeContext, event *model.PolymorphicEvent) {
+// appendMarkRowEvent adds the mark row event into the cache.
+func (n *cyclicMarkNode) appendMarkRowEvent(ctx pipeline.NodeContext, event *model.PolymorphicEvent) {
 	if event.CRTs != n.currentCommitTs {
 		log.Panic("the CommitTs of the received event is not equal to the currentCommitTs, please report a bug", zap.Reflect("event", event), zap.Uint64("currentCommitTs", n.currentCommitTs))
 	}
@@ -114,10 +116,10 @@ func (n *cyclicMarkNode) appendMarkRow(ctx pipeline.NodeContext, event *model.Po
 	replicaID := extractReplicaID(markRow)
 	// Establishing the mapping from StartTs to ReplicaID
 	n.currentReplicaIDs[markRow.StartTs] = replicaID
-	if rows, exist := n.rowsUnknownReplicaID[markRow.StartTs]; exist {
-		// the replicaID of these rows we did not know before, but now we know through received mark row now.
-		delete(n.rowsUnknownReplicaID, markRow.StartTs)
-		n.sendNormalRowToNextNode(ctx, replicaID, rows...)
+	if events, exist := n.unknownReplicaIDEvents[markRow.StartTs]; exist {
+		// the replicaID of these events we did not know before, but now we know through received mark row now.
+		delete(n.unknownReplicaIDEvents, markRow.StartTs)
+		n.sendNormalRowEventToNextNode(ctx, replicaID, events...)
 	}
 }
 
@@ -125,16 +127,16 @@ func (n *cyclicMarkNode) flush(ctx pipeline.NodeContext, commitTs uint64) {
 	if n.currentCommitTs == commitTs {
 		return
 	}
-	// all mark rows and normal rows in current transaction is received now.
-	// there are still unmatched normal rows in the cache, their replicaID should be local replicaID.
-	for _, rows := range n.rowsUnknownReplicaID {
-		for _, row := range rows {
+	// all mark events and normal events in current transaction is received now.
+	// there are still unmatched normal events in the cache, their replicaID should be local replicaID.
+	for _, events := range n.unknownReplicaIDEvents {
+		for _, row := range events {
 			row.ReplicaID = n.localReplicaID
 		}
-		n.sendNormalRowToNextNode(ctx, n.localReplicaID, rows...)
+		n.sendNormalRowEventToNextNode(ctx, n.localReplicaID, events...)
 	}
-	if len(n.rowsUnknownReplicaID) != 0 {
-		n.rowsUnknownReplicaID = make(map[model.Ts][]*model.PolymorphicEvent)
+	if len(n.unknownReplicaIDEvents) != 0 {
+		n.unknownReplicaIDEvents = make(map[model.Ts][]*model.PolymorphicEvent)
 	}
 	if len(n.currentReplicaIDs) != 0 {
 		n.currentReplicaIDs = make(map[model.Ts]uint64)
@@ -142,15 +144,16 @@ func (n *cyclicMarkNode) flush(ctx pipeline.NodeContext, commitTs uint64) {
 	n.currentCommitTs = commitTs
 }
 
-// sendNormalRowToNextNode filter the specified normal rows by the FilterReplicaID config item, and send rows to the next node.
-func (n *cyclicMarkNode) sendNormalRowToNextNode(ctx pipeline.NodeContext, replicaID uint64, rows ...*model.PolymorphicEvent) {
+// sendNormalRowEventToNextNode filter the specified normal row events by the FilterReplicaID config item,
+// and send events to the next node.
+func (n *cyclicMarkNode) sendNormalRowEventToNextNode(ctx pipeline.NodeContext, replicaID uint64, events ...*model.PolymorphicEvent) {
 	if _, shouldFilter := n.filterReplicaID[replicaID]; shouldFilter {
 		return
 	}
-	for _, row := range rows {
-		row.ReplicaID = replicaID
-		row.Row.ReplicaID = replicaID
-		ctx.SendToNextNode(pipeline.PolymorphicEventMessage(row))
+	for _, event := range events {
+		event.ReplicaID = replicaID
+		event.Row.ReplicaID = replicaID
+		ctx.SendToNextNode(pipeline.PolymorphicEventMessage(event))
 	}
 }
 

--- a/cdc/processor/pipeline/cyclic_mark.go
+++ b/cdc/processor/pipeline/cyclic_mark.go
@@ -149,6 +149,7 @@ func (n *cyclicMarkNode) sendNormalRowToNextNode(ctx pipeline.NodeContext, repli
 	}
 	for _, row := range rows {
 		row.ReplicaID = replicaID
+		row.Row.ReplicaID = replicaID
 		ctx.SendToNextNode(pipeline.PolymorphicEventMessage(row))
 	}
 }

--- a/cdc/processor/pipeline/cyclic_mark.go
+++ b/cdc/processor/pipeline/cyclic_mark.go
@@ -110,10 +110,6 @@ func (n *cyclicMarkNode) appendMarkRow(ctx pipeline.NodeContext, event *model.Po
 	if event.CRTs != n.currentCommitTs {
 		log.Panic("the CommitTs of the received event is not equal to the currentCommitTs, please report a bug", zap.Reflect("event", event), zap.Uint64("currentCommitTs", n.currentCommitTs))
 	}
-	err := event.WaitPrepare(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	markRow := event.Row
 	if markRow == nil {
 		return nil

--- a/cdc/processor/pipeline/cyclic_mark_test.go
+++ b/cdc/processor/pipeline/cyclic_mark_test.go
@@ -175,16 +175,17 @@ func (s *markSuite) TestCyclicMarkNode(c *check.C) {
 				if row.PolymorphicEvent.RawKV.OpType == model.OpTypeResolved {
 					continue
 				}
-				row.PolymorphicEvent.Row.ReplicaID = row.PolymorphicEvent.ReplicaID
 				output = append(output, row.PolymorphicEvent.Row)
 			}
 		}()
 		wg.Wait()
 		// check the commitTs is increasing
 		var lastCommitTs model.Ts
-		for _, event := range output {
-			c.Assert(event.CommitTs, check.GreaterEqual, lastCommitTs)
-			lastCommitTs = event.CommitTs
+		for _, row := range output {
+			c.Assert(row.CommitTs, check.GreaterEqual, lastCommitTs)
+			// Ensure that the ReplicaID of the row is set correctly.
+			c.Assert(row.ReplicaID, check.Not(check.Equals), 0)
+			lastCommitTs = row.CommitTs
 		}
 		sort.Slice(output, func(i, j int) bool {
 			if output[i].CommitTs == output[j].CommitTs {

--- a/cdc/processor/pipeline/cyclic_mark_test.go
+++ b/cdc/processor/pipeline/cyclic_mark_test.go
@@ -168,7 +168,7 @@ func (s *markSuite) TestCyclicMarkNode(c *check.C) {
 			err := n.Receive(pipeline.MockNodeContext4Test(ctx, pipeline.PolymorphicEventMessage(model.NewResolvedPolymorphicEvent(0, lastCommitTs+1)), outputCh))
 			c.Assert(err, check.IsNil)
 		}()
-		output := []*model.RowChangedEvent{}
+		var output []*model.RowChangedEvent
 		go func() {
 			defer wg.Done()
 			for row := range outputCh {

--- a/cdc/processor/pipeline/cyclic_mark_test.go
+++ b/cdc/processor/pipeline/cyclic_mark_test.go
@@ -168,7 +168,7 @@ func (s *markSuite) TestCyclicMarkNode(c *check.C) {
 			err := n.Receive(pipeline.MockNodeContext4Test(ctx, pipeline.PolymorphicEventMessage(model.NewResolvedPolymorphicEvent(0, lastCommitTs+1)), outputCh))
 			c.Assert(err, check.IsNil)
 		}()
-		var output []*model.RowChangedEvent
+		output := []*model.RowChangedEvent{}
 		go func() {
 			defer wg.Done()
 			for row := range outputCh {

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -153,8 +153,6 @@ func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicE
 		return nil
 	}
 
-	event.Row.ReplicaID = event.ReplicaID
-
 	colLen := len(event.Row.Columns)
 	preColLen := len(event.Row.PreColumns)
 	config := ctx.ChangefeedVars().Info.Config

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -153,6 +153,8 @@ func (n *sinkNode) emitEvent(ctx pipeline.NodeContext, event *model.PolymorphicE
 		return nil
 	}
 
+	event.Row.ReplicaID = event.ReplicaID
+
 	colLen := len(event.Row.Columns)
 	preColLen := len(event.Row.PreColumns)
 	config := ctx.ChangefeedVars().Info.Config
@@ -274,14 +276,6 @@ func (n *sinkNode) clearBuffers() {
 
 func (n *sinkNode) emitRow2Sink(ctx pipeline.NodeContext) error {
 	for _, ev := range n.eventBuffer {
-		err := ev.WaitPrepare(ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if ev.Row == nil {
-			continue
-		}
-		ev.Row.ReplicaID = ev.ReplicaID
 		n.rowBuffer = append(n.rowBuffer, ev.Row)
 	}
 	failpoint.Inject("ProcessorSyncResolvedPreEmit", func() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

part of https://github.com/pingcap/ticdc/issues/2632

### What is changed and how it works?
clean up useless WaitPrepare call.
The mounter will ensure the row is ready to use.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

None

Side effects

None

Related changes

 - Need to cherry-pick to the release branch
 

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
