### PR TITLE
test(pkg/leakutil): extract leak helper func to a new pkg

### DIFF
--- a/pkg/leakutil/leak_helper.go
+++ b/pkg/leakutil/leak_helper.go
@@ -19,7 +19,8 @@ import (
 	"go.uber.org/goleak"
 )
 
-//ignore common etcd and opencensus stack function for goleak
+//SetUpLeakTest ignore unexpected common etcd and opencensus stack functions for goleak
+//options can be used to implement other ignore items
 func SetUpLeakTest(m *testing.M, options ...goleak.Option) {
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),

--- a/pkg/leakutil/leak_helper.go
+++ b/pkg/leakutil/leak_helper.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/goleak"
 )
 
+//ignore common etcd and opencensus stack function for goleak
 func SetUpLeakTest(m *testing.M, options ...goleak.Option) {
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),

--- a/pkg/leakutil/leak_helper.go
+++ b/pkg/leakutil/leak_helper.go
@@ -1,0 +1,31 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leakutil
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func SetUpLeakTest(m *testing.M, options ...goleak.Option) {
+	opts := []goleak.Option{
+		goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+	}
+
+	opts = append(opts, options...)
+
+	goleak.VerifyTestMain(m, opts...)
+}

--- a/pkg/leakutil/leak_helper.go
+++ b/pkg/leakutil/leak_helper.go
@@ -19,8 +19,8 @@ import (
 	"go.uber.org/goleak"
 )
 
-//SetUpLeakTest ignore unexpected common etcd and opencensus stack functions for goleak
-//options can be used to implement other ignore items
+// SetUpLeakTest ignore unexpected common etcd and opencensus stack functions for goleak
+// options can be used to implement other ignore items
 func SetUpLeakTest(m *testing.M, options ...goleak.Option) {
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),

--- a/pkg/leakutil/leak_helper_test.go
+++ b/pkg/leakutil/leak_helper_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leakutil
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestSetUpLeakTest(t *testing.T) {
+	leakChan := make(chan interface{})
+
+	go func() {
+		<-leakChan
+	}()
+}
+
+func TestMain(m *testing.M) {
+	opts := []goleak.Option{
+		goleak.IgnoreTopFunction("github.com/pingcap/ticdc/pkg/leakutil.TestSetUpLeakTest.func1"),
+	}
+
+	SetUpLeakTest(m, opts...)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Extract leak helper func to a new pkg to avoid the circle deps in pkg/util

### What is changed and how it works?
Extract leak helper func to a new pkg, avoid adding other unnecessary deps.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
Add leakutil.SetUpLeakTest() to ignore some common unexpected stack top functions

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Extract leak helper func to a new pkg to avoid the circle deps in pkg/util
```
