### PR TITLE
tests: fix MySQL error that redo applier may meet

### DIFF
--- a/pkg/applier/redo_test.go
+++ b/pkg/applier/redo_test.go
@@ -236,5 +236,5 @@ func TestApplyMeetSinkError(t *testing.T) {
 	}
 	ap := NewRedoApplier(cfg)
 	err = ap.Apply(ctx)
-	require.Regexp(t, "fail to open MySQL connection:.*connect: connection refused.*", err)
+	require.Regexp(t, "CDC:ErrMySQLConnectionError", err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close #3185 

MySQL sink can return error either in `sql.Open()` or `db.PingContext()`

`fail to open MySQL connection: [CDC:ErrMySQLConnectionError]dial tcp 127.0.0.1:37853: connect: connection refused: dial tcp 127.0.0.1:37853: connect: connection refused`

or 

`[CDC:ErrMySQLConnectionError]Open database connection failed: dial tcp 127.0.0.1:37390: connect: connection refused`

### What is changed and how it works?

Use `CDC:ErrMySQLConnectionError` to match both of these two errors.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
