### PR TITLE
cmd: remove unnecessary arch log output in cdc cmd

### DIFF
--- a/cmd/cdc/main.go
+++ b/cmd/cdc/main.go
@@ -121,10 +121,8 @@ func main() {
 	newarch = parseNewarchFlagFromOSArgs() || (os.Getenv("TICDC_NEWARCH") == "true")
 
 	if newarch || isNewArchEnabledByConfig(serverConfigFilePath) {
-		cmd.Println("=== Command to ticdc(new arch).")
 		addNewArchCommandTo(cmd)
 	} else {
-		cmd.Println("=== Command to ticdc(tiflow).")
 		tiflowCmd.AddTiCDCCommandTo(cmd)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #981

### What is changed and how it works?

### Description
This PR removes the log output `=== Command to ticdc(xxx).` that was previously added to indicate whether the old or new architecture was being used. Since this log is no longer necessary, it is now removed to clean up command output.

### Changes
- Deleted the log statement that prints `=== Command to ticdc(xxx).`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

NO

##### Do you need to update user documentation, design documentation or monitoring documentation?

NO

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
