### PR TITLE
ci: remove check_coverage.sh exit before all missing test added

### DIFF
--- a/tests/integration_tests/_utils/check_coverage.sh
+++ b/tests/integration_tests/_utils/check_coverage.sh
@@ -64,7 +64,8 @@ check_test_coverage() {
 		echo
 		echo "Choose the file based on the test case's resource requirements."
 		echo
-		has_error=1
+		#TODO: add this "has_error=1" when we have added all the missing test cases to the groups
+		# has_error=1
 	fi
 
 	if [ ${#nonexistent_tests[@]} -gt 0 ]; then


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1050

### What is changed and how it works?

This PR modifies the check_test_coverage function to prevent the script from failing when missing test cases are found. Since we are still adding tests, it is expected that some test cases will be missing. Instead of failing CI, the script will now only display a warning.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
