### PR TITLE
newarch: add `NEWARCH` env variable to running newarch commands

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	// Double check to aviod some corner cases
 	serverConfigFilePath = parseConfigFlagFromOSArgs()
-	newarch = parseNewarchFlagFromOSArgs()
+	newarch = parseNewarchFlagFromOSArgs() || (os.Getenv("NEWARCH") == "true")
 
 	if newarch || isNewArchEnabledByConfig(serverConfigFilePath) {
 		cmd.Println("=== Command to ticdc(new arch).")


### PR DESCRIPTION
#### Description:

This PR introduces a `NEWARCH` environment variable to control command execution in TiCDC. When `NEWARCH=true` is set, the new architecture commands are activated automatically, removing the need to specify the `--newarch` flag in each command line call. This enhancement simplifies command usage by offering a more seamless way to opt into the new architecture.

#### Usage:

To activate the new architecture commands:

```bash
export NEWARCH=true
./cdc_binary <command>
```

When `NEWARCH` is not set or set to false, TiFlow’s original command set will remain the default behavior.

This update simplifies user workflows and enables easier testing and deployment of the new architecture commands.