### PR TITLE
tests: fix `region_merge` case.

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -466,7 +466,7 @@ var (
 
 	ErrMetaOpFailed = errors.Normalize(
 		"unexpected meta operation failure: %s",
-		errors.RFCCodeText("DFLOW:ErrMetaOpFailed"),
+		errors.RFCCodeText("CDC:ErrMetaOpFailed"),
 	)
 
 	ErrUnexpected = errors.Normalize(

--- a/tests/integration_tests/_utils/check_contains
+++ b/tests/integration_tests/_utils/check_contains
@@ -3,10 +3,10 @@
 set -eu
 OUT_DIR=/tmp/tidb_cdc_test
 
-if ! grep -Fq "$1" "$OUT_DIR/sql_res.$TEST_NAME.txt"; then
+if ! grep -Fq "$1" "$OUT_DIR/sql_res.$TEST_NAME.log"; then
 	echo "TEST FAILED: OUTPUT DOES NOT CONTAIN '$1'"
 	echo "____________________________________"
-	cat "$OUT_DIR/sql_res.$TEST_NAME.txt"
+	cat "$OUT_DIR/sql_res.$TEST_NAME.log"
 	echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 	exit 1
 fi

--- a/tests/integration_tests/_utils/check_logs
+++ b/tests/integration_tests/_utils/check_logs
@@ -16,16 +16,21 @@ echo "log files: $logs"
 grep -q -i 'DATA RACE' $WORK_DIR/stdout*.log
 
 if [ $? -eq 0 ]; then
+	# check each log file to see if it contains DATA RACE
 	for log in $logs; do
 		echo "check $log"
+		grep -q -i 'DATA RACE' $log
+		if [ $? -eq 1 ]; then
+			continue
+		fi
 		# Contains reportStoreReplicaFlows means it is a kv client issue, not a TiCDC issue, so we can ignore it
 		grep -q -i 'reportStoreReplicaFlows' $log
 		if [ $? -eq 1 ]; then
-			echo "found DATA RACE, please check the logs"
+			echo "found DATA RACE in $log, please check the logs"
 			exit 1
 		fi
 	done
-	echo "found DATA RACE, But it is not a TiCDC issue, please check the logs"
+	echo "found DATA RACE, but it is not a TiCDC issue, please check the logs"
 	exit 0
 else
 	echo "no DATA RACE found"

--- a/tests/integration_tests/_utils/check_logs
+++ b/tests/integration_tests/_utils/check_logs
@@ -33,6 +33,6 @@ if [ $? -eq 0 ]; then
 	echo "found DATA RACE, but it is not a TiCDC issue, please check the logs"
 	exit 0
 else
-	echo "no DATA RACE found"`
+	echo "no DATA RACE found"
 	exit 0
 fi

--- a/tests/integration_tests/_utils/check_logs
+++ b/tests/integration_tests/_utils/check_logs
@@ -33,6 +33,6 @@ if [ $? -eq 0 ]; then
 	echo "found DATA RACE, but it is not a TiCDC issue, please check the logs"
 	exit 0
 else
-	echo "no DATA RACE found"
+	echo "no DATA RACE found"`
 	exit 0
 fi

--- a/tests/integration_tests/_utils/check_not_contains
+++ b/tests/integration_tests/_utils/check_not_contains
@@ -3,10 +3,10 @@
 set -eu
 OUT_DIR=/tmp/tidb_cdc_test
 
-if grep -Fq "$1" "$OUT_DIR/sql_res.$TEST_NAME.txt"; then
+if grep -Fq "$1" "$OUT_DIR/sql_res.$TEST_NAME.log"; then
 	echo "TEST FAILED: OUTPUT CONTAINS '$1'"
 	echo "____________________________________"
-	cat "$OUT_DIR/sql_res.$TEST_NAME.txt"
+	cat "$OUT_DIR/sql_res.$TEST_NAME.log"
 	echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 	exit 1
 fi

--- a/tests/integration_tests/_utils/run_sql
+++ b/tests/integration_tests/_utils/run_sql
@@ -27,7 +27,7 @@ fi
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-echo "[$(date)] Executing SQL: ${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
+echo "[$(date)] Executing SQL: ${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
 
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"

--- a/tests/integration_tests/_utils/run_sql_file
+++ b/tests/integration_tests/_utils/run_sql_file
@@ -7,6 +7,6 @@ set -eu
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-echo "[$(date)] Executing SQL: $1" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
-mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
-mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -vv <"$1" >>"$OUT_DIR/sql_res.$TEST_NAME.txt"
+echo "[$(date)] Executing SQL: $1" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -vv <"$1" >>"$OUT_DIR/sql_res.$TEST_NAME.log"

--- a/tests/integration_tests/_utils/run_sql_ignore_error
+++ b/tests/integration_tests/_utils/run_sql_ignore_error
@@ -25,7 +25,7 @@ fi
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-echo "[$(date)] Executing SQL: ${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
+echo "[$(date)] Executing SQL: ${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
 
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.txt"
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"

--- a/tests/integration_tests/region_merge/run.sh
+++ b/tests/integration_tests/region_merge/run.sh
@@ -14,7 +14,7 @@ function split_and_random_merge() {
 	echo "split_and_random_merge scale: $scale"
 	run_sql "SPLIT TABLE region_merge.t1 BETWEEN (-9223372036854775808) AND (9223372036854775807) REGIONS $scale;" ${UP_TIDB_HOST} ${UP_TIDB_PORT} || true
 	run_sql "SELECT count(distinct region_id) from information_schema.tikv_region_status where db_name = 'region_merge' and table_name = 't1';" &&
-		cat $OUT_DIR/sql_res.region_merge.txt
+		cat $OUT_DIR/sql_res.region_merge.log
 	run_sql "insert into region_merge.t1 values (-9223372036854775808),(0),(1),(9223372036854775807);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "delete from region_merge.t1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	# sleep 5s to wait some region merge

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -55,7 +55,7 @@ mysql_groups=(
 	# G12
 	'tidb_mysql_test'
 	# G13
-	'fail_over'
+	'fail_over' 'region_merge'
 	# G14
 	'fail_over_ddl_mix'
 	# G15

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -33,7 +33,7 @@ mysql_groups=(
 	# G01
 	'common_1 foreign_key changefeed_pause_resume fail_over_ddl_B'
 	# G02
-	'new_ci_collation safe_mode savepoint region_merge fail_over_ddl_C'
+	'new_ci_collation safe_mode savepoint fail_over_ddl_C'
 	# G03
 	'capture_suicide_while_balance_table kv_client_stream_reconnect fail_over_ddl_D'
 	# G04

--- a/tests/integration_tests/syncpoint/run.sh
+++ b/tests/integration_tests/syncpoint/run.sh
@@ -118,8 +118,8 @@ function checkValidSyncPointTs() {
 }
 
 function checkDiff() {
-	primaryArr=($(grep primary_ts $OUT_DIR/sql_res.$TEST_NAME.txt | awk -F ": " '{print $2}'))
-	secondaryArr=($(grep secondary_ts $OUT_DIR/sql_res.$TEST_NAME.txt | awk -F ": " '{print $2}'))
+	primaryArr=($(grep primary_ts $OUT_DIR/sql_res.$TEST_NAME.log | awk -F ": " '{print $2}'))
+	secondaryArr=($(grep secondary_ts $OUT_DIR/sql_res.$TEST_NAME.log | awk -F ": " '{print $2}'))
 	tsos=($(curl -s http://$UP_TIDB_HOST:$UP_TIDB_STATUS/ddl/history | grep -E "real_start_ts|FinishedTS" | grep -oE "[0-9]*"))
 	firstDDLTs=($(curl -s http://$UP_TIDB_HOST:$UP_TIDB_STATUS/ddl/history | grep -B 3 "CREATE table testSync" | grep "real_start_ts" | grep -oE "[0-9]*"))
 	num=${#primaryArr[*]}
@@ -175,7 +175,7 @@ function run() {
 
 	run_sql "SELECT primary_ts, secondary_ts FROM tidb_cdc.syncpoint_v1;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	echo "____________________________________"
-	cat "$OUT_DIR/sql_res.$TEST_NAME.txt"
+	cat "$OUT_DIR/sql_res.$TEST_NAME.log"
 	checkDiff
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config_final.toml
 

--- a/tests/integration_tests/syncpoint_check_ts/run.sh
+++ b/tests/integration_tests/syncpoint_check_ts/run.sh
@@ -44,8 +44,8 @@ function run() {
 
 	run_sql "SELECT primary_ts, secondary_ts FROM tidb_cdc.syncpoint_v1 order by primary_ts limit 1;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	echo "____________________________________"
-	cat "$OUT_DIR/sql_res.$TEST_NAME.txt"
-	primary_ts=($(grep primary_ts $OUT_DIR/sql_res.$TEST_NAME.txt | awk -F ": " '{print $2}'))
+	cat "$OUT_DIR/sql_res.$TEST_NAME.log"
+	primary_ts=($(grep primary_ts $OUT_DIR/sql_res.$TEST_NAME.log | awk -F ": " '{print $2}'))
 	echo "primary_ts is " $primary_ts "start_ts is " $start_ts
 
 	shifted_primary_ts=$(($primary_ts >> 18))


### PR DESCRIPTION
Signed-off-by: dongmen <414110582@qq.com><!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1119 

### What is changed and how it works?

Move region_merge to the heavy group since it always encounters the error of SQL execution timeout.
Change the output files with the .txt suffix produced by the integration test to .log so that they can be uploaded to Artifacts for debugging. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->



#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
