### PR TITLE
perf(pkg/flags): migrate test-infra to testify for pkg/flags pkg

### DIFF
--- a/pkg/flags/main_test.go
+++ b/pkg/flags/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/leakutil"
+)
+
+func TestMain(m *testing.M) {
+	leakutil.SetUpLeakTest(m)
+}

--- a/pkg/flags/urls_test.go
+++ b/pkg/flags/urls_test.go
@@ -38,7 +38,7 @@ func TestNewURLsValue(t *testing.T) {
 		urlsValue, err := NewURLsValue(testCase.url)
 		require.Nil(t, err)
 		hs := urlsValue.HostString()
-		require.Equal(t, hs, testCase.hostString)
+		require.Equal(t, testCase.hostString, hs)
 	}
 }
 

--- a/pkg/flags/urls_test.go
+++ b/pkg/flags/urls_test.go
@@ -16,20 +16,12 @@ package flags
 import (
 	"testing"
 
-	"github.com/pingcap/check"
-	"github.com/pingcap/ticdc/pkg/util/testleak"
+	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
+func TestNewURLsValue(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&testUrlsSuite{})
-
-type testUrlsSuite struct{}
-
-func (t *testUrlsSuite) TestNewURLsValue(c *check.C) {
-	defer testleak.AfterTest(c)()
 	cases := []struct {
 		url        string
 		hostString string
@@ -44,14 +36,15 @@ func (t *testUrlsSuite) TestNewURLsValue(c *check.C) {
 
 	for _, testCase := range cases {
 		urlsValue, err := NewURLsValue(testCase.url)
-		c.Assert(err, check.IsNil)
+		require.Nil(t, err)
 		hs := urlsValue.HostString()
-		c.Assert(hs, check.Equals, testCase.hostString)
+		require.Equal(t, hs, testCase.hostString)
 	}
 }
 
-func (t *testUrlsSuite) TestNewURLsValueError(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestNewURLsValueError(t *testing.T) {
+	t.Parallel()
+
 	urls := []string{
 		"http:///192.168.199.111:2379",
 		"http://192.168.199.111",
@@ -60,6 +53,6 @@ func (t *testUrlsSuite) TestNewURLsValueError(c *check.C) {
 	}
 	for _, url := range urls {
 		_, err := NewURLsValue(url)
-		c.Assert(err, check.NotNil)
+		require.NotNil(t, err)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
migrate test-infra to testify for pkg/flags pkg, close  #2935 

### What is changed and how it works?

1. migrate test-infra from gocheck to testify
2. migrate leak test from leaktest to goleak

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
