### PR TITLE
makefile: add prepare_test_binaries target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: clean fmt check tidy \
 	generate-protobuf generate_mock \
 	cdc kafka_consumer storage_consumer pulsar_consumer filter_helper \
+	prepare_test_binaries \
 	unit_test_in_verify_ci integration_test_build integration_test_mysql integration_test_kafka integration_test_storage integration_test_pulsar \
 
 
@@ -153,6 +154,9 @@ fmt: tools/bin/gofumports tools/bin/shfmt tools/bin/gci
 	@echo "check log style"
 	scripts/check-log-style.sh
 	@make check-diff-line-width
+
+prepare_test_binaries:
+	./tests/scripts/download-integration-test-binaries.sh "$(branch)" "$(community)" "$(ver)" "$(os)" "$(arch)"
 
 check_third_party_binary:
 	@which bin/tidb-server


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1075

### What is changed and how it works?

This PR adds a prepare_test_binaries target to the Makefile, allowing users to easily download TiCDC-related binaries for integration testing using a single make command.

Usage:

```
make prepare_test_binaries
```

To specify a version, OS, or architecture, use:

```
make prepare_test_binaries community=true ver=v8.0.0 os=linux arch=amd64
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test

```
make prepare_test_binaries
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
