### PR TITLE
ticdc/redolog: refine configuration in redo log

### DIFF
--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -16,7 +16,6 @@ package redo
 import (
 	"context"
 	"math"
-	"net/url"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -29,6 +28,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/tidb/br/pkg/storage"
 	"go.uber.org/zap"
 )
 
@@ -37,7 +37,7 @@ var updateRtsInterval = time.Second
 type consistentLevelType string
 
 const (
-	consistentLevelNormal   consistentLevelType = "normal"
+	consistentLevelNone     consistentLevelType = "none"
 	consistentLevelEventual consistentLevelType = "eventual"
 )
 
@@ -58,7 +58,7 @@ const (
 // IsValidConsistentLevel checks whether a give consistent level is valid
 func IsValidConsistentLevel(level string) bool {
 	switch consistentLevelType(level) {
-	case consistentLevelNormal, consistentLevelEventual:
+	case consistentLevelNone, consistentLevelEventual:
 		return true
 	default:
 		return false
@@ -77,7 +77,7 @@ func IsValidConsistentStorage(storage string) bool {
 
 // IsConsistentEnabled returns whether the consistent feature is enabled
 func IsConsistentEnabled(level string) bool {
-	return IsValidConsistentLevel(level) && consistentLevelType(level) != consistentLevelNormal
+	return IsValidConsistentLevel(level) && consistentLevelType(level) != consistentLevelNone
 }
 
 // IsS3StorageEnabled returns whether s3 storage is enabled
@@ -117,9 +117,9 @@ type cacheRows struct {
 // ManagerImpl manages redo log writer, buffers un-persistent redo logs, calculates
 // redo log resolved ts. It implements LogManager interface.
 type ManagerImpl struct {
-	enabled bool
-	level   consistentLevelType
-	storage consistentStorage
+	enabled     bool
+	level       consistentLevelType
+	storageType consistentStorage
 
 	logBuffer chan cacheRows
 	writer    writer.RedoLogWriter
@@ -136,47 +136,55 @@ type ManagerImpl struct {
 // NewManager creates a new Manager
 func NewManager(ctx context.Context, cfg *config.ConsistentConfig, opts *ManagerOptions) (*ManagerImpl, error) {
 	// return a disabled Manager if no consistent config or normal consistent level
-	if cfg == nil || consistentLevelType(cfg.Level) == consistentLevelNormal {
+	if cfg == nil || consistentLevelType(cfg.Level) == consistentLevelNone {
 		return &ManagerImpl{enabled: false}, nil
 	}
-	m := &ManagerImpl{
-		enabled:   true,
-		level:     consistentLevelType(cfg.Level),
-		storage:   consistentStorage(cfg.Storage),
-		rtsMap:    make(map[model.TableID]uint64),
-		logBuffer: make(chan cacheRows, logBufferChanSize),
+	uri, err := storage.ParseRawURL(cfg.Storage)
+	if err != nil {
+		return nil, err
 	}
-	switch m.storage {
+	m := &ManagerImpl{
+		enabled:     true,
+		level:       consistentLevelType(cfg.Level),
+		storageType: consistentStorage(uri.Scheme),
+		rtsMap:      make(map[model.TableID]uint64),
+		logBuffer:   make(chan cacheRows, logBufferChanSize),
+	}
+
+	changeFeedID := util.ChangefeedIDFromCtx(ctx)
+	var redoDir string
+	switch m.storageType {
 	case consistentStorageBlackhole:
 		m.writer = writer.NewBlackHoleWriter()
-	case consistentStorageLocal, consistentStorageS3:
+	case consistentStorageLocal:
+		// When using local as backend, the uri path should be an NFS path.
+		redoDir = uri.Path
+	case consistentStorageS3:
 		globalConf := config.GetGlobalServerConfig()
-		changeFeedID := util.ChangefeedIDFromCtx(ctx)
-		redoDir := filepath.Join(globalConf.DataDir, config.DefaultRedoDir, changeFeedID)
-		writerCfg := &writer.LogWriterConfig{
-			Dir:               redoDir,
-			CaptureID:         util.CaptureAddrFromCtx(ctx),
-			ChangeFeedID:      changeFeedID,
-			CreateTime:        time.Now(),
-			MaxLogSize:        cfg.MaxLogSize,
-			FlushIntervalInMs: cfg.FlushIntervalInMs,
-			S3Storage:         cfg.Storage == string(consistentStorageS3),
-		}
-		if writerCfg.S3Storage {
-			s3URI, err := url.Parse(cfg.S3URI)
-			if err != nil {
-				return nil, cerror.WrapError(cerror.ErrInvalidS3URI, err)
-			}
-			writerCfg.S3URI = *s3URI
-		}
-		writer, err := writer.NewLogWriter(ctx, writerCfg)
-		if err != nil {
-			return nil, err
-		}
-		m.writer = writer
+		// When using S3 as backend, the local redo dir is a temporary dir.
+		redoDir = filepath.Join(globalConf.DataDir, config.DefaultRedoDir, changeFeedID)
 	default:
-		return nil, cerror.ErrConsistentStorage.GenWithStackByArgs(m.storage)
+		return nil, cerror.ErrConsistentStorage.GenWithStackByArgs(m.storageType)
 	}
+
+	writerCfg := &writer.LogWriterConfig{
+		Dir:               redoDir,
+		CaptureID:         util.CaptureAddrFromCtx(ctx),
+		ChangeFeedID:      changeFeedID,
+		CreateTime:        time.Now(),
+		MaxLogSize:        cfg.MaxLogSize,
+		FlushIntervalInMs: cfg.FlushIntervalInMs,
+		S3Storage:         m.storageType == consistentStorageS3,
+	}
+	if writerCfg.S3Storage {
+		writerCfg.S3URI = *uri
+	}
+	writer, err := writer.NewLogWriter(ctx, writerCfg)
+	if err != nil {
+		return nil, err
+	}
+	m.writer = writer
+
 	if opts.EnableBgRunner {
 		go m.bgUpdateResolvedTs(ctx, opts.ErrCh)
 		go m.bgWriteLog(ctx, opts.ErrCh)

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -29,9 +29,9 @@ func TestConsistentConfig(t *testing.T) {
 		level string
 		valid bool
 	}{
-		{"normal", true},
+		{"none", true},
 		{"eventual", true},
-		{"NORMAL", false},
+		{"NONE", false},
 		{"", false},
 	}
 	for _, lc := range levelCases {
@@ -43,7 +43,7 @@ func TestConsistentConfig(t *testing.T) {
 		consistent bool
 	}{
 		{"invalid-level", false},
-		{"normal", false},
+		{"none", false},
 		{"eventual", true},
 	}
 	for _, lc := range levelEnableCases {
@@ -93,7 +93,7 @@ func TestLogManagerInProcessor(t *testing.T) {
 
 	cfg := &config.ConsistentConfig{
 		Level:   string(consistentLevelEventual),
-		Storage: string(consistentStorageBlackhole),
+		Storage: "blackhole://",
 	}
 	errCh := make(chan error, 1)
 	opts := &ManagerOptions{
@@ -181,7 +181,7 @@ func TestLogManagerInOwner(t *testing.T) {
 
 	cfg := &config.ConsistentConfig{
 		Level:   string(consistentLevelEventual),
-		Storage: string(consistentStorageBlackhole),
+		Storage: "blackhole://",
 	}
 	opts := &ManagerOptions{
 		EnableBgRunner: false,

--- a/pkg/applier/redo_test.go
+++ b/pkg/applier/redo_test.go
@@ -231,7 +231,7 @@ func TestApplyMeetSinkError(t *testing.T) {
 	port, err := freeport.GetFreePort()
 	require.Nil(t, err)
 	cfg := &RedoApplierConfig{
-		Storage: "blackhole",
+		Storage: "blackhole://",
 		SinkURI: fmt.Sprintf("mysql://127.0.0.1:%d/?read-timeout=1s&timeout=1s", port),
 	}
 	ap := NewRedoApplier(cfg)

--- a/pkg/cmd/redo/apply.go
+++ b/pkg/cmd/redo/apply.go
@@ -21,10 +21,8 @@ import (
 
 // applyRedoOptions defines flags for the `redo apply` command.
 type applyRedoOptions struct {
-	storage string
+	options
 	sinkURI string
-	dir     string
-	s3URI   string
 }
 
 // newapplyRedoOptions creates new applyRedoOptions for the `redo apply` command.
@@ -35,12 +33,8 @@ func newapplyRedoOptions() *applyRedoOptions {
 // addFlags receives a *cobra.Command reference and binds
 // flags related to template printing to it.
 func (o *applyRedoOptions) addFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.storage, "storage", "", "storage of redo log")
 	cmd.Flags().StringVar(&o.sinkURI, "sink-uri", "", "target database sink-uri")
-	cmd.Flags().StringVar(&o.dir, "dir", "", "local path of redo log")
-	cmd.Flags().StringVar(&o.s3URI, "s3-uri", "", "s3 uri of redo log")
 	// the possible error returned from MarkFlagRequired is `no such flag`
-	cmd.MarkFlagRequired("storage")  //nolint:errcheck
 	cmd.MarkFlagRequired("sink-uri") //nolint:errcheck
 }
 
@@ -52,7 +46,6 @@ func (o *applyRedoOptions) run(cmd *cobra.Command) error {
 		Storage: o.storage,
 		SinkURI: o.sinkURI,
 		Dir:     o.dir,
-		S3URI:   o.s3URI,
 	}
 	ap := applier.NewRedoApplier(cfg)
 	err := ap.Apply(ctx)
@@ -64,12 +57,13 @@ func (o *applyRedoOptions) run(cmd *cobra.Command) error {
 }
 
 // newCmdApply creates the `redo apply` command.
-func newCmdApply() *cobra.Command {
+func newCmdApply(opt *options) *cobra.Command {
 	o := newapplyRedoOptions()
 	command := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply redo logs in target sink",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			o.options = *opt
 			return o.run(cmd)
 		},
 	}

--- a/pkg/cmd/redo/meta.go
+++ b/pkg/cmd/redo/meta.go
@@ -21,25 +21,12 @@ import (
 
 // metaOptions defines flags for the `redo meta` command.
 type metaOptions struct {
-	storage string
-	dir     string
-	s3URI   string
+	options
 }
 
 // newMetaOptions creates new MetaOptions for the `redo apply` command.
 func newMetaOptions() *metaOptions {
 	return &metaOptions{}
-}
-
-// addFlags receives a *cobra.Command reference and binds
-// flags related to template printing to it.
-func (o *metaOptions) addFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.storage, "storage", "", "storage of redo log")
-	cmd.Flags().StringVar(&o.dir, "dir", "", "local path of redo log")
-	cmd.Flags().StringVar(&o.s3URI, "s3-uri", "", "s3 uri of redo log")
-	// the possible error returned from MarkFlagRequired is `no such flag`
-	cmd.MarkFlagRequired("storage")  //nolint:errcheck
-	cmd.MarkFlagRequired("sink-uri") //nolint:errcheck
 }
 
 // run runs the `redo apply` command.
@@ -49,7 +36,6 @@ func (o *metaOptions) run(cmd *cobra.Command) error {
 	cfg := &applier.RedoApplierConfig{
 		Storage: o.storage,
 		Dir:     o.dir,
-		S3URI:   o.s3URI,
 	}
 	ap := applier.NewRedoApplier(cfg)
 	checkpointTs, resolvedTs, err := ap.ReadMeta(ctx)
@@ -61,16 +47,16 @@ func (o *metaOptions) run(cmd *cobra.Command) error {
 }
 
 // newCmdMeta creates the `redo meta` command.
-func newCmdMeta() *cobra.Command {
-	o := newMetaOptions()
+func newCmdMeta(opt *options) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "meta",
 		Short: "read redo log meta",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			o := newMetaOptions()
+			o.options = *opt
 			return o.run(cmd)
 		},
 	}
-	o.addFlags(command)
 
 	return command
 }

--- a/pkg/cmd/redo/redo.go
+++ b/pkg/cmd/redo/redo.go
@@ -21,6 +21,8 @@ import (
 
 // options defines flags for the `redo` command.
 type options struct {
+	storage  string
+	dir      string
 	logLevel string
 }
 
@@ -32,7 +34,11 @@ func newOptions() *options {
 // addFlags receives a *cobra.Command reference and binds
 // flags related to template printing to it.
 func (o *options) addFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&o.storage, "storage", "", "storage of redo log")
+	cmd.PersistentFlags().StringVar(&o.dir, "tmp-dir", "", "temporary path used to download redo log with S3 backend")
 	cmd.PersistentFlags().StringVar(&o.logLevel, "log-level", "info", "log level (etc: debug|info|warn|error)")
+	// the possible error returned from MarkFlagRequired is `no such flag`
+	cmd.MarkFlagRequired("storage") //nolint:errcheck
 }
 
 // NewCmdRedo creates the `redo` command.
@@ -46,6 +52,7 @@ func NewCmdRedo() *cobra.Command {
 			// Here we will initialize the logging configuration and set the current default context.
 			util.InitCmd(cmd, &logutil.Config{Level: o.logLevel})
 			util.LogHTTPProxies()
+
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -54,8 +61,8 @@ func NewCmdRedo() *cobra.Command {
 	o.addFlags(cmds)
 
 	// Add subcommands.
-	cmds.AddCommand(newCmdApply())
-	cmds.AddCommand(newCmdMeta())
+	cmds.AddCommand(newCmdApply(o))
+	cmds.AddCommand(newCmdMeta(o))
 
 	return cmds
 }

--- a/pkg/cmd/util/changefeed.toml
+++ b/pkg/cmd/util/changefeed.toml
@@ -63,12 +63,9 @@ max-log-size = 64
 # 刷新或上传 redo log 至 S3 的间隔，单位毫秒
 # interval to flush or upload redo log, default is 1000ms, unit is microseconds
 flush-interval = 1000
-# 存储 redo log 的形式，包括 local（本地文件），S3（上传至S3），blackhole（测试用）
+# 存储 redo log 的形式，包括 local（NFS 目录），S3（上传至S3），blackhole（测试用）
 # storage type for redo log
 # local: local file system
 # s3: s3 storage
 # blackhole: used for test only
-storage = "local"
-# S3 地址，示例：s3-uri="s3://logbucket/test-changefeed?endpoint=http://$S3_ENDPOINT/"
-# S3 address, sample: s3-uri="s3://logbucket/test-changefeed?endpoint=http://$S3_ENDPOINT/"
-s3-uri = ""
+storage = "s3://logbucket/test-changefeed?endpoint=http://$S3_ENDPOINT/"

--- a/pkg/cmd/util/changefeed.toml
+++ b/pkg/cmd/util/changefeed.toml
@@ -52,11 +52,11 @@ filter-replica-ids = [2,3]
 sync-ddl = true
 
 [consistent]
-# 一致性级别，normal 为默认，非灾难场景，提供 finished-ts 情况下的最终一致性；eventual 使用 redo log，提供上游灾难情况下的最终一致性
-# consistent level, normal is the default value.
-# normal: eventual consistent support in non-disaster scenario(should provide a finished-ts)
+# 一致性级别，none 为默认，非灾难场景，提供 finished-ts 情况下的最终一致性；eventual 使用 redo log，提供上游灾难情况下的最终一致性
+# consistent level, none is the default value.
+# none: eventual consistent support in non-disaster scenario(should provide a finished-ts)
 # eventual: eventual consistent in disaster scenario
-level = "normal"
+level = "none"
 # 单个 redo log 文件大小，单位 MB
 # file size of single redo log, unit is MB
 max-log-size = 64

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultSortDir = "/tmp/sorter"
 
 	// DefaultRedoDir is the sub directory path of data-dir.
-	DefaultRedoDir = "/redo"
+	DefaultRedoDir = "/tmp/redo"
 )
 
 func init() {
@@ -62,11 +62,10 @@ var defaultReplicaConfig = &ReplicaConfig{
 		PollingTime: -1,
 	},
 	Consistent: &ConsistentConfig{
-		Level:             "normal",
+		Level:             "none",
 		MaxLogSize:        64,
 		FlushIntervalInMs: 1000,
-		Storage:           "local",
-		S3URI:             "",
+		Storage:           "",
 	},
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,9 +28,9 @@ func TestReplicaConfigMarshal(t *testing.T) {
 	conf.Mounter.WorkerNum = 3
 	b, err := conf.Marshal()
 	require.Nil(t, err)
-	require.Equal(t, `{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","max-log-size":64,"flush-interval":1000,"storage":"local","s3-uri":""}}`, b)
+	require.Equal(t, `{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"none","max-log-size":64,"flush-interval":1000,"storage":""}}`, b)
 	conf2 := new(ReplicaConfig)
-	err = conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","max-log-size":64,"flush-interval":1000,"storage":"local","s3-uri":""}}`))
+	err = conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null},"mounter":{"worker-num":3},"sink":{"dispatchers":null,"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"none","max-log-size":64,"flush-interval":1000,"storage":""}}`))
 	require.Nil(t, err)
 	require.Equal(t, conf, conf2)
 }
@@ -51,7 +51,7 @@ func TestReplicaConfigClone(t *testing.T) {
 func TestReplicaConfigOutDated(t *testing.T) {
 	t.Parallel()
 	conf2 := new(ReplicaConfig)
-	err := conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":3},"sink":{"dispatch-rules":[{"db-name":"a","tbl-name":"b","rule":"r1"},{"db-name":"a","tbl-name":"c","rule":"r2"},{"db-name":"a","tbl-name":"d","rule":"r2"}],"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"normal","max-log-size":64,"flush-interval":1000,"storage":"local","s3-uri":""}}`))
+	err := conf2.Unmarshal([]byte(`{"case-sensitive":false,"enable-old-value":true,"force-replicate":true,"check-gc-safe-point":true,"filter":{"rules":["1.1"],"ignore-txn-start-ts":null,"ddl-allow-list":null},"mounter":{"worker-num":3},"sink":{"dispatch-rules":[{"db-name":"a","tbl-name":"b","rule":"r1"},{"db-name":"a","tbl-name":"c","rule":"r2"},{"db-name":"a","tbl-name":"d","rule":"r2"}],"protocol":"default"},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"scheduler":{"type":"table-number","polling-time":-1},"consistent":{"level":"none","max-log-size":64,"flush-interval":1000,"storage":""}}`))
 	require.Nil(t, err)
 
 	conf := GetDefaultReplicaConfig()

--- a/pkg/config/consistent.go
+++ b/pkg/config/consistent.go
@@ -19,5 +19,4 @@ type ConsistentConfig struct {
 	MaxLogSize        int64  `toml:"max-log-size" json:"max-log-size"`
 	FlushIntervalInMs int64  `toml:"flush-interval" json:"flush-interval"`
 	Storage           string `toml:"storage" json:"storage"`
-	S3URI             string `toml:"s3-uri" json:"s3-uri"`
 }

--- a/tests/consistent_replicate_local/conf/changefeed.toml
+++ b/tests/consistent_replicate_local/conf/changefeed.toml
@@ -1,3 +1,3 @@
 [consistent]
 level = "eventual"
-storage = "local"
+storage = "local:///tmp/tidb_cdc_test/consistent_replicate_local/nfs/redo"

--- a/tests/consistent_replicate_s3/conf/changefeed.toml
+++ b/tests/consistent_replicate_s3/conf/changefeed.toml
@@ -1,4 +1,3 @@
 [consistent]
 level = "eventual"
-storage = "s3"
-s3-uri = "s3://logbucket/test-changefeed?endpoint=http://127.0.0.1:24927/"
+storage = "s3://logbucket/test-changefeed?endpoint=http://127.0.0.1:24927/"

--- a/tests/consistent_replicate_s3/run.sh
+++ b/tests/consistent_replicate_s3/run.sh
@@ -48,7 +48,7 @@ function check_resolved_ts() {
 	changefeedid=$1
 	check_tso=$2
 	read_dir=$3
-	rts=$(cdc redo meta --storage=s3 --s3-uri="s3://logbucket/test-changefeed?endpoint=http://127.0.0.1:24927/" --dir="$read_dir" | grep -oE "resolved-ts:[0-9]+" | awk -F: '{print $2}')
+	rts=$(cdc redo meta --storage="s3://logbucket/test-changefeed?endpoint=http://127.0.0.1:24927/" --tmp-dir="$read_dir" | grep -oE "resolved-ts:[0-9]+" | awk -F: '{print $2}')
 	if [[ "$rts" -gt "$check_tso" ]]; then
 		return
 	fi
@@ -106,8 +106,8 @@ function run() {
 	export GO_FAILPOINTS=''
 	export AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY
 	export AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY
-	cdc redo apply --dir="$WORK_DIR/reod/apply" --storage="s3" \
-		--s3-uri="s3://logbucket/test-changefeed?endpoint=http://127.0.0.1:24927/" \
+	cdc redo apply --tmp-dir="$WORK_DIR/reod/apply" \
+		--storage="s3://logbucket/test-changefeed?endpoint=http://127.0.0.1:24927/" \
 		--sink-uri="mysql://normal:123456@127.0.0.1:3306/"
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Update some redo log related configuration, according to GA document.

### What is changed and how it works?

- Use `storage`, instead of `storage` and `s3-uri`, keep the same backend storage style with br. Ref: https://docs.pingcap.com/tidb/stable/backup-and-restore-storages#external-storages
- Change `dir` to `tmp-dir` in `cdc redo apply` and `cdc redo meta` commands.
- Change default consistent level to `none`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
