### PR TITLE
ticdc/processor: don't close error channel in receiver

### DIFF
--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -225,6 +225,9 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 	ctx, cancel := cdcContext.WithCancel(ctx)
 	p.cancel = cancel
 
+	// We don't close this error channel, since it is only safe to close channel
+	// in sender, and this channel will be used in many modules including sink,
+	// redo log manager, etc. Let runtime GC to recycle it.
 	errCh := make(chan error, 16)
 	p.wg.Add(1)
 	go func() {
@@ -236,7 +239,6 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
-				close(errCh)
 				return
 			case err := <-errCh:
 				if err == nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close #3411

### What is changed and how it works?

The error channel created in processor will be used in sink, sink manager and redo log manager. It is not safe to close a channel from channel receiver (ref: https://go101.org/article/channel-closing.html).
We don't close this error channel and let runtime GC to recycle it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
