### PR TITLE
Fix handling of JSON columns

### DIFF
--- a/cdc/sink/codec/avro.go
+++ b/cdc/sink/codec/avro.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/types"
-	tijson "github.com/pingcap/tidb/types/json"
 	"go.uber.org/zap"
 )
 
@@ -476,7 +475,7 @@ func columnToAvroNativeData(col *model.Column, tz *time.Location) (interface{}, 
 	case mysql.TypeYear:
 		return col.Value.(int64), "long", nil
 	case mysql.TypeJSON:
-		return col.Value.(tijson.BinaryJSON).String(), "string", nil
+		return col.Value.(string), "string", nil
 	case mysql.TypeNewDecimal:
 		return col.Value.(string), "string", nil
 	case mysql.TypeEnum:

--- a/cdc/sink/codec/avro_test.go
+++ b/cdc/sink/codec/avro_test.go
@@ -88,6 +88,7 @@ func (s *avroBatchEncoderSuite) TestAvroEncodeOnly(c *check.C) {
 		{Name: "myfloat", Value: float64(3.14), Type: mysql.TypeFloat},
 		{Name: "mybytes", Value: []byte("Hello World"), Type: mysql.TypeBlob},
 		{Name: "ts", Value: time.Now().Format(types.TimeFSPFormat), Type: mysql.TypeTimestamp},
+		{Name: "myjson", Value: "{\"foo\": \"bar\"}", Type: mysql.TypeJSON},
 	}, time.Local)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Closes #3624

### What is changed and how it works?

When inserting valid JSON into a column of the `json` type this happens:
```
panic: interface conversion: interface {} is string, not json.BinaryJSON

goroutine 1228 [running]:
github.com/pingcap/ticdc/cdc/sink/codec.columnToAvroNativeData(0xc003f93bc0, 0xc000e14cb0, 0xc0027471c8, 0x2, 0xc00197a1a8, 0xd, 0x0, 0x0)
	github.com/pingcap/ticdc/cdc/sink/codec/avro.go:479 +0x19c5
github.com/pingcap/ticdc/cdc/sink/codec.rowToAvroNativeData(0xc00274e1f0, 0x2, 0x2, 0xc000e14cb0, 0x4, 0xc002747190, 0xc, 0x37)
	github.com/pingcap/ticdc/cdc/sink/codec/avro.go:274 +0xa8
github.com/pingcap/ticdc/cdc/sink/codec.avroEncode(0xc003f93bf0, 0xc0026817c0, 0x5f5736086ec0002, 0xc00274e1f0, 0x2, 0x2, 0xc000e14cb0, 0xc0044ef560, 0xc0044ef570, 0x3a071e8)
	github.com/pingcap/ticdc/cdc/sink/codec/avro.go:197 +0x191
github.com/pingcap/ticdc/cdc/sink/codec.(*AvroEventBatchEncoder).AppendRowChangedEvent(0xc002615200, 0xc001b52280, 0x0, 0x0, 0x3)
	github.com/pingcap/ticdc/cdc/sink/codec/avro.go:94 +0x830
github.com/pingcap/ticdc/cdc/sink.(*mqSink).runWorker(0xc0018fc280, 0x3a34708, 0xc0018aa1c0, 0x2, 0x0, 0x0)
	github.com/pingcap/ticdc/cdc/sink/mq.go:345 +0x3f1
github.com/pingcap/ticdc/cdc/sink.(*mqSink).run.func1(0x0, 0x0)
	github.com/pingcap/ticdc/cdc/sink/mq.go:275 +0x46
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0026151d0, 0xc002941400)
	golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x66
```

The `Value` seems to be a `string` instead of `json.BinaryJSON` as the error indicates

```
(dlv) print col
*github.com/pingcap/ticdc/cdc/model.Column {
	Name: "json_payload",
	Type: 245,
	Flag: BinaryFlag|NullableFlag (65),
	Value: interface {}(string) "{\"foo\": \"bar\"}",}
```

### Manual test

Setup a test environment:

```
tiup playground v5.2.2 --tiflash 0 --without-monitor=false
./bin/cdc server
curl --silent --output docker-compose.yml https://raw.githubusercontent.com/confluentinc/cp-all-in-one/6.2.0-post/cp-all-in-one-community/docker-compose.yml
sudo docker-compose up -d
./bin/cdc cli changefeed create --no-confirm --changefeed-id="simple-replication-task" --sort-engine="unified" --sink-uri="kafka://127.0.0.1:9092/cdc-test?protocol=avro&kafka-version=2.8.0" --log-level debug --opts registry="http://127.0.0.1:8081"
```

Create a table and insert some JSON:

```
CREATE TABLE `sample_table` (
  `id` bigint(20) unsigned primary key NOT NULL AUTO_INCREMENT,
  `json_payload` json DEFAULT NULL
);
INSERT INTO sample_table(json_payload) VALUES(NULL);
INSERT INTO sample_table(json_payload) VALUES(JSON_OBJECT('foo', 'bar'));
SELECT * FROM sample_table;
```

Start an Avro Console Consumer:

```
sudo docker-compose exec schema-registry /bin/sh
kafka-avro-console-consumer  --topic cdc-test --from-beginning --bootstrap-server broker:29092
```

Output:

```json
{"id":"\t","json_payload":{"string":"{\"foo\": \"bar\"}"}}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)



Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
The Avro sink was updated to handle JSON columns
```
