### PR TITLE
schema storage shallow copy DBInfo

### DIFF
--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -226,7 +226,7 @@ func (s *schemaSnapshot) Clone() *schemaSnapshot {
 
 	schemas := make(map[int64]*timodel.DBInfo, len(s.schemas))
 	for k, v := range s.schemas {
-		schemas[k] = v.Clone()
+		schemas[k] = v.Copy()
 	}
 	clone.schemas = schemas
 
@@ -389,7 +389,7 @@ func (s *schemaSnapshot) createSchema(db *timodel.DBInfo) error {
 		return cerror.ErrSnapshotSchemaExists.GenWithStackByArgs(db.Name, db.ID)
 	}
 
-	s.schemas[db.ID] = db.Clone()
+	s.schemas[db.ID] = db.Copy()
 	s.schemaNameToID[db.Name.O] = db.ID
 	s.tableInSchema[db.ID] = []int64{}
 
@@ -402,7 +402,7 @@ func (s *schemaSnapshot) replaceSchema(db *timodel.DBInfo) error {
 	if !ok {
 		return cerror.ErrSnapshotSchemaNotFound.GenWithStack("schema %s(%d) not found", db.Name, db.ID)
 	}
-	s.schemas[db.ID] = db.Clone()
+	s.schemas[db.ID] = db.Copy()
 	s.schemaNameToID[db.Name.O] = db.ID
 	return nil
 }

--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -226,6 +226,7 @@ func (s *schemaSnapshot) Clone() *schemaSnapshot {
 
 	schemas := make(map[int64]*timodel.DBInfo, len(s.schemas))
 	for k, v := range s.schemas {
+		// DBInfo is readonly in TiCDC, shallow copy to reduce memory
 		schemas[k] = v.Copy()
 	}
 	clone.schemas = schemas


### PR DESCRIPTION
Signed-off-by: sdojjy <sdojjy@qq.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In TiCDC DBInfo is ready only data, to reduce memory, we can use DBInfo.Copy() method to shallow copy DBInfo

### What is changed and how it works?
replace DBInfo.Clone() with DBInfo.Copy()



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 None
```
