### PR TITLE
coordinator: fix a bug that keep changefeed in warning state

### DIFF
--- a/coordinator/changefeed/backoff.go
+++ b/coordinator/changefeed/backoff.go
@@ -67,7 +67,11 @@ type Backoff struct {
 }
 
 // NewBackoff creates Backoff and initialize the exponential backoff
-func NewBackoff(id common.ChangeFeedID, changefeedErrorStuckDuration time.Duration, checkpointTs uint64) *Backoff {
+func NewBackoff(
+	id common.ChangeFeedID,
+	changefeedErrorStuckDuration time.Duration,
+	checkpointTs uint64,
+) *Backoff {
 	m := &Backoff{
 		id:                           id,
 		errBackoff:                   backoff.NewExponentialBackOff(),
@@ -111,6 +115,7 @@ func (m *Backoff) CheckStatus(status *heartbeatpb.MaintainerStatus) (bool, model
 	if m.failed.Load() {
 		return false, model.StateFailed, nil
 	}
+
 	if m.checkpointTs < status.CheckpointTs {
 		m.checkpointTs = status.CheckpointTs
 		if m.retrying.Load() {

--- a/coordinator/changefeed/changefeed.go
+++ b/coordinator/changefeed/changefeed.go
@@ -67,25 +67,33 @@ func NewChangefeed(cfID common.ChangeFeedID,
 		log.Panic("unable to marshal changefeed config",
 			zap.Error(err))
 	}
-	log.Info("changefeed instance created",
-		zap.String("id", cfID.String()),
-		zap.Uint64("checkpointTs", checkpointTs),
-		zap.String("state", string(info.State)))
-	return &Changefeed{
+
+	res := &Changefeed{
 		ID:                    cfID,
 		info:                  atomic.NewPointer(info),
 		configBytes:           bytes,
 		lastSavedCheckpointTs: atomic.NewUint64(checkpointTs),
 		isMQSink:              sink.IsMQScheme(uri.Scheme),
 		isNew:                 isNew,
-		// init the first Status
-		status: atomic.NewPointer[heartbeatpb.MaintainerStatus](
+		// Initialize the status
+		status: atomic.NewPointer(
 			&heartbeatpb.MaintainerStatus{
+				ChangefeedID: cfID.ToPB(),
 				CheckpointTs: checkpointTs,
 				FeedState:    string(info.State),
 			}),
 		backoff: NewBackoff(cfID, *info.Config.ChangefeedErrorStuckDuration, checkpointTs),
 	}
+	// Must set retrying to true when the changefeed is in warning state.
+	if info.State == model.StateWarning {
+		res.backoff.retrying.Store(true)
+	}
+
+	log.Info("changefeed instance created",
+		zap.String("id", cfID.String()),
+		zap.Uint64("checkpointTs", checkpointTs),
+		zap.String("info", info.String()))
+	return res
 }
 
 func (c *Changefeed) GetInfo() *config.ChangeFeedInfo {
@@ -127,6 +135,7 @@ func (c *Changefeed) ShouldRun() bool {
 
 func (c *Changefeed) UpdateStatus(newStatus *heartbeatpb.MaintainerStatus) (bool, model.FeedState, *heartbeatpb.RunningError) {
 	old := c.status.Load()
+
 	if newStatus != nil && newStatus.CheckpointTs >= old.CheckpointTs {
 		c.status.Store(newStatus)
 		info := c.GetInfo()

--- a/coordinator/changefeed/changefeed_db.go
+++ b/coordinator/changefeed/changefeed_db.go
@@ -61,6 +61,7 @@ func (db *ChangefeedDB) withRLock(action func()) {
 }
 
 // AddAbsentChangefeed adds the changefeed to the absent map
+// It will be scheduled later
 func (db *ChangefeedDB) AddAbsentChangefeed(tasks ...*Changefeed) {
 	db.lock.Lock()
 	defer db.lock.Unlock()

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -293,7 +293,6 @@ func TestCoordinatorScheduling(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(co.controller.changefeedDB.GetByNodeID(info.ID)) == cfSize
 	}, time.Second*time.Duration(waitTime), time.Millisecond*5)
-
 }
 
 func TestScaleNode(t *testing.T) {

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -77,7 +77,7 @@ func NewMaintainerManager(mc messaging.MessageCenter) *mockMaintainerManager {
 }
 
 func (m *mockMaintainerManager) Run(ctx context.Context) error {
-	tick := time.NewTicker(time.Millisecond * 1000)
+	tick := time.NewTicker(time.Millisecond * 50)
 	for {
 		select {
 		case <-ctx.Done():
@@ -254,7 +254,7 @@ func TestCoordinatorScheduling(t *testing.T) {
 		t.Fatal("unexpected args", argList)
 	}
 	cfSize := 100
-	sleepTime := 5
+	waitTime := 10
 	if len(argList) == 1 {
 		cfSize, _ = strconv.Atoi(argList[0])
 	}
@@ -282,17 +282,18 @@ func TestCoordinatorScheduling(t *testing.T) {
 	co := cr.(*coordinator)
 
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
 		_ = cr.Run(ctx)
 	}()
-	time.Sleep(time.Second * time.Duration(sleepTime))
 
-	cancel()
-	// co.stream.Close()
-	require.Equal(t, cfSize,
-		co.controller.changefeedDB.GetReplicatingSize())
-	require.Equal(t, cfSize,
-		len(co.controller.changefeedDB.GetByNodeID(info.ID)))
+	require.Eventually(t, func() bool {
+		return co.controller.changefeedDB.GetReplicatingSize() == cfSize
+	}, time.Second*time.Duration(waitTime), time.Millisecond*5)
+	require.Eventually(t, func() bool {
+		return len(co.controller.changefeedDB.GetByNodeID(info.ID)) == cfSize
+	}, time.Second*time.Duration(waitTime), time.Millisecond*5)
+
 }
 
 func TestScaleNode(t *testing.T) {
@@ -314,8 +315,8 @@ func TestScaleNode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	backend := mock_changefeed.NewMockBackend(ctrl)
 	cfs := make(map[common.ChangeFeedID]*changefeed.ChangefeedMetaWrapper)
-	cfSize := 6
-	for i := 0; i < cfSize; i++ {
+	changefeedNumber := 6
+	for i := 0; i < changefeedNumber; i++ {
 		cfID := common.NewChangeFeedIDWithDisplayName(common.ChangeFeedDisplayName{
 			Name:      fmt.Sprintf("%d", i),
 			Namespace: model.DefaultNamespace,
@@ -331,14 +332,17 @@ func TestScaleNode(t *testing.T) {
 	}
 	backend.EXPECT().GetAllChangefeeds(gomock.Any()).Return(cfs, nil).AnyTimes()
 
-	cr := New(info, &mockPdClient{}, pdutil.NewClock4Test(), backend, serviceID, 100, 10000, time.Millisecond*10)
+	cr := New(info, &mockPdClient{}, pdutil.NewClock4Test(), backend, serviceID, 100, 10000, time.Millisecond*1)
 
 	// run coordinator
 	go func() { cr.Run(ctx) }()
 
-	time.Sleep(time.Second * 5)
 	co := cr.(*coordinator)
-	require.Equal(t, cfSize, co.controller.changefeedDB.GetReplicatingSize())
+	waitTime := time.Second * 10
+
+	require.Eventually(t, func() bool {
+		return co.controller.changefeedDB.GetReplicatingSize() == changefeedNumber
+	}, waitTime, time.Millisecond*5)
 
 	// add two nodes
 	info2 := node.NewInfo("127.0.0.1:28400", "")
@@ -359,11 +363,15 @@ func TestScaleNode(t *testing.T) {
 			model.CaptureID(info3.ID): {ID: model.CaptureID(info3.ID), AdvertiseAddr: info3.AdvertiseAddr},
 		},
 	})
-	time.Sleep(time.Second * 5)
-	require.Equal(t, cfSize, co.controller.changefeedDB.GetReplicatingSize())
-	require.Equal(t, 2, len(co.controller.changefeedDB.GetByNodeID(info.ID)))
-	require.Equal(t, 2, len(co.controller.changefeedDB.GetByNodeID(info2.ID)))
-	require.Equal(t, 2, len(co.controller.changefeedDB.GetByNodeID(info3.ID)))
+
+	require.Eventually(t, func() bool {
+		return co.controller.changefeedDB.GetReplicatingSize() == changefeedNumber
+	}, waitTime, time.Millisecond*5)
+	require.Eventually(t, func() bool {
+		return len(co.controller.changefeedDB.GetByNodeID(info.ID)) == 2 &&
+			len(co.controller.changefeedDB.GetByNodeID(info2.ID)) == 2 &&
+			len(co.controller.changefeedDB.GetByNodeID(info3.ID)) == 2
+	}, waitTime, time.Millisecond*5)
 
 	// notify node changes
 	_, _ = nodeManager.Tick(ctx, &orchestrator.GlobalReactorState{
@@ -372,14 +380,18 @@ func TestScaleNode(t *testing.T) {
 			model.CaptureID(info2.ID): {ID: model.CaptureID(info2.ID), AdvertiseAddr: info2.AdvertiseAddr},
 		},
 	})
-	time.Sleep(time.Second * 5)
-	require.Equal(t, cfSize, co.controller.changefeedDB.GetReplicatingSize())
-	require.Equal(t, 3, len(co.controller.changefeedDB.GetByNodeID(info.ID)))
-	require.Equal(t, 3, len(co.controller.changefeedDB.GetByNodeID(info2.ID)))
+	require.Eventually(t, func() bool {
+		return co.controller.changefeedDB.GetReplicatingSize() == changefeedNumber
+	}, waitTime, time.Millisecond*5)
+	require.Eventually(t, func() bool {
+		return len(co.controller.changefeedDB.GetByNodeID(info.ID)) == 3 &&
+			len(co.controller.changefeedDB.GetByNodeID(info2.ID)) == 3
+	}, waitTime, time.Millisecond*5)
 }
 
 func TestBootstrapWithUnStoppedChangefeed(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	info := node.NewInfo("127.0.0.1:28301", "")
 	etcdClient := newMockEtcdClient(string(info.ID))
 	nodeManager := watcher.NewNodeManager(nil, etcdClient)
@@ -457,11 +469,13 @@ func TestBootstrapWithUnStoppedChangefeed(t *testing.T) {
 	// run coordinator
 	go func() { cr.Run(ctx) }()
 
-	time.Sleep(time.Second * 5)
 	co := cr.(*coordinator)
-	require.Equal(t, 0, co.controller.changefeedDB.GetReplicatingSize())
-	require.Equal(t, 2, co.controller.changefeedDB.GetStoppedSize())
-	require.Equal(t, 0, co.controller.operatorController.OperatorSize())
+	waitTime := time.Second * 10
+	require.Eventually(t, func() bool {
+		return co.controller.changefeedDB.GetReplicatingSize() == 0 &&
+			co.controller.changefeedDB.GetStoppedSize() == 2 &&
+			co.controller.operatorController.OperatorSize() == 0
+	}, waitTime, time.Millisecond*5)
 }
 
 type maintainNode struct {

--- a/heartbeatpb/heartbeat.pb.go
+++ b/heartbeatpb/heartbeat.pb.go
@@ -2369,10 +2369,10 @@ func (m *ChangefeedID) GetLow() uint64 {
 }
 
 func (m *ChangefeedID) GetName() string {
-	if m != nil {
-		return m.Name
+	if m == nil {
+		return ""
 	}
-	return ""
+	return m.Name
 }
 
 func (m *ChangefeedID) GetNamespace() string {

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -1445,7 +1445,8 @@ func buildDDLEventForDropSchema(rawEvent *PersistedDDLEvent, tableFilter filter.
 }
 
 func buildDDLEventForModifySchemaCharsetAndCollate(
-	rawEvent *PersistedDDLEvent, tableFilter filter.Filter) (commonEvent.DDLEvent, bool) {
+	rawEvent *PersistedDDLEvent, tableFilter filter.Filter,
+) (commonEvent.DDLEvent, bool) {
 	ddlEvent, ok := buildDDLEventCommon(rawEvent, tableFilter, WithoutTiDBOnly)
 	if !ok {
 		return ddlEvent, false

--- a/maintainer/maintainer.go
+++ b/maintainer/maintainer.go
@@ -152,7 +152,6 @@ func NewMaintainer(cfID common.ChangeFeedID,
 	checkpointTs uint64,
 	newChangfeed bool,
 ) *Maintainer {
-
 	mc := appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()

--- a/maintainer/maintainer.go
+++ b/maintainer/maintainer.go
@@ -352,6 +352,7 @@ func (m *Maintainer) initialize() error {
 	}, time.Now().Add(periodEventInterval))
 	log.Info("changefeed maintainer initialized",
 		zap.String("id", m.id.String()),
+		zap.String("status", common.FormatMaintainerStatus(m.GetMaintainerStatus())),
 		zap.Duration("duration", time.Since(start)))
 	m.state.Store(int32(heartbeatpb.ComponentState_Working))
 	m.statusChanged.Store(true)

--- a/maintainer/maintainer_manager.go
+++ b/maintainer/maintainer_manager.go
@@ -193,9 +193,6 @@ func (m *Manager) onCoordinatorBootstrapRequest(msg *messaging.TargetMessage) {
 	m.maintainers.Range(func(key, value interface{}) bool {
 		maintainer := value.(*Maintainer)
 		status := maintainer.GetMaintainerStatus()
-		if status.GetErr() != nil {
-			log.Info("fizz changefeed meet error", zap.Any("status", status))
-		}
 		response.Statuses = append(response.Statuses, status)
 		maintainer.statusChanged.Store(false)
 		maintainer.lastReportTime = time.Now()
@@ -299,9 +296,6 @@ func (m *Manager) sendHeartbeat() {
 			cfMaintainer := value.(*Maintainer)
 			if cfMaintainer.statusChanged.Load() || time.Since(cfMaintainer.lastReportTime) > time.Second*2 {
 				mStatus := cfMaintainer.GetMaintainerStatus()
-				if mStatus.GetErr() != nil {
-					log.Info("fizz changefeed meet error", zap.Any("status", mStatus))
-				}
 				response.Statuses = append(response.Statuses, mStatus)
 				cfMaintainer.statusChanged.Store(false)
 				cfMaintainer.lastReportTime = time.Now()

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -52,8 +52,10 @@ func NewBootstrapper[T any](id string, newBootstrapMsg NewBootstrapMessageFn) *B
 	}
 }
 
-// HandleBootstrapResponse cache the message reported remote node
-// return cached bootstrap response if all node are initialized
+// HandleBootstrapResponse do the following:
+// 1. cache the bootstrap response reported from remote nodes
+// 2. check if all node are initialized
+// 3. return cached bootstrap response if all nodes are initialized
 func (b *Bootstrapper[T]) HandleBootstrapResponse(
 	from node.ID,
 	msg *T,

--- a/pkg/common/format.go
+++ b/pkg/common/format.go
@@ -18,11 +18,17 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
+	"go.uber.org/zap"
 )
 
 func FormatBlockStatusRequest(r *heartbeatpb.BlockStatusRequest) string {
 	if r == nil {
+		return ""
+	}
+	if r.ChangefeedID == nil {
+		log.Warn("changefeedID is nil, it should not happen", zap.String("request", r.String()))
 		return ""
 	}
 	sb := strings.Builder{}
@@ -38,6 +44,10 @@ func FormatBlockStatusRequest(r *heartbeatpb.BlockStatusRequest) string {
 
 func FormatTableSpanBlockStatus(s *heartbeatpb.TableSpanBlockStatus) string {
 	if s == nil {
+		return ""
+	}
+	if s.ID == nil {
+		log.Warn("dispatcherID is nil, it should not happen", zap.String("status", s.String()))
 		return ""
 	}
 	sb := strings.Builder{}

--- a/pkg/common/format.go
+++ b/pkg/common/format.go
@@ -1,0 +1,117 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/ticdc/heartbeatpb"
+)
+
+func FormatBlockStatusRequest(r *heartbeatpb.BlockStatusRequest) string {
+	if r == nil {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("changefeed: %s, changefeedID: %s",
+		r.ChangefeedID.GetName(),
+		NewChangefeedGIDFromPB(r.ChangefeedID).String()))
+	for _, status := range r.BlockStatuses {
+		sb.WriteString(FormatTableSpanBlockStatus(status))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func FormatTableSpanBlockStatus(s *heartbeatpb.TableSpanBlockStatus) string {
+	if s == nil {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("[ dispatcherID: %s, state: %s ]",
+		NewDispatcherIDFromPB(s.ID).String(),
+		s.State.String()))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func FormatDispatcherStatus(d *heartbeatpb.DispatcherStatus) string {
+	if d == nil {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("action: %s, ack: %s, influencedDispatchers: %s",
+		d.Action.String(),
+		d.Ack.String(),
+		FormatInfluencedDispatchers(d.InfluencedDispatchers)))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func FormatInfluencedDispatchers(d *heartbeatpb.InfluencedDispatchers) string {
+	if d == nil {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("schemaID: %d, influenceType: %s",
+		d.SchemaID,
+		d.InfluenceType.String()))
+	sb.WriteString("dispatcherIDs: [")
+	for _, dispatcherID := range d.DispatcherIDs {
+		sb.WriteString(fmt.Sprintf("%s, ",
+			NewDispatcherIDFromPB(dispatcherID).String()))
+	}
+	sb.WriteString("]")
+	if d.ExcludeDispatcherId != nil {
+		sb.WriteString(fmt.Sprintf(", excludeDispatcherID: %s",
+			NewDispatcherIDFromPB(d.ExcludeDispatcherId).String()))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func FormatTableSpan(s *heartbeatpb.TableSpan) string {
+	if s == nil {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("tableID: %d, startKey: %s, endKey: %s",
+		s.TableID,
+		hex.EncodeToString(s.StartKey),
+		hex.EncodeToString(s.EndKey)))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func FormatMaintainerStatus(s *heartbeatpb.MaintainerStatus) string {
+	if s == nil {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf(
+		"changefeed: %s, feedState: %s, state: %s, checkpointTs: %d, errs: [",
+		s.ChangefeedID.GetName(),
+		s.FeedState,
+		s.State.String(),
+		s.CheckpointTs,
+	))
+	for _, err := range s.Err {
+		sb.WriteString(err.String())
+	}
+	sb.WriteString("]")
+	sb.WriteString("\n")
+	return sb.String()
+}

--- a/pkg/common/format_test.go
+++ b/pkg/common/format_test.go
@@ -1,0 +1,236 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package common
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/stretchr/testify/require"
+)
+
+// All test cases in this file are to make sure the format functions will not panic.
+
+func TestFormatBlockStatusRequest(t *testing.T) {
+	t.Parallel()
+
+	cfID := NewChangefeedID4Test("test-namespace", "test-changefeed")
+	dispatcherID := NewDispatcherID()
+
+	testCases := []struct {
+		name          string
+		input         *heartbeatpb.BlockStatusRequest
+		isEmptyString bool
+	}{
+		{
+			name:          "nil request",
+			input:         nil,
+			isEmptyString: true,
+		},
+		{
+			name: "normal request",
+			input: &heartbeatpb.BlockStatusRequest{
+				ChangefeedID: cfID.ToPB(),
+				BlockStatuses: []*heartbeatpb.TableSpanBlockStatus{
+					{
+						ID: dispatcherID.ToPB(),
+						State: &heartbeatpb.State{
+							Stage: heartbeatpb.BlockStage_WAITING,
+						},
+					},
+				},
+			},
+			isEmptyString: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := FormatBlockStatusRequest(tc.input)
+			require.Equal(t, tc.isEmptyString, result == "")
+		})
+	}
+}
+
+func TestFormatTableSpanBlockStatus(t *testing.T) {
+	t.Parallel()
+
+	dispatcherID := NewDispatcherID()
+
+	testCases := []struct {
+		name          string
+		input         *heartbeatpb.TableSpanBlockStatus
+		isEmptyString bool
+	}{
+		{
+			name:          "nil status",
+			input:         nil,
+			isEmptyString: true,
+		},
+		{
+			name: "normal status",
+			input: &heartbeatpb.TableSpanBlockStatus{
+				ID: dispatcherID.ToPB(),
+			},
+			isEmptyString: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := FormatTableSpanBlockStatus(tc.input)
+			require.Equal(t, tc.isEmptyString, result == "")
+		})
+	}
+}
+
+func TestFormatDispatcherStatus(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		input         *heartbeatpb.DispatcherStatus
+		isEmptyString bool
+	}{
+		{
+			name:          "nil status",
+			input:         nil,
+			isEmptyString: true,
+		},
+		{
+			name: "normal status",
+			input: &heartbeatpb.DispatcherStatus{
+				Action: &heartbeatpb.DispatcherAction{
+					Action: heartbeatpb.Action_Write,
+				},
+			},
+			isEmptyString: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := FormatDispatcherStatus(tc.input)
+			require.Equal(t, tc.isEmptyString, result == "")
+		})
+	}
+}
+
+func TestFormatInfluencedDispatchers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		input         *heartbeatpb.InfluencedDispatchers
+		isEmptyString bool
+	}{
+		{
+			name:          "nil dispatchers",
+			input:         nil,
+			isEmptyString: true,
+		},
+		{
+			name: "normal dispatchers",
+			input: &heartbeatpb.InfluencedDispatchers{
+				SchemaID:      1,
+				InfluenceType: heartbeatpb.InfluenceType_All,
+			},
+			isEmptyString: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := FormatInfluencedDispatchers(tc.input)
+			require.Equal(t, tc.isEmptyString, result == "")
+		})
+	}
+}
+
+func TestFormatTableSpan(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		input         *heartbeatpb.TableSpan
+		isEmptyString bool
+	}{
+		{
+			name:          "nil span",
+			input:         nil,
+			isEmptyString: true,
+		},
+		{
+			name: "normal span",
+			input: &heartbeatpb.TableSpan{
+				TableID:  1,
+				StartKey: []byte("start"),
+				EndKey:   []byte("end"),
+			},
+			isEmptyString: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := FormatTableSpan(tc.input)
+			require.Equal(t, tc.isEmptyString, result == "")
+		})
+	}
+}
+
+func TestFormatMaintainerStatus(t *testing.T) {
+	t.Parallel()
+
+	cfID := NewChangefeedID4Test("test-namespace", "test-changefeed")
+	testCases := []struct {
+		name          string
+		input         *heartbeatpb.MaintainerStatus
+		isEmptyString bool
+	}{
+		{
+			name:          "nil status",
+			input:         nil,
+			isEmptyString: true,
+		},
+		{
+			name: "normal status",
+			input: &heartbeatpb.MaintainerStatus{
+				ChangefeedID: cfID.ToPB(),
+				FeedState:    "Normal",
+				State:        heartbeatpb.ComponentState_Working,
+				CheckpointTs: 100,
+			},
+			isEmptyString: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := FormatMaintainerStatus(tc.input)
+			require.Equal(t, tc.isEmptyString, result == "")
+		})
+	}
+}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -50,6 +50,9 @@ func NewDispatcherID() DispatcherID {
 }
 
 func NewDispatcherIDFromPB(pb *heartbeatpb.DispatcherID) DispatcherID {
+	if pb == nil {
+		return DispatcherID{}
+	}
 	d := DispatcherID{Low: pb.Low, High: pb.High}
 	return d
 }

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -50,9 +50,6 @@ func NewDispatcherID() DispatcherID {
 }
 
 func NewDispatcherIDFromPB(pb *heartbeatpb.DispatcherID) DispatcherID {
-	if pb == nil {
-		return DispatcherID{}
-	}
 	d := DispatcherID{Low: pb.Low, High: pb.High}
 	return d
 }

--- a/pkg/messaging/message_center.go
+++ b/pkg/messaging/message_center.go
@@ -278,22 +278,17 @@ func (mc *messageCenter) ReceiveCmd() (*TargetMessage, error) {
 
 // Close stops the grpc server and stops all the connections to the remote targets.
 func (mc *messageCenter) Close() {
-	log.Info("fizz message center is closing, lock requiring", zap.Stringer("id", mc.id))
 	mc.remoteTargets.RLock()
 	defer mc.remoteTargets.RUnlock()
-	log.Info("fizz message center is closing, lock required", zap.Stringer("id", mc.id))
 
 	for _, target := range mc.remoteTargets.m {
 		target.close()
 	}
 
-	log.Info("fizz message center is closing, closed remote targets", zap.Stringer("id", mc.id))
-
 	mc.cancel()
 	if mc.grpcServer != nil {
 		mc.grpcServer.Stop()
 	}
-	log.Info("fizz message center is closing, stopped grpc server", zap.Stringer("id", mc.id))
 
 	mc.grpcServer = nil
 	_ = mc.g.Wait()

--- a/tests/integration_tests/ddl_attributes/run.sh
+++ b/tests/integration_tests/ddl_attributes/run.sh
@@ -43,7 +43,6 @@ function run() {
 	sleep 3
 	check_table_exists ddl_attributes.attributes_t1_new ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists ddl_attributes.finish_mark ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-	
 
 	ensure 30 "run_sql 'show create table ddl_attributes.placement_t1;' ${UP_TIDB_HOST} ${UP_TIDB_PORT}"
 	ensure 30 "run_sql 'show create table ddl_attributes.placement_t2;' ${UP_TIDB_HOST} ${UP_TIDB_PORT}"


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #921 

### What is changed and how it works?

When reconstructing a changefeed from the meta DB to the coordinator's memory, check whether it is in a warning state. If so, set its backoff state to retrying. 
The core fix is implemented here: 
```go
	// Must set retrying to true when the changefeed is in warning state.
	if info.State == model.StateWarning {
		res.backoff.retrying.Store(true)
	}
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
