### PR TITLE
cdc/sink: adjust kafka producer configuration

### DIFF
--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -610,7 +610,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// replication logs, this process will last from a few seconds to a few minutes.
 	// Kafka cluster will not provide a writing service in this process.
 	config.Metadata.Retry.Max = math.MaxInt
-	config.Metadata.Timeout = 10 * time.Second
+	config.Metadata.Timeout = time.Minute
 
 	config.Producer.Partitioner = sarama.NewManualPartitioner
 	config.Producer.MaxMessageBytes = c.MaxMessageBytes

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -606,7 +606,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// Kafka cluster will not provide a writing service in this process.
 	// Time out in one minute
 	config.Metadata.Retry.Max = math.MaxInt32
-	config.Metadata.Timeout = time.Minute
+	config.Metadata.Timeout = 10 * time.Second
 
 	config.Producer.Partitioner = sarama.NewManualPartitioner
 	config.Producer.MaxMessageBytes = c.MaxMessageBytes

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -554,10 +554,6 @@ func NewKafkaSaramaProducer(ctx context.Context, topic string, protocol codec.Pr
 	return k, nil
 }
 
-func init() {
-	sarama.MaxRequestSize = 1024 * 1024 * 1024 // 1GB
-}
-
 var (
 	validClientID     = regexp.MustCompile(`\A[A-Za-z0-9._-]+\z`)
 	commonInvalidChar = regexp.MustCompile(`[\?:,"]`)

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -608,7 +608,6 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// Time out in one minute
 	config.Metadata.Retry.Max = math.MaxInt32
 	config.Metadata.Timeout = time.Minute
-	config.Metadata.Full = false
 
 	config.Producer.Partitioner = sarama.NewManualPartitioner
 	config.Producer.MaxMessageBytes = c.MaxMessageBytes

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -599,6 +599,10 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// in an unstable network environment, the default `Timeout` is 3s, just keep retry.
 	config.Admin.Retry.Max = math.MaxInt32
 
+	config.Net.DialTimeout = 5 * time.Second
+	config.Net.WriteTimeout = 5 * time.Second
+	config.Net.ReadTimeout = 5 * time.Second
+
 	// See: https://kafka.apache.org/documentation/#replication
 	// When one of the brokers in a Kafka cluster is down, the partition leaders
 	// in this broker is broken, Kafka will election a new partition leader and

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -595,9 +595,10 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 		return nil, errors.Trace(err)
 	}
 
+	// For admin related operation, such as `CreateTopic`, use the default Admin configuration.
+
 	// TiCDC would do some admin operation with kafka broker cluster, and could block the owner
 	// in an unstable network environment, the default `Timeout` is 3s, just keep retry.
