### PR TITLE
test(pkg/cyclic): migrate test-infra to testify for pkg/cyclic pkg

### DIFF
--- a/pkg/cyclic/filter_test.go
+++ b/pkg/cyclic/filter_test.go
@@ -17,20 +17,13 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
-	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"github.com/stretchr/testify/require"
 )
 
-type markSuite struct{}
-
-var _ = check.Suite(&markSuite{})
-
-func TestCyclic(t *testing.T) { check.TestingT(t) }
-
-func (s *markSuite) TestFilterAndReduceTxns(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestFilterAndReduceTxns(t *testing.T) {
+	t.Parallel()
 	rID := mark.CyclicReplicaIDCol
 	testCases := []struct {
 		input     map[model.TableID][]*model.SingleTableTxn
@@ -212,6 +205,6 @@ func (s *markSuite) TestFilterAndReduceTxns(c *check.C) {
 
 	for i, tc := range testCases {
 		FilterAndReduceTxns(tc.input, tc.filterID, tc.replicaID)
-		c.Assert(tc.input, check.DeepEquals, tc.output, check.Commentf("case %d %s\n", i, spew.Sdump(tc)))
+		require.Equal(t, tc.input, tc.output, "case %d %s\n", i, spew.Sdump(tc))
 	}
 }

--- a/pkg/cyclic/main_test.go
+++ b/pkg/cyclic/main_test.go
@@ -16,9 +16,9 @@ package cyclic
 import (
 	"testing"
 
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/leakutil"
 )
 
 func TestMain(m *testing.M) {
-	util.SetUpLeakTest(m)
+	leakutil.SetUpLeakTest(m)
 }

--- a/pkg/cyclic/main_test.go
+++ b/pkg/cyclic/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyclic
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/util"
+)
+
+func TestMain(m *testing.M) {
+	util.SetUpLeakTest(m)
+}

--- a/pkg/cyclic/mark/main_test.go
+++ b/pkg/cyclic/mark/main_test.go
@@ -16,9 +16,9 @@ package mark
 import (
 	"testing"
 
-	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/pkg/leakutil"
 )
 
 func TestMain(m *testing.M) {
-	util.SetUpLeakTest(m)
+	leakutil.SetUpLeakTest(m)
 }

--- a/pkg/cyclic/mark/main_test.go
+++ b/pkg/cyclic/mark/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mark
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/util"
+)
+
+func TestMain(m *testing.M) {
+	util.SetUpLeakTest(m)
+}

--- a/pkg/cyclic/mark/mark_test.go
+++ b/pkg/cyclic/mark/mark_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (s *markSuite) TestIsMarkTable(t *testing.T) {
+func TestIsMarkTable(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		schema, table string

--- a/pkg/cyclic/mark/mark_test.go
+++ b/pkg/cyclic/mark/mark_test.go
@@ -16,18 +16,11 @@ package mark
 import (
 	"testing"
 
-	"github.com/pingcap/check"
-	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"github.com/stretchr/testify/require"
 )
 
-type markSuite struct{}
-
-var _ = check.Suite(&markSuite{})
-
-func Test(t *testing.T) { check.TestingT(t) }
-
-func (s *markSuite) TestIsMarkTable(c *check.C) {
-	defer testleak.AfterTest(c)()
+func (s *markSuite) TestIsMarkTable(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		schema, table string
 		isMarkTable   bool
@@ -45,7 +38,7 @@ func (s *markSuite) TestIsMarkTable(c *check.C) {
 	}
 
 	for _, test := range tests {
-		c.Assert(IsMarkTable(test.schema, test.table), check.Equals, test.isMarkTable,
-			check.Commentf("%v", test))
+		require.Equal(t, IsMarkTable(test.schema, test.table), test.isMarkTable,
+			"%v", test)
 	}
 }

--- a/pkg/cyclic/replication_test.go
+++ b/pkg/cyclic/replication_test.go
@@ -16,40 +16,33 @@ package cyclic
 import (
 	"testing"
 
-	"github.com/pingcap/check"
 	"github.com/pingcap/ticdc/cdc/model"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/cyclic/mark"
-	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"github.com/stretchr/testify/require"
 )
 
-type cyclicSuite struct{}
-
-var _ = check.Suite(&cyclicSuite{})
-
-func Test(t *testing.T) { check.TestingT(t) }
-
-func (s *cyclicSuite) TestCyclicConfig(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestCyclicConfig(t *testing.T) {
+	t.Parallel()
 	cfg := &config.CyclicConfig{
 		Enable:          true,
 		ReplicaID:       1,
 		FilterReplicaID: []uint64{2, 3},
 	}
 	cyc := NewCyclic(cfg)
-	c.Assert(cyc, check.NotNil)
-	c.Assert(cyc.Enabled(), check.IsTrue)
-	c.Assert(cyc.ReplicaID(), check.Equals, uint64(1))
-	c.Assert(cyc.FilterReplicaID(), check.DeepEquals, []uint64{2, 3})
+	require.NotNil(t, cyc)
+	require.True(t, cyc.Enabled())
+	require.Equal(t, cyc.ReplicaID(), uint64(1))
+	require.Equal(t, cyc.FilterReplicaID(), []uint64{2, 3})
 
 	cyc = NewCyclic(nil)
-	c.Assert(cyc, check.IsNil)
+	require.Nil(t, cyc)
 	cyc = NewCyclic(&config.CyclicConfig{ReplicaID: 0})
-	c.Assert(cyc, check.IsNil)
+	require.Nil(t, cyc)
 }
 
-func (s *cyclicSuite) TestRelaxSQLMode(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestRelaxSQLMode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		oldMode string
 		newMode string
@@ -62,12 +55,12 @@ func (s *cyclicSuite) TestRelaxSQLMode(c *check.C) {
 
 	for _, test := range tests {
 		getNew := RelaxSQLMode(test.oldMode)
-		c.Assert(getNew, check.Equals, test.newMode)
+		require.Equal(t, getNew, test.newMode)
 	}
 }
 
-func (s *cyclicSuite) TestIsTablePaired(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestIsTablePaired(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		tables   []model.TableName
 		isParied bool
@@ -100,7 +93,7 @@ func (s *cyclicSuite) TestIsTablePaired(c *check.C) {
 	}
 
 	for _, test := range tests {
-		c.Assert(IsTablesPaired(test.tables), check.Equals, test.isParied,
-			check.Commentf("%v", test))
+		require.Equal(t, IsTablesPaired(test.tables), test.isParied,
+			"%v", test)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
migrate test-infra to testify for pkg/cyclic pkg,  close #2869  close #2870

### What is changed and how it works?

1. migrate test-infra from gocheck to testify
2. migrate leak test from leaktest to goleak

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
migrate test-infra to testify for pkg/cyclic pkg
```
