### PR TITLE
Use ddl_ts to fix the atomic problem of ddl_ts and ddl event; Add a mix failover test for test ddl failover cases randomly

### DIFF
--- a/.github/workflows/integration_test_mysql.yaml
+++ b/.github/workflows/integration_test_mysql.yaml
@@ -523,6 +523,46 @@ jobs:
           go build -o ./tools/bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl 
           make integration_test_build
           ls -l bin/ && ls -l tools/bin/
+      
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
       - name: Test fail_over
         run: |

--- a/.github/workflows/integration_test_mysql.yaml
+++ b/.github/workflows/integration_test_mysql.yaml
@@ -523,46 +523,6 @@ jobs:
           go build -o ./tools/bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl 
           make integration_test_build
           ls -l bin/ && ls -l tools/bin/
-      
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
-
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
-
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
-
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
-
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
-
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
-
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
-
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
       - name: Test fail_over
         run: |
@@ -643,6 +603,11 @@ jobs:
         run: |
           pwd && ls -l bin/ && ls -l tools/bin/
           export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_O
+      
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
       - name: Upload test logs
         if: always()

--- a/.github/workflows/integration_test_mysql.yaml
+++ b/.github/workflows/integration_test_mysql.yaml
@@ -524,45 +524,45 @@ jobs:
           make integration_test_build
           ls -l bin/ && ls -l tools/bin/
       
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      - name: Test fail_over_ddl_mix
-        run: |
-          pwd && ls -l bin/ && ls -l tools/bin/
-          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      # - name: Test fail_over_ddl_mix
+      #   run: |
+      #     pwd && ls -l bin/ && ls -l tools/bin/
+      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
       - name: Test fail_over
         run: |

--- a/.github/workflows/integration_test_mysql.yaml
+++ b/.github/workflows/integration_test_mysql.yaml
@@ -524,45 +524,45 @@ jobs:
           make integration_test_build
           ls -l bin/ && ls -l tools/bin/
       
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
-      # - name: Test fail_over_ddl_mix
-      #   run: |
-      #     pwd && ls -l bin/ && ls -l tools/bin/
-      #     export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
+      - name: Test fail_over_ddl_mix
+        run: |
+          pwd && ls -l bin/ && ls -l tools/bin/
+          export TICDC_NEWARCH=true && make integration_test CASE=fail_over_ddl_mix 
 
       - name: Test fail_over
         run: |

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -375,6 +375,10 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 			}
 			block = true
 			syncPoint := event.(*commonEvent.SyncPointEvent)
+			log.Info("dispatcher receive sync point event",
+				zap.Stringer("dispatcher", d.id),
+				zap.Uint64("commitTs", event.GetCommitTs()),
+				zap.Uint64("seq", event.GetSeq()))
 			syncPoint.AddPostFlushFunc(func() {
 				wakeCallback()
 			})

