### PR TITLE
owner(ticdc): correctly handle the state after the old owner is upgraded to the new owner

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -48,7 +48,7 @@ const (
 	StateError    FeedState = "error"
 	StateFailed   FeedState = "failed"
 	StateStopped  FeedState = "stopped"
-	StateRemoved  FeedState = "removed" // deprecated, will be removed in the next version
+	StateRemoved  FeedState = "removed"
 	StateFinished FeedState = "finished"
 )
 

--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -225,6 +225,7 @@ func (s *changefeedSuite) TestExecDDL(c *check.C) {
 		Info: &model.ChangeFeedInfo{
 			StartTs: startTs,
 			Config:  config.GetDefaultReplicaConfig(),
+			State:   model.StateNormal,
 		},
 	})
 

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -83,6 +83,7 @@ func (s *ownerSuite) TestCreateRemoveChangefeed(c *check.C) {
 	changefeedInfo := &model.ChangeFeedInfo{
 		StartTs: oracle.ComposeTS(oracle.GetPhysical(time.Now()), 0),
 		Config:  config.GetDefaultReplicaConfig(),
+		State:   model.StateNormal,
 	}
 	changefeedStr, err := changefeedInfo.Marshal()
 	c.Assert(err, check.IsNil)
@@ -149,6 +150,7 @@ func (s *ownerSuite) TestStopChangefeed(c *check.C) {
 	changefeedInfo := &model.ChangeFeedInfo{
 		StartTs: oracle.ComposeTS(oracle.GetPhysical(time.Now()), 0),
 		Config:  config.GetDefaultReplicaConfig(),
+		State:   model.StateNormal,
 	}
 	changefeedStr, err := changefeedInfo.Marshal()
 	c.Assert(err, check.IsNil)
@@ -196,6 +198,7 @@ func (s *ownerSuite) TestCheckClusterVersion(c *check.C) {
 	changefeedInfo := &model.ChangeFeedInfo{
 		StartTs: oracle.ComposeTS(oracle.GetPhysical(time.Now()), 0),
 		Config:  config.GetDefaultReplicaConfig(),
+		State:   model.StateNormal,
 	}
 	changefeedStr, err := changefeedInfo.Marshal()
 	c.Assert(err, check.IsNil)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -193,6 +193,7 @@ func NewBackendContext4Test(withChangefeedVars bool) Context {
 			Info: &model.ChangeFeedInfo{
 				StartTs: oracle.ComposeTS(oracle.GetPhysical(time.Now()), 0),
 				Config:  config.GetDefaultReplicaConfig(),
+				State:   model.StateNormal,
 			},
 		})
 	}


### PR DESCRIPTION
…
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part of #3473

### What is changed and how it works?
correctly handle the state after the old owner is upgraded to the new owner.
Fix it in changefeed manager tick.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (TBD)

Code changes

 - Has exported function/method change

Side effects

None

Related changes

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
Fix the problem of changefeed resuming automatically after upgrading cluster
```
