### PR TITLE
cdc/sink: adjust kafka initialization logic

### DIFF
--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -397,7 +397,9 @@ func newKafkaSaramaSink(ctx context.Context, sinkURI *url.URL, filter *filter.Fi
 		return nil, cerror.ErrKafkaInvalidConfig.GenWithStack("topic name not found")
 	}
 
-	producer, err := kafka.NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	var protocol codec.Protocol
+	protocol.FromString(replicaConfig.Sink.Protocol)
+	producer, err := kafka.NewKafkaSaramaProducer(ctx, topic, protocol, config, errCh)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -16,6 +16,7 @@ package sink
 import (
 	"context"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -389,7 +390,14 @@ func newKafkaSaramaSink(ctx context.Context, sinkURI *url.URL, filter *filter.Fi
 		return nil, cerror.WrapError(cerror.ErrKafkaInvalidConfig, err)
 	}
 
-	producer, err := kafka.NewKafkaSaramaProducer(ctx, config, errCh)
+	topic := strings.TrimFunc(sinkURI.Path, func(r rune) bool {
+		return r == '/'
+	})
+	if topic == "" {
+		return nil, cerror.ErrKafkaInvalidConfig.GenWithStack("topic name not found")
+	}
+
+	producer, err := kafka.NewKafkaSaramaProducer(ctx, topic, config, errCh)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -394,7 +394,7 @@ func newKafkaSaramaSink(ctx context.Context, sinkURI *url.URL, filter *filter.Fi
 		return r == '/'
 	})
 	if topic == "" {
-		return nil, cerror.ErrKafkaInvalidConfig.GenWithStack("topic name not found")
+		return nil, cerror.ErrKafkaInvalidConfig.GenWithStack("no topic is specified in sink-uri")
 	}
 
 	var protocol codec.Protocol

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -63,7 +63,7 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
 	defer func() {
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
 	}()
@@ -168,7 +168,7 @@ func (s mqSinkSuite) TestKafkaSinkFilter(c *check.C) {
 	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
 	defer func() {
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
 	}()

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -51,7 +51,7 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	prodSuccess := new(sarama.ProduceResponse)
 	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
 
-	uriTemplate := "kafka://%s/kafka-test?kafka-version=2.4.0&max-batch-size=1" +
+	uriTemplate := "kafka://%s/kafka-test?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=4194304&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=default"
 	uri := fmt.Sprintf(uriTemplate, leader.Addr())
@@ -155,7 +155,7 @@ func (s mqSinkSuite) TestKafkaSinkFilter(c *check.C) {
 	prodSuccess := new(sarama.ProduceResponse)
 	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
 
-	uriTemplate := "kafka://%s/kafka-test?kafka-version=2.4.0&auto-create-topic=false&protocol=default"
+	uriTemplate := "kafka://%s/kafka-test?kafka-version=0.9.0.0&auto-create-topic=false&protocol=default"
 	uri := fmt.Sprintf(uriTemplate, leader.Addr())
 	sinkURI, err := url.Parse(uri)
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -51,7 +51,7 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	prodSuccess := new(sarama.ProduceResponse)
 	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
 
-	uriTemplate := "kafka://%s/kafka-test?kafka-version=0.9.0.0&max-batch-size=1" +
+	uriTemplate := "kafka://%s/kafka-test?kafka-version=2.4.0&max-batch-size=1" +
 		"&max-message-bytes=4194304&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=default"
 	uri := fmt.Sprintf(uriTemplate, leader.Addr())
@@ -149,7 +149,7 @@ func (s mqSinkSuite) TestKafkaSinkFilter(c *check.C) {
 	prodSuccess := new(sarama.ProduceResponse)
 	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
 
-	uriTemplate := "kafka://%s/kafka-test?kafka-version=0.9.0.0&auto-create-topic=false&protocol=default"
+	uriTemplate := "kafka://%s/kafka-test?kafka-version=2.4.0&auto-create-topic=false&protocol=default"
 	uri := fmt.Sprintf(uriTemplate, leader.Addr())
 	sinkURI, err := url.Parse(uri)
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -63,9 +63,9 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
 	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 	}()
 
 	sink, err := newKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)
@@ -168,9 +168,9 @@ func (s mqSinkSuite) TestKafkaSinkFilter(c *check.C) {
 	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
 	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 	}()
 
 	sink, err := newKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -62,6 +62,12 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	c.Assert(err, check.IsNil)
 	opts := map[string]string{}
 	errCh := make(chan error, 1)
+
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+	}()
+
 	sink, err := newKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)
 	c.Assert(err, check.IsNil)
 
@@ -161,6 +167,12 @@ func (s mqSinkSuite) TestKafkaSinkFilter(c *check.C) {
 	c.Assert(err, check.IsNil)
 	opts := map[string]string{}
 	errCh := make(chan error, 1)
+
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+	}()
+
 	sink, err := newKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)
 	c.Assert(err, check.IsNil)
 

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -480,6 +480,16 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 			zap.String("topic", topic), zap.Int32("partitions", config.PartitionNum))
 		config.PartitionNum = defaultPartitionNum
 	}
