### PR TITLE
ci: fix typo in run_light_it_in_ci.sh (chartset_gbk → charset_gbk)

### DIFF
--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -29,7 +29,7 @@ group_num=${group#G}
 
 mysql_groups=(
 	# G00
-	'chartset_gbk changefeed_finish sql_mode changefeed_reconstruct'
+	'charset_gbk changefeed_finish sql_mode changefeed_reconstruct'
 	# G01
 	'common_1 foreign_key generate_column many_ok_or_uk drop_many_tables'
 	# G02


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1033

### What is changed and how it works?

This PR fixes a typo in the run_light_it_in_ci.sh where charset_gbk was mistakenly written as chartset_gbk. This issue caused integration tests to fail due to missing directories and files.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
