### PR TITLE
chore(dm): grpc.WithBackoffMaxDelay has been deprecated

### DIFF
--- a/dm/dm/master/workerrpc/rawgrpc.go
+++ b/dm/dm/master/workerrpc/rawgrpc.go
@@ -49,8 +49,7 @@ func NewGRPCClient(addr string, securityCfg config.Security) (*GRPCClient, error
 		return nil, terror.ErrMasterGRPCCreateConn.Delegate(err)
 	}
 
-	//nolint:staticcheck
-	conn, err := grpc.Dial(addr, tls.ToGRPCDialOption(), grpc.WithBackoffMaxDelay(3*time.Second),
+	conn, err := grpc.Dial(addr, tls.ToGRPCDialOption(),
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: backoff.Config{
 				BaseDelay:  100 * time.Millisecond,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`// Deprecated: use WithConnectParams instead. Will be supported throughout 1.x.` and the client has using `grpc.WithConnectParams`, the `grpc.WithBackoffMaxDelay` is duplicate.


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No need to add tests


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```