### PR TITLE
coordinator: send checkpointTs message when changefeed state is finished

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -89,10 +89,8 @@ type coordinator struct {
 	// eventCh is used to receive the event from message center, basically these messages
 	// are from maintainer.
 	eventCh *chann.DrainableChann[*Event]
-	// changefeedProgressReportCh is used to receive the changefeed progress report from the controller
-	changefeedProgressReportCh chan map[common.ChangeFeedID]*changefeed.Changefeed
-	// changefeedStateChangedCh is used to receive the changefeed state changed event from the controller
-	changefeedStateChangedCh chan *ChangefeedStateChangeEvent
+	// changefeedChangeEventCh is used to receive the changefeed progress report from the controller
+	changefeedChangeEventCh chan []*ChangefeedStateChangeEvent
 
 	cancel func()
 	closed atomic.Bool
@@ -109,18 +107,17 @@ func New(node *node.Info,
 ) server.Coordinator {
 	mc := appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter)
 	c := &coordinator{
-		version:                    version,
-		nodeInfo:                   node,
-		gcServiceID:                gcServiceID,
-		lastTickTime:               time.Now(),
-		gcManager:                  gc.NewManager(gcServiceID, pdClient, pdClock),
-		eventCh:                    chann.NewAutoDrainChann[*Event](),
-		pdClient:                   pdClient,
-		pdClock:                    pdClock,
-		mc:                         mc,
-		changefeedProgressReportCh: make(chan map[common.ChangeFeedID]*changefeed.Changefeed, 1024),
-		changefeedStateChangedCh:   make(chan *ChangefeedStateChangeEvent, 1024),
-		backend:                    backend,
+		version:                 version,
+		nodeInfo:                node,
+		gcServiceID:             gcServiceID,
+		lastTickTime:            time.Now(),
+		gcManager:               gc.NewManager(gcServiceID, pdClient, pdClock),
+		eventCh:                 chann.NewAutoDrainChann[*Event](),
+		pdClient:                pdClient,
+		pdClock:                 pdClock,
+		mc:                      mc,
+		changefeedChangeEventCh: make(chan []*ChangefeedStateChangeEvent, 1024),
+		backend:                 backend,
 	}
 	// handle messages from message center
 	mc.RegisterHandler(messaging.CoordinatorTopic, c.recvMessages)
@@ -131,8 +128,7 @@ func New(node *node.Info,
 	controller := NewController(
 		c.version,
 		c.nodeInfo,
-		c.changefeedProgressReportCh,
-		c.changefeedStateChangedCh,
+		c.changefeedChangeEventCh,
 		c.backend,
 		c.eventCh,
 		c.taskScheduler,
@@ -210,13 +206,16 @@ func (c *coordinator) run(ctx context.Context) error {
 			now := time.Now()
 			metrics.CoordinatorCounter.Add(float64(now.Sub(c.lastTickTime)) / float64(time.Second))
 			c.lastTickTime = now
-		case cfs := <-c.changefeedProgressReportCh:
-			if err := c.saveCheckpointTs(ctx, cfs); err != nil {
+		case events := <-c.changefeedChangeEventCh:
+			if err := c.saveCheckpointTs(ctx, events); err != nil {
 				return errors.Trace(err)
 			}
-		case event := <-c.changefeedStateChangedCh:
-			if err := c.handleStateChangedEvent(ctx, event); err != nil {
-				return errors.Trace(err)
+			for _, event := range events {
+				if event.changeType == ChangeState || event.changeType == ChangeStateAndTs {
+					if err := c.handleStateChangedEvent(ctx, event); err != nil {
+						return errors.Trace(err)
+					}
+				}
 			}
 		}
 	}
@@ -238,9 +237,9 @@ func (c *coordinator) handleStateChangedEvent(
 	ctx context.Context,
 	event *ChangefeedStateChangeEvent,
 ) error {
-	cf := c.controller.getChangefeed(event.ChangefeedID)
+	cf := c.controller.getChangefeed(event.changefeedID)
 	if cf == nil {
-		log.Warn("changefeed not found", zap.String("changefeed", event.ChangefeedID.String()))
+		log.Warn("changefeed not found", zap.String("changefeed", event.changefeedID.String()))
 		return nil
 	}
 	cfInfo, err := cf.GetInfo().Clone()
@@ -262,22 +261,22 @@ func (c *coordinator) handleStateChangedEvent(
 
 	switch event.State {
 	case model.StateWarning:
-		c.controller.operatorController.StopChangefeed(ctx, event.ChangefeedID, false)
-		c.controller.updateChangefeedEpoch(ctx, event.ChangefeedID)
-		c.controller.moveChangefeedToSchedulingQueue(event.ChangefeedID, false, false)
+		c.controller.operatorController.StopChangefeed(ctx, event.changefeedID, false)
+		c.controller.updateChangefeedEpoch(ctx, event.changefeedID)
+		c.controller.moveChangefeedToSchedulingQueue(event.changefeedID, false, false)
 	case model.StateFailed, model.StateFinished:
-		c.controller.operatorController.StopChangefeed(ctx, event.ChangefeedID, false)
+		c.controller.operatorController.StopChangefeed(ctx, event.changefeedID, false)
 	case model.StateNormal:
 		log.Info("changefeed is resumed or created successfully, try to delete its safeguard gc safepoint",
-			zap.String("changefeed", event.ChangefeedID.String()))
+			zap.String("changefeed", event.changefeedID.String()))
 		// We need to clean its gc safepoint when changefeed is resumed or created
 		gcServiceID := c.getEnsureGCServiceID(gc.EnsureGCServiceCreating)
-		err := gc.UndoEnsureChangefeedStartTsSafety(ctx, c.pdClient, gcServiceID, event.ChangefeedID)
+		err := gc.UndoEnsureChangefeedStartTsSafety(ctx, c.pdClient, gcServiceID, event.changefeedID)
 		if err != nil {
 			log.Warn("failed to delete create changefeed gc safepoint", zap.Error(err))
 		}
 		gcServiceID = c.getEnsureGCServiceID(gc.EnsureGCServiceResuming)
-		err = gc.UndoEnsureChangefeedStartTsSafety(ctx, c.pdClient, gcServiceID, event.ChangefeedID)
+		err = gc.UndoEnsureChangefeedStartTsSafety(ctx, c.pdClient, gcServiceID, event.changefeedID)
 		if err != nil {
 			log.Warn("failed to delete resume changefeed gc safepoint", zap.Error(err))
 		}
@@ -297,6 +296,15 @@ func (c *coordinator) checkStaleCheckpointTs(ctx context.Context, id common.Chan
 		if !errors.IsChangefeedGCFastFailErrorCode(errCode) {
 			state = model.StateWarning
 		}
+		event := &ChangefeedStateChangeEvent{
+			changefeedID: id,
+			State:        state,
+			err: &model.RunningError{
+				Code:    string(errCode),
+				Message: err.Error(),
+			},
+			changeType: ChangeState,
+		}
 		select {
 		case <-ctx.Done():
 			log.Warn("Failed to send state change event to stateChangedCh since context timeout, "+
@@ -304,24 +312,23 @@ func (c *coordinator) checkStaleCheckpointTs(ctx context.Context, id common.Chan
 				zap.String("changefeed", id.String()),
 				zap.Error(ctx.Err()))
 			return
-		case c.changefeedStateChangedCh <- &ChangefeedStateChangeEvent{
-			ChangefeedID: id,
-			State:        state,
-			err: &model.RunningError{
-				Code:    string(errCode),
-				Message: err.Error(),
-			},
-		}:
+		case c.changefeedChangeEventCh <- []*ChangefeedStateChangeEvent{event}:
 		}
 	}
 }
 
-func (c *coordinator) saveCheckpointTs(ctx context.Context, cfs map[common.ChangeFeedID]*changefeed.Changefeed) error {
+func (c *coordinator) saveCheckpointTs(ctx context.Context, events []*ChangefeedStateChangeEvent) error {
 	statusMap := make(map[common.ChangeFeedID]uint64)
-	for _, upCf := range cfs {
+	cfsMap := make(map[common.ChangeFeedID]*changefeed.Changefeed)
+	for _, event := range events {
+		if event.changeType == ChangeState {
+			continue
+		}
+		upCf := event.changefeed
 		reportedCheckpointTs := upCf.GetStatus().CheckpointTs
 		if upCf.GetLastSavedCheckPointTs() < reportedCheckpointTs {
 			statusMap[upCf.ID] = reportedCheckpointTs
+			cfsMap[upCf.ID] = upCf
 			c.checkStaleCheckpointTs(ctx, upCf.ID, reportedCheckpointTs)
 		}
 	}
@@ -335,10 +342,7 @@ func (c *coordinator) saveCheckpointTs(ctx context.Context, cfs map[common.Chang
 	}
 	// update the last saved checkpoint ts and send checkpointTs to maintainer
 	for id, cp := range statusMap {
-		cf, ok := cfs[id]
-		if !ok {
-			continue
-		}
+		cf := cfsMap[id]
 		cf.SetLastSavedCheckPointTs(cp)
 		if cf.IsMQSink() {
 			msg := cf.NewCheckpointTsMessage(cf.GetLastSavedCheckPointTs())

--- a/coordinator/helper.go
+++ b/coordinator/helper.go
@@ -17,6 +17,17 @@ import (
 	"github.com/pingcap/ticdc/pkg/messaging"
 )
 
+type ChangeType int
+
+const (
+	// ChangeStateAndTs indicate changefeed state and checkpointTs need update
+	ChangeStateAndTs ChangeType = iota
+	// ChangeTs indicate changefeed checkpointTs needs update
+	ChangeTs
+	// ChangeState indicate changefeed state needs update
+	ChangeState
+)
+
 const (
 	// EventMessage is triggered when a grpc message received
 	EventMessage = iota


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #442

### What is changed and how it works?
change changefeed state is ahead of sending checkpointTs message in the past. This makes no checkpointTs message if the state is finished. 
Kafka consumer depends on checkpointTs messages to write previous DDL/DML events.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