+
+	brokerConfigEntry, err := admin.DescribeConfig(sarama.ConfigResource{
+		Type:        sarama.BrokerResource,
+		Name:        "message.max.bytes",
+		ConfigNames: nil,
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	maxMessageBytes := strconv.Itoa(config.MaxMessageBytes)
 	err = admin.CreateTopic(topic, &sarama.TopicDetail{
 		NumPartitions:     config.PartitionNum,

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -449,7 +449,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 			NumPartitions:     config.PartitionNum,
 			ReplicationFactor: config.ReplicationFactor,
 		}, false)
-		// TODO idenfity the cause of "Topic with this name already exists"
+		// TODO identify the cause of "Topic with this name already exists"
 		if err != nil && !strings.Contains(err.Error(), "already exists") {
 			return err
 		}

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -490,8 +490,10 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 	}
 
 	if config.PartitionNum < realPartitionCount {
-		log.Warn("number of partition specified in sink-uri is less than that of the actual topic. Some partitions will not have messages dispatched to",
-			zap.Int32("sink-uri partitions", config.PartitionNum), zap.Int32("topic partitions", realPartitionCount))
+		log.Warn("number of partition specified in sink-uri is less than that of the actual topic. "+
+			"Some partitions will not have messages dispatched to",
+			zap.Int32("sink-uri partitions", config.PartitionNum),
+			zap.Int32("topic partitions", realPartitionCount))
 		return nil
 	}
 
@@ -500,7 +502,8 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 	// messages would be dispatched to different partitions, this could prevent potential correctness problems.
 	if config.PartitionNum > realPartitionCount {
 		return cerror.ErrKafkaInvalidPartitionNum.GenWithStack(
-			"the number of partition (%d) specified in sink-uri is more than that of actual topic (%d)", config.PartitionNum, realPartitionCount)
+			"the number of partition (%d) specified in sink-uri is more than that of actual topic (%d)",
+			config.PartitionNum, realPartitionCount)
 	}
 
 	return nil

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -440,7 +440,6 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 		// less than given `max-message-size`
 		if ok {
 			if a, ok := info.ConfigEntries["max.message.bytes"]; ok {
-				log.Warn("show topic info", zap.Any("topic info", info))
 				topicMaxMessageBytes, err := strconv.Atoi(*a)
 				if err != nil {
 					return err

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -488,7 +488,7 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 
 	configEntries, err := admin.DescribeConfig(sarama.ConfigResource{
 		Type: sarama.BrokerResource,
-		Name: string(controllerID),
+		Name: strconv.Itoa(int(controllerID)),
 	})
 	if err != nil {
 		return errors.Trace(err)

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -480,8 +480,9 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 	}
 
 	configEntries, err := admin.DescribeConfig(sarama.ConfigResource{
-		Type: sarama.BrokerResource,
-		Name: strconv.Itoa(int(controllerID)),
+		Type:        sarama.BrokerResource,
+		Name:        strconv.Itoa(int(controllerID)),
+		ConfigNames: []string{"message.max.bytes"},
 	})
 	if err != nil {
 		return errors.Trace(err)

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -449,6 +449,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 			NumPartitions:     config.PartitionNum,
 			ReplicationFactor: config.ReplicationFactor,
 		}, false)
+		// TODO idenfity the cause of "Topic with this name already exists"
 		if err != nil && !strings.Contains(err.Error(), "already exists") {
 			return err
 		}

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -459,7 +459,11 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 		return nil
 	}
 
-	// topic should have already created by the user, `realPartitionCount` won't be 0.
+	// if `auto-create-topic` is disabled by user, we would assume topic should have already created
+	if !ok {
+		return cerror.ErrKafkaInvalidConfig.GenWithStack("auto-create-topic is false, and topic not found")
+	}
+
 	if config.PartitionNum == 0 {
 		config.PartitionNum = realPartitionCount
 		return nil

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -431,8 +431,8 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 			}
 			if topicMaxMessageBytes < config.MaxMessageBytes {
 				return cerror.ErrKafkaInvalidConfig.GenWithStack(
-					"topic already exist, and topic's max.message.bytes(%d) less than max-message-bytes(%d) "+
-						"specified in sink-uri. Please make sure `max-message-bytes` not greater than topic `max.message.bytes`",
+					"topic already exist, and topic's max.message.bytes(%d) less than max-message-bytes(%d)."+
+						"Please make sure `max-message-bytes` not greater than topic `max.message.bytes`",
 					topicMaxMessageBytes, config.MaxMessageBytes)
 			}
 		}
@@ -513,7 +513,7 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 
 	if brokerMessageMaxBytes < config.MaxMessageBytes {
 		return cerror.ErrKafkaInvalidConfig.GenWithStack(
-			"broker's message.max.bytes(%d) less than max-message-bytes(%d) specified in sink-uri."+
+			"broker's message.max.bytes(%d) less than max-message-bytes(%d)"+
 				"Please make sure `max-message-bytes` not greater than broker's `message.max.bytes`",
 			brokerMessageMaxBytes, config.MaxMessageBytes)
 	}

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -501,8 +501,9 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 	// this should not happen, broker would have a default setting for
 	if !found {
 		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration")
-		return cerror.ErrKafkaNewSaramaProducer.GenWithStack("topic cannot be created, " +
-			"since doesn't the `max.message.bytes` for the topic")
+		return cerror.ErrKafkaNewSaramaProducer.GenWithStack(
+			"since cannot find the `message.max.bytes` from the broker's configuration, " +
+				"ticdc decline to create the topic and changefeed to prevent potential error")
 	}
 
 	brokerMessageMaxBytes, err := strconv.Atoi(maxMessageBytes)

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -434,7 +434,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 		realPartitionCount = info.NumPartitions
 	}
 
