### PR TITLE
p2p: fix unstable test TestServerWrapperDelayed

### DIFF
--- a/pkg/p2p/server_wrapper_test.go
+++ b/pkg/p2p/server_wrapper_test.go
@@ -181,6 +181,5 @@ func TestServerWrapperDelayed(t *testing.T) {
 
 	_ = failpoint.Disable("github.com/pingcap/ticdc/pkg/p2p/ServerWrapperSendMessageDelay")
 
-	time.Sleep(100 * time.Millisecond)
-	innerServer.AssertExpectations(t)
+	// It is enough for this test case to finish without panicking.
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```

[2021-11-03T03:03:49.175Z] [2021/11/03 11:01:57.701 +08:00] [INFO] [server_wrapper_test.go:49] ["error received"] [error="rpc error: code = Canceled desc = context canceled"]

[2021-11-03T03:03:49.175Z] --- FAIL: TestServerWrapperDelayed (0.13s)

[2021-11-03T03:03:49.175Z]     server_wrapper_test.go:185: FAIL:	OnNewMessage(*p2p.MessagePacket)

[2021-11-03T03:03:49.175Z]         		at: [server_wrapper_test.go:165]

[2021-11-03T03:03:49.175Z]     server_wrapper_test.go:185: FAIL: 0 out of 1 expectation(s) were met.

[2021-11-03T03:03:49.175Z]         	The code you are testing needs to make 1 more call(s).

[2021-11-03T03:03:49.175Z]         	at: [server_wrapper_test.go:185]

[2021-11-03T03:03:49.175Z] FAIL
```

### What is changed and how it works?
- This test case should be considered passed only if it does not panic, because we should not require a cancelled gRPC server to handle the request before it exits.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
