### PR TITLE
mysql: fix and add test for async ddl `add index`

### DIFF
--- a/pkg/sink/mysql/mysql_writer_ddl.go
+++ b/pkg/sink/mysql/mysql_writer_ddl.go
@@ -44,7 +44,7 @@ func (w *MysqlWriter) asyncExecAddIndexDDLIfTimeout(event *commonEvent.DDLEvent)
 	}
 
 	done := make(chan error, 1)
-	// wait for 2 seconds at most
+
 	tick := time.NewTimer(2 * time.Second)
 	defer tick.Stop()
 	log.Info("async exec add index ddl start",
@@ -136,7 +136,7 @@ func (w *MysqlWriter) execDDL(event *commonEvent.DDLEvent) error {
 
 	ctx := w.ctx
 	// We check the most of the ddl event executed with timeout.
-	if !needTimeoutCheck(event.GetDDLType()) {
+	if needTimeoutCheck(event.GetDDLType()) {
 		writeTimeout, _ := time.ParseDuration(w.cfg.WriteTimeout)
 		writeTimeout += networkDriftDuration
 		var cancelFunc func()

--- a/pkg/sink/mysql/mysql_writer_test.go
+++ b/pkg/sink/mysql/mysql_writer_test.go
@@ -20,11 +20,13 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/sink/util"
+	timodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/stretchr/testify/require"
 )
@@ -36,6 +38,22 @@ func newTestMysqlWriter(t *testing.T) (*MysqlWriter, *sql.DB, sqlmock.Sqlmock) {
 	cfg := &MysqlConfig{
 		MaxAllowedPacket:   int64(variable.DefMaxAllowedPacket),
 		SyncPointRetention: 100 * time.Second,
+	}
+	changefeedID := common.NewChangefeedID4Test("test", "test")
+	statistics := metrics.NewStatistics(changefeedID, "mysqlSink")
+	writer := NewMysqlWriter(ctx, db, cfg, changefeedID, statistics, false)
+
+	return writer, db, mock
+}
+
+func newTestMysqlWriterForTiDB(t *testing.T) (*MysqlWriter, *sql.DB, sqlmock.Sqlmock) {
+	db, mock := newTestMockDB(t)
+
+	ctx := context.Background()
+	cfg := &MysqlConfig{
+		MaxAllowedPacket:   int64(variable.DefMaxAllowedPacket),
+		SyncPointRetention: 100 * time.Second,
+		IsTiDB:             true,
 	}
 	changefeedID := common.NewChangefeedID4Test("test", "test")
 	statistics := metrics.NewStatistics(changefeedID, "mysqlSink")
@@ -270,5 +288,190 @@ func TestMysqlWriter_RemoveDDLTsTable(t *testing.T) {
 	mock.ExpectCommit()
 
 	err := writer.RemoveDDLTsItem()
+	require.NoError(t, err)
+}
+
+// Test the async ddl can be write successfully
+func TestMysqlWriter_AsyncDDL(t *testing.T) {
+	writer, db, mock := newTestMysqlWriterForTiDB(t)
+	defer db.Close()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	createTableSQL := "create table t (id int primary key, name varchar(32));"
+	job := helper.DDL2Job(createTableSQL)
+	require.NotNil(t, job)
+
+	ddlEvent := &commonEvent.DDLEvent{
+		Query:      job.Query,
+		SchemaName: job.SchemaName,
+		TableName:  job.TableName,
+		FinishedTs: 1,
+		BlockedTables: &commonEvent.InfluencedTables{
+			InfluenceType: commonEvent.InfluenceTypeNormal,
+			TableIDs:      []int64{0},
+		},
+		NeedAddedTables: []commonEvent.Table{{TableID: 1, SchemaID: 1}},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("USE tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS ddl_ts_v1
+		(
+			ticdc_cluster_id varchar (255),
+			changefeed varchar(255),
+			ddl_ts varchar(18),
+			table_id bigint(21),
+			finished bool,
+			related_table_id bigint(21),
+			is_syncpoint bool,
+			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			INDEX (ticdc_cluster_id, changefeed, table_id),
+			PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
+		);`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 1, 0, 0), ('default', 'test/test', '1', 1, 1, 0, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW(), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("create table t (id int primary key, name varchar(32));").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 1, 1, 0), ('default', 'test/test', '1', 1, 1, 1, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW(), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := writer.FlushDDLEvent(ddlEvent)
+	require.NoError(t, err)
+
+	// test the case with add index ddl, and the later ddl/dmls
+	err = mock.ExpectationsWereMet()
+	require.NoError(t, err)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
+	log.Info("before add index")
+	mock.ExpectExec("alter table t add index nameIndex(name);").WillDelayFor(10 * time.Second).WillReturnResult(sqlmock.NewResult(1, 1))
+	log.Info("after add index")
+
+	// for dml event
+	mock.ExpectBegin()
+	mock.ExpectExec("REPLACE INTO `test`.`t` (`id`,`name`) VALUES (?,?)").
+		WithArgs(3, "test3").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	// for ddl job for table t1
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '2', 0, 2, 0, 0), ('default', 'test/test', '2', 2, 2, 0, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW(), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("create table t1 (id int primary key, name varchar(32));").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '2', 0, 2, 1, 0), ('default', 'test/test', '2', 2, 2, 1, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW(), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	// this commit is for add index ddl
+	mock.ExpectCommit()
+
+	// for add column ddl for table t
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '3', 1, 1, 0, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW(), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("alter table t add column age int;").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, related_table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '3', 1, 1, 1, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), related_table_id=VALUES(related_table_id), ddl_ts=VALUES(ddl_ts), created_at=NOW(), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	{
+		// add index ddl
+		addIndexSQL := "alter table t add index nameIndex(name);"
+		addIndexjob := helper.DDL2Job(addIndexSQL)
+		require.NotNil(t, addIndexjob)
+
+		addIndexddlEvent := &commonEvent.DDLEvent{
+			Type:       byte(timodel.ActionAddIndex),
+			Query:      addIndexjob.Query,
+			SchemaName: addIndexjob.SchemaName,
+			TableName:  addIndexjob.TableName,
+			FinishedTs: 1,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+				TableIDs:      []int64{1},
+			},
+		}
+
+		err = writer.FlushDDLEvent(addIndexddlEvent)
+		require.NoError(t, err)
+	}
+
+	{
+		// ensure the dml can be writen succesfully before add index finished
+		dmlEvent := helper.DML2Event("test", "t", "insert into t values (3, 'test3');")
+		dmlEvent.CommitTs = 3
+		dmlEvent.ReplicatingTs = 4
+
+		err = writer.Flush([]*commonEvent.DMLEvent{dmlEvent})
+		require.NoError(t, err)
+	}
+
+	{
+		// ensure the ddl for other tables can write successfully before add index finished
+		createTableSQL2 := "create table t1 (id int primary key, name varchar(32));"
+		job2 := helper.DDL2Job(createTableSQL2)
+		require.NotNil(t, job2)
+
+		ddlEvent2 := &commonEvent.DDLEvent{
+			Query:      job2.Query,
+			SchemaName: job2.SchemaName,
+			TableName:  job2.TableName,
+			FinishedTs: 2,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+				TableIDs:      []int64{0},
+			},
+			NeedAddedTables: []commonEvent.Table{{TableID: 2, SchemaID: 1}},
+		}
+
+		err = writer.FlushDDLEvent(ddlEvent2)
+		require.NoError(t, err)
+	}
+
+	{
+		// ensure the ddl for the table t can only executed after the add index finished
+		job = helper.DDL2Job("alter table t add column age int;")
+		require.NotNil(t, job)
+
+		ddlEvent = &commonEvent.DDLEvent{
+			Query:      job.Query,
+			SchemaName: job.SchemaName,
+			TableName:  job.TableName,
+			FinishedTs: 3,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+				TableIDs:      []int64{1},
+			},
+		}
+
+		err = writer.FlushDDLEvent(ddlEvent)
+		require.NoError(t, err)
+	}
+
+	err = mock.ExpectationsWereMet()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
Add test to ensure the async ddl `add index` can be deal with correctly, including:
1. the async ddl can be written successfully
2. the dmls will not be blocked by the async ddl
3. the ddl of other tables will not be blocked by the async ddl
4. the ddl of this table will be blocked by the async ddl.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
