### PR TITLE
kafka_consumer: remove useless kafka_consumer Dockerfile

### DIFF
--- a/kafka_consumer/Dockerfile
+++ b/kafka_consumer/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.13 as builder
-WORKDIR /go/src/github.com/pingcap/ticdc
-COPY . .
-RUN go mod download
-RUN make kafka_consumer
-
-FROM alpine:3.11
-COPY --from=builder  /go/src/github.com/pingcap/ticdc/bin/cdc_kafka_consumer /cdc_kafka_consumer
-CMD [ "/cdc_kafka_consumer" ]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

part of https://github.com/pingcap/ticdc/issues/2199

### What is changed and how it works?

remove useless kafka_consumer Dockerfile. We have reduced a root folder.
It is still using 1.13 of golang, which I believe is not used anywhere.
If you still want to keep it, I can move it to the right place.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

None
Side effects


None

Related changes

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note

None
```
