### PR TITLE
cli_with_auth: enable_table_across_nodes should be true in mysql after supported

### DIFF
--- a/tests/integration_tests/cli_with_auth/run.sh
+++ b/tests/integration_tests/cli_with_auth/run.sh
@@ -110,17 +110,9 @@ EOF
 		echo "[$(date)] <<<<< changefeed info is not updated as expected ${changefeed_info} >>>>>"
 		exit 1
 	fi
-	if [ "$SINK_TYPE" == "kafka" ]; then
-		if [[ ! $changefeed_info == *"\"enable_table_across_nodes\":true"* ]]; then
-			echo "[$(date)] <<<<< changefeed info is not updated as expected ${changefeed_info} >>>>>"
-			exit 1
-		fi
-	else
-		# Currently, MySQL changefeed does not support scale out feature.
-		if [[ $changefeed_info == *"\"enable_table_across_nodes\":true"* ]]; then
-			echo "[$(date)] <<<<< changefeed info is not updated as expected ${changefeed_info} >>>>>"
-			exit 1
-		fi
+	if [[ ! $changefeed_info == *"\"enable_table_across_nodes\":true"* ]]; then
+		echo "[$(date)] <<<<< changefeed info is not updated as expected ${changefeed_info} >>>>>"
+		exit 1
 	fi
 
 	# Resume changefeed


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1082

### What is changed and how it works?

Remove the check for enable_table_across_nodes being true for the MySQL type in the integration test cli_with_auth.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
