### PR TITLE
cdc/scheduler_v2: refine TableSet for scheduler

### DIFF
--- a/cdc/scheduler/util/table_set.go
+++ b/cdc/scheduler/util/table_set.go
@@ -14,7 +14,10 @@
 package util
 
 import (
+	"log"
+
 	"github.com/pingcap/ticdc/cdc/model"
+	"go.uber.org/zap"
 )
 
 // TableSet provides a data structure to store the tables' states for the
@@ -100,10 +103,10 @@ func (s *TableSet) UpdateTableRecord(record *TableRecord) (successful bool) {
 	// by AddTableRecord.
 	if record.CaptureID != oldRecord.CaptureID {
 		if ok := s.RemoveTableRecord(record.TableID); !ok {
-			panic("unreachable")
+			log.Panic("unreachable", zap.Any("record", record))
 		}
 		if ok := s.AddTableRecord(record); !ok {
-			panic("unreachable")
+			log.Panic("unreachable", zap.Any("record", record))
 		}
 	}
 	return true
@@ -129,7 +132,7 @@ func (s *TableSet) RemoveTableRecord(tableID model.TableID) bool {
 
 	captureIndexEntry, ok := s.captureIndex[record.CaptureID]
 	if !ok {
-		panic("unreachable")
+		log.Panic("unreachable", zap.Int64("table-id", tableID))
 	}
 	delete(captureIndexEntry, record.TableID)
 	if len(captureIndexEntry) == 0 {

--- a/cdc/scheduler/util/table_set.go
+++ b/cdc/scheduler/util/table_set.go
@@ -38,6 +38,9 @@ type TableRecord struct {
 	Status    TableStatus
 }
 
+// Clone returns a copy of the TableSet.
+// This method is future-proof in case we add
+// something not trivially copyable.
 func (r *TableRecord) Clone() *TableRecord {
 	return &TableRecord{
 		TableID:   r.TableID,
@@ -70,7 +73,8 @@ func (s *TableSet) AddTableRecord(record *TableRecord) (successful bool) {
 		// duplicate tableID
 		return false
 	}
-	s.tableIDMap[record.TableID] = record.Clone()
+	recordCloned := record.Clone()
+	s.tableIDMap[record.TableID] = recordCloned
 
 	captureIndexEntry := s.captureIndex[record.CaptureID]
 	if captureIndexEntry == nil {
@@ -78,7 +82,7 @@ func (s *TableSet) AddTableRecord(record *TableRecord) (successful bool) {
 		s.captureIndex[record.CaptureID] = captureIndexEntry
 	}
 
-	captureIndexEntry[record.TableID] = record.Clone()
+	captureIndexEntry[record.TableID] = recordCloned
 	return true
 }
 
@@ -94,8 +98,9 @@ func (s *TableSet) UpdateTableRecord(record *TableRecord) (successful bool) {
 	// If there is no need to modify the CaptureID, we simply
 	// update the record.
 	if record.CaptureID == oldRecord.CaptureID {
-		s.tableIDMap[record.TableID] = record.Clone()
-		s.captureIndex[record.CaptureID][record.TableID] = record.Clone()
+		recordCloned := record.Clone()
+		s.tableIDMap[record.TableID] = recordCloned
+		s.captureIndex[record.CaptureID][record.TableID] = recordCloned
 		return true
 	}
 

--- a/cdc/scheduler/util/table_set.go
+++ b/cdc/scheduler/util/table_set.go
@@ -88,12 +88,16 @@ func (s *TableSet) UpdateTableRecord(record *TableRecord) (successful bool) {
 		return false
 	}
 
+	// If there is no need to modify the CaptureID, we simply
+	// update the record.
 	if record.CaptureID == oldRecord.CaptureID {
 		s.tableIDMap[record.TableID] = record.Clone()
 		s.captureIndex[record.CaptureID][record.TableID] = record.Clone()
 		return true
 	}
 
+	// If the CaptureID is changed, we do a proper RemoveTableRecord followed
+	// by AddTableRecord.
 	if record.CaptureID != oldRecord.CaptureID {
 		if ok := s.RemoveTableRecord(record.TableID); !ok {
 			panic("unreachable")
@@ -145,6 +149,8 @@ func (s *TableSet) RemoveTableRecordByCaptureID(captureID model.CaptureID) []*Ta
 	var ret []*TableRecord
 	for tableID, record := range captureIndexEntry {
 		delete(s.tableIDMap, tableID)
+		// Since the record has been removed,
+		// there is no need to clone it before returning.
 		ret = append(ret, record)
 	}
 	delete(s.captureIndex, captureID)

--- a/cdc/scheduler/util/table_set_test.go
+++ b/cdc/scheduler/util/table_set_test.go
@@ -145,7 +145,19 @@ func TestTableSetCaptures(t *testing.T) {
 		},
 	}, captureToTableMap)
 
-	ts.RemoveTableRecordByCaptureID("capture-3")
+	removed := ts.RemoveTableRecordByCaptureID("capture-3")
+	require.Len(t, removed, 2)
+	require.Contains(t, removed, &TableRecord{
+		TableID:   5,
+		CaptureID: "capture-3",
+		Status:    0,
+	})
+	require.Contains(t, removed, &TableRecord{
+		TableID:   6,
+		CaptureID: "capture-3",
+		Status:    0,
+	})
+
 	_, ok = ts.GetTableRecord(5)
 	require.False(t, ok)
 	_, ok = ts.GetTableRecord(6)
@@ -214,4 +226,66 @@ func TestCountTableByStatus(t *testing.T) {
 	require.Equal(t, 2, ts.CountTableByStatus(1))
 	require.Equal(t, 2, ts.CountTableByStatus(2))
 	require.Equal(t, 1, ts.CountTableByStatus(3))
+}
+
+func TestUpdateTableRecord(t *testing.T) {
+	ts := NewTableSet()
+	ok := ts.AddTableRecord(&TableRecord{
+		TableID:   1,
+		CaptureID: "capture-1",
+		Status:    0,
+	})
+	require.True(t, ok)
+
+	ok = ts.AddTableRecord(&TableRecord{
+		TableID:   2,
+		CaptureID: "capture-1",
+		Status:    0,
+	})
+	require.True(t, ok)
+
+	ok = ts.AddTableRecord(&TableRecord{
+		TableID:   3,
+		CaptureID: "capture-2",
+		Status:    0,
+	})
+	require.True(t, ok)
+
+	ok = ts.AddTableRecord(&TableRecord{
+		TableID:   4,
+		CaptureID: "capture-2",
+		Status:    0,
+	})
+	require.True(t, ok)
+
+	ok = ts.AddTableRecord(&TableRecord{
+		TableID:   5,
+		CaptureID: "capture-3",
+		Status:    0,
+	})
+	require.True(t, ok)
+
+	ok = ts.UpdateTableRecord(&TableRecord{
+		TableID:   5,
+		CaptureID: "capture-3",
+		Status:    1,
+	})
+	require.True(t, ok)
+
+	rec, ok := ts.GetTableRecord(5)
+	require.True(t, ok)
+	require.Equal(t, TableStatus(1), rec.Status)
+	require.Equal(t, TableStatus(1), ts.GetAllTablesGroupedByCaptures()["capture-3"][5].Status)
+
+	ok = ts.UpdateTableRecord(&TableRecord{
+		TableID:   4,
+		CaptureID: "capture-3",
+		Status:    1,
+	})
+	require.True(t, ok)
+	rec, ok = ts.GetTableRecord(4)
+	require.True(t, ok)
+	require.Equal(t, TableStatus(1), rec.Status)
+	require.Equal(t, "capture-3", rec.CaptureID)
+	require.Equal(t, TableStatus(1), ts.GetAllTablesGroupedByCaptures()["capture-3"][4].Status)
 }

--- a/cdc/scheduler/util/table_set_test.go
+++ b/cdc/scheduler/util/table_set_test.go
@@ -231,27 +231,6 @@ func TestCountTableByStatus(t *testing.T) {
 func TestUpdateTableRecord(t *testing.T) {
 	ts := NewTableSet()
 	ok := ts.AddTableRecord(&TableRecord{
-		TableID:   1,
-		CaptureID: "capture-1",
-		Status:    0,
-	})
-	require.True(t, ok)
-
-	ok = ts.AddTableRecord(&TableRecord{
-		TableID:   2,
-		CaptureID: "capture-1",
-		Status:    0,
-	})
-	require.True(t, ok)
-
-	ok = ts.AddTableRecord(&TableRecord{
-		TableID:   3,
-		CaptureID: "capture-2",
-		Status:    0,
-	})
-	require.True(t, ok)
-
-	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   4,
 		CaptureID: "capture-2",
 		Status:    0,

--- a/cdc/scheduler/util/table_set_test.go
+++ b/cdc/scheduler/util/table_set_test.go
@@ -25,14 +25,14 @@ func TestTableSetBasics(t *testing.T) {
 	ok := ts.AddTableRecord(&TableRecord{
 		TableID:   1,
 		CaptureID: "capture-1",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   1,
 		CaptureID: "capture-2",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	// Adding a duplicate table record should fail
 	require.False(t, ok)
@@ -42,7 +42,7 @@ func TestTableSetBasics(t *testing.T) {
 	require.Equal(t, &TableRecord{
 		TableID:   1,
 		CaptureID: "capture-1",
-		Status:    0,
+		Status:    AddingTable,
 	}, record)
 
 	ok = ts.RemoveTableRecord(1)
@@ -57,35 +57,35 @@ func TestTableSetCaptures(t *testing.T) {
 	ok := ts.AddTableRecord(&TableRecord{
 		TableID:   1,
 		CaptureID: "capture-1",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   2,
 		CaptureID: "capture-1",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   3,
 		CaptureID: "capture-2",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   4,
 		CaptureID: "capture-2",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   5,
 		CaptureID: "capture-3",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
@@ -96,7 +96,7 @@ func TestTableSetCaptures(t *testing.T) {
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   6,
 		CaptureID: "capture-3",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 	require.Equal(t, 2, ts.CountTableByCaptureID("capture-3"))
@@ -123,24 +123,24 @@ func TestTableSetCaptures(t *testing.T) {
 			1: &TableRecord{
 				TableID:   1,
 				CaptureID: "capture-1",
-				Status:    0,
+				Status:    AddingTable,
 			},
 			2: &TableRecord{
 				TableID:   2,
 				CaptureID: "capture-1",
-				Status:    0,
+				Status:    AddingTable,
 			},
 		},
 		"capture-3": {
 			5: &TableRecord{
 				TableID:   5,
 				CaptureID: "capture-3",
-				Status:    0,
+				Status:    AddingTable,
 			},
 			6: &TableRecord{
 				TableID:   6,
 				CaptureID: "capture-3",
-				Status:    0,
+				Status:    AddingTable,
 			},
 		},
 	}, captureToTableMap)
@@ -150,12 +150,12 @@ func TestTableSetCaptures(t *testing.T) {
 	require.Contains(t, removed, &TableRecord{
 		TableID:   5,
 		CaptureID: "capture-3",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.Contains(t, removed, &TableRecord{
 		TableID:   6,
 		CaptureID: "capture-3",
-		Status:    0,
+		Status:    AddingTable,
 	})
 
 	_, ok = ts.GetTableRecord(5)
@@ -168,12 +168,12 @@ func TestTableSetCaptures(t *testing.T) {
 		1: {
 			TableID:   1,
 			CaptureID: "capture-1",
-			Status:    0,
+			Status:    AddingTable,
 		},
 		2: {
 			TableID:   2,
 			CaptureID: "capture-1",
-			Status:    0,
+			Status:    AddingTable,
 		},
 	}, allTables)
 
@@ -191,41 +191,41 @@ func TestCountTableByStatus(t *testing.T) {
 	ok := ts.AddTableRecord(&TableRecord{
 		TableID:   1,
 		CaptureID: "capture-1",
-		Status:    1,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   2,
 		CaptureID: "capture-1",
-		Status:    2,
+		Status:    RunningTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   3,
 		CaptureID: "capture-2",
-		Status:    3,
+		Status:    RemovingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   4,
 		CaptureID: "capture-2",
-		Status:    1,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   5,
 		CaptureID: "capture-3",
-		Status:    2,
+		Status:    RunningTable,
 	})
 	require.True(t, ok)
 
-	require.Equal(t, 2, ts.CountTableByStatus(1))
-	require.Equal(t, 2, ts.CountTableByStatus(2))
-	require.Equal(t, 1, ts.CountTableByStatus(3))
+	require.Equal(t, 2, ts.CountTableByStatus(AddingTable))
+	require.Equal(t, 2, ts.CountTableByStatus(RunningTable))
+	require.Equal(t, 1, ts.CountTableByStatus(RemovingTable))
 }
 
 func TestUpdateTableRecord(t *testing.T) {
@@ -233,38 +233,38 @@ func TestUpdateTableRecord(t *testing.T) {
 	ok := ts.AddTableRecord(&TableRecord{
 		TableID:   4,
 		CaptureID: "capture-2",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.AddTableRecord(&TableRecord{
 		TableID:   5,
 		CaptureID: "capture-3",
-		Status:    0,
+		Status:    AddingTable,
 	})
 	require.True(t, ok)
 
 	ok = ts.UpdateTableRecord(&TableRecord{
 		TableID:   5,
 		CaptureID: "capture-3",
-		Status:    1,
+		Status:    RunningTable,
 	})
 	require.True(t, ok)
 
 	rec, ok := ts.GetTableRecord(5)
 	require.True(t, ok)
-	require.Equal(t, TableStatus(1), rec.Status)
-	require.Equal(t, TableStatus(1), ts.GetAllTablesGroupedByCaptures()["capture-3"][5].Status)
+	require.Equal(t, RunningTable, rec.Status)
+	require.Equal(t, RunningTable, ts.GetAllTablesGroupedByCaptures()["capture-3"][5].Status)
 
 	ok = ts.UpdateTableRecord(&TableRecord{
 		TableID:   4,
 		CaptureID: "capture-3",
-		Status:    1,
+		Status:    RunningTable,
 	})
 	require.True(t, ok)
 	rec, ok = ts.GetTableRecord(4)
 	require.True(t, ok)
-	require.Equal(t, TableStatus(1), rec.Status)
+	require.Equal(t, RunningTable, rec.Status)
 	require.Equal(t, "capture-3", rec.CaptureID)
-	require.Equal(t, TableStatus(1), ts.GetAllTablesGroupedByCaptures()["capture-3"][4].Status)
+	require.Equal(t, RunningTable, ts.GetAllTablesGroupedByCaptures()["capture-3"][4].Status)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- The scheduler needs a convenient way to update the table records.
- The scheduler needs to know which tables are removed when a capture goes offline, for better observability.

### What is changed and how it works?
- Implemented `func (s *TableSet) UpdateTableRecord(record *TableRecord) (successful bool)`
- Added return value for `func (s *TableSet) RemoveTableRecordByCaptureID(captureID model.CaptureID) []*TableRecord`.
- Minor adjustment of unit test cases.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
