### PR TITLE
puller: fix dynamic stream deadlock when UseBuffer is false

### DIFF
--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -452,9 +452,9 @@ func (s *SubscriptionClient) onTableDrained(rt *subscribedSpan) {
 	log.Info("subscription client stop span is finished",
 		zap.Uint64("subscriptionID", uint64(rt.subID)))
 
+	s.ds.RemovePath(rt.subID)
 	s.totalSpans.Lock()
 	defer s.totalSpans.Unlock()
-	s.ds.RemovePath(rt.subID)
 	delete(s.totalSpans.spanMap, rt.subID)
 }
 

--- a/utils/dynstream/parallel_dynamic_stream.go
+++ b/utils/dynstream/parallel_dynamic_stream.go
@@ -92,6 +92,7 @@ func (s *parallelDynamicStream[A, P, T, D, H]) Push(path P, e T) {
 		s.mutex.RLock()
 		if pi, ok = s.pathMap[path]; !ok {
 			s.handler.OnDrop(e)
+			s.mutex.RUnlock()
 			return
 		}
 		s.mutex.RUnlock()
@@ -115,6 +116,7 @@ func (s *parallelDynamicStream[A, P, T, D, H]) Wake(path P) {
 	{
 		s.mutex.RLock()
 		if pi, ok = s.pathMap[path]; !ok {
+			s.mutex.RUnlock()
 			return
 		}
 		s.mutex.RUnlock()
@@ -152,6 +154,7 @@ func (s *parallelDynamicStream[A, P, T, D, H]) RemovePath(path P) error {
 	s.mutex.Lock()
 	pi, ok := s.pathMap[path]
 	if !ok {
+		s.mutex.Unlock()
 		return NewAppErrorS(ErrorTypeNotExist)
 	}
 	delete(s.pathMap, path)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
```
goroutine 2520 [chan send, 751 minutes]:
github.com/pingcap/ticdc/utils/dynstream.(*parallelDynamicStream[...]).Push(0x64977a0, 0xc00a405cd8, {0xc006c38420?, 0xc008a802d0?, 0xc3cf279060?, 0x0?})
    github.com/pingcap/ticdc/utils/dynstream/parallel_dynamic_stream.go:109 +0x31c
github.com/pingcap/ticdc/logservice/logpuller.(*SubscriptionClient).pushRegionEventToDS(0xc008a802d0?, 0x0?, {0xc006c38420?, 0xc008a802d0?, 0xc3cf279060?, 0xc00a405bf8?})
    github.com/pingcap/ticdc/logservice/logpuller/subscription_client.go:361 +0xbe
github.com/pingcap/ticdc/logservice/logpuller.(*regionRequestWorker).dispatchRegionChangeEvents(0xc008a802d0, {0xc3cf279050, 0x1, 0x56a9ca0?})
    github.com/pingcap/ticdc/logservice/logpuller/region_request_worker.go:273 +0x991
github.com/pingcap/ticdc/logservice/logpuller.(*regionRequestWorker).receiveAndDispatchChangeEvents(0xc008a802d0, 0xc0088e6810)
    github.com/pingcap/ticdc/logservice/logpuller/region_request_worker.go:226 +0x6f
github.com/pingcap/ticdc/logservice/logpuller.(*regionRequestWorker).run.func4()
    github.com/pingcap/ticdc/logservice/logpuller/region_request_worker.go:191 +0x1b
golang.org/x/sync/errgroup.(*Group).Go.func1()
    golang.org/x/sync@v0.10.0/errgroup/errgroup.go:78 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1978
    golang.org/x/sync@v0.10.0/errgroup/errgroup.go:75 +0x96

goroutine 1248 [sync.RWMutex.Lock, 751 minutes]:
sync.runtime_SemacquireRWMutex(0x0?, 0x0?, 0x7f5b49e0dc58?)
	runtime/sema.go:105 +0x25
sync.(*RWMutex).Lock(0xb3b5ec0?)
	sync/rwmutex.go:153 +0x6a
github.com/pingcap/ticdc/utils/dynstream.(*parallelDynamicStream[...]).RemovePath(0x64977a0, 0x24a)
	github.com/pingcap/ticdc/utils/dynstream/parallel_dynamic_stream.go:152 +0x5a
github.com/pingcap/ticdc/logservice/logpuller.(*SubscriptionClient).onTableDrained(0xc001da2a50, 0xc06ca38900)
	github.com/pingcap/ticdc/logservice/logpuller/subscription_client.go:457 +0x163
github.com/pingcap/ticdc/logservice/logpuller.(*SubscriptionClient).onRegionFail(0xc001da2a50, {{{0xd8c0, 0x5, 0x2bb}, {0x0, {0xc008498240, 0x12, 0x12}, {0xc008498258, 0x12, ...}}, ...}, ...})
	github.com/pingcap/ticdc/logservice/logpuller/subscription_client.go:467 +0xde
github.com/pingcap/ticdc/logservice/logpuller.(*regionEventHandler).handleRegionError(0xc0034b2178, 0xc0158906e0, 0xc008a80370)
	github.com/pingcap/ticdc/logservice/logpuller/region_event_handler.go:188 +0x618
github.com/pingcap/ticdc/logservice/logpuller.(*regionEventHandler).Handle(0xc0034b2178, 0xc06ca38900, {0xc004726000, 0x1, 0x400})
	github.com/pingcap/ticdc/logservice/logpuller/region_event_handler.go:84 +0x57c
github.com/pingcap/ticdc/utils/dynstream.(*stream[...]).handleLoop(0x643a320)
	github.com/pingcap/ticdc/utils/dynstream/stream.go:253 +0x2a3
created by github.com/pingcap/ticdc/utils/dynstream.(*stream[...]).start in goroutine 1
	github.com/pingcap/ticdc/utils/dynstream/stream.go:114 +0x125
```

1. parallelDynamicStream::Push is holding the lock and blocked by sending event to the channel of th stream;
2. the channel of the stream is full and waiting for stream:::handleLoop to consume the events;
3. stream:::handleLoop is calling `Handle` which is blocked in calling parallelDynamicStream::RemovePath and try to holding the lock;

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
