### PR TITLE
newarch: rename `NEWARCH` env variable to `TICDC_NEWARCH`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	// Double check to aviod some corner cases
 	serverConfigFilePath = parseConfigFlagFromOSArgs()
-	newarch = parseNewarchFlagFromOSArgs() || (os.Getenv("NEWARCH") == "true")
+	newarch = parseNewarchFlagFromOSArgs() || (os.Getenv("TICDC_NEWARCH") == "true")
 
 	if newarch || isNewArchEnabledByConfig(serverConfigFilePath) {
 		cmd.Println("=== Command to ticdc(new arch).")


### PR DESCRIPTION
#### Description:

This PR introduces a `TICDC_NEWARCH` environment variable to control command execution in TiCDC. When `TICDC_NEWARCH=true` is set, the new architecture commands are activated automatically, removing the need to specify the `--newarch` flag in each command line call. This enhancement simplifies command usage by offering a more seamless way to opt into the new architecture.

#### Usage:

To activate the new architecture commands:

```bash
export TICDC_NEWARCH=true
./cdc_binary <command>
```

When `TICDC_NEWARCH` is not set or set to false, TiFlow’s original command set will remain the default behavior.

This update simplifies user workflows and enables easier testing and deployment of the new architecture commands.