### PR TITLE
kv/client: fix region loss in single region handler

### DIFF
--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -235,7 +235,7 @@ func (w *regionWorker) checkShouldExit() error {
 	return nil
 }
 
-func (w *regionWorker) handleSingleRegionError(ctx context.Context, err error, state *regionFeedState) error {
+func (w *regionWorker) handleSingleRegionError(err error, state *regionFeedState) error {
 	if state.lastResolvedTs > state.sri.ts {
 		state.sri.ts = state.lastResolvedTs
 	}
@@ -388,26 +388,25 @@ func (w *regionWorker) processEvent(ctx context.Context, event *regionStatefulEv
 		case *cdcpb.Event_Entries_:
 			err = w.handleEventEntry(ctx, x, event.state)
 			if err != nil {
-				err = w.handleSingleRegionError(ctx, err, event.state)
+				err = w.handleSingleRegionError(err, event.state)
 			}
 		case *cdcpb.Event_Admin_:
 			log.Info("receive admin event", zap.Stringer("event", event.changeEvent))
 		case *cdcpb.Event_Error:
 			err = w.handleSingleRegionError(
-				ctx,
 				cerror.WrapError(cerror.ErrEventFeedEventError, &eventError{err: x.Error}),
 				event.state,
 			)
 		case *cdcpb.Event_ResolvedTs:
 			if err = w.handleResolvedTs(ctx, x.ResolvedTs, event.state); err != nil {
-				err = w.handleSingleRegionError(ctx, err, event.state)
+				err = w.handleSingleRegionError(err, event.state)
 			}
 		}
 	}
 
 	if event.resolvedTs != nil {
 		if err = w.handleResolvedTs(ctx, event.resolvedTs.Ts, event.state); err != nil {
-			err = w.handleSingleRegionError(ctx, err, event.state)
+			err = w.handleSingleRegionError(err, event.state)
 		}
 	}
 	event.state.lock.Unlock()

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -273,7 +273,7 @@ func (w *regionWorker) handleSingleRegionError(ctx context.Context, err error, s
 	}
 
 	revokeToken := !state.initialized
-	err2 := w.session.onRegionFail(ctx, regionErrorInfo{
+	err2 := w.session.onRegionFail(w.parentCtx, regionErrorInfo{
 		singleRegionInfo: state.sri,
 		err:              err,
 	}, revokeToken)

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -273,6 +273,8 @@ func (w *regionWorker) handleSingleRegionError(err error, state *regionFeedState
 	}
 
 	revokeToken := !state.initialized
+	// since the context used in region worker will be cancelled after region
+	// worker exits, we must use the parent context to prevent regionErrorInfo loss.
 	err2 := w.session.onRegionFail(w.parentCtx, regionErrorInfo{
 		singleRegionInfo: state.sri,
 		err:              err,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close #3288

Fix a region loss case, we can reproduce as following steps

1. Create a TiDB cluster with 5 TiKV nodes, create a table with 4TB data(or 100K regions)
2. Setup a TiCDC cluster to replicate table in step-1
3. Use TiUP to restart all these TiKVs without transferring leader region, by ` tiup cluster restart <cluster-name> -R tikv` command for example.
4. Observe the replication stucks even all regions are initialized. (Both cached regions and scanning regions are zero)

By comparing the initialized regions in TiCDC and all regions by querying `select region_id from information_schema.tikv_region_status where db_name = 'xx' and table_name = 'yy'` from TiDB, we can observe some regions are lost.

By querying the lost region id in TiCDC log, we found the region disconnected without reconnect

```
[2021/11/04 17:22:10.083 +08:00] [INFO] [client.go:777] ["start new request"] [request="{\"header\":{\"cluster_id\":7012827302444215878,\"ticdc_version\":\"5.2.0-master\"},\"region_id\":1122272,\"region_epoch\":{\"conf_ver\":980,\"version\":57145},\"checkpoint_ts\":428872226710487042,\"start_key\":\"dIAAAAAAAAD/L19ygAAAADL/CQwfAAAAAAD6\",\"end_key\":\"dIAAAAAAAAD/L19ygAAAADL/CpK/AAAAAAD6\",\"request_id\":383728,\"extra_op\":1,\"Request\":null}"] [addr=172.16.7.56:20161]
[2021/11/04 17:22:10.086 +08:00] [INFO] [region_worker.go:243] ["single region event feed disconnected"] [regionID=1122272] [requestID=383728] [span="[7480000000000000ff2f5f728000000032ff090c1f0000000000fa, 7480000000000000ff2f5f728000000032ff0a92bf0000000000fa)"] [checkpoint=428872226710487042] [error="[CDC:ErrEventFeedEventError]not_leader:<region_id:1122272 > : not_leader:<region_id:1122272 > "]
[2021/11/04 17:22:10.087 +08:00] [INFO] [region_range_lock.go:370] ["unlocked range"] [lockID=105] [regionID=1122272] [startKey=7480000000000000ff2f5f728000000032ff090c1f0000000000fa] [endKey=7480000000000000ff2f5f728000000032ff0a92bf0000000000fa] [checkpointTs=428872226710487042]
```

The root cause is kv client must recycle all failed regions, so we should use the root context of a kv client to call `onRegionFail`

This bug tends to happen when multiple TiKVs crash or forcing restart, and based on existing test, one TiKV crashes or restarts doesn't trigger this bug. And the more regions, the higher probability.

### What is changed and how it works?

Use the parent context of region worker to call `onRegionFail` when processing region failure.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
    - As the PR description described
 

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a bug that TiCDC could meet replication interruption when multiple TiKVs crash or forcing restart.
```
