### PR TITLE
kv: reduce gRPC window size to avoid OOM

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -89,7 +89,8 @@ func (c *Capture) reset(ctx context.Context) error {
 	}
 	c.processorManager = c.newProcessorManager()
 	if c.session != nil {
-		c.session.Close() //nolint:errcheck
+		// It can't be handled even after it fails, so we ignore it.
+		_ = c.session.Close()
 	}
 	sess, err := concurrency.NewSession(c.etcdClient.Client.Unwrap(),
 		concurrency.WithTTL(conf.CaptureSessionTTL))
@@ -169,9 +170,9 @@ func (c *Capture) run(stdCtx context.Context) error {
 	go func() {
 		defer wg.Done()
 		defer c.AsyncClose()
-		// when the campaignOwner returns an error, it means that the the owner throws an unrecoverable serious errors
+		// when the campaignOwner returns an error, it means that the owner throws an unrecoverable serious errors
 		// (recoverable errors are intercepted in the owner tick)
-		// so we should also stop the processor and let capture restart or exit
+		// so we should also stop the owner and let capture restart or exit
 		ownerErr = c.campaignOwner(ctx)
 		log.Info("the owner routine has exited", zap.Error(ownerErr))
 	}()
@@ -180,9 +181,9 @@ func (c *Capture) run(stdCtx context.Context) error {
 		defer c.AsyncClose()
 		conf := config.GetGlobalServerConfig()
 		processorFlushInterval := time.Duration(conf.ProcessorFlushInterval)
-		// when the etcd worker of processor returns an error, it means that the the processor throws an unrecoverable serious errors
+		// when the etcd worker of processor returns an error, it means that the processor throws an unrecoverable serious errors
 		// (recoverable errors are intercepted in the processor tick)
-		// so we should also stop the owner and let capture restart or exit
+		// so we should also stop the processor and let capture restart or exit
 		processorErr = c.runEtcdWorker(ctx, c.processorManager, model.NewGlobalState(), processorFlushInterval)
 		log.Info("the processor routine has exited", zap.Error(processorErr))
 	}()
@@ -309,7 +310,7 @@ func (c *Capture) OperateOwnerUnderLock(fn func(*owner.Owner) error) error {
 	return fn(c.owner)
 }
 
-// Campaign to be an owner
+// campaign to be an owner.
 func (c *Capture) campaign(ctx cdcContext.Context) error {
 	failpoint.Inject("capture-campaign-compacted-error", func() {
 		failpoint.Return(errors.Trace(mvcc.ErrCompacted))
@@ -317,7 +318,7 @@ func (c *Capture) campaign(ctx cdcContext.Context) error {
 	return cerror.WrapError(cerror.ErrCaptureCampaignOwner, c.election.Campaign(ctx, c.info.ID))
 }
 
-// Resign lets a owner start a new election.
+// resign lets an owner start a new election.
 func (c *Capture) resign(ctx cdcContext.Context) error {
 	failpoint.Inject("capture-resign-failed", func() {
 		failpoint.Return(errors.New("capture resign failed"))
@@ -337,7 +338,9 @@ func (c *Capture) register(ctx cdcContext.Context) error {
 // AsyncClose closes the capture by unregistering it from etcd
 func (c *Capture) AsyncClose() {
 	defer c.cancel()
-	c.OperateOwnerUnderLock(func(o *owner.Owner) error { //nolint:errcheck
+	// Safety: Here we mainly want to stop the owner
+	// and ignore it if the owner does not exist or is not set.
+	_ = c.OperateOwnerUnderLock(func(o *owner.Owner) error {
 		o.AsyncStop()
 		return nil
 	})
@@ -353,7 +356,9 @@ func (c *Capture) AsyncClose() {
 
 // WriteDebugInfo writes the debug info into writer.
 func (c *Capture) WriteDebugInfo(w io.Writer) {
-	c.OperateOwnerUnderLock(func(o *owner.Owner) error { //nolint:errcheck
+	// Safety: Because we are mainly outputting information about the owner here,
+	// if the owner does not exist or is not set, the information will not be output.
+	_ = c.OperateOwnerUnderLock(func(o *owner.Owner) error {
 		fmt.Fprintf(w, "\n\n*** owner info ***:\n\n")
 		o.WriteDebugInfo(w)
 		return nil
@@ -368,9 +373,9 @@ func (c *Capture) WriteDebugInfo(w io.Writer) {
 
 // IsOwner returns whether the capture is an owner
 func (c *Capture) IsOwner() bool {
-	return c.OperateOwnerUnderLock(func(o *owner.Owner) error {
-		return nil
-	}) == nil
+	c.ownerMu.Lock()
+	defer c.ownerMu.Unlock()
+	return c.owner != nil
 }
 
 // GetOwner return the owner of current TiCDC cluster

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -54,7 +54,7 @@ const (
 	tikvRequestMaxBackoff = 20000 // Maximum total sleep time(in ms)
 	// TiCDC may open numerous gRPC streams,
 	// with 64KB window size, 10K streams takes about 27GB memory.
-	grpcInitialWindowSize     = 65535 // 64 KB The value for initial window size on a stream
+	grpcInitialWindowSize     = 65535   // 64 KB The value for initial window size on a stream
 	grpcInitialConnWindowSize = 1 << 23 // 8 MB The value for initial window size on a connection
 	grpcMaxCallRecvMsgSize    = 1 << 28 // 256 MB The maximum message size the client can receive
 

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -52,10 +52,10 @@ import (
 const (
 	dialTimeout           = 10 * time.Second
 	tikvRequestMaxBackoff = 20000 // Maximum total sleep time(in ms)
-	// TODO find optimal values and test extensively before releasing
-	// The old values cause the gRPC stream to stall for some unknown reason.
-	grpcInitialWindowSize     = 1 << 26 // 64 MB The value for initial window size on a stream
-	grpcInitialConnWindowSize = 1 << 27 // 128 MB The value for initial window size on a connection
+	// TiCDC may open numerous gRPC streams,
+	// with 64KB window size, 10K streams takes about 27GB memory.
+	grpcInitialWindowSize     = 65535 // 64 KB The value for initial window size on a stream
+	grpcInitialConnWindowSize = 1 << 23 // 8 MB The value for initial window size on a connection
 	grpcMaxCallRecvMsgSize    = 1 << 28 // 256 MB The maximum message size the client can receive
 
 	// The threshold of warning a message is too large. TiKV split events into 6MB per-message.

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -52,11 +52,16 @@ import (
 const (
 	dialTimeout           = 10 * time.Second
 	tikvRequestMaxBackoff = 20000 // Maximum total sleep time(in ms)
+
 	// TiCDC may open numerous gRPC streams,
-	// with 64KB window size, 10K streams takes about 27GB memory.
-	grpcInitialWindowSize     = 65535   // 64 KB The value for initial window size on a stream
-	grpcInitialConnWindowSize = 1 << 23 // 8 MB The value for initial window size on a connection
-	grpcMaxCallRecvMsgSize    = 1 << 28 // 256 MB The maximum message size the client can receive
+	// with 65535 bytes window size, 10K streams takes about 27GB memory.
+	//
+	// 65535 bytes, the initial window size in http2 spec.
+	grpcInitialWindowSize = (1 << 16) - 1
+	// 8 MB The value for initial window size on a connection
+	grpcInitialConnWindowSize = 1 << 23
+	// 256 MB The maximum message size the client can receive
+	grpcMaxCallRecvMsgSize = 1 << 28
 
 	// The threshold of warning a message is too large. TiKV split events into 6MB per-message.
 	warnRecvMsgSizeThreshold = 12 * 1024 * 1024


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Note: TiCDC in the following tests includes https://github.com/pingcap/ticdc/pull/2214.  

### Memory usage (pause sorter)

Tested with following changes

```diff
diff --git a/cdc/puller/sorter/unified_sorter.go b/cdc/puller/sorter/unified_sorter.go
index 9cd9c898..6e033429 100644
--- a/cdc/puller/sorter/unified_sorter.go
+++ b/cdc/puller/sorter/unified_sorter.go
@@ -197,9 +197,9 @@ func (s *UnifiedSorter) Run(ctx context.Context) error {
                }
        })
 
-       errg.Go(func() error {
-               return printError(runMerger(subctx, numConcurrentHeaps, heapSorterCollectCh, s.outputCh, ioCancelFunc))
-       })
+       // errg.Go(func() error {
+       //      return printError(runMerger(subctx, numConcurrentHeaps, heapSorterCollectCh, s.outputCh, ioCancelFunc))
+       // })
 
        errg.Go(func() error {
                captureAddr := util.CaptureAddrFromCtx(ctx)
```

| 64MB vs 64KB |
| -- |
| ![image](https://user-images.githubusercontent.com/2150711/131610396-13e9b1e3-0de3-42e4-897c-b9a13abe6cb7.png) |
| ![image](https://user-images.githubusercontent.com/2150711/131610409-c71bb4f2-b09e-4cfa-b2db-a6a319116175.png) |
| ![image](https://user-images.githubusercontent.com/2150711/131610531-f40fcbb2-cf2b-4fd4-a4c6-bfd203853859.png) |

The last image shows TiKV snapshot is holded for a long time, because CDC scan is flow controlled. Through, I doubt if it will actually happen as TiCDC sorter can always make progress.

## Performance

No significant difference.

| 64MB (OOM) vs 64KB |
| -- |
| ![image](https://user-images.githubusercontent.com/2150711/131609994-7bb7bddd-a8ec-49af-b64f-498d4930dd5d.png) |
| ![image](https://user-images.githubusercontent.com/2150711/131610066-9a3a5af2-dbe7-4662-a391-8014313562b6.png) |
| ![image](https://user-images.githubusercontent.com/2150711/131610088-af7971c8-9434-475d-9fa9-9221f8add6e0.png) |

Close #2673 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix OOM when TiCDC captures too many regions
```