--- a/downstreamadapter/sink/mysql_sink_test.go
+++ b/downstreamadapter/sink/mysql_sink_test.go
@@ -90,14 +90,16 @@ func TestMysqlSinkBasicFunctionality(t *testing.T) {
 			changefeed varchar(255),
 			ddl_ts varchar(18),
 			table_id bigint(21),
-			created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			finished bool,
+			related_table_id bigint(21),
+			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			INDEX (ticdc_cluster_id, changefeed, table_id),
 			PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
 		);`).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	mock.ExpectBegin()
-	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id) VALUES ('default', 'test/test', '1', 0), ('default', 'test/test', '1', 1) ON DUPLICATE KEY UPDATE ddl_ts=VALUES(ddl_ts), created_at=CURRENT_TIMESTAMP;").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished) VALUES ('default', 'test/test', '1',  0, 1, 1), ('default', 'test/test', '1', 1, 1, 1) ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW();").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	mock.ExpectBegin()

--- a/maintainer/barrier.go
+++ b/maintainer/barrier.go
@@ -166,7 +166,7 @@ func (b *Barrier) HandleBootstrapResponse(bootstrapRespMap map[node.ID]*heartbea
 			key := getEventKey(blockState.BlockTs, blockState.IsSyncPoint)
 			event, ok := b.blockedEvents.Get(key)
 			if !ok {
-				event = NewBlockEvent(common.NewChangefeedIDFromPB(resp.ChangefeedID), common.NewDispatcherIDFromPB(span.ID), b.controller, blockState, b.splitTableEnabled)
+				event = NewBlockEvent(common.NewChangefeedIDFromPB(resp.ChangefeedID), common.NewDispatcherIDFromPB(span.ID), b.controller, blockState, b.splitTableEnabled, true)
 				b.blockedEvents.Set(key, event)
 			}
 			switch blockState.Stage {
@@ -306,7 +306,7 @@ func (b *Barrier) handleEventDone(changefeedID common.ChangeFeedID, dispatcherID
 	event, ok := b.blockedEvents.Get(key)
 	if !ok {
 		// no block event found
-		be := NewBlockEvent(changefeedID, dispatcherID, b.controller, status.State, b.splitTableEnabled)
+		be := NewBlockEvent(changefeedID, dispatcherID, b.controller, status.State, b.splitTableEnabled, false)
 		// the event is a fake event, the dispatcher will not send the block event
 		be.rangeChecker = range_checker.NewBoolRangeChecker(false)
 		return be
@@ -361,7 +361,7 @@ func (b *Barrier) handleBlockState(changefeedID common.ChangeFeedID,
 	// it's not a blocked event, it must be sent by table event trigger dispatcher, just for doing scheduler
 	// and the ddl already synced to downstream , e.g.: create table
 	// if ack failed, dispatcher will send a heartbeat again, so we do not need to care about resend message here
-	event := NewBlockEvent(changefeedID, dispatcherID, b.controller, blockState, b.splitTableEnabled)
+	event := NewBlockEvent(changefeedID, dispatcherID, b.controller, blockState, b.splitTableEnabled, false)
 	event.scheduleBlockEvent()
 	return event, nil
 }
@@ -372,7 +372,7 @@ func (b *Barrier) getOrInsertNewEvent(changefeedID common.ChangeFeedID, dispatch
 ) *BarrierEvent {
 	event, ok := b.blockedEvents.Get(key)
 	if !ok {
-		event = NewBlockEvent(changefeedID, dispatcherID, b.controller, blockState, b.splitTableEnabled)
+		event = NewBlockEvent(changefeedID, dispatcherID, b.controller, blockState, b.splitTableEnabled, false)
 		b.blockedEvents.Set(key, event)
 	}
 	return event

--- a/maintainer/barrier_event.go
+++ b/maintainer/barrier_event.go
@@ -68,6 +68,7 @@ func NewBlockEvent(cfID common.ChangeFeedID,
 	controller *Controller,
 	status *heartbeatpb.State,
 	dynamicSplitEnabled bool,
+	bootstraped bool,
 ) *BarrierEvent {
 	event := &BarrierEvent{
 		controller:          controller,
@@ -97,7 +98,7 @@ func NewBlockEvent(cfID common.ChangeFeedID,
 			// TODO:clean code
 			// create range checker if dispatcher is ddl dispatcher
 			// otherwise store dispatcherID in reportedDispatchers, and not create rangeChecker
-			if dispatcherID == controller.ddlDispatcherID {
+			if bootstraped || dispatcherID == controller.ddlDispatcherID {
 				event.createRangeCheckerForTypeDB()
 			} else {
 				event.reportedDispatchers[dispatcherID] = struct{}{}
@@ -105,7 +106,7 @@ func NewBlockEvent(cfID common.ChangeFeedID,
 		case heartbeatpb.InfluenceType_All:
 			// create range checker if dispatcher is ddl dispatcher
 			// otherwise store dispatcherID in reportedDispatchers, and not create rangeChecker
-			if dispatcherID == controller.ddlDispatcherID {
+			if bootstraped || dispatcherID == controller.ddlDispatcherID {
 				event.createRangeCheckerForTypeAll()
 			} else {
 				event.reportedDispatchers[dispatcherID] = struct{}{}

--- a/maintainer/barrier_event_test.go
+++ b/maintainer/barrier_event_test.go
@@ -50,7 +50,7 @@ func TestScheduleEvent(t *testing.T) {
 		BlockTs:           10,
 		NeedDroppedTables: &heartbeatpb.InfluencedTables{InfluenceType: heartbeatpb.InfluenceType_All},
 		NeedAddedTables:   []*heartbeatpb.Table{{2, 1}, {3, 1}},
-	}, true)
+	}, true, false)
 	event.scheduleBlockEvent()
 	// drop table will be executed first
 	require.Equal(t, 2, controller.replicationDB.GetAbsentSize())
@@ -63,7 +63,7 @@ func TestScheduleEvent(t *testing.T) {
 			SchemaID:      1,
 		},
 		NeedAddedTables: []*heartbeatpb.Table{{4, 1}},
-	}, false)
+	}, false, false)
 	event.scheduleBlockEvent()
 	// drop table will be executed first, then add the new table
 	require.Equal(t, 1, controller.replicationDB.GetAbsentSize())
@@ -76,7 +76,7 @@ func TestScheduleEvent(t *testing.T) {
 			TableIDs:      []int64{4},
 		},
 		NeedAddedTables: []*heartbeatpb.Table{{5, 1}},
-	}, false)
+	}, false, false)
 	event.scheduleBlockEvent()
 	// drop table will be executed first, then add the new table
 	require.Equal(t, 1, controller.replicationDB.GetAbsentSize())
@@ -111,7 +111,7 @@ func TestResendAction(t *testing.T) {
 		BlockTables: &heartbeatpb.InfluencedTables{
 			InfluenceType: heartbeatpb.InfluenceType_All,
 		},
-	}, false)
+	}, false, false)
 	// time is not reached
 	event.lastResendTime = time.Now()
 	event.selected.Store(true)
@@ -138,7 +138,7 @@ func TestResendAction(t *testing.T) {
 			InfluenceType: heartbeatpb.InfluenceType_DB,
 			SchemaID:      1,
 		},
-	}, false)
+	}, false, false)
 	event.selected.Store(true)
 	event.writerDispatcherAdvanced = true
 	msgs = event.resend()
@@ -156,7 +156,7 @@ func TestResendAction(t *testing.T) {
 			InfluenceType: heartbeatpb.InfluenceType_All,
 			SchemaID:      1,
 		},
-	}, false)
+	}, false, false)
 	event.selected.Store(true)
 	event.writerDispatcherAdvanced = true
 	msgs = event.resend()
@@ -175,7 +175,7 @@ func TestResendAction(t *testing.T) {
 			TableIDs:      []int64{1, 2},
 			SchemaID:      1,
 		},
-	}, false)
+	}, false, false)
 	event.selected.Store(true)
 	event.writerDispatcherAdvanced = true
 	msgs = event.resend()
@@ -217,8 +217,7 @@ func TestUpdateSchemaID(t *testing.T) {
 				NewSchemaID: 2,
 			},
 		},
-	}, true,
-	)
+	}, true, false)
 	event.scheduleBlockEvent()
 	require.Equal(t, 1, controller.replicationDB.GetAbsentSize())
 	// check the schema id and map is updated

--- a/pkg/sink/mysql/mysql_writer.go
+++ b/pkg/sink/mysql/mysql_writer.go
@@ -139,7 +139,7 @@ func (w *MysqlWriter) FlushDDLEvent(event *commonEvent.DDLEvent) error {
 func (w *MysqlWriter) FlushSyncPointEvent(event *commonEvent.SyncPointEvent) error {
 	if !w.syncPointTableInit {
 		// create sync point table if not exist
-		err := w.CreateSyncTable()
+		err := w.createSyncTable()
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/sink/mysql/mysql_writer.go
+++ b/pkg/sink/mysql/mysql_writer.go
@@ -106,6 +106,12 @@ func (w *MysqlWriter) FlushDDLEvent(event *commonEvent.DDLEvent) error {
 			return errors.Trace(err)
 		}
 	} else if !(event.TiDBOnly && !w.cfg.IsTiDB) {
+		if w.cfg.IsTiDB {
+			// if downstream is tidb, we write ddl ts before ddl first, and update the ddl ts item after ddl executed,
+			// to ensure the atomic with ddl writing when server is restarted.
+			w.FlushDDLTsPre(event)
+		}
+
 		err := w.execDDLWithMaxRetries(event)
 		if err != nil {
 			return errors.Trace(err)
@@ -122,6 +128,44 @@ func (w *MysqlWriter) FlushDDLEvent(event *commonEvent.DDLEvent) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	for _, callback := range event.PostTxnFlushed {
+		callback()
+	}
+	return nil
+}
+
+func (w *MysqlWriter) FlushSyncPointEvent(event *commonEvent.SyncPointEvent) error {
+	if !w.syncPointTableInit {
+		// create sync point table if not exist
+		err := w.CreateSyncTable()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		w.syncPointTableInit = true
+	}
+	if w.cfg.IsTiDB {
+		// if downstream is tidb, we write ddl ts before ddl first, and update the ddl ts item after ddl executed,
+		// to ensure the atomic with ddl writing when server is restarted.
+		w.FlushDDLTsPre(event)
+	}
+
+	err := w.SendSyncPointEvent(event)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// We need to record ddl' ts after each ddl for each table in the downstream when sink is mysql-compatible.
+	// Only in this way, when the node restart, we can continue sync data from the last ddl ts at least.
+	// Otherwise, after restarting, we may sync old data in new schema, which will leading to data loss.
+
+	// We make Flush ddl ts before callback(), in order to make sure the ddl ts is flushed
+	// before new checkpointTs will report to maintainer. Therefore, when the table checkpointTs is forward,
+	// we can ensure the ddl and ddl ts are both flushed downstream successfully.
+	err = w.FlushDDLTs(event)
+	if err != nil {
+		return err
 	}
 
 	for _, callback := range event.PostTxnFlushed {

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -30,136 +30,37 @@ import (
 	"go.uber.org/zap"
 )
 
+// FlushDDLTsPre is used to flush ddl ts before the ddl event is sent to downstream.
+// It only be called when downstream is tidb.
+// It's used to fix the potential data loss problem leading by the ddl ts event and ddl event can't be atomicly send to downstream.
+//
+// For example,
+// If we don't flush ddl ts pre before the ddl event,
+// it may happens that the ddl event is sent to downstream, and the server is down
+// so the ddl ts event is not sent to downstream.
+// Then when the server is up, we search the ddl ts table and find the ddl ts is not exist,
+// and we may think the ddl event is not sent to downstream, so we will use the startTs with the last ddl ts.
+// It will cause we use the wrong startTs and cause the data loss.
+//
+// Thus, we try to flush ddl ts pre first before the ddl event is sent to downstream,
+// and after send the ddl ts, we update the ddl ts item to finished.
+// It can maximum guarantee we use the correct startTs.
 func (w *MysqlWriter) FlushDDLTsPre(event commonEvent.BlockEvent) error {
-	if !w.ddlTsTableInit {
-		// create checkpoint ts table if not exist
-		err := w.CreateDDLTsTable()
-		if err != nil {
-			return err
-		}
-		w.ddlTsTableInit = true
+	err := w.createDDLTsTableIfNotExist()
+	if err != nil {
+		return err
 	}
-
-	err := w.SendDDLTsPre(event)
+	err = w.SendDDLTsPre(event)
 	return errors.Trace(err)
 }
 
 func (w *MysqlWriter) FlushDDLTs(event commonEvent.BlockEvent) error {
-	if !w.ddlTsTableInit {
-		// create checkpoint ts table if not exist
-		err := w.CreateDDLTsTable()
-		if err != nil {
-			return err
-		}
-		w.ddlTsTableInit = true
+	err := w.createDDLTsTableIfNotExist()
+	if err != nil {
+		return err
 	}
-
-	err := w.SendDDLTs(event)
+	err = w.SendDDLTs(event)
 	return errors.Trace(err)
-}
-
-func (w *MysqlWriter) RemoveDDLTsItem() error {
-	tx, err := w.db.BeginTx(w.ctx, nil)
-	if err != nil {
-		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, "select ddl ts table: begin Tx fail;"))
-	}
-
-	changefeedID := w.ChangefeedID.String()
-	ticdcClusterID := config.GetGlobalServerConfig().ClusterID
-
-	var builder strings.Builder
-	builder.WriteString("DELETE FROM ")
-	builder.WriteString(filter.TiCDCSystemSchema)
-	builder.WriteString(".")
-	builder.WriteString(filter.DDLTsTable)
-	builder.WriteString(" WHERE (ticdc_cluster_id, changefeed) IN (")
-
-	builder.WriteString("('")
-	builder.WriteString(ticdcClusterID)
-	builder.WriteString("', '")
-	builder.WriteString(changefeedID)
-	builder.WriteString("')")
-	builder.WriteString(")")
-	query := builder.String()
-
-	_, err = tx.Exec(query)
-	if err != nil {
-		if apperror.IsTableNotExistsErr(err) {
-			// If this table is not existed, this means the changefeed has not table, so we just return nil.
-			log.Info("ddl ts table is not found when RemoveDDLTsItem",
-				zap.String("namespace", w.ChangefeedID.Namespace()),
-				zap.String("changefeedID", w.ChangefeedID.Name()),
-				zap.Error(err))
-			return nil
-		}
-		log.Error("failed to delete ddl ts item ", zap.Error(err))
-		err2 := tx.Rollback()
-		if err2 != nil {
-			log.Error("failed to delete ddl ts item", zap.Error(err2))
-		}
-		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
-	}
-
-	err = tx.Commit()
-	return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
-}
-
-// TODO
-func (w *MysqlWriter) isDDLExecuted(tableID int64, ddlTs uint64) (bool, error) {
-	changefeedID := w.ChangefeedID.String()
-	ticdcClusterID := config.GetGlobalServerConfig().ClusterID
-
-	// select * from xx where (ticdc_cluster_id, changefeed, table_id, ddl_ts) in (("xx","xx",x,x));
-	var builder strings.Builder
-	builder.WriteString("SELECT * FROM ")
-	builder.WriteString(filter.TiCDCSystemSchema)
-	builder.WriteString(".")
-	builder.WriteString(filter.DDLTsTable)
-	builder.WriteString(" WHERE (ticdc_cluster_id, changefeed, table_id, ddl_ts, finished) IN (")
-
-	builder.WriteString("('")
-	builder.WriteString(ticdcClusterID)
-	builder.WriteString("', '")
-	builder.WriteString(changefeedID)
-	builder.WriteString("', ")
-	builder.WriteString(strconv.FormatInt(tableID, 10))
-	builder.WriteString(", ")
-	builder.WriteString(strconv.FormatUint(ddlTs, 10))
-	builder.WriteString(", ")
-	builder.WriteString("1")
-	builder.WriteString(")")
-	builder.WriteString(")")
-	query := builder.String()
-
-	rows, err := w.db.Query(query)
-	if err != nil {
-		return false, cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
-	}
-
-	defer rows.Close()
-	if rows.Next() {
-		return true, nil
-	}
-	return false, nil
-}
-
-func (w *MysqlWriter) CreateDDLTsTable() error {
-	database := filter.TiCDCSystemSchema
-	query := `CREATE TABLE IF NOT EXISTS %s
-	(
-		ticdc_cluster_id varchar (255),
-		changefeed varchar(255),
-		ddl_ts varchar(18),
-		table_id bigint(21),
-		finished bool,
-		related_table_id bigint(21),
-		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		INDEX (ticdc_cluster_id, changefeed, table_id),
-		PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
-	);`
-	query = fmt.Sprintf(query, filter.DDLTsTable)
-
-	return w.CreateTable(database, filter.DDLTsTable, query)
 }
 
 func (w *MysqlWriter) SendDDLTsPre(event commonEvent.BlockEvent) error {
@@ -192,43 +93,7 @@ func (w *MysqlWriter) SendDDLTsPre(event commonEvent.BlockEvent) error {
 	}
 
 	if len(tableIds) > 0 {
-		// choose one related table_id to help table trigger event dispatcher to find the ddl jobs.
-		relatedTableID := tableIds[0]
-		if relatedTableID == 0 {
-			if len(tableIds) > 1 {
-				relatedTableID = tableIds[1]
-			}
-		}
-		// generate query
-		// INSERT INTO `tidb_cdc`.`ddl_ts` (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished) values(...) ON DUPLICATE KEY UPDATE ddl_ts=VALUES(ddl_ts), created_at=CURRENT_TIMESTAMP;
-		var builder strings.Builder
-		builder.WriteString("INSERT INTO ")
-		builder.WriteString(filter.TiCDCSystemSchema)
-		builder.WriteString(".")
-		builder.WriteString(filter.DDLTsTable)
-		builder.WriteString(" (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished) VALUES ")
-
-		for idx, tableId := range tableIds {
-			builder.WriteString("('")
-			builder.WriteString(ticdcClusterID)
-			builder.WriteString("', '")
-			builder.WriteString(changefeedID)
-			builder.WriteString("', '")
-			builder.WriteString(ddlTs)
-			builder.WriteString("', ")
-			builder.WriteString(strconv.FormatInt(tableId, 10))
-			builder.WriteString(", ")
-			builder.WriteString(strconv.FormatInt(relatedTableID, 10))
-			builder.WriteString(", ")
-			builder.WriteString("0")
-			builder.WriteString(")")
-			if idx < len(tableIds)-1 {
-				builder.WriteString(", ")
-			}
-		}
-		builder.WriteString(" ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW();")
-
-		query := builder.String()
+		query := insertItemQuery(tableIds, ticdcClusterID, changefeedID, ddlTs, "0")
 		log.Info("send ddl ts table query", zap.String("query", query))
 
 		_, err = tx.Exec(query)
@@ -295,43 +160,7 @@ func (w *MysqlWriter) SendDDLTs(event commonEvent.BlockEvent) error {
 	}
 
 	if len(tableIds) > 0 {
-		// choose one related table_id to help table trigger event dispatcher to find the ddl jobs.
-		relatedTableID := tableIds[0] // TODO: 这个 related table id 要合理挑选一下，主要是 partition 要选 physical table 才行？主要是看 tableID 用的是哪个
-		if relatedTableID == 0 {
-			if len(tableIds) > 1 {
-				relatedTableID = tableIds[1]
-			}
-		}
-		// generate query
-		// INSERT INTO `tidb_cdc`.`ddl_ts` (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished) values(...) ON DUPLICATE KEY UPDATE ddl_ts=VALUES(ddl_ts), created_at=CURRENT_TIMESTAMP;
-		var builder strings.Builder
-		builder.WriteString("INSERT INTO ")
-		builder.WriteString(filter.TiCDCSystemSchema)
-		builder.WriteString(".")
-		builder.WriteString(filter.DDLTsTable)
-		builder.WriteString(" (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished) VALUES ")
-
-		for idx, tableId := range tableIds {
-			builder.WriteString("('")
-			builder.WriteString(ticdcClusterID)
-			builder.WriteString("', '")
-			builder.WriteString(changefeedID)
-			builder.WriteString("', '")
-			builder.WriteString(ddlTs)
-			builder.WriteString("', ")
-			builder.WriteString(strconv.FormatInt(tableId, 10))
-			builder.WriteString(", ")
-			builder.WriteString(strconv.FormatInt(relatedTableID, 10))
-			builder.WriteString(", ")
-			builder.WriteString("1")
-			builder.WriteString(")")
-			if idx < len(tableIds)-1 {
-				builder.WriteString(", ")
-			}
-		}
-		builder.WriteString(" ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW();")
-
-		query := builder.String()
+		query := insertItemQuery(tableIds, ticdcClusterID, changefeedID, ddlTs, "1")
 		log.Info("send ddl ts table query", zap.String("query", query))
 
 		_, err = tx.Exec(query)
@@ -349,28 +178,7 @@ func (w *MysqlWriter) SendDDLTs(event commonEvent.BlockEvent) error {
 
 	if len(dropTableIds) > 0 {
 		// drop item for this tableid
-		var builder strings.Builder
-		builder.WriteString("DELETE FROM ")
-		builder.WriteString(filter.TiCDCSystemSchema)
-		builder.WriteString(".")
-		builder.WriteString(filter.DDLTsTable)
-		builder.WriteString(" WHERE (ticdc_cluster_id, changefeed, table_id) IN (")
-
-		for idx, tableId := range dropTableIds {
-			builder.WriteString("('")
-			builder.WriteString(ticdcClusterID)
-			builder.WriteString("', '")
-			builder.WriteString(changefeedID)
-			builder.WriteString("', ")
-			builder.WriteString(strconv.FormatInt(tableId, 10))
-			builder.WriteString(")")
-			if idx < len(dropTableIds)-1 {
-				builder.WriteString(", ")
-			}
-		}
-
-		builder.WriteString(")")
-		query := builder.String()
+		query := dropItemQuery(dropTableIds, ticdcClusterID, changefeedID)
 		log.Debug("send ddl ts table query", zap.String("query", query))
 
 		_, err = tx.Exec(query)
@@ -388,10 +196,80 @@ func (w *MysqlWriter) SendDDLTs(event commonEvent.BlockEvent) error {
 	return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, "failed to write ddl ts table; Commit Fail;"))
 }
 
+func insertItemQuery(tableIds []int64, ticdcClusterID string, changefeedID string, ddlTs string, finished string) string {
+	// choose one related table_id to help table trigger event dispatcher to find the ddl jobs.
+	relatedTableID := tableIds[0] // TODO: relatedID need to be selected carefully, especially for partitioned tables
+	if relatedTableID == 0 {
+		if len(tableIds) > 1 {
+			relatedTableID = tableIds[1]
+		}
+	}
+	var builder strings.Builder
+	builder.WriteString("INSERT INTO ")
+	builder.WriteString(filter.TiCDCSystemSchema)
+	builder.WriteString(".")
+	builder.WriteString(filter.DDLTsTable)
+	builder.WriteString(" (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished) VALUES ")
+
+	for idx, tableId := range tableIds {
+		builder.WriteString("('")
+		builder.WriteString(ticdcClusterID)
+		builder.WriteString("', '")
+		builder.WriteString(changefeedID)
+		builder.WriteString("', '")
+		builder.WriteString(ddlTs)
+		builder.WriteString("', ")
+		builder.WriteString(strconv.FormatInt(tableId, 10))
+		builder.WriteString(", ")
+		builder.WriteString(strconv.FormatInt(relatedTableID, 10))
+		builder.WriteString(", ")
+		builder.WriteString("finished")
+		builder.WriteString(")")
+		if idx < len(tableIds)-1 {
+			builder.WriteString(", ")
+		}
+	}
+	builder.WriteString(" ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW();")
+
+	return builder.String()
+}
+
+func dropItemQuery(dropTableIds []int64, ticdcClusterID string, changefeedID string) string {
+	var builder strings.Builder
+	builder.WriteString("DELETE FROM ")
+	builder.WriteString(filter.TiCDCSystemSchema)
+	builder.WriteString(".")
+	builder.WriteString(filter.DDLTsTable)
+	builder.WriteString(" WHERE (ticdc_cluster_id, changefeed, table_id) IN (")
+
+	for idx, tableId := range dropTableIds {
+		builder.WriteString("('")
+		builder.WriteString(ticdcClusterID)
+		builder.WriteString("', '")
+		builder.WriteString(changefeedID)
+		builder.WriteString("', ")
+		builder.WriteString(strconv.FormatInt(tableId, 10))
+		builder.WriteString(")")
+		if idx < len(dropTableIds)-1 {
+			builder.WriteString(", ")
+		}
+	}
+
+	builder.WriteString(")")
+	return builder.String()
+}
+
 // GetStartTsList return the startTs list for each table in the tableIDs list.
 // For each table,
-// If no ddl-ts-v1 table or no the row for the table , startTs = 0; -- means the table is new.
-// Otherwise, startTs = ddl-ts value.
+//  1. If no ddl-ts-v1 table or no the row for the table , startTs = 0; -- means the table is new.
+//  2. Else,
+//     2.1 If the downstream is non-tidb, startTs = ddlTs
+//     2.2 Else
+//     2.2.1 if the ddlTs is finished, startTs = ddlTs
+//     2.2.2 else query the ddl_jobs table to find the latest ddl job time for the table
+//     (we use related table to find the ddl job -- take `truncate table` as an example, the ddl job used the table truncated, but not the new table)
+//     2.2.2.1 if the latest ddl job time is larger than the createdAt, startTs = ddlTs
+//     2.2.2.2 else startTs = ddlTs - 1
 func (w *MysqlWriter) GetStartTsList(tableIDs []int64) ([]int64, error) {
 	retStartTsList := make([]int64, len(tableIDs))
 	tableIdIdxMap := make(map[int64]int, 0)
@@ -402,6 +280,67 @@ func (w *MysqlWriter) GetStartTsList(tableIDs []int64) ([]int64, error) {
 	changefeedID := w.ChangefeedID.String()
 	ticdcClusterID := config.GetGlobalServerConfig().ClusterID
 
+	query := selectDDLTsQuery(tableIDs, ticdcClusterID, changefeedID)
+	rows, err := w.db.Query(query)
+	if err != nil {
+		if apperror.IsTableNotExistsErr(err) {
+			// If this table is not existed, this means the table is first being synced
+			log.Info("ddl ts table is not found",
+				zap.String("namespace", w.ChangefeedID.Namespace()),
+				zap.String("changefeedID", w.ChangefeedID.Name()),
+				zap.Error(err))
+			return retStartTsList, nil
+		}
+		return retStartTsList, cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
+	}
+
+	defer rows.Close()
+	var ddlTs, tableId, relatedTableId int64
+	var finished bool
+	var createdAtBytes []byte
+	for rows.Next() {
+		err := rows.Scan(&tableId, &relatedTableId, &ddlTs, &finished, &createdAtBytes)
+		if err != nil {
+			return retStartTsList, cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
+		}
+		if finished {
+			retStartTsList[tableIdIdxMap[tableId]] = ddlTs
+		} else {
+			if !w.cfg.IsTiDB {
+				log.Panic("ddl ts table is not finished, but downstream is not tidb, FIX IT")
+			}
+
+			createdAt, err := time.Parse("2006-01-02 15:04:05", string(createdAtBytes))
+			if err != nil {
+				log.Error("Failed to parse created_at", zap.Any("createdAtBytes", createdAtBytes), zap.Any("error", err))
+				retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
+				continue
+			}
+
+			// query the ddl_jobs table to find whether the ddl is executed and the ddl created time
+			createdTime, ok := w.queryDDLJobs(relatedTableId)
+			if !ok {
+				retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
+			} else {
+				if createdAt.Before(createdTime) {
+					// show the ddl is executed
+					retStartTsList[tableIdIdxMap[tableId]] = ddlTs
+					log.Debug("createdTime is larger than createdAt", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs))
+					continue
+				} else {
+					// show the ddl is not executed
+					retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
+					log.Debug("createdTime is less than  createdAt", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs-1))
+					continue
+				}
+			}
+		}
+	}
+
+	return retStartTsList, nil
+}
+
+func selectDDLTsQuery(tableIDs []int64, ticdcClusterID string, changefeedID string) string {
 	var builder strings.Builder
 	builder.WriteString("SELECT table_id, related_table_id, ddl_ts, finished, created_at FROM ")
 	builder.WriteString(filter.TiCDCSystemSchema)
@@ -422,104 +361,128 @@ func (w *MysqlWriter) GetStartTsList(tableIDs []int64) ([]int64, error) {
 		}
 	}
 	builder.WriteString(")")
-	query := builder.String()
-
-	rows, err := w.db.Query(query)
-	if err != nil {
-		if apperror.IsTableNotExistsErr(err) {
-			// If this table is not existed, this means the table is first being synced
-			log.Info("ddl ts table is not found",
-				zap.String("namespace", w.ChangefeedID.Namespace()),
-				zap.String("changefeedID", w.ChangefeedID.Name()),
-				zap.Error(err))
-			return retStartTsList, nil
-		}
-		return retStartTsList, cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
-	}
-
-	defer rows.Close()
-	var ddlTs int64
-	var tableId int64
-	var relatedTableId int64
-	var finished bool
-	var createdAtBytes []byte
-	var createdAt time.Time
-	for rows.Next() {
-		err := rows.Scan(&tableId, &relatedTableId, &ddlTs, &finished, &createdAtBytes)
-		if err != nil {
-			return retStartTsList, cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
-		}
-		if finished {
-			retStartTsList[tableIdIdxMap[tableId]] = ddlTs
-		} else {
-			if w.cfg.IsTiDB {
-				createdAt, err = time.Parse("2006-01-02 15:04:05", string(createdAtBytes))
-				if err != nil {
-					log.Error("Failed to parse created_at", zap.Any("createdAtBytes", createdAtBytes), zap.Any("error", err))
-					retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
-					continue
-				}
-				// query the ddl_jobs table to find whether the ddl is executed
-				// if tableId == 0 {
-				// 	tableId = relatedTableId
-				// }
-				query := fmt.Sprintf(queryDDLJobs, strconv.FormatInt(relatedTableId, 10))
-				log.Info("query ddl jobs", zap.String("query", query))
-
-				start := time.Now()
-				ddlJobRows, err := w.db.Query(query)
-				if err != nil {
-					log.Error("failed to query ddl jobs", zap.Error(err))
-					retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
-					continue
-				}
-				log.Info("query ddl jobs cost time", zap.Duration("cost", time.Since(start)))
-
-				defer rows.Close()
-				var createdTimeBytes []byte
-				var createdTime time.Time
-				for ddlJobRows.Next() {
-					err := ddlJobRows.Scan(&createdTimeBytes)
-					if err != nil {
-						log.Error("failed to query ddl jobs", zap.Error(err))
-						retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
-						continue
-					}
-					createdTime, err = time.Parse("2006-01-02 15:04:05", string(createdTimeBytes))
-					if err != nil {
-						log.Error("Failed to parse createdTimeBytes", zap.Any("createdTimeBytes", createdTimeBytes), zap.Any("error", err))
-						retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
-						continue
-					}
-					if createdAt.Before(createdTime) {
-						// show the ddl is executed
-						retStartTsList[tableIdIdxMap[tableId]] = ddlTs
-						log.Debug("createdTime is larger than createdAt", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs))
-						continue
-					} else {
-						// show the ddl is not executed
-						retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
-						log.Debug("createdTime is less than  createdAt", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs-1))
-						continue
-					}
-				}
-				// if no ddl job item
-				retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
-				log.Debug("no ddl job item", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs-1))
-				continue
-			} else {
-				// if downstream is not tidb, we can't know whether the ddl is executed or not, so we just set the startTs to ddl_ts - 1.
-				retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
-			}
-		}
-	}
-
-	return retStartTsList, nil
+	return builder.String()
 }
 
 var queryDDLJobs = `SELECT CREATE_TIME FROM information_schema.ddl_jobs WHERE TABLE_ID = "%s" order by CREATE_TIME desc limit 1;`
 
-func (w *MysqlWriter) CreateTable(dbName string, tableName string, createTableQuery string) error {
+func (w *MysqlWriter) queryDDLJobs(tableID int64) (time.Time, bool) {
+	// query the ddl_jobs table to find whether the ddl is executed
+	query := fmt.Sprintf(queryDDLJobs, strconv.FormatInt(tableID, 10))
+	log.Info("query the info from ddl jobs", zap.String("query", query))
+
+	start := time.Now()
+	ddlJobRows, err := w.db.Query(query)
+	if err != nil {
+		log.Error("failed to query ddl jobs", zap.Error(err))
+		return time.Time{}, false
+	}
+	log.Info("query ddl jobs cost time", zap.Duration("cost", time.Since(start)))
+
+	defer ddlJobRows.Close()
+	var createdTimeBytes []byte
+	var createdTime time.Time
+	for ddlJobRows.Next() {
+		err := ddlJobRows.Scan(&createdTimeBytes)
+		if err != nil {
+			log.Error("failed to query ddl jobs", zap.Error(err))
+			return time.Time{}, false
+		}
+		createdTime, err = time.Parse("2006-01-02 15:04:05", string(createdTimeBytes))
+		if err != nil {
+			log.Error("Failed to parse createdTimeBytes", zap.Any("createdTimeBytes", createdTimeBytes), zap.Any("error", err))
+			return time.Time{}, false
+		}
+		return createdTime, true
+	}
+	log.Debug("no ddl job item", zap.Int64("relatedTableId", tableID))
+	return time.Time{}, false
+}
+func (w *MysqlWriter) RemoveDDLTsItem() error {
+	tx, err := w.db.BeginTx(w.ctx, nil)
+	if err != nil {
+		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, "select ddl ts table: begin Tx fail;"))
+	}
+
+	changefeedID := w.ChangefeedID.String()
+	ticdcClusterID := config.GetGlobalServerConfig().ClusterID
+
+	var builder strings.Builder
+	builder.WriteString("DELETE FROM ")
+	builder.WriteString(filter.TiCDCSystemSchema)
+	builder.WriteString(".")
+	builder.WriteString(filter.DDLTsTable)
+	builder.WriteString(" WHERE (ticdc_cluster_id, changefeed) IN (")
+
+	builder.WriteString("('")
+	builder.WriteString(ticdcClusterID)
+	builder.WriteString("', '")
+	builder.WriteString(changefeedID)
+	builder.WriteString("')")
+	builder.WriteString(")")
+	query := builder.String()
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		if apperror.IsTableNotExistsErr(err) {
+			// If this table is not existed, this means the changefeed has not table, so we just return nil.
+			log.Info("ddl ts table is not found when RemoveDDLTsItem",
+				zap.String("namespace", w.ChangefeedID.Namespace()),
+				zap.String("changefeedID", w.ChangefeedID.Name()),
+				zap.Error(err))
+			return nil
+		}
+		log.Error("failed to delete ddl ts item ", zap.Error(err))
+		err2 := tx.Rollback()
+		if err2 != nil {
+			log.Error("failed to delete ddl ts item", zap.Error(err2))
+		}
+		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+	}
+
+	err = tx.Commit()
+	return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+}
+
+func (w *MysqlWriter) isDDLExecuted(tableID int64, ddlTs uint64) (bool, error) {
+	changefeedID := w.ChangefeedID.String()
+	ticdcClusterID := config.GetGlobalServerConfig().ClusterID
+
+	// select * from xx where (ticdc_cluster_id, changefeed, table_id, ddl_ts) in (("xx","xx",x,x));
+	var builder strings.Builder
+	builder.WriteString("SELECT * FROM ")
+	builder.WriteString(filter.TiCDCSystemSchema)
+	builder.WriteString(".")
+	builder.WriteString(filter.DDLTsTable)
+	builder.WriteString(" WHERE (ticdc_cluster_id, changefeed, table_id, ddl_ts, finished) IN (")
+
+	builder.WriteString("('")
+	builder.WriteString(ticdcClusterID)
+	builder.WriteString("', '")
+	builder.WriteString(changefeedID)
+	builder.WriteString("', ")
+	builder.WriteString(strconv.FormatInt(tableID, 10))
+	builder.WriteString(", ")
+	builder.WriteString(strconv.FormatUint(ddlTs, 10))
+	builder.WriteString(", ")
+	builder.WriteString("1")
+	builder.WriteString(")")
+	builder.WriteString(")")
+	query := builder.String()
+
+	rows, err := w.db.Query(query)
+	if err != nil {
+		return false, cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
+	}
+
+	defer rows.Close()
+	if rows.Next() {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (w *MysqlWriter) createTable(dbName string, tableName string, createTableQuery string) error {
 	tx, err := w.db.BeginTx(w.ctx, nil)
 	if err != nil {
 		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("create %s table: begin Tx fail;", tableName)))
@@ -562,4 +525,35 @@ func (w *MysqlWriter) CreateTable(dbName string, tableName string, createTableQu
 	}
 	err = tx.Commit()
 	return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("create %s table: Commit Failed; Query is %s", tableName, createTableQuery)))
+}
+
+func (w *MysqlWriter) createDDLTsTable() error {
+	database := filter.TiCDCSystemSchema
+	query := `CREATE TABLE IF NOT EXISTS %s
+	(
+		ticdc_cluster_id varchar (255),
+		changefeed varchar(255),
+		ddl_ts varchar(18),
+		table_id bigint(21),
+		finished bool,
+		related_table_id bigint(21),
+		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		INDEX (ticdc_cluster_id, changefeed, table_id),
+		PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
+	);`
+	query = fmt.Sprintf(query, filter.DDLTsTable)
+
+	return w.createTable(database, filter.DDLTsTable, query)
+}
+
+func (w *MysqlWriter) createDDLTsTableIfNotExist() error {
+	if !w.ddlTsTableInit {
+		// create checkpoint ts table if not exist
+		err := w.createDDLTsTable()
+		if err != nil {
+			return err
+		}
+		w.ddlTsTableInit = true
+	}
+	return nil
 }

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -226,7 +226,7 @@ func (w *MysqlWriter) SendDDLTsPre(event commonEvent.BlockEvent) error {
 				builder.WriteString(", ")
 			}
 		}
-		builder.WriteString(" ON DUPLICATE KEY UPDATE ddl_ts=VALUES(ddl_ts), created_at=NOW();")
+		builder.WriteString(" ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW();")
 
 		query := builder.String()
 		log.Info("send ddl ts table query", zap.String("query", query))
@@ -329,7 +329,7 @@ func (w *MysqlWriter) SendDDLTs(event commonEvent.BlockEvent) error {
 				builder.WriteString(", ")
 			}
 		}
-		builder.WriteString(" ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), created_at=NOW();")
+		builder.WriteString(" ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW();")
 
 		query := builder.String()
 		log.Info("send ddl ts table query", zap.String("query", query))

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -197,8 +197,6 @@ func (w *MysqlWriter) SendDDLTsPre(event commonEvent.BlockEvent) error {
 		if relatedTableID == 0 {
 			if len(tableIds) > 1 {
 				relatedTableID = tableIds[1]
-			} else {
-				log.Panic("relatedTableID is 0 and tableIds is empty, FIX IT", zap.Any("event", event))
 			}
 		}
 		// generate query
@@ -298,12 +296,10 @@ func (w *MysqlWriter) SendDDLTs(event commonEvent.BlockEvent) error {
 
 	if len(tableIds) > 0 {
 		// choose one related table_id to help table trigger event dispatcher to find the ddl jobs.
-		relatedTableID := tableIds[0]
+		relatedTableID := tableIds[0] // TODO: 这个 related table id 要合理挑选一下，主要是 partition 要选 physical table 才行？主要是看 tableID 用的是哪个
 		if relatedTableID == 0 {
 			if len(tableIds) > 1 {
 				relatedTableID = tableIds[1]
-			} else {
-				log.Panic("relatedTableID is 0 and tableIds is empty, FIX IT", zap.Any("event", event))
 			}
 		}
 		// generate query
@@ -464,10 +460,10 @@ func (w *MysqlWriter) GetStartTsList(tableIDs []int64) ([]int64, error) {
 					continue
 				}
 				// query the ddl_jobs table to find whether the ddl is executed
-				if tableId == 0 {
-					tableId = relatedTableId
-				}
-				query := fmt.Sprintf(queryDDLJobs, strconv.FormatInt(tableId, 10))
+				// if tableId == 0 {
+				// 	tableId = relatedTableId
+				// }
+				query := fmt.Sprintf(queryDDLJobs, strconv.FormatInt(relatedTableId, 10))
 				log.Info("query ddl jobs", zap.String("query", query))
 
 				start := time.Now()

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -494,11 +494,19 @@ func (w *MysqlWriter) GetStartTsList(tableIDs []int64) ([]int64, error) {
 					if createdAt.Before(createdTime) {
 						// show the ddl is executed
 						retStartTsList[tableIdIdxMap[tableId]] = ddlTs
+						log.Debug("createdTime is larger than createdAt", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs))
+						continue
 					} else {
 						// show the ddl is not executed
 						retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
+						log.Debug("createdTime is less than  createdAt", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs-1))
+						continue
 					}
 				}
+				// if no ddl job item
+				retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1
+				log.Debug("no ddl job item", zap.Int64("tableId", tableId), zap.Int64("relatedTableId", relatedTableId), zap.Int64("ddlTs", ddlTs), zap.Int64("startTs", ddlTs-1))
+				continue
 			} else {
 				// if downstream is not tidb, we can't know whether the ddl is executed or not, so we just set the startTs to ddl_ts - 1.
 				retStartTsList[tableIdIdxMap[tableId]] = ddlTs - 1

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -223,7 +223,7 @@ func insertItemQuery(tableIds []int64, ticdcClusterID string, changefeedID strin
 		builder.WriteString(", ")
 		builder.WriteString(strconv.FormatInt(relatedTableID, 10))
 		builder.WriteString(", ")
-		builder.WriteString("finished")
+		builder.WriteString(finished)
 		builder.WriteString(")")
 		if idx < len(tableIds)-1 {
 			builder.WriteString(", ")

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -398,6 +398,7 @@ func (w *MysqlWriter) queryDDLJobs(tableID int64) (time.Time, bool) {
 	log.Debug("no ddl job item", zap.Int64("relatedTableId", tableID))
 	return time.Time{}, false
 }
+
 func (w *MysqlWriter) RemoveDDLTsItem() error {
 	tx, err := w.db.BeginTx(w.ctx, nil)
 	if err != nil {

--- a/pkg/sink/mysql/mysql_writer_for_syncpoint.go
+++ b/pkg/sink/mysql/mysql_writer_for_syncpoint.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (w *MysqlWriter) CreateSyncTable() error {
+func (w *MysqlWriter) createSyncTable() error {
 	database := filter.TiCDCSystemSchema
 	query := `CREATE TABLE IF NOT EXISTS %s
 	(
@@ -42,7 +42,7 @@ func (w *MysqlWriter) CreateSyncTable() error {
 		PRIMARY KEY (changefeed, primary_ts)
 	);`
 	query = fmt.Sprintf(query, filter.SyncPointTable)
-	return w.CreateTable(database, filter.SyncPointTable, query)
+	return w.createTable(database, filter.SyncPointTable, query)
 }
 
 func (w *MysqlWriter) SendSyncPointEvent(event *commonEvent.SyncPointEvent) error {

--- a/pkg/sink/mysql/mysql_writer_for_syncpoint.go
+++ b/pkg/sink/mysql/mysql_writer_for_syncpoint.go
@@ -45,25 +45,6 @@ func (w *MysqlWriter) CreateSyncTable() error {
 	return w.CreateTable(database, filter.SyncPointTable, query)
 }
 
-func (w *MysqlWriter) FlushSyncPointEvent(event *commonEvent.SyncPointEvent) error {
-	if !w.syncPointTableInit {
-		// create sync point table if not exist
-		err := w.CreateSyncTable()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		w.syncPointTableInit = true
-	}
-	err := w.SendSyncPointEvent(event)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for _, callback := range event.PostTxnFlushed {
-		callback()
-	}
-	return nil
-}
-
 func (w *MysqlWriter) SendSyncPointEvent(event *commonEvent.SyncPointEvent) error {
 	tx, err := w.db.BeginTx(w.ctx, nil)
 	if err != nil {
@@ -106,6 +87,8 @@ func (w *MysqlWriter) SendSyncPointEvent(event *commonEvent.SyncPointEvent) erro
 		}
 		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to write syncpoint table; Exec Failed; Query is %s", query)))
 	}
+
+	log.Debug("exec syncpoint ts query", zap.String("query", query))
 
 	// set global tidb_external_ts to secondary ts
 	// TiDB supports tidb_external_ts system variable since v6.4.0.

--- a/tests/integration_tests/_utils/run_sql_ignore_error
+++ b/tests/integration_tests/_utils/run_sql_ignore_error
@@ -1,0 +1,31 @@
+#!/bin/sh
+# parameter 1: sql
+# parameter 2: database host
+# parameter 3: database port
+# parameter 4: other mysql client settings
+
+sql=${1}
+
+host=127.0.0.1
+if [ $# -gt 1 ]; then
+	shift
+	host=${1}
+fi
+
+port=4000
+if [ $# -gt 1 ]; then
+	shift
+	port=${1}
+fi
+
+if [ $# -gt 1 ]; then
+	shift
+	other=${*}
+fi
+
+prepare="set global tidb_enable_clustered_index = 'int_only';"
+
+echo "[$(date)] Executing SQL: ${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
+
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"

--- a/tests/integration_tests/fail_over_ddl_mix/conf/changefeed.toml
+++ b/tests/integration_tests/fail_over_ddl_mix/conf/changefeed.toml
@@ -1,0 +1,2 @@
+enable-sync-point = true
+sync-point-interval = "30s"

--- a/tests/integration_tests/fail_over_ddl_mix/conf/changefeed.toml
+++ b/tests/integration_tests/fail_over_ddl_mix/conf/changefeed.toml
@@ -1,2 +1,0 @@
-enable-sync-point = true
-sync-point-interval = "30s"

--- a/tests/integration_tests/fail_over_ddl_mix/conf/diff_config.toml
+++ b/tests/integration_tests/fail_over_ddl_mix/conf/diff_config.toml
@@ -1,0 +1,28 @@
+# diff Configuration.
+check-thread-count = 4
+
+export-fix-sql = true
+
+check-struct-only = false
+
+[task]
+output-dir = "/tmp/tidb_cdc_test/fail_over_ddl_mix/sync_diff/output"
+
+source-instances = ["mysql1"]
+
+target-instance = "tidb0"
+
+target-check-tables = ["test.*"]
+
+[data-sources]
+[data-sources.mysql1]
+host = "127.0.0.1"
+port = 4000
+user = "root"
+password = ""
+
+[data-sources.tidb0]
+host = "127.0.0.1"
+port = 3306
+user = "root"
+password = ""

--- a/tests/integration_tests/fail_over_ddl_mix/run.sh
+++ b/tests/integration_tests/fail_over_ddl_mix/run.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# This test case is going to test the situation with dmls, ddls and random server down.
+# The test case is as follows:
+# 1. Start two ticdc servers.
+# 2. Create 10 tables. And then randomly exec the ddls: 
+#    such as: drop table, and then create table
+#             drop table, and then recover table
+#             truncate table
+# 3. Simultaneously we exec the dmls, continues insert data to these 10 tables.
+# 4. Besides, we also enable sync point
+# 5. Furthermore, we will randomly kill the ticdc server, and then restart it.
+# 6. We execute these threads for a time, and then check the data consistency between the upstream and downstream.
+
+set -eux
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+check_time=60
+
+function prepare() {
+	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+	start_tidb_cluster --workdir $WORK_DIR
+
+	cd $WORK_DIR
+
+	# record tso before we create tables to skip the system table DDLs
+	start_ts=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
+
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "0" --addr "127.0.0.1:8300"
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301"
+
+	TOPIC_NAME="ticdc-failover-ddl-test-mix-$RANDOM"
+	SINK_URI="mysql://root@127.0.0.1:3306/"
+	run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c "test" --config="$CUR/conf/changefeed.toml"
+}
+
+function create_tables() {
+    for i in {1..5}; do
+        echo "Creating table table_$i..."
+        run_sql "CREATE TABLE IF NOT EXISTS test.table_$i (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    done
+}
+
+function execute_ddl() {
+    while true; do
+        table_num=$((RANDOM % 5 + 1))
+        table_name="table_$table_num"
+
+        case $((RANDOM % 3)) in
+            0)
+                echo "DDL: Dropping and recreating $table_name..."
+                run_sql "DROP TABLE IF EXISTS test.$table_name;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+                sleep 0.5
+                run_sql "CREATE TABLE IF NOT EXISTS test.$table_name (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+                ;;
+            1)
+                echo "DDL: Dropping and recovering $table_name..."
+                run_sql "DROP TABLE IF EXISTS test.$table_name;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+                sleep 0.5
+                run_sql "RECOVER TABLE test.$table_name;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+                ;;
+            2)
+                echo "DDL: Truncating $table_name..."
+                run_sql "TRUNCATE TABLE test.$table_name;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+                ;;
+        esac
+
+        sleep 1
+    done
+}
+
+function execute_dml() {
+    table_name="table_$1"
+    echo "DML: Inserting data into $table_name..."
+    while true; do
+        run_sql "INSERT INTO test.$table_name (data) VALUES ('$(date +%s)');" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    done
+}
+
+function kill_server() {
+    for count in {1..10}; do
+        case $((RANDOM % 2)) in
+            0)
+                cdc_pid_1=$(ps aux | grep cdc | grep 8300 | awk '{print $2}')
+                kill -9 $cdc_pid_1
+
+                sleep 5
+                run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "0-$count" --addr "127.0.0.1:8300"
+            ;;
+            1)
+                cdc_pid_2=$(ps aux | grep cdc | grep 8301 | awk '{print $2}')
+                kill -9 $cdc_pid_2
+
+                sleep 5
+                run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-$count" --addr "127.0.0.1:8301"
+            ;;
+        esac
+        sleep 15
+    done
+}
+
+
+main() {
+    prepare
+    
+    create_tables
+    execute_ddl &
+    DDL_PID=$!
+
+    # 启动 DML 线程
+    execute_dml 1 &
+    DML_PID_1=$!
+    execute_dml 2 &
+    DML_PID_2=$!
+    execute_dml 3 &
+    DML_PID_3=$!
+    execute_dml 4 &
+    DML_PID_4=$!
+    execute_dml 5 &
+    DML_PID_5=$!
+
+    kill_server
+
+    sleep 10
+
+    kill -9 $DDL_PID $DML_PID_1 $DML_PID_2 $DML_PID_3 $DML_PID_4 $DML_PID_5
+
+    sleep 10
+
+    check_table_exists test.table_1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    check_table_exists test.table_2 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    check_table_exists test.table_3 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    check_table_exists test.table_4 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    check_table_exists test.table_5 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+main
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/fail_over_ddl_mix/run.sh
+++ b/tests/integration_tests/fail_over_ddl_mix/run.sh
@@ -7,9 +7,8 @@
 #             drop table, and then recover table
 #             truncate table
 # 3. Simultaneously we exec the dmls, continues insert data to these 10 tables.
-# 4. Besides, we also enable sync point
-# 5. Furthermore, we will randomly kill the ticdc server, and then restart it.
-# 6. We execute these threads for a time, and then check the data consistency between the upstream and downstream.
+# 4. Furthermore, we will randomly kill the ticdc server, and then restart it.
+# 5. We execute these threads for a time, and then check the data consistency between the upstream and downstream.
 
 set -eux
 
@@ -35,8 +34,6 @@ function prepare() {
 
 	TOPIC_NAME="ticdc-failover-ddl-test-mix-$RANDOM"
 	SINK_URI="mysql://root@127.0.0.1:3306/"
-	# run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c "test" --config="$CUR/conf/changefeed.toml"
-    # TODO:确实可以开两个，纯 ddl 和有 syncpoint，便于定位问题
     run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c "test"
 }
 
@@ -138,12 +135,6 @@ main() {
     kill -9 $DDL_PID $DML_PID_1 $DML_PID_2 $DML_PID_3 $DML_PID_4 $DML_PID_5
 
     sleep 10
-
-    # check_table_exists test.table_1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    # check_table_exists test.table_2 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    # check_table_exists test.table_3 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    # check_table_exists test.table_4 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    # check_table_exists test.table_5 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
 
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 500
 

--- a/tests/integration_tests/fail_over_ddl_mix/run.sh
+++ b/tests/integration_tests/fail_over_ddl_mix/run.sh
@@ -86,6 +86,9 @@ function kill_server() {
         case $((RANDOM % 2)) in
             0)
                 cdc_pid_1=$(ps aux | grep cdc | grep 8300 | awk '{print $2}')
+                if $cdc_pid_1 == "" ; then
+                    continue
+                fi
                 kill -9 $cdc_pid_1
 
                 sleep 5
@@ -93,6 +96,9 @@ function kill_server() {
             ;;
             1)
                 cdc_pid_2=$(ps aux | grep cdc | grep 8301 | awk '{print $2}')
+                if $cdc_pid_2 == "" ; then
+                    continue
+                fi
                 kill -9 $cdc_pid_2
 
                 sleep 5

--- a/tests/integration_tests/fail_over_ddl_mix/run.sh
+++ b/tests/integration_tests/fail_over_ddl_mix/run.sh
@@ -139,16 +139,14 @@ main() {
 
     sleep 10
 
-    check_table_exists test.table_1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    check_table_exists test.table_2 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    check_table_exists test.table_3 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    check_table_exists test.table_4 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
-    check_table_exists test.table_5 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    # check_table_exists test.table_1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    # check_table_exists test.table_2 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    # check_table_exists test.table_3 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    # check_table_exists test.table_4 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+    # check_table_exists test.table_5 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
 
-    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 500
 
-    sleep 100
-    
     cleanup_process $CDC_BINARY
 }
 

--- a/tests/integration_tests/fail_over_ddl_mix/run.sh
+++ b/tests/integration_tests/fail_over_ddl_mix/run.sh
@@ -147,6 +147,8 @@ main() {
 
     check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
 
+    sleep 100
+    
     cleanup_process $CDC_BINARY
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

1. insert ddl ts item before ddl event sent to downstream when downstream is tidb, to fix the atomic corner problem when server crash when ddl event is sent, but ddl ts is not sent.
2. Add a mix random test for ddl failover cases for more completely test

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
