### PR TITLE
tests: fix stop sequence of test binaries

### DIFF
--- a/tests/_utils/stop_tidb_cluster
+++ b/tests/_utils/stop_tidb_cluster
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-killall -q -w -s 9 tikv-server || true
-killall -q -w -s 9 pd-server || true
-killall -q -w -s 9 tidb-server || true
-killall -q -w -s 9 cdc || true
+# cdc server is ran by binary cdc.test, kill cdc server first to avoid too much
+# noise in cdc logs.
 killall -q -w -s 9 cdc.test || true
+killall -q -w -s 9 cdc || true
+killall -q -w -s 9 cdc_state_checker || true
+killall -q -w -s 9 tidb-server || true
+killall -q -w -s 9 tikv-server || true
 killall -q -w -s 9 tiflash || true
 killall -q -w -s 9 flash_cluster_manager || true
-killall -q -w -s 9 cdc_state_checker || true
+killall -q -w -s 9 pd-server || true
 
 CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source $CUR/../_utils/test_prepare


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

kill cdc server first to avoid too much noise in cdc logs, such as, which will benefit for debugging when case runs failed.

```
[2021/09/16 13:51:54.150 +08:00] [INFO] [client.go:377] ["establish stream to store failed, retry later"] [addr=127.0.0.1:20162] [error="[CDC:ErrTiKVEventFeed]rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:20162: connect: connection refused\": rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:20162: connect: connection refused\""] [errorVerbose="[CDC:ErrTiKVEventFeed]rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:20162: connect: connection refused\": rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:20162: connect: connection refused\"\ngithub.com/pingcap/errors.AddStack\n\t/nfs/cache/mod/github.com/pingcap/errors@v0.11.5-0.20210425183316-da1aaba5fb63/errors.go:174\ngithub.com/pingcap/errors.(*Error).GenWithStackByCause\n\t/nfs/cache/mod/github.com/pingcap/errors@v0.11.5-0.20210425183316-da1aaba5fb63/normalize.go:282\ngithub.com/pingcap/ticdc/pkg/errors.WrapError\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/pkg/errors/helper.go:30\ngithub.com/pingcap/ticdc/cdc/kv.(*CDCClient).newStream.func1\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/kv/client.go:376\ngithub.com/pingcap/ticdc/pkg/retry.run\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/pkg/retry/retry_with_opt.go:54\ngithub.com/pingcap/ticdc/pkg/retry.Do\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/pkg/retry/retry_with_opt.go:32\ngithub.com/pingcap/ticdc/cdc/kv.(*CDCClient).newStream\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/kv/client.go:347\ngithub.com/pingcap/ticdc/cdc/kv.(*eventFeedSession).requestRegionToStore\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/kv/client.go:733\ngithub.com/pingcap/ticdc/cdc/kv.(*eventFeedSession).eventFeed.func2\n\t/home/jenkins/agent/workspace/cdc_ghpr_integration_test/go/src/github.com/pingcap/ticdc/cdc/kv/client.go:518\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/nfs/cache/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371"]

[2021/09/16 13:51:58.028 +08:00] [ERROR] [base_client.go:167] ["[pd] failed updateMember"] [error="[PD:client:ErrClientGetLeader]get leader from [http://127.0.0.1:2379] error"]
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