-	// if user specify cdc to create the topic, we must make sure that topic number and replication-factor is given
+	// if user specify cdc to create the topic, we must make sure that `partition-num` and `replication-factor` is given
 	if config.AutoCreate {
 		// if the specified topic name already exist, we should make sure that topic's `max.message.bytes` is not
 		// less than given `max-message-size`

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -410,6 +410,9 @@ func (k *kafkaSaramaProducer) run(ctx context.Context) error {
 }
 
 func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
+	failpoint.Inject("workaround4NewClusterAdmin", func() {
+		failpoint.Return(nil)
+	})
 	admin, err := sarama.NewClusterAdmin(config.BrokerEndpoints, saramaConfig)
 	if err != nil {
 		return err

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -445,7 +445,7 @@ func topicPreProcess(topic string, protocol codec.Protocol, config *Config, sara
 		}
 
 		if err := config.adjustPartitionNum(info.NumPartitions); err != nil {
-			return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+			return errors.Trace(err)
 		}
 
 		return nil
@@ -461,7 +461,7 @@ func topicPreProcess(topic string, protocol codec.Protocol, config *Config, sara
 	brokerMessageMaxBytes, err := getBrokerMessageMaxBytes(admin)
 	if err != nil {
 		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration")
-		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+		return errors.Trace(err)
 	}
 
 	if brokerMessageMaxBytes < config.MaxMessageBytes {
@@ -664,7 +664,7 @@ func getBrokerMessageMaxBytes(admin sarama.ClusterAdmin) (int, error) {
 	target := "message.max.bytes"
 	_, controllerID, err := admin.DescribeCluster()
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
 	}
 
 	configEntries, err := admin.DescribeConfig(sarama.ConfigResource{
@@ -673,7 +673,7 @@ func getBrokerMessageMaxBytes(admin sarama.ClusterAdmin) (int, error) {
 		ConfigNames: []string{target},
 	})
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
 	}
 
 	if len(configEntries) == 0 || configEntries[0].Name != target {
@@ -684,7 +684,7 @@ func getBrokerMessageMaxBytes(admin sarama.ClusterAdmin) (int, error) {
 
 	result, err := strconv.Atoi(configEntries[0].Value)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
 	}
 
 	return result, nil
@@ -694,7 +694,7 @@ func getTopicMaxMessageBytes(admin sarama.ClusterAdmin, info sarama.TopicDetail)
 	if a, ok := info.ConfigEntries["max.message.bytes"]; ok {
 		result, err := strconv.Atoi(*a)
 		if err != nil {
-			return 0, errors.Trace(err)
+			return 0, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
 		}
 		return result, nil
 	}

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -493,7 +493,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 		return nil
 	}
 
-	// for topic already exist, we just make sure that the user specified partition count is not greater than the real
+	// For a topic already existing, we just make sure that the user-specified partition count is not greater than the real
 	// partition count, since we would dispatch messages to different partitions, this could prevent potential message loss.
 	if config.PartitionNum > realPartitionCount {
 		return cerror.ErrKafkaInvalidPartitionNum.GenWithStack(

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -461,9 +461,13 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 			log.Warn("partition-num is not set, use the default partition count",
 				zap.String("topic", config.TopicName), zap.Int32("partitions", config.PartitionNum))
 		}
+		maxMessageBytes := strconv.Itoa(config.MaxMessageBytes)
 		err := admin.CreateTopic(config.TopicName, &sarama.TopicDetail{
 			NumPartitions:     config.PartitionNum,
 			ReplicationFactor: config.ReplicationFactor,
+			ConfigEntries: map[string]*string{
+				"max.message.bytes": &maxMessageBytes,
+			},
 		}, false)
 		// TODO identify the cause of "Topic with this name already exists"
 		if err != nil && !strings.Contains(err.Error(), "already exists") {

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -421,7 +421,7 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 	}
 
 	info, created := topics[topic]
-	// once we have found the topic, no matter `auto-create-topic`, make sure all user input parameters are valid.
+	// once we have found the topic, no matter `auto-create-topic`, make sure user input parameters are valid.
 	if created {
 		// make sure that topic's `max.message.bytes` is not less than given `max-message-size`
 		// else the producer will send message that too large to make topic reject, then changefeed would error.
@@ -433,7 +433,7 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 			if topicMaxMessageBytes < config.MaxMessageBytes {
 				return cerror.ErrKafkaInvalidConfig.GenWithStack(
 					"topic already exist, and max.message.size(%d) less than max-message-size(%d)."+
-						"Please make sure max-message-size not greater than topic max.message.size",
+						"Please make sure `max-message-size` not greater than topic `max.message.size`",
 					topicMaxMessageBytes, config.MaxMessageBytes)
 			}
 		}

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -604,8 +604,10 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	}
 	config.Version = version
 	// See: https://kafka.apache.org/documentation/#replication
-	// When one of the brokers in a Kafka cluster is down, the partition leaders in this broker is broken,
-	// Kafka will election a new partition leader and replication logs, this process will last from a few seconds to a few minutes.
+	// When one of the brokers in a Kafka cluster is down, the partition leaders
+	// in this broker is broken, Kafka will election a new partition leader and
+	// replication logs, this process will last from a few seconds to a few
+	// minutes.
 	// Kafka cluster will not provide a writing service in this process.
 	// Time out in one minute(120 * 500ms).
 	config.Metadata.Retry.Max = 120

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -42,8 +42,8 @@ const defaultPartitionNum = 3
 // Config stores user specified Kafka producer configuration
 type Config struct {
 	BrokerEndpoints []string
+	PartitionNum    int32
 
-	PartitionNum int32
 	// User should make sure that `replication-factor` not greater than the number of kafka brokers.
 	ReplicationFactor int16
 
@@ -74,7 +74,6 @@ func NewConfig() *Config {
 // Initialize the kafka configuration
 func (c *Config) Initialize(sinkURI *url.URL, replicaConfig *config.ReplicaConfig, opts map[string]string) error {
 	c.BrokerEndpoints = strings.Split(sinkURI.Host, ",")
-
 	params := sinkURI.Query()
 	s := params.Get("partition-num")
 	if s != "" {

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -434,10 +434,11 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 		realPartitionCount = info.NumPartitions
 	}
 
-	// if user specify cdc to create the topic, we must make sure that `partition-num` and `replication-factor` is given
+	// if user specify cdc to create the topic, we must make sure
+	// that `partition-num` and `replication-factor` is given
 	if config.AutoCreate {
-		// if the specified topic name already exist, we should make sure that topic's `max.message.bytes` is not
-		// less than given `max-message-size`
+		// if the specified topic name already exist, we should make sure that
+		// topic's `max.message.bytes` is not less than given `max-message-size`
 		if ok {
 			if a, ok := info.ConfigEntries["max.message.bytes"]; ok {
 				topicMaxMessageBytes, err := strconv.Atoi(*a)

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -600,6 +600,10 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	config.Producer.Return.Errors = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
+	// Time out in five minutes(600 * 500ms).
+	config.Producer.Retry.Max = 600
+	config.Producer.Retry.Backoff = 500 * time.Millisecond
+
 	switch strings.ToLower(strings.TrimSpace(c.Compression)) {
 	case "none":
 		config.Producer.Compression = sarama.CompressionNone
@@ -615,10 +619,6 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 		log.Warn("Unsupported compression algorithm", zap.String("compression", c.Compression))
 		config.Producer.Compression = sarama.CompressionNone
 	}
-
-	// Time out in five minutes(600 * 500ms).
-	config.Producer.Retry.Max = 600
-	config.Producer.Retry.Backoff = 500 * time.Millisecond
 
 	// Time out in one minute(120 * 500ms).
 	config.Admin.Retry.Max = 120

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -445,6 +445,12 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 		}
 
 		realPartitionCount := info.NumPartitions
+		// user does not specify the `partition-num` in the sink-uri
+		if config.PartitionNum == 0 {
+			config.PartitionNum = realPartitionCount
+			return nil
+		}
+
 		if config.PartitionNum < realPartitionCount {
 			log.Warn("number of partition specified in sink-uri is less than that of the actual topic. "+
 				"Some partitions will not have messages dispatched to",
@@ -453,8 +459,9 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 			return nil
 		}
 
-		// Make sure that the user-specified partition count is not greater than the real partition count,
-		// since messages would be dispatched to different partitions, this could prevent potential correctness problems.
+		// Make sure that the user-specified `partition-num` is not greater than
+		// the real partition count, since messages would be dispatched to different
+		// partitions, this could prevent potential correctness problems.
 		if config.PartitionNum > realPartitionCount {
 			return cerror.ErrKafkaInvalidPartitionNum.GenWithStack(
 				"the number of partition (%d) specified in sink-uri is more than that of actual topic (%d)",

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -481,14 +481,20 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 		config.PartitionNum = defaultPartitionNum
 	}
 
-	brokerConfigEntry, err := admin.DescribeConfig(sarama.ConfigResource{
-		Type:        sarama.BrokerResource,
-		Name:        "message.max.bytes",
-		ConfigNames: nil,
+	_, controllerID, err := admin.DescribeCluster()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	configEntries, err := admin.DescribeConfig(sarama.ConfigResource{
+		Type: sarama.BrokerResource,
+		Name: string(controllerID),
 	})
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	log.Info("broker config", zap.Any("entries", configEntries))
 
 	maxMessageBytes := strconv.Itoa(config.MaxMessageBytes)
 	err = admin.CreateTopic(topic, &sarama.TopicDetail{

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -482,12 +482,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 	return nil
 }
 
-var (
-	newSaramaConfigImpl = newSaramaConfig
-	// when use kafka broker version less than "1.0.0", we would have to disable topicPreProcess
-	// this could happen in some unit testcase.
-	enableTopicPreProcess = true
-)
+var newSaramaConfigImpl = newSaramaConfig
 
 // NewKafkaSaramaProducer creates a kafka sarama producer
 func NewKafkaSaramaProducer(ctx context.Context, config *Config, errCh chan error) (*kafkaSaramaProducer, error) {
@@ -497,10 +492,8 @@ func NewKafkaSaramaProducer(ctx context.Context, config *Config, errCh chan erro
 		return nil, err
 	}
 
-	if enableTopicPreProcess {
-		if err := topicPreProcess(config, cfg); err != nil {
-			return nil, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
-		}
+	if err := topicPreProcess(config, cfg); err != nil {
+		return nil, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
 	}
 
 	asyncClient, err := sarama.NewAsyncProducer(config.BrokerEndpoints, cfg)

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -587,7 +587,9 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	}
 	config.Version = version
 	// See: https://kafka.apache.org/documentation/#replication
-	// When one of the brokers in a Kafka cluster is down, the partition leaders in this broker is broken, Kafka will election a new partition leader and replication logs, this process will last from a few seconds to a few minutes. Kafka cluster will not provide a writing service in this process.
+	// When one of the brokers in a Kafka cluster is down, the partition leaders in this broker is broken,
+	// Kafka will election a new partition leader and replication logs, this process will last from a few seconds to a few minutes.
+	// Kafka cluster will not provide a writing service in this process.
 	// Time out in one minute(120 * 500ms).
 	config.Metadata.Retry.Max = 120
 	config.Metadata.Retry.Backoff = 500 * time.Millisecond

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -422,7 +422,7 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 	info, created := topics[topic]
 	// once we have found the topic, no matter `auto-create-topic`, make sure user input parameters are valid.
 	if created {
-		// make sure that topic's `max.message.bytes` is not less than given `max-message-size`
+		// make sure that topic's `max.message.bytes` is not less than given `max-message-bytes`
 		// else the producer will send message that too large to make topic reject, then changefeed would error.
 		if a, found := info.ConfigEntries["max.message.bytes"]; found {
 			topicMaxMessageBytes, err := strconv.Atoi(*a)
@@ -498,7 +498,7 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 		}
 	}
 
-	// this should not happen, broker would have a default setting for
+	// this should not happen, broker should have a default setting.
 	if !found {
 		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration")
 		return cerror.ErrKafkaNewSaramaProducer.GenWithStack(

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -410,6 +410,9 @@ func (k *kafkaSaramaProducer) run(ctx context.Context) error {
 }
 
 func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
+	failpoint.Inject("workaround4Test", func() {
+		failpoint.Return(nil)
+	})
 	admin, err := sarama.NewClusterAdmin(config.BrokerEndpoints, saramaConfig)
 	if err != nil {
 		return err

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -440,6 +440,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 		// less than given `max-message-size`
 		if ok {
 			if a, ok := info.ConfigEntries["max.message.bytes"]; ok {
+				log.Warn("show topic info", zap.Any("topic info", info))
 				topicMaxMessageBytes, err := strconv.Atoi(*a)
 				if err != nil {
 					return err

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -600,8 +600,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// See: https://kafka.apache.org/documentation/#replication
 	// When one of the brokers in a Kafka cluster is down, the partition leaders
 	// in this broker is broken, Kafka will election a new partition leader and
-	// replication logs, this process will last from a few seconds to a few
-	// minutes.
+	// replication logs, this process will last from a few seconds to a few minutes.
 	// Kafka cluster will not provide a writing service in this process.
 	// Time out in one minute(120 * 500ms).
 	config.Metadata.Retry.Max = 120

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -476,9 +476,9 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 
 	// topic not created yet, and user does not specify the `partition-num` in the sink uri.
 	if config.PartitionNum == 0 {
+		config.PartitionNum = defaultPartitionNum
 		log.Warn("partition-num is not set, use the default partition count",
 			zap.String("topic", topic), zap.Int32("partitions", config.PartitionNum))
-		config.PartitionNum = defaultPartitionNum
 	}
 
 	_, controllerID, err := admin.DescribeCluster()

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -488,7 +488,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 	}
 
 	if config.PartitionNum < realPartitionCount {
-		log.Warn("partition count assigned in sink-uri is less than that of topic, some partitions would not have messages to be dispatched",
+		log.Warn("number of partition specified in sink-uri is less than that of the actual topic. Some partitions will not have messages dispatched to",
 			zap.Int32("sink-uri partitions", config.PartitionNum), zap.Int32("topic partitions", realPartitionCount))
 		return nil
 	}

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -527,9 +527,6 @@ func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) 
 	err = admin.CreateTopic(topic, &sarama.TopicDetail{
 		NumPartitions:     config.PartitionNum,
 		ReplicationFactor: config.ReplicationFactor,
-		ConfigEntries: map[string]*string{
-			"max.message.bytes": &maxMessageBytes,
-		},
 	}, false)
 	// TODO identify the cause of "Topic with this name already exists"
 	if err != nil && !strings.Contains(err.Error(), "already exists") {

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -485,7 +485,11 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 	return nil
 }
 
-var newSaramaConfigImpl = newSaramaConfig
+var (
+	newSaramaConfigImpl = newSaramaConfig
+	// when use kafka broker version less than "1.0.0", we would have to disable topicPreProcess
+	enableTopicPreProcess = true
+)
 
 // NewKafkaSaramaProducer creates a kafka sarama producer
 func NewKafkaSaramaProducer(ctx context.Context, config *Config, errCh chan error) (*kafkaSaramaProducer, error) {
@@ -495,8 +499,10 @@ func NewKafkaSaramaProducer(ctx context.Context, config *Config, errCh chan erro
 		return nil, err
 	}
 
-	if err := topicPreProcess(config, cfg); err != nil {
-		return nil, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+	if enableTopicPreProcess {
+		if err := topicPreProcess(config, cfg); err != nil {
+			return nil, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+		}
 	}
 
 	asyncClient, err := sarama.NewAsyncProducer(config.BrokerEndpoints, cfg)

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -410,9 +410,6 @@ func (k *kafkaSaramaProducer) run(ctx context.Context) error {
 }
 
 func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
-	failpoint.Inject("workaround4NewClusterAdmin", func() {
-		failpoint.Return(nil)
-	})
 	admin, err := sarama.NewClusterAdmin(config.BrokerEndpoints, saramaConfig)
 	if err != nil {
 		return err
@@ -488,6 +485,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 var (
 	newSaramaConfigImpl = newSaramaConfig
 	// when use kafka broker version less than "1.0.0", we would have to disable topicPreProcess
+	// this could happen in some unit testcase.
 	enableTopicPreProcess = true
 )
 

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -497,7 +497,7 @@ func topicPreProcess(config *Config, saramaConfig *sarama.Config) error {
 	// partition count, since we would dispatch messages to different partitions, this could prevent potential message loss.
 	if config.PartitionNum > realPartitionCount {
 		return cerror.ErrKafkaInvalidPartitionNum.GenWithStack(
-			"partition number(%d) assigned in sink-uri is more than that of topic(%d)", config.PartitionNum, realPartitionCount)
+			"the number of partition (%d) specified in sink-uri is more than that of actual topic (%d)", config.PartitionNum, realPartitionCount)
 	}
 
 	return nil

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -130,7 +130,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
 	prodSuccess.AddTopicPartition(topic, 1, sarama.ErrNoError)
 	// 200 async messages and 2 sync message, Kafka flush could be in batch,
-	// we can set flush.maxmessages to 1 to control message count exactly.
+	// we can set flush.max.messages to 1 to control message count exactly.
 	for i := 0; i < 202; i++ {
 		leader.Returns(prodSuccess)
 	}

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -99,12 +99,6 @@ func (s *kafkaSuite) TestInitializeConfig(c *check.C) {
 		c.Assert(v, check.Equals, expectedOpts[k])
 	}
 
-	uri = "kafka://127.0.0.1:9092/?kafka-version=2.6.0"
-	sinkURI, err = url.Parse(uri)
-	c.Assert(err, check.IsNil)
-	err = cfg.Initialize(sinkURI, replicaConfig, opts)
-	c.Assert(err, check.ErrorMatches, ".*topic name not found.*")
-
 	uri = "kafka://127.0.0.1:9092/abc?kafka-version=2.6.0&partition-num=0"
 	sinkURI, err = url.Parse(uri)
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/cdc/sink/codec"
 	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
@@ -155,6 +156,9 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	defer func() {
 		newSaramaConfigImpl = newSaramaConfigImplBak
 	}()
+
+	err := failpoint.Enable("workaround4NewClusterAdmin", "")
+	c.Assert(err, check.IsNil)
 
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	c.Assert(err, check.IsNil)
@@ -414,6 +418,9 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 		newSaramaConfigImpl = newSaramaConfigImplBak
 	}()
 
+	err := failpoint.Enable("workaround4NewClusterAdmin", "")
+	c.Assert(err, check.IsNil)
+
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	defer func() {
@@ -466,6 +473,9 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
 	leader.Returns(metadataResponse)
 	leader.Returns(metadataResponse)
+
+	err := failpoint.Enable("workaround4NewClusterAdmin", "")
+	c.Assert(err, check.IsNil)
 
 	config := NewConfig()
 	// Because the sarama mock broker is not compatible with version larger than 1.0.0

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -146,6 +146,8 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 	config.TopicName = topic
 
+	c.Assert(failpoint.Enable("workaround4NewClusterAdmin", ""), check.IsNil)
+
 	newSaramaConfigImplBak := newSaramaConfigImpl
 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
 		cfg, err := newSaramaConfigImplBak(ctx, config)
@@ -155,10 +157,8 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	}
 	defer func() {
 		newSaramaConfigImpl = newSaramaConfigImplBak
+		_ = failpoint.Disable("workaround4NewClusterAdmin")
 	}()
-
-	err := failpoint.Enable("workaround4NewClusterAdmin", "")
-	c.Assert(err, check.IsNil)
 
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	c.Assert(err, check.IsNil)
@@ -450,12 +450,12 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 		newSaramaConfigImpl = newSaramaConfigImplBak
 	}()
 
-	err := failpoint.Enable("workaround4NewClusterAdmin", "")
-	c.Assert(err, check.IsNil)
+	c.Assert(failpoint.Enable("workaround4NewClusterAdmin", ""), check.IsNil)
 
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	defer func() {
+		_ = failpoint.Disable("workaround4NewClusterAdmin")
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
 	}()
@@ -506,9 +506,7 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	leader.Returns(metadataResponse)
 	leader.Returns(metadataResponse)
 
-	err := failpoint.Enable("workaround4NewClusterAdmin", "")
-	c.Assert(err, check.IsNil)
-
+	c.Assert(failpoint.Enable("workaround4NewClusterAdmin", ""), check.IsNil)
 	config := NewConfig()
 	// Because the sarama mock broker is not compatible with version larger than 1.0.0
 	// We use a smaller version in the following producer tests.
@@ -522,6 +520,7 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	defer func() {
+		_ = failpoint.Disable("workaround4NewClusterAdmin")
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
 	}()

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -153,7 +153,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 		cfg.Producer.Flush.MaxMessages = 1
 		return cfg, err
 	}
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
 	defer func() {
 		newSaramaConfigImpl = newSaramaConfigImplBak
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
@@ -407,7 +407,7 @@ func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
 	config.Version = "invalid"
 	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
 	config.TopicName = "topic"
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
 	_, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
 	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
@@ -438,7 +438,7 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 	config.TopicName = topic
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
 
 	newSaramaConfigImplBak := newSaramaConfigImpl
 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
@@ -517,7 +517,7 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 	config.TopicName = topic
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
 
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -390,138 +390,138 @@ func (s *kafkaSuite) TestNewSaramaConfig(c *check.C) {
 	c.Assert(cfg.Net.SASL.Mechanism, check.Equals, sarama.SASLMechanism("SCRAM-SHA-256"))
 }
 
-func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
-	defer testleak.AfterTest(c)()
-	ctx := context.Background()
-	errCh := make(chan error, 1)
-	config := NewConfig()
-	config.Version = "invalid"
-	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
-	topic := "topic"
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
-	_, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
-	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
-	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
-}
-
-func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
-	defer testleak.AfterTest(c)()
-	topic := "unit_test_4"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	leader := sarama.NewMockBroker(c, 2)
-	defer leader.Close()
-	metadataResponse := new(sarama.MetadataResponse)
-	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
-	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-	leader.Returns(metadataResponse)
-	leader.Returns(metadataResponse)
-
-	config := NewConfig()
-	// Because the sarama mock broker is not compatible with version larger than 1.0.0
-	// We use a smaller version in the following producer tests.
-	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
-	config.Version = "0.9.0.0"
-	config.PartitionNum = int32(2)
-	config.AutoCreate = false
-	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
-
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
-
-	newSaramaConfigImplBak := newSaramaConfigImpl
-	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
-		cfg, err := newSaramaConfigImplBak(ctx, config)
-		c.Assert(err, check.IsNil)
-		cfg.Producer.Flush.MaxMessages = 1
-		cfg.Producer.Retry.Max = 2
-		cfg.Producer.MaxMessageBytes = 8
-		return cfg, err
-	}
-	defer func() {
-		newSaramaConfigImpl = newSaramaConfigImplBak
-	}()
-
-	errCh := make(chan error, 1)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
-	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
-		err := producer.Close()
-		c.Assert(err, check.IsNil)
-	}()
-
-	c.Assert(err, check.IsNil)
-	c.Assert(producer, check.NotNil)
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 20; i++ {
-			err = producer.AsyncSendMessage(ctx, &codec.MQMessage{
-				Key:   []byte("test-key-1"),
-				Value: []byte("test-value"),
-			}, int32(0))
-			c.Assert(err, check.IsNil)
-		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		select {
-		case <-ctx.Done():
-			c.Fatal("TestProducerSendMessageFailed timed out")
-		case err := <-errCh:
-			c.Assert(err, check.ErrorMatches, ".*too large.*")
-		}
-	}()
-
-	wg.Wait()
-}
-
-func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
-	defer testleak.AfterTest(c)()
-	topic := "unit_test_4"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	leader := sarama.NewMockBroker(c, 2)
-	defer leader.Close()
-	metadataResponse := new(sarama.MetadataResponse)
-	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
-	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-	leader.Returns(metadataResponse)
-	leader.Returns(metadataResponse)
-
-	config := NewConfig()
-	// Because the sarama mock broker is not compatible with version larger than 1.0.0
-	// We use a smaller version in the following producer tests.
-	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
-	config.Version = "0.9.0.0"
-	config.PartitionNum = int32(2)
-	config.AutoCreate = false
-	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
-
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
-
-	errCh := make(chan error, 1)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
-	defer func() {
-		err := producer.Close()
-		c.Assert(err, check.IsNil)
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
-	}()
-
-	c.Assert(err, check.IsNil)
-	c.Assert(producer, check.NotNil)
-
-	err = producer.Close()
-	c.Assert(err, check.IsNil)
-
-	err = producer.Close()
-	c.Assert(err, check.IsNil)
-}
+// func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
+// 	defer testleak.AfterTest(c)()
+// 	ctx := context.Background()
+// 	errCh := make(chan error, 1)
+// 	config := NewConfig()
+// 	config.Version = "invalid"
+// 	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
+// 	topic := "topic"
+// 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+// 	_, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+// 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
+// 	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
+// }
+//
+// func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
+// 	defer testleak.AfterTest(c)()
+// 	topic := "unit_test_4"
+// 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+// 	defer cancel()
+//
+// 	leader := sarama.NewMockBroker(c, 2)
+// 	defer leader.Close()
+// 	metadataResponse := new(sarama.MetadataResponse)
+// 	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+// 	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+// 	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+// 	leader.Returns(metadataResponse)
+// 	leader.Returns(metadataResponse)
+//
+// 	config := NewConfig()
+// 	// Because the sarama mock broker is not compatible with version larger than 1.0.0
+// 	// We use a smaller version in the following producer tests.
+// 	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
+// 	config.Version = "0.9.0.0"
+// 	config.PartitionNum = int32(2)
+// 	config.AutoCreate = false
+// 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
+//
+// 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+//
+// 	newSaramaConfigImplBak := newSaramaConfigImpl
+// 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
+// 		cfg, err := newSaramaConfigImplBak(ctx, config)
+// 		c.Assert(err, check.IsNil)
+// 		cfg.Producer.Flush.MaxMessages = 1
+// 		cfg.Producer.Retry.Max = 2
+// 		cfg.Producer.MaxMessageBytes = 8
+// 		return cfg, err
+// 	}
+// 	defer func() {
+// 		newSaramaConfigImpl = newSaramaConfigImplBak
+// 	}()
+//
+// 	errCh := make(chan error, 1)
+// 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+// 	defer func() {
+// 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
+// 		err := producer.Close()
+// 		c.Assert(err, check.IsNil)
+// 	}()
+//
+// 	c.Assert(err, check.IsNil)
+// 	c.Assert(producer, check.NotNil)
+//
+// 	var wg sync.WaitGroup
+//
+// 	wg.Add(1)
+// 	go func() {
+// 		defer wg.Done()
+// 		for i := 0; i < 20; i++ {
+// 			err = producer.AsyncSendMessage(ctx, &codec.MQMessage{
+// 				Key:   []byte("test-key-1"),
+// 				Value: []byte("test-value"),
+// 			}, int32(0))
+// 			c.Assert(err, check.IsNil)
+// 		}
+// 	}()
+//
+// 	wg.Add(1)
+// 	go func() {
+// 		defer wg.Done()
+// 		select {
+// 		case <-ctx.Done():
+// 			c.Fatal("TestProducerSendMessageFailed timed out")
+// 		case err := <-errCh:
+// 			c.Assert(err, check.ErrorMatches, ".*too large.*")
+// 		}
+// 	}()
+//
+// 	wg.Wait()
+// }
+//
+// func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
+// 	defer testleak.AfterTest(c)()
+// 	topic := "unit_test_4"
+// 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+// 	defer cancel()
+//
+// 	leader := sarama.NewMockBroker(c, 2)
+// 	defer leader.Close()
+// 	metadataResponse := new(sarama.MetadataResponse)
+// 	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+// 	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+// 	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+// 	leader.Returns(metadataResponse)
+// 	leader.Returns(metadataResponse)
+//
+// 	config := NewConfig()
+// 	// Because the sarama mock broker is not compatible with version larger than 1.0.0
+// 	// We use a smaller version in the following producer tests.
+// 	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
+// 	config.Version = "0.9.0.0"
+// 	config.PartitionNum = int32(2)
+// 	config.AutoCreate = false
+// 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
+//
+// 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+//
+// 	errCh := make(chan error, 1)
+// 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+// 	defer func() {
+// 		err := producer.Close()
+// 		c.Assert(err, check.IsNil)
+// 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
+// 	}()
+//
+// 	c.Assert(err, check.IsNil)
+// 	c.Assert(producer, check.NotNil)
+//
+// 	err = producer.Close()
+// 	c.Assert(err, check.IsNil)
+//
+// 	err = producer.Close()
+// 	c.Assert(err, check.IsNil)
+// }

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -274,7 +274,7 @@ func (s *kafkaSuite) TestTopicPreProcess(c *check.C) {
 	c.Assert(errors.Cause(err), check.Equals, sarama.ErrOutOfBrokers)
 
 	config.BrokerEndpoints = strings.Split(broker.Addr(), ",")
-	config.PartitionNum = int32(4)
+	config.PartitionNum = int32(3)
 
 	err = topicPreProcess(config, cfg)
 	c.Assert(cerror.ErrKafkaInvalidPartitionNum.Equal(err), check.IsTrue)

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -152,10 +152,10 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 		cfg.Producer.Flush.MaxMessages = 1
 		return cfg, err
 	}
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
 	defer func() {
 		newSaramaConfigImpl = newSaramaConfigImplBak
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 	}()
 
 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
@@ -404,10 +404,10 @@ func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
 	config.Version = "invalid"
 	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
 	topic := "topic"
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
 	_, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
-	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 }
 
 func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
@@ -434,7 +434,7 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	config.AutoCreate = false
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
 
 	newSaramaConfigImplBak := newSaramaConfigImpl
 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
@@ -452,7 +452,7 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
 	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
 	}()
@@ -512,14 +512,14 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	config.AutoCreate = false
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 
-	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(true)"), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
 
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
 	defer func() {
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
-		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 	}()
 
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -152,7 +152,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 	}()
 
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, codec.ProtocolDefault, config, errCh)
 	c.Assert(err, check.IsNil)
 	c.Assert(producer.GetPartitionNum(), check.Equals, int32(2))
 	for i := 0; i < 100; i++ {
@@ -278,7 +278,7 @@ func (s *kafkaSuite) TestTopicPreProcess(c *check.C) {
 	config.BrokerEndpoints = []string{""}
 	cfg.Metadata.Retry.Max = 1
 
-	err = topicPreProcess(topic, config, cfg)
+	err = topicPreProcess(topic, codec.ProtocolDefault, config, cfg)
 	c.Assert(errors.Cause(err), check.Equals, sarama.ErrOutOfBrokers)
 }
 
@@ -347,7 +347,7 @@ func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
 	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
 	topic := "topic"
 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
-	_, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	_, err := NewKafkaSaramaProducer(ctx, topic, codec.ProtocolDefault, config, errCh)
 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
 	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 }
@@ -392,7 +392,7 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	}()
 
 	errCh := make(chan error, 1)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, codec.ProtocolDefault, config, errCh)
 	defer func() {
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 		err := producer.Close()
@@ -457,7 +457,7 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
 
 	errCh := make(chan error, 1)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, codec.ProtocolDefault, config, errCh)
 	defer func() {
 		err := producer.Close()
 		c.Assert(err, check.IsNil)

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -235,6 +235,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 }
 
 func (s *kafkaSuite) TestAdjustPartitionNum(c *check.C) {
+	defer testleak.AfterTest(c)()
 	config := NewConfig()
 	err := config.adjustPartitionNum(2)
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -338,138 +338,138 @@ func (s *kafkaSuite) TestNewSaramaConfig(c *check.C) {
 	c.Assert(cfg.Net.SASL.Mechanism, check.Equals, sarama.SASLMechanism("SCRAM-SHA-256"))
 }
 
-// func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
-// 	defer testleak.AfterTest(c)()
-// 	ctx := context.Background()
-// 	errCh := make(chan error, 1)
-// 	config := NewConfig()
-// 	config.Version = "invalid"
-// 	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
-// 	topic := "topic"
-// 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
-// 	_, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
-// 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
-// 	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
-// }
-//
-// func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
-// 	defer testleak.AfterTest(c)()
-// 	topic := "unit_test_4"
-// 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-// 	defer cancel()
-//
-// 	leader := sarama.NewMockBroker(c, 2)
-// 	defer leader.Close()
-// 	metadataResponse := new(sarama.MetadataResponse)
-// 	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
-// 	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-// 	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-// 	leader.Returns(metadataResponse)
-// 	leader.Returns(metadataResponse)
-//
-// 	config := NewConfig()
-// 	// Because the sarama mock broker is not compatible with version larger than 1.0.0
-// 	// We use a smaller version in the following producer tests.
-// 	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
-// 	config.Version = "0.9.0.0"
-// 	config.PartitionNum = int32(2)
-// 	config.AutoCreate = false
-// 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
-//
-// 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
-//
-// 	newSaramaConfigImplBak := newSaramaConfigImpl
-// 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
-// 		cfg, err := newSaramaConfigImplBak(ctx, config)
-// 		c.Assert(err, check.IsNil)
-// 		cfg.Producer.Flush.MaxMessages = 1
-// 		cfg.Producer.Retry.Max = 2
-// 		cfg.Producer.MaxMessageBytes = 8
-// 		return cfg, err
-// 	}
-// 	defer func() {
-// 		newSaramaConfigImpl = newSaramaConfigImplBak
-// 	}()
-//
-// 	errCh := make(chan error, 1)
-// 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
-// 	defer func() {
-// 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
-// 		err := producer.Close()
-// 		c.Assert(err, check.IsNil)
-// 	}()
-//
-// 	c.Assert(err, check.IsNil)
-// 	c.Assert(producer, check.NotNil)
-//
-// 	var wg sync.WaitGroup
-//
-// 	wg.Add(1)
-// 	go func() {
-// 		defer wg.Done()
-// 		for i := 0; i < 20; i++ {
-// 			err = producer.AsyncSendMessage(ctx, &codec.MQMessage{
-// 				Key:   []byte("test-key-1"),
-// 				Value: []byte("test-value"),
-// 			}, int32(0))
-// 			c.Assert(err, check.IsNil)
-// 		}
-// 	}()
-//
-// 	wg.Add(1)
-// 	go func() {
-// 		defer wg.Done()
-// 		select {
-// 		case <-ctx.Done():
-// 			c.Fatal("TestProducerSendMessageFailed timed out")
-// 		case err := <-errCh:
-// 			c.Assert(err, check.ErrorMatches, ".*too large.*")
-// 		}
-// 	}()
-//
-// 	wg.Wait()
-// }
-//
-// func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
-// 	defer testleak.AfterTest(c)()
-// 	topic := "unit_test_4"
-// 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-// 	defer cancel()
-//
-// 	leader := sarama.NewMockBroker(c, 2)
-// 	defer leader.Close()
-// 	metadataResponse := new(sarama.MetadataResponse)
-// 	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
-// 	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-// 	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-// 	leader.Returns(metadataResponse)
-// 	leader.Returns(metadataResponse)
-//
-// 	config := NewConfig()
-// 	// Because the sarama mock broker is not compatible with version larger than 1.0.0
-// 	// We use a smaller version in the following producer tests.
-// 	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
-// 	config.Version = "0.9.0.0"
-// 	config.PartitionNum = int32(2)
-// 	config.AutoCreate = false
-// 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
-//
-// 	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
-//
-// 	errCh := make(chan error, 1)
-// 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
-// 	defer func() {
-// 		err := producer.Close()
-// 		c.Assert(err, check.IsNil)
-// 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
-// 	}()
-//
-// 	c.Assert(err, check.IsNil)
-// 	c.Assert(producer, check.NotNil)
-//
-// 	err = producer.Close()
-// 	c.Assert(err, check.IsNil)
-//
-// 	err = producer.Close()
-// 	c.Assert(err, check.IsNil)
-// }
+func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
+	defer testleak.AfterTest(c)()
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	config := NewConfig()
+	config.Version = "invalid"
+	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
+	topic := "topic"
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+	_, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
+	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
+}
+
+func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
+	defer testleak.AfterTest(c)()
+	topic := "unit_test_4"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	leader := sarama.NewMockBroker(c, 2)
+	defer leader.Close()
+	metadataResponse := new(sarama.MetadataResponse)
+	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+	leader.Returns(metadataResponse)
+	leader.Returns(metadataResponse)
+
+	config := NewConfig()
+	// Because the sarama mock broker is not compatible with version larger than 1.0.0
+	// We use a smaller version in the following producer tests.
+	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
+	config.Version = "0.9.0.0"
+	config.PartitionNum = int32(2)
+	config.AutoCreate = false
+	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
+
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+
+	newSaramaConfigImplBak := newSaramaConfigImpl
+	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
+		cfg, err := newSaramaConfigImplBak(ctx, config)
+		c.Assert(err, check.IsNil)
+		cfg.Producer.Flush.MaxMessages = 1
+		cfg.Producer.Retry.Max = 2
+		cfg.Producer.MaxMessageBytes = 8
+		return cfg, err
+	}
+	defer func() {
+		newSaramaConfigImpl = newSaramaConfigImplBak
+	}()
+
+	errCh := make(chan error, 1)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
+		err := producer.Close()
+		c.Assert(err, check.IsNil)
+	}()
+
+	c.Assert(err, check.IsNil)
+	c.Assert(producer, check.NotNil)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			err = producer.AsyncSendMessage(ctx, &codec.MQMessage{
+				Key:   []byte("test-key-1"),
+				Value: []byte("test-value"),
+			}, int32(0))
+			c.Assert(err, check.IsNil)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-ctx.Done():
+			c.Fatal("TestProducerSendMessageFailed timed out")
+		case err := <-errCh:
+			c.Assert(err, check.ErrorMatches, ".*too large.*")
+		}
+	}()
+
+	wg.Wait()
+}
+
+func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
+	defer testleak.AfterTest(c)()
+	topic := "unit_test_4"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	leader := sarama.NewMockBroker(c, 2)
+	defer leader.Close()
+	metadataResponse := new(sarama.MetadataResponse)
+	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+	metadataResponse.AddTopicPartition(topic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+	leader.Returns(metadataResponse)
+	leader.Returns(metadataResponse)
+
+	config := NewConfig()
+	// Because the sarama mock broker is not compatible with version larger than 1.0.0
+	// We use a smaller version in the following producer tests.
+	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac030c15cf08e9e57925/async_producer_test.go#L1445-L1447
+	config.Version = "0.9.0.0"
+	config.PartitionNum = int32(2)
+	config.AutoCreate = false
+	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
+
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+
+	errCh := make(chan error, 1)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	defer func() {
+		err := producer.Close()
+		c.Assert(err, check.IsNil)
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/SkipTopicAutoCreate")
+	}()
+
+	c.Assert(err, check.IsNil)
+	c.Assert(producer, check.NotNil)
+
+	err = producer.Close()
+	c.Assert(err, check.IsNil)
+
+	err = producer.Close()
+	c.Assert(err, check.IsNil)
+}

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -145,8 +145,6 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 	config.TopicName = topic
 
-	enableTopicPreProcess = false
-
 	newSaramaConfigImplBak := newSaramaConfigImpl
 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
 		cfg, err := newSaramaConfigImplBak(ctx, config)
@@ -435,8 +433,6 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 	config.TopicName = topic
 
-	enableTopicPreProcess = false
-
 	newSaramaConfigImplBak := newSaramaConfigImpl
 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
 		cfg, err := newSaramaConfigImplBak(ctx, config)
@@ -513,7 +509,6 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 	config.TopicName = topic
 
-	enableTopicPreProcess = false
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	defer func() {

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -281,7 +281,7 @@ func (s *kafkaSuite) TestTopicPreProcess(c *check.C) {
 	cfg, err = newSaramaConfigImpl(ctx, config)
 	c.Assert(err, check.IsNil)
 	err = topicPreProcess(topic, config, cfg)
-	c.Assert(errors.Cause(err), check.ErrorMatches, ".*assigned in sink-uri is more than that of topic.*")
+	c.Assert(errors.Cause(err), check.ErrorMatches, ".*assigned in sink-uri is more than that of.*")
 
 	config.BrokerEndpoints = []string{""}
 	cfg.Metadata.Retry.Max = 1

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -146,7 +146,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 	config.TopicName = topic
 
-	c.Assert(failpoint.Enable("workaround4NewClusterAdmin", ""), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4NewClusterAdmin", ""), check.IsNil)
 
 	newSaramaConfigImplBak := newSaramaConfigImpl
 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
@@ -157,7 +157,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	}
 	defer func() {
 		newSaramaConfigImpl = newSaramaConfigImplBak
-		_ = failpoint.Disable("workaround4NewClusterAdmin")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4NewClusterAdmin")
 	}()
 
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
@@ -450,12 +450,12 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 		newSaramaConfigImpl = newSaramaConfigImplBak
 	}()
 
-	c.Assert(failpoint.Enable("workaround4NewClusterAdmin", ""), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4NewClusterAdmin", ""), check.IsNil)
 
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	defer func() {
-		_ = failpoint.Disable("workaround4NewClusterAdmin")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4NewClusterAdmin")
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
 	}()
@@ -506,7 +506,7 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	leader.Returns(metadataResponse)
 	leader.Returns(metadataResponse)
 
-	c.Assert(failpoint.Enable("workaround4NewClusterAdmin", ""), check.IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4NewClusterAdmin", ""), check.IsNil)
 	config := NewConfig()
 	// Because the sarama mock broker is not compatible with version larger than 1.0.0
 	// We use a smaller version in the following producer tests.
@@ -520,7 +520,7 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	errCh := make(chan error, 1)
 	producer, err := NewKafkaSaramaProducer(ctx, config, errCh)
 	defer func() {
-		_ = failpoint.Disable("workaround4NewClusterAdmin")
+		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4NewClusterAdmin")
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
 	}()

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -153,7 +153,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 		cfg.Producer.Flush.MaxMessages = 1
 		return cfg, err
 	}
-	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")
+	c.Assert(failpoint.Enable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test", "return(nil)"), check.IsNil)
 	defer func() {
 		newSaramaConfigImpl = newSaramaConfigImplBak
 		_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sink/producer/kafka/workaround4Test")

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -281,7 +281,7 @@ func (s *kafkaSuite) TestTopicPreProcess(c *check.C) {
 	cfg, err = newSaramaConfigImpl(ctx, config)
 	c.Assert(err, check.IsNil)
 	err = topicPreProcess(topic, config, cfg)
-	c.Assert(errors.Cause(err), check.ErrorMatches, ".*assigned in sink-uri is more than that of.*")
+	c.Assert(errors.Cause(err), check.ErrorMatches, ".*specified in sink-uri is more than that of actual topic.*")
 
 	config.BrokerEndpoints = []string{""}
 	cfg.Metadata.Retry.Max = 1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #3337

This is part work of making Kafka GA. Contain the following:
* Refine the logic of creating topic
* Make some variable become a field of the `Config`, which would be helpful if we would support one producer per topic in the future since this group producer parameters together.
* Bugfix
  * If `auto-create-topic` disable by the user, the partition count will not be checked.
  * before create the topic, make sure broker's `message.max.bytes` not less than `max-message-bytes`

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
<img width="2546" alt="Screen Shot 2021-11-09 at 13 24 36" src="https://user-images.githubusercontent.com/7138436/140867736-d1868f23-3671-4d53-8f6d-cd4c9873e982.png">


Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update key monitor metrics in both TiCDC document and official document

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with `None`.
```
