### PR TITLE
sorter: rename some structures and methods to make revive happy

### DIFF
--- a/cdc/processor/pipeline/sorter.go
+++ b/cdc/processor/pipeline/sorter.go
@@ -47,7 +47,7 @@ type sorterNode struct {
 
 	mounter entry.Mounter
 
-	wg     errgroup.Group
+	eg     errgroup.Group
 	cancel context.CancelFunc
 
 	// The latest resolved ts that sorter has received.
@@ -81,7 +81,7 @@ func (n *sorterNode) Init(ctx pipeline.NodeContext) error {
 				zap.String("changefeed-id", ctx.ChangefeedVars().ID), zap.String("table-name", n.tableName))
 		}
 		sortDir := ctx.ChangefeedVars().Info.SortDir
-		err := unified.UnifiedSorterCheckDir(sortDir)
+		err := unified.CheckDir(sortDir)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -95,11 +95,11 @@ func (n *sorterNode) Init(ctx pipeline.NodeContext) error {
 	failpoint.Inject("ProcessorAddTableError", func() {
 		failpoint.Return(errors.New("processor add table injected error"))
 	})
-	n.wg.Go(func() error {
+	n.eg.Go(func() error {
 		ctx.Throw(errors.Trace(sorter.Run(stdCtx)))
 		return nil
 	})
-	n.wg.Go(func() error {
+	n.eg.Go(func() error {
 		// Since the flowController is implemented by `Cond`, it is not cancelable
 		// by a context. We need to listen on cancellation and aborts the flowController
 		// manually.
@@ -107,7 +107,7 @@ func (n *sorterNode) Init(ctx pipeline.NodeContext) error {
 		n.flowController.Abort()
 		return nil
 	})
-	n.wg.Go(func() error {
+	n.eg.Go(func() error {
 		lastSentResolvedTs := uint64(0)
 		lastSendResolvedTsTime := time.Now() // the time at which we last sent a resolved-ts.
 		lastCRTs := uint64(0)                // the commit-ts of the last row changed we sent.
@@ -222,7 +222,7 @@ func (n *sorterNode) Receive(ctx pipeline.NodeContext) error {
 func (n *sorterNode) Destroy(ctx pipeline.NodeContext) error {
 	defer tableMemoryHistogram.DeleteLabelValues(ctx.ChangefeedVars().ID, ctx.GlobalVars().CaptureInfo.AdvertiseAddr)
 	n.cancel()
-	return n.wg.Wait()
+	return n.eg.Wait()
 }
 
 func (n *sorterNode) ResolvedTs() model.Ts {

--- a/cdc/sorter/unified/merger.go
+++ b/cdc/sorter/unified/merger.go
@@ -64,7 +64,7 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 			default:
 				// The task has not finished, so we give up.
 				// It does not matter because:
-				// 1) if the async workerpool has exited, it means the CDC process is exiting, UnifiedSorterCleanUp will
+				// 1) if the async workerpool has exited, it means the CDC process is exiting, CleanUp will
 				// take care of the temp files,
 				// 2) if the async workerpool is not exiting, the unfinished tasks will eventually be executed,
 				// and by that time, since the `onExit` have canceled them, they will not do any IO and clean up themselves.

--- a/cdc/sorter/unified/sorter_test.go
+++ b/cdc/sorter/unified/sorter_test.go
@@ -59,7 +59,7 @@ func generateMockRawKV(ts uint64) *model.RawKVEntry {
 
 func (s *sorterSuite) TestSorterBasic(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	conf := config.GetDefaultServerConfig()
 	conf.DataDir = c.MkDir()
@@ -87,7 +87,7 @@ func (s *sorterSuite) TestSorterBasic(c *check.C) {
 
 func (s *sorterSuite) TestSorterCancel(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	conf := config.GetDefaultServerConfig()
 	conf.DataDir = c.MkDir()
@@ -231,7 +231,7 @@ func testSorter(ctx context.Context, c *check.C, sorter sorter.EventSorter, coun
 
 func (s *sorterSuite) TestSortDirConfigLocal(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	poolMu.Lock()
 	// Clean up the back-end pool if one has been created
@@ -261,7 +261,7 @@ func (s *sorterSuite) TestSortDirConfigLocal(c *check.C) {
 
 func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	poolMu.Lock()
 	// Clean up the back-end pool if one has been created
@@ -290,7 +290,7 @@ func (s *sorterSuite) TestSortDirConfigChangeFeed(c *check.C) {
 // restarted. There should not be any problem, especially file corruptions.
 func (s *sorterSuite) TestSorterCancelRestart(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	conf := config.GetDefaultServerConfig()
 	conf.DataDir = c.MkDir()
@@ -334,7 +334,7 @@ func (s *sorterSuite) TestSorterCancelRestart(c *check.C) {
 
 func (s *sorterSuite) TestSorterIOError(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	conf := config.GetDefaultServerConfig()
 	conf.DataDir = c.MkDir()
@@ -378,7 +378,7 @@ func (s *sorterSuite) TestSorterIOError(c *check.C) {
 	case <-finishedCh:
 	}
 
-	UnifiedSorterCleanUp()
+	CleanUp()
 	_ = failpoint.Disable("github.com/pingcap/ticdc/cdc/sorter/unified/InjectErrorBackEndAlloc")
 	// enable the failpoint to simulate backEnd write error (usually would happen when writing to a file)
 	err = failpoint.Enable("github.com/pingcap/ticdc/cdc/sorter/unified/InjectErrorBackEndWrite", "return(true)")
@@ -408,7 +408,7 @@ func (s *sorterSuite) TestSorterIOError(c *check.C) {
 
 func (s *sorterSuite) TestSorterErrorReportCorrect(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	log.SetLevel(zapcore.DebugLevel)
 	defer log.SetLevel(zapcore.InfoLevel)
@@ -464,7 +464,7 @@ func (s *sorterSuite) TestSorterErrorReportCorrect(c *check.C) {
 
 func (s *sorterSuite) TestSortClosedAddEntry(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	sorter, err := NewUnifiedSorter(c.MkDir(),
 		"test-cf",
@@ -494,7 +494,7 @@ func (s *sorterSuite) TestSortClosedAddEntry(c *check.C) {
 
 func (s *sorterSuite) TestUnifiedSorterFileLockConflict(c *check.C) {
 	defer testleak.AfterTest(c)()
-	defer UnifiedSorterCleanUp()
+	defer CleanUp()
 
 	dir := c.MkDir()
 	captureAddr := "0.0.0.0:0"

--- a/cdc/sorter/unified/unified_sorter.go
+++ b/cdc/sorter/unified/unified_sorter.go
@@ -34,9 +34,8 @@ const (
 	heapCollectChSize = 128 // this should be not be too small, to guarantee IO concurrency
 )
 
-// UnifiedSorter provides both sorting in memory and in file. Memory pressure is used to determine which one to use.
-//nolint:revive
-type UnifiedSorter struct {
+// Sorter provides both sorting in memory and in file. Memory pressure is used to determine which one to use.
+type Sorter struct {
 	inputCh     chan *model.PolymorphicEvent
 	outputCh    chan *model.PolymorphicEvent
 	dir         string
@@ -55,13 +54,12 @@ type metricsInfo struct {
 
 type ctxKey struct{}
 
-// UnifiedSorterCheckDir checks whether the directory needed exists and is writable.
+// CheckDir checks whether the directory needed exists and is writable.
 // If it does not exist, we try to create one.
 // parameter: cfSortDir - the directory designated in changefeed's setting,
 // which will be overridden by a non-empty local setting of `sort-dir`.
 // TODO better way to organize this function after we obsolete chanegfeed setting's `sort-dir`
-//nolint:revive
-func UnifiedSorterCheckDir(cfSortDir string) error {
+func CheckDir(cfSortDir string) error {
 	dir := cfSortDir
 	sorterConfig := config.GetGlobalServerConfig().Sorter
 	if sorterConfig.SortDir != "" {
@@ -84,13 +82,13 @@ func UnifiedSorterCheckDir(cfSortDir string) error {
 	return nil
 }
 
-// NewUnifiedSorter creates a new UnifiedSorter
+// NewUnifiedSorter creates a new Sorter
 func NewUnifiedSorter(
 	dir string,
 	changeFeedID model.ChangeFeedID,
 	tableName string,
 	tableID model.TableID,
-	captureAddr string) (*UnifiedSorter, error) {
+	captureAddr string) (*Sorter, error) {
 	poolMu.Lock()
 	defer poolMu.Unlock()
 
@@ -108,7 +106,7 @@ func NewUnifiedSorter(
 	}
 
 	lazyInitWorkerPool()
-	return &UnifiedSorter{
+	return &Sorter{
 		inputCh:  make(chan *model.PolymorphicEvent, inputChSize),
 		outputCh: make(chan *model.PolymorphicEvent, outputChSize),
 		dir:      dir,
@@ -123,9 +121,8 @@ func NewUnifiedSorter(
 	}, nil
 }
 
-// UnifiedSorterCleanUp cleans up the files that might have been used.
-//nolint:revive
-func UnifiedSorterCleanUp() {
+// CleanUp cleans up the files that might have been used.
+func CleanUp() {
 	poolMu.Lock()
 	defer poolMu.Unlock()
 
@@ -146,7 +143,7 @@ func ResetGlobalPoolWithoutCleanup() {
 }
 
 // Run implements the EventSorter interface
-func (s *UnifiedSorter) Run(ctx context.Context) error {
+func (s *Sorter) Run(ctx context.Context) error {
 	failpoint.Inject("sorterDebug", func() {
 		log.Info("sorterDebug: Running Unified Sorter in debug mode")
 	})
@@ -275,7 +272,7 @@ func (s *UnifiedSorter) Run(ctx context.Context) error {
 }
 
 // AddEntry implements the EventSorter interface
-func (s *UnifiedSorter) AddEntry(ctx context.Context, entry *model.PolymorphicEvent) {
+func (s *Sorter) AddEntry(ctx context.Context, entry *model.PolymorphicEvent) {
 	select {
 	case <-ctx.Done():
 		return
@@ -285,7 +282,7 @@ func (s *UnifiedSorter) AddEntry(ctx context.Context, entry *model.PolymorphicEv
 }
 
 // Output implements the EventSorter interface
-func (s *UnifiedSorter) Output() <-chan *model.PolymorphicEvent {
+func (s *Sorter) Output() <-chan *model.PolymorphicEvent {
 	return s.outputCh
 }
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -131,7 +131,7 @@ func (o *options) run(cmd *cobra.Command) error {
 		return errors.Annotate(err, "run server")
 	}
 	server.Close()
-	unified.UnifiedSorterCleanUp()
+	unified.CleanUp()
 	log.Info("cdc server exits successfully")
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

None

### What is changed and how it works?

trivial refactor for unified sorter.

rename some structures and methods to make happy.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

None

Related changes

None


### Release note <!-- bugfixes or new feature need a release note -->

```release-note

None

```
