### PR TITLE
metrics: unify the metrics in dataflow to rows/s

### DIFF
--- a/downstreamadapter/eventcollector/event_collector.go
+++ b/downstreamadapter/eventcollector/event_collector.go
@@ -432,9 +432,9 @@ func (c *EventCollector) runProcessMessage(ctx context.Context, inCh <-chan *mes
 							event.Event = e
 							c.ds.Push(e.DispatcherID, event)
 						}
-						c.metricDispatcherReceivedResolvedTsEventCount.Add(float64(len(events)))
+						c.metricDispatcherReceivedResolvedTsEventCount.Add(float64(event.Len()))
 					default:
-						c.metricDispatcherReceivedKVEventCount.Inc()
+						c.metricDispatcherReceivedKVEventCount.Add(float64(event.Len()))
 						c.ds.Push(event.GetDispatcherID(), dispatcher.NewDispatcherEvent(&targetMessage.From, event))
 					}
 				default:

--- a/maintainer/replica/checker.go
+++ b/maintainer/replica/checker.go
@@ -127,7 +127,7 @@ func (s *hotSpanChecker) UpdateStatus(span *SpanReplication) {
 		return
 	}
 
-	log.Debug("hotSpanChecker EventSizePerSecond", zap.Any("span", span.Span), zap.Any("dispatcher", span.ID), zap.Any("EventSizePerSecond", status.EventSizePerSecond), zap.Any("writeThreshold", s.writeThreshold))
+	log.Debug("hotSpanChecker EventSizePerSecond", zap.Any("changefeed", span.ChangefeedID.Name()), zap.Any("span", span.Span), zap.Any("dispatcher", span.ID), zap.Any("EventSizePerSecond", status.EventSizePerSecond), zap.Any("writeThreshold", s.writeThreshold))
 
 	if status.EventSizePerSecond != 0 && status.EventSizePerSecond < s.writeThreshold {
 		if hotSpan, ok := s.hotTasks[span.ID]; ok {

--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -413,7 +413,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Sink Event Count / s",
+          "title": "Sink Event Row Count / s",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -1666,7 +1666,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Puller output events",
+          "title": "Puller output event rows",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1769,7 +1769,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "EventService output events / s",
+          "title": "EventService output event row / s",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1874,7 +1874,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "EventService output events",
+          "title": "EventService output event rows",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1978,7 +1978,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Event Collector received event / s",
+          "title": "Event Collector received event rows / s",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -2081,7 +2081,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Event collector Received events",
+          "title": "Event collector Received event rows",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -16691,7 +16691,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Puller output events / s",
+          "title": "Puller output event rows / s",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/pkg/common/event/ddl_event.go
+++ b/pkg/common/event/ddl_event.go
@@ -344,6 +344,10 @@ func (t *DDLEvent) IsPaused() bool {
 	return t.State.IsPaused()
 }
 
+func (t *DDLEvent) Len() int32 {
+	return 1
+}
+
 type SchemaTableName struct {
 	SchemaName string
 	TableName  string

--- a/pkg/common/event/handshake_event.go
+++ b/pkg/common/event/handshake_event.go
@@ -81,6 +81,10 @@ func (e *HandshakeEvent) IsPaused() bool {
 	return e.State.IsPaused()
 }
 
+func (t *HandshakeEvent) Len() int32 {
+	return 0
+}
+
 func (e HandshakeEvent) Marshal() ([]byte, error) {
 	return e.encode()
 }

--- a/pkg/common/event/handshake_event.go
+++ b/pkg/common/event/handshake_event.go
@@ -81,7 +81,7 @@ func (e *HandshakeEvent) IsPaused() bool {
 	return e.State.IsPaused()
 }
 
-func (t *HandshakeEvent) Len() int32 {
+func (e *HandshakeEvent) Len() int32 {
 	return 0
 }
 

--- a/pkg/common/event/interface.go
+++ b/pkg/common/event/interface.go
@@ -29,6 +29,8 @@ type Event interface {
 	// It's used for memory control and monitoring.
 	GetSize() int64
 	IsPaused() bool
+	// GetLen returns the number of rows in the event.
+	Len() int64
 }
 
 // FlushableEvent is an event that can be flushed to downstream by a dispatcher.

--- a/pkg/common/event/interface.go
+++ b/pkg/common/event/interface.go
@@ -30,7 +30,7 @@ type Event interface {
 	GetSize() int64
 	IsPaused() bool
 	// GetLen returns the number of rows in the event.
-	Len() int64
+	Len() int32
 }
 
 // FlushableEvent is an event that can be flushed to downstream by a dispatcher.

--- a/pkg/common/event/ready_event.go
+++ b/pkg/common/event/ready_event.go
@@ -73,6 +73,10 @@ func (e *ReadyEvent) IsPaused() bool {
 	return false
 }
 
+func (e *ReadyEvent) Len() int32 {
+	return 0
+}
+
 func (e ReadyEvent) Marshal() ([]byte, error) {
 	return e.encode()
 }

--- a/pkg/common/event/resolved_ts_event.go
+++ b/pkg/common/event/resolved_ts_event.go
@@ -52,6 +52,11 @@ func (b *BatchResolvedEvent) GetSeq() uint64 {
 	return 0
 }
 
+func (b *BatchResolvedEvent) Len() int64 {
+	// Return the length of events.
+	return int64(len(b.Events))
+}
+
 func (b *BatchResolvedEvent) Marshal() ([]byte, error) {
 	if len(b.Events) == 0 {
 		return nil, nil
@@ -134,6 +139,10 @@ func (e ResolvedEvent) GetStartTs() common.Ts {
 
 func (e ResolvedEvent) GetSeq() uint64 {
 	return 0
+}
+
+func (e ResolvedEvent) Len() int64 {
+	return 1
 }
 
 func (e ResolvedEvent) Marshal() ([]byte, error) {

--- a/pkg/common/event/resolved_ts_event.go
+++ b/pkg/common/event/resolved_ts_event.go
@@ -52,9 +52,9 @@ func (b *BatchResolvedEvent) GetSeq() uint64 {
 	return 0
 }
 
-func (b *BatchResolvedEvent) Len() int64 {
+func (b *BatchResolvedEvent) Len() int32 {
 	// Return the length of events.
-	return int64(len(b.Events))
+	return int32(len(b.Events))
 }
 
 func (b *BatchResolvedEvent) Marshal() ([]byte, error) {
@@ -141,7 +141,7 @@ func (e ResolvedEvent) GetSeq() uint64 {
 	return 0
 }
 
-func (e ResolvedEvent) Len() int64 {
+func (e ResolvedEvent) Len() int32 {
 	return 1
 }
 

--- a/pkg/common/event/sync_point_event.go
+++ b/pkg/common/event/sync_point_event.go
@@ -102,3 +102,7 @@ func (e *SyncPointEvent) PushFrontFlushFunc(f func()) {
 func (e *SyncPointEvent) ClearPostFlushFunc() {
 	e.PostTxnFlushed = e.PostTxnFlushed[:0]
 }
+
+func (e *SyncPointEvent) Len() int32 {
+	return 0
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
Modify the metric unit in the `EventService output events / s` panel from `event/s` to `row/s` to align with other panels in the `Dataflow` row.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
