### PR TITLE
ut, makefile: consolidate unit tests into single makefile target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ tools/workload/bin
 .idea
 *.log
 .DS_Store
+
+# Unit test reports
+cdc-junit-report.xml

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+# Phony targets are targets that are not associated with files.
+# Add new phony targets here to make them available in the `make` command.
+.PHONY: clean fmt check tidy \
+	generate-protobuf generate_mock \
+	cdc kafka_consumer storage_consumer pulsar_consumer filter_helper \
+	unit_test_in_verify_ci integration_test_build integration_test_mysql integration_test_kafka integration_test_storage integration_test_pulsar \
+
+
 FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1  }  }'
 
 PROJECT=ticdc
@@ -36,7 +44,7 @@ GOVERSION := $(shell go version)
 # ref: https://github.com/pingcap/tidb/pull/39526#issuecomment-1407952955
 OS := "$(shell go env GOOS)"
 SED_IN_PLACE ?= $(shell which sed)
-IS_ALPINE := $(shell grep -qi Alpine /etc/os-release && echo 1)
+IS_ALPINE := $(shell if [ -f /etc/os-release ]; then grep -qi Alpine /etc/os-release && echo 1; else echo 0; fi)
 ifeq (${OS}, "linux")
 	CGO := 0
 	SED_IN_PLACE += -i
@@ -98,6 +106,16 @@ FAILPOINT_DIR := $$(for p in $(PACKAGES); do echo $${p\#"github.com/pingcap/$(PR
 FAILPOINT := tools/bin/failpoint-ctl
 FAILPOINT_ENABLE  := $$(echo $(FAILPOINT_DIR) | xargs $(FAILPOINT) enable >/dev/null)
 FAILPOINT_DISABLE := $$(echo $(FAILPOINT_DIR) | xargs $(FAILPOINT) disable >/dev/null)
+
+# go test -p parameter for unit tests
+P=3
+
+# The following packages are used in unit tests.
+# Add new packages here if you want to include them in unit tests.
+UT_PACKAGES_DISPATCHER := ./pkg/sink/mysql/... ./pkg/sink/util/... ./downstreamadapter/sink/... ./downstreamadapter/dispatcher/... ./downstreamadapter/worker/... ./pkg/sink/codec/open/... ./pkg/sink/codec/canal/...
+UT_PACKAGES_MAINTAINER := ./maintainer/...
+UT_PACKAGES_COORDINATOR := ./coordinator/...
+UT_PACKAGES_OTHERS := ./pkg/eventservice/... ./utils/dynstream/...
 
 include tools/Makefile
 
@@ -186,6 +204,21 @@ unit_test: check_failpoint_ctl generate-protobuf
 	@export log_level=error;\
 	$(GOTEST) -cover -covermode=atomic -coverprofile="$(TEST_DIR)/cov.unit.out" $(PACKAGES) \
 	|| { $(FAILPOINT_DISABLE); exit 1; }
+	$(FAILPOINT_DISABLE)
+
+unit_test_in_verify_ci: check_failpoint_ctl tools/bin/gotestsum tools/bin/gocov tools/bin/gocov-xml
+	mkdir -p "$(TEST_DIR)"
+	$(FAILPOINT_ENABLE)
+	@echo "Running unit tests..."
+	@export log_level=error;\
+	CGO_ENABLED=1 tools/bin/gotestsum --junitfile cdc-junit-report.xml -- -v -timeout 120s -p $(P) --race --tags=intest \
+	-covermode=atomic -coverprofile="$(TEST_DIR)/cov.unit.out" \
+	$(UT_PACKAGES_DISPATCHER) \
+	$(UT_PACKAGES_MAINTAINER) \
+	$(UT_PACKAGES_COORDINATOR) \
+	$(UT_PACKAGES_OTHERS) \
+	|| { $(FAILPOINT_DISABLE); exit 1; }
+	tools/bin/gocov convert "$(TEST_DIR)/cov.unit.out" | tools/bin/gocov-xml > cdc-coverage.xml
 	$(FAILPOINT_DISABLE)
 
 tidy:


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #909

### What is changed and how it works?

This PR consolidates our scattered unit tests from GitHub Actions into a single Makefile target. Currently, we have 4 separate test jobs in our CI workflow (dispatcher, maintainer, coordinator, and eventservice).

To ensure a more streamlined development process, we are consolidating all unit tests under a single Makefile target, `unit_test_in_verify_ci`. This improvement will result in:
* Simplified CI configuration: Making the setup easier to manage and maintain.
* Unified test reports and coverage: Providing a clearer and more consistent overview of test results.

Key Changes:

- Combine dispatcher, maintainer, coordinator and eventservice unit tests
- Add UT_PACKAGES variables for different test modules
- Standardize timeout to 120s
- Use single gotestsum command for all tests
- Maintain coverage reporting functionality

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
