### PR TITLE
makefile: simplify makefile version retrieval for compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,18 +57,7 @@ endif
 
 RELEASE_VERSION =
 ifeq ($(RELEASE_VERSION),)
-	RELEASE_VERSION := v8.2.0-master
-	release_version_regex := ^v[0-9]\..*$$
-	release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/v[0-9]\.[0-9]\..*$$"
-	ifneq ($(shell git rev-parse --abbrev-ref HEAD | grep -E $(release_branch_regex)),)
-		# If we are in release branch, try to use tag version.
-		ifneq ($(shell git describe --tags --dirty | grep -E $(release_version_regex)),)
-			RELEASE_VERSION := $(shell git describe --tags --dirty)
-		endif
-	else ifneq ($(shell git status --porcelain),)
-		# Add -dirty if the working tree is dirty for non release branch.
-		RELEASE_VERSION := $(RELEASE_VERSION)-dirty
-	endif
+	RELEASE_VERSION := $(shell git describe --tags --dirty)
 endif
 
 # Version LDFLAGS.


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #841

### What is changed and how it works?

**Pull Request Description**

This PR simplifies the logic for retrieving the `RELEASE_VERSION` variable in the Makefile.

**Changes**:
* Replaces the complex branch and tag regex checks with a direct call to `git describe --tags --dirty`.
* Improves compatibility across different platforms and Bash versions.
* Ensures consistent behavior in environments with different shell implementations.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