-	config.Admin.Retry.Max = math.MaxInt32
 
 	config.Net.DialTimeout = 5 * time.Second
 	config.Net.WriteTimeout = 5 * time.Second

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -617,7 +617,6 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
-
 	config.Producer.Retry.Max = 5
 
 	switch strings.ToLower(strings.TrimSpace(c.Compression)) {

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -16,7 +16,6 @@ package kafka
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -613,7 +612,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// replication logs, this process will last from a few seconds to a few minutes.
 	// Kafka cluster will not provide a writing service in this process.
 	// Time out in one minute
-	config.Metadata.Retry.Max = math.MaxInt32
+	config.Metadata.Retry.Max = 50
 	config.Metadata.Timeout = 10 * time.Second
 
 	config.Producer.Partitioner = sarama.NewManualPartitioner

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -619,9 +619,9 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	config.Producer.Return.Errors = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
-	// Time out in five minutes(600 * 500ms).
-	config.Producer.Retry.Max = 600
-	config.Producer.Retry.Backoff = 500 * time.Millisecond
+	// Time out in 30s.
+	config.Producer.Retry.Max = math.MaxInt
+	config.Producer.Timeout = 30 * time.Second
 
 	switch strings.ToLower(strings.TrimSpace(c.Compression)) {
 	case "none":

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -614,7 +614,6 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	config.Producer.Return.Errors = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
-	// Time out in 30s.
 	config.Producer.Retry.Max = 5
 
 	switch strings.ToLower(strings.TrimSpace(c.Compression)) {

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -615,8 +615,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
 	// Time out in 30s.
-	config.Producer.Retry.Max = math.MaxInt32
-	config.Producer.Timeout = 30 * time.Second
+	config.Producer.Retry.Max = 5
 
 	switch strings.ToLower(strings.TrimSpace(c.Compression)) {
 	case "none":

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -609,6 +609,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// in this broker is broken, Kafka will election a new partition leader and
 	// replication logs, this process will last from a few seconds to a few minutes.
 	// Kafka cluster will not provide a writing service in this process.
+	// Time out in one minute
 	config.Metadata.Retry.Max = math.MaxInt
 	config.Metadata.Timeout = time.Minute
 

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -597,7 +597,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 
 	// TiCDC would do some admin operation with kafka broker cluster, and could block the owner
 	// in an unstable network environment, we set timeout to 10s at most.
-	config.Admin.Retry.Max = math.MaxInt
+	config.Admin.Retry.Max = math.MaxInt32
 	config.Admin.Timeout = 10 * time.Second
 
 	// See: https://kafka.apache.org/documentation/#replication
@@ -606,7 +606,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// replication logs, this process will last from a few seconds to a few minutes.
 	// Kafka cluster will not provide a writing service in this process.
 	// Time out in one minute
-	config.Metadata.Retry.Max = math.MaxInt
+	config.Metadata.Retry.Max = math.MaxInt32
 	config.Metadata.Timeout = time.Minute
 
 	config.Producer.Partitioner = sarama.NewManualPartitioner
@@ -616,7 +616,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
 	// Time out in 30s.
-	config.Producer.Retry.Max = math.MaxInt
+	config.Producer.Retry.Max = math.MaxInt32
 	config.Producer.Timeout = 30 * time.Second
 
 	switch strings.ToLower(strings.TrimSpace(c.Compression)) {

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -595,11 +595,10 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// For admin related operation, such as `CreateTopic`, use the default Admin configuration.
+	// TiCDC would do some admin operation, such as `CreateTopic`, use the default Admin configuration.
 
-	// TiCDC would do some admin operation with kafka broker cluster, and could block the owner
-	// in an unstable network environment, the default `Timeout` is 3s, just keep retry.
-
+	// The default Net Timeout is 30 seconds, which is quite long.
+	// For operation that cannot get response in 3 ~ 5 seconds, it seems unlikely be responded in 30 seconds.
 	config.Net.DialTimeout = 5 * time.Second
 	config.Net.WriteTimeout = 5 * time.Second
 	config.Net.ReadTimeout = 5 * time.Second

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -608,6 +608,7 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	// Time out in one minute
 	config.Metadata.Retry.Max = math.MaxInt32
 	config.Metadata.Timeout = time.Minute
+	config.Metadata.Full = false
 
 	config.Producer.Partitioner = sarama.NewManualPartitioner
 	config.Producer.MaxMessageBytes = c.MaxMessageBytes

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -596,9 +596,8 @@ func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
 	}
 
 	// TiCDC would do some admin operation with kafka broker cluster, and could block the owner
-	// in an unstable network environment, we set timeout to 10s at most.
+	// in an unstable network environment, the default `Timeout` is 3s, just keep retry.
 	config.Admin.Retry.Max = math.MaxInt32
-	config.Admin.Timeout = 10 * time.Second
 
 	// See: https://kafka.apache.org/documentation/#replication
 	// When one of the brokers in a Kafka cluster is down, the partition leaders

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -119,7 +119,6 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	metadataResponse.AddTopicPartition(topic, 1, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
 	leader.Returns(metadataResponse)
 	leader.Returns(metadataResponse)
-
 	prodSuccess := new(sarama.ProduceResponse)
 	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
 	prodSuccess.AddTopicPartition(topic, 1, sarama.ErrNoError)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR tries to make producer configuration, especially `retry` and `timeout` related items be more reasonable.

### What is changed and how it works?
* For Net-related, Set `DialTimeout` / `WriteTimeout` / `ReadTimeout` to 5s at the moment. `30s -> 5s`
  * **Net-related timeout is the base for almost all operations, and it's the lower bound for all other Timeout**
  * At the moment, `30s` is quite long which will make the owner block.
  * When creating the changefeed, WriteTimeout will affect `NewClient` / `ListTopic` / `DescribeCluster` / `DescribeConfig` operation et al. 
* For Admin-related
  * When creating the changefeed, it will affect the `CreateTopic` operation. 
  * Set single request timeout to `5s`.
* For Metadata-related, it's Timeout is the hard upper bound with retry. set `Metadata.Retry.Max` to infinity, and set hard timeout to `10s`.
  * Current configuration, the maximum block time may be as long as `3690` seconds. take https://github.com/Shopify/sarama/blob/main/config.go#L150 as a reference.
  * When creating the changefeed, the sarama client will try to GetMedadata, just the timeout to `10s`.
  * When the changefeed running, the producer will refresh metadata in the background every 10 minutes. 
* For producer-related, 
  * Set `Producer.Timeout` to `10s`, which is the single request timeout for receiving all required `RequiredAcks`.
  * set `Producer.Retry.Max` to 5, and `Producer.Retry.Backoff` to 100ms, around 50 seconds at all.
  * Original, Set `Producer.Retry.Max` to`600`. In the worst case, would cost 6000s for the message.
 
* Remove `sarama.MaxRequestSize = 1024 * 1024 *1024`, use the default 100MB.
  * For each CDC message, it will be batched into a `batch`, batchByteSize will not be greater than user configured `max-message-bytes` or default `1M`.
  * When a producer sends a request to the broker cluster, it may send multiple batches in a single request.
  * `MaxRequestSize` is identical to [socket.request.max.bytes](https://kafka.apache.org/documentation/?from=from_parent_mindnote#brokerconfigs_socket.request.max.bytes), which is default to 100MB, just use the default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
