### PR TITLE
cdc/sink: Refine sink interface

### DIFF
--- a/cdc/owner/async_sink_test.go
+++ b/cdc/owner/async_sink_test.go
@@ -65,7 +65,7 @@ func (m *mockSink) Close(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockSink) Barrier(ctx context.Context) error {
+func (m *mockSink) Barrier(ctx context.Context, tableID model.TableID) error {
 	return nil
 }
 

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -202,7 +202,7 @@ func NewTablePipeline(ctx cdcContext.Context,
 
 	p := pipeline.NewPipeline(ctx, 500*time.Millisecond, runnerSize, defaultOutputChannelSize)
 	sorterNode := newSorterNode(tableName, tableID, replicaInfo.StartTs, flowController, mounter)
-	sinkNode := newSinkNode(sink, replicaInfo.StartTs, targetTs, flowController)
+	sinkNode := newSinkNode(tableID, sink, replicaInfo.StartTs, targetTs, flowController)
 
 	p.AppendNode(ctx, "puller", newPullerNode(tableID, replicaInfo, tableName))
 	p.AppendNode(ctx, "sorter", sorterNode)

--- a/cdc/sink/black_hole.go
+++ b/cdc/sink/black_hole.go
@@ -46,7 +46,7 @@ func (b *blackHoleSink) EmitRowChangedEvents(ctx context.Context, rows ...*model
 	return nil
 }
 
-func (b *blackHoleSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error) {
+func (b *blackHoleSink) FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error) {
 	log.Debug("BlockHoleSink: FlushRowChangedEvents", zap.Uint64("resolvedTs", resolvedTs))
 	err := b.statistics.RecordBatchExecution(func() (int, error) {
 		// TODO: add some random replication latency
@@ -79,6 +79,6 @@ func (b *blackHoleSink) Close(ctx context.Context) error {
 	return nil
 }
 
-func (b *blackHoleSink) Barrier(ctx context.Context) error {
+func (b *blackHoleSink) Barrier(ctx context.Context, tableID model.TableID) error {
 	return nil
 }

--- a/cdc/sink/buffer_sink.go
+++ b/cdc/sink/buffer_sink.go
@@ -109,7 +109,8 @@ func (b *bufferSink) run(ctx context.Context, errCh chan error) {
 			b.bufferMu.Unlock()
 
 			start := time.Now()
-			checkpointTs, err := b.Sink.FlushRowChangedEvents(ctx, resolvedTs)
+			// todo: use real table ID
+			checkpointTs, err := b.Sink.FlushRowChangedEvents(ctx, 0, resolvedTs)
 			if err != nil {
 				if errors.Cause(err) != context.Canceled {
 					errCh <- err
@@ -146,7 +147,7 @@ func (b *bufferSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.Ro
 	return nil
 }
 
-func (b *bufferSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error) {
+func (b *bufferSink) FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error) {
 	select {
 	case <-ctx.Done():
 		return atomic.LoadUint64(&b.checkpointTs), ctx.Err()

--- a/cdc/sink/cdclog/file.go
+++ b/cdc/sink/cdclog/file.go
@@ -225,7 +225,7 @@ func (f *fileSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowC
 	return f.emitRowChangedEvents(ctx, newTableStream, rows...)
 }
 
-func (f *fileSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error) {
+func (f *fileSink) FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error) {
 	log.Debug("[FlushRowChangedEvents] enter", zap.Uint64("ts", resolvedTs))
 	return f.flushRowChangedEvents(ctx, resolvedTs)
 }
@@ -349,7 +349,7 @@ func (f *fileSink) Close(ctx context.Context) error {
 	return nil
 }
 
-func (f *fileSink) Barrier(ctx context.Context) error {
+func (f *fileSink) Barrier(ctx context.Context, tableID model.TableID) error {
 	// Barrier does nothing because FlushRowChangedEvents in file sink has flushed
 	// all buffered events forcedlly.
 	return nil

--- a/cdc/sink/cdclog/s3.go
+++ b/cdc/sink/cdclog/s3.go
@@ -222,7 +222,7 @@ func (s *s3Sink) flushLogMeta(ctx context.Context) error {
 	return cerror.WrapError(cerror.ErrS3SinkWriteStorage, s.storage.WriteFile(ctx, logMetaFile, data))
 }
 
-func (s *s3Sink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error) {
+func (s *s3Sink) FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error) {
 	// we should flush all events before resolvedTs, there are two kind of flush policy
 	// 1. flush row events to a s3 chunk: if the event size is not enough,
 	//    TODO: when cdc crashed, we should repair these chunks to a complete file
@@ -347,7 +347,7 @@ func (s *s3Sink) Close(ctx context.Context) error {
 	return nil
 }
 
-func (s *s3Sink) Barrier(ctx context.Context) error {
+func (s *s3Sink) Barrier(ctx context.Context, tableID model.TableID) error {
 	// Barrier does nothing because FlushRowChangedEvents in s3 sink has flushed
 	// all buffered events forcedlly.
 	return nil

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -155,7 +155,7 @@ func (k *mqSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowCha
 	return nil
 }
 
-func (k *mqSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error) {
+func (k *mqSink) FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error) {
 	if resolvedTs <= k.checkpointTs {
 		return k.checkpointTs, nil
 	}
@@ -260,7 +260,7 @@ func (k *mqSink) Close(ctx context.Context) error {
 	return errors.Trace(err)
 }
 
-func (k *mqSink) Barrier(cxt context.Context) error {
+func (k *mqSink) Barrier(cxt context.Context, tableID model.TableID) error {
 	// Barrier does nothing because FlushRowChangedEvents in mq sink has flushed
 	// all buffered events by force.
 	return nil

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -80,10 +80,12 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 
 	// mock kafka broker processes 1 row changed event
 	leader.Returns(prodSuccess)
+	tableID := model.TableID(1)
 	row := &model.RowChangedEvent{
 		Table: &model.TableName{
-			Schema: "test",
-			Table:  "t1",
+			Schema:  "test",
+			Table:   "t1",
+			TableID: tableID,
 		},
 		StartTs:  100,
 		CommitTs: 120,
@@ -91,11 +93,11 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	}
 	err = sink.EmitRowChangedEvents(ctx, row)
 	c.Assert(err, check.IsNil)
-	checkpointTs, err := sink.FlushRowChangedEvents(ctx, uint64(120))
+	checkpointTs, err := sink.FlushRowChangedEvents(ctx, tableID, uint64(120))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTs, check.Equals, uint64(120))
 	// flush older resolved ts
-	checkpointTs, err = sink.FlushRowChangedEvents(ctx, uint64(110))
+	checkpointTs, err = sink.FlushRowChangedEvents(ctx, tableID, uint64(110))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTs, check.Equals, uint64(120))
 

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -678,7 +678,7 @@ func (s MySQLSinkSuite) TestNewMySQLSinkExecDML(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	err = retry.Do(context.Background(), func() error {
-		ts, err := sink.FlushRowChangedEvents(ctx, uint64(2))
+		ts, err := sink.FlushRowChangedEvents(ctx, 2, uint64(2))
 		c.Assert(err, check.IsNil)
 		if ts < uint64(2) {
 			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts, 2)
@@ -689,7 +689,7 @@ func (s MySQLSinkSuite) TestNewMySQLSinkExecDML(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	err = retry.Do(context.Background(), func() error {
-		ts, err := sink.FlushRowChangedEvents(ctx, uint64(4))
+		ts, err := sink.FlushRowChangedEvents(ctx, 2, uint64(4))
 		c.Assert(err, check.IsNil)
 		if ts < uint64(4) {
 			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts, 4)
@@ -698,7 +698,7 @@ func (s MySQLSinkSuite) TestNewMySQLSinkExecDML(c *check.C) {
 	}, retry.WithBackoffBaseDelay(20), retry.WithMaxTries(10), retry.WithIsRetryableErr(cerror.IsRetryableError))
 	c.Assert(err, check.IsNil)
 
-	err = sink.Barrier(ctx)
+	err = sink.Barrier(ctx, 2)
 	c.Assert(err, check.IsNil)
 
 	err = sink.Close(ctx)

--- a/cdc/sink/simple_mysql_tester.go
+++ b/cdc/sink/simple_mysql_tester.go
@@ -186,7 +186,7 @@ func (s *simpleMySQLSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent)
 
 // FlushRowChangedEvents flushes each row which of commitTs less than or equal to `resolvedTs` into downstream.
 // TiCDC guarantees that all of Event which of commitTs less than or equal to `resolvedTs` are sent to Sink through `EmitRowChangedEvents`
-func (s *simpleMySQLSink) FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error) {
+func (s *simpleMySQLSink) FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error) {
 	s.rowsBufferLock.Lock()
 	defer s.rowsBufferLock.Unlock()
 	newBuffer := make([]*model.RowChangedEvent, 0, len(s.rowsBuffer))
@@ -216,7 +216,7 @@ func (s *simpleMySQLSink) Close(ctx context.Context) error {
 	return s.db.Close()
 }
 
-func (s *simpleMySQLSink) Barrier(ctx context.Context) error {
+func (s *simpleMySQLSink) Barrier(ctx context.Context, tableID model.TableID) error {
 	return nil
 }
 

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -45,7 +45,7 @@ type Sink interface {
 
 	// FlushRowChangedEvents flushes each row which of commitTs less than or equal to `resolvedTs` into downstream.
 	// TiCDC guarantees that all the Events whose commitTs is less than or equal to `resolvedTs` are sent to Sink through `EmitRowChangedEvents`
-	FlushRowChangedEvents(ctx context.Context, resolvedTs uint64) (uint64, error)
+	FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error)
 
 	// EmitCheckpointTs sends CheckpointTs to Sink
 	// TiCDC guarantees that all Events **in the cluster** which of commitTs less than or equal `checkpointTs` are sent to downstream successfully.
@@ -56,7 +56,7 @@ type Sink interface {
 
 	// Barrier is a synchronous function to wait all events to be flushed in underlying sink
 	// Note once Barrier is called, the resolved ts won't be pushed until the Barrier call returns.
-	Barrier(ctx context.Context) error
+	Barrier(ctx context.Context, tableID model.TableID) error
 }
 
 var sinkIniterMap = make(map[string]sinkInitFunc)

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -593,7 +593,7 @@ func syncFlushRowChangedEvents(ctx context.Context, sink sink.Sink, resolvedTs u
 			return ctx.Err()
 		default:
 		}
-		//todo: use real table id
+		// todo: use real table id
 		checkpointTs, err := sink.FlushRowChangedEvents(ctx, 0, resolvedTs)
 		if err != nil {
 			return err

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -593,7 +593,8 @@ func syncFlushRowChangedEvents(ctx context.Context, sink sink.Sink, resolvedTs u
 			return ctx.Err()
 		default:
 		}
-		checkpointTs, err := sink.FlushRowChangedEvents(ctx, resolvedTs)
+		//todo: use real table id
+		checkpointTs, err := sink.FlushRowChangedEvents(ctx, 0, resolvedTs)
 		if err != nil {
 			return err
 		}

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -151,7 +151,8 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 				lastSafeResolvedTs, lastResolvedTs = lastResolvedTs, redoLog.Row.CommitTs
 			}
 		}
-		_, err = s.FlushRowChangedEvents(ctx, lastSafeResolvedTs)
+		// todo: use real table ID
+		_, err = s.FlushRowChangedEvents(ctx, 0, lastSafeResolvedTs)
 		if err != nil {
 			return err
 		}
@@ -160,11 +161,11 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = s.FlushRowChangedEvents(ctx, resolvedTs)
+	_, err = s.FlushRowChangedEvents(ctx, 0, resolvedTs)
 	if err != nil {
 		return err
 	}
-	err = s.Barrier(ctx)
+	err = s.Barrier(ctx, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
To fix the bug of #3503 , we should manage table checkpoint per table in the sink, this is PR is a part of the fix. In this PR, only change the interface method, no real logic is changed.

### What is changed and how it works?
add table ID to Sink interface, below functions will be changed,
```
type Sink interface {
   FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error)
   Barrier(ctx context.Context, tableID model.TableID) error
}
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes
 - Has interface methods change

Side effects



Related changes


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 `None`.
```
