### PR TITLE
add fallback value for RELEASE_VERSION in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ RELEASE_VERSION =
 ifeq ($(RELEASE_VERSION),)
 	RELEASE_VERSION := $(shell git describe --tags --dirty)
 endif
+ifeq ($(RELEASE_VERSION),)
+	RELEASE_VERSION := v9.0.0-alpha
+endif
 
 # Version LDFLAGS.
 LDFLAGS += -X "$(CDC_PKG)/version.ReleaseVersion=$(RELEASE_VERSION)"


### PR DESCRIPTION
**Pull Request Description**

This PR updates the Makefile logic for setting the `RELEASE_VERSION` variable to handle cases where `git describe --tags --dirty` returns an empty value.

**Problem**:
In environments like GitHub Actions where tags are not fetched by default, the `RELEASE_VERSION` variable is empty. This causes issues during the startup of the CDC component, as a valid version is required.

**Solution**:
Add a fallback value (`v9.0.0-alpha`) to ensure that `RELEASE_VERSION` is never empty:
	•	If `git describe --tags --dirty` returns an empty value, the `RELEASE_VERSION` variable defaults to `v9.0.0-alpha`.
	
**Test Plan**

1. Local Environment:
* Ensure `git describe --tags --dirty` sets `RELEASE_VERSION` correctly when tags are available.
* Test in a dirty working tree to verify correct behavior.
2. GitHub Actions:
* Run workflows without fetching tags to confirm the fallback value `v9.0.0-alpha` is used.