### PR TITLE
tests: make region_merge more stable

### DIFF
--- a/.github/workflows/integration_test_mysql.yaml
+++ b/.github/workflows/integration_test_mysql.yaml
@@ -27,9 +27,13 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
+# Currently, we have migrated all integration tests to the self - hosted CI environment. 
+# Only keep the boilerplate test group to facilitate future debugging. 
+# For example, if we want to trigger certain test cases multiple times, 
+# we can use GitHub Actions as a convenient way to do so. You can achieve this by adding your 
+# test case to the all group and pushing a PR to run them concurrently in the GitHub Actions environment.
 jobs:
-  # # To boost the test speed, we split every 15 test cases into a group.
-  e2e_test_group_1:
+  test_group_1:
     ## Only run ci when PR is not draft
     if: github.event.pull_request.draft == false
 
@@ -55,104 +59,6 @@ jobs:
         run: |
           pwd && ls -l bin/ && ls -l tools/bin/
           export TICDC_NEWARCH=true && make integration_test CASE=charset_gbk 
-
-      - name: Test changefeed_finish
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=changefeed_finish
-      
-      - name: Test sql_mode
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=sql_mode
-        
-      - name: Test changefeed_pause_resume
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=changefeed_pause_resume
-
-      - name: Test changefeed_reconstruct
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=changefeed_reconstruct
-
-      - name: Test common_1
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=common_1
-
-      - name: Test foreign_key
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=foreign_key
-
-      # The 7th case in this group
-      - name: Test generate_column
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=generate_column
-      
-      # The 8th case in this group
-      - name: Test many_pk_or_uk
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=many_pk_or_uk
-      
-      # The 9th case in this group
-      - name: Test drop_many_tables
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=drop_many_tables
-
-      # The 10th case in this group     
-      - name: Test new_ci_collation
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=new_ci_collation
-
-      # The 11th case in this group     
-      - name: Test region_merge
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=region_merge
-
-      # The 12th case in this group     
-      - name: Test safe mode
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=safe_mode
-
-      # The 13th case in this group     
-      - name: Test savepoint
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=savepoint
-
-      - name: Test server config compatibility
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=server_config_compatibility
-
-      - name: Test split region
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=split_region
-      
-      # The 16th case in this group     
-      - name: Test changefeed resume with checkpoint ts
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=changefeed_resume_with_checkpoint_ts  
-
-      - name: Test capture suicide while balance table
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=capture_suicide_while_balance_table 
-
-      - name: Test kv client stream reconnect
-        if: ${{ success() }}
-        run: |
-          export TICDC_NEWARCH=true && make integration_test CASE=kv_client_stream_reconnect  
 
       - name: Upload test logs
         if: always()

--- a/tests/integration_tests/_utils/check_contains
+++ b/tests/integration_tests/_utils/check_contains
@@ -2,11 +2,12 @@
 
 set -eu
 OUT_DIR=/tmp/tidb_cdc_test
+LOG_FILE="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
 
-if ! grep -Fq "$1" "$OUT_DIR/sql_res.$TEST_NAME.log"; then
+if ! grep -Fq "$1" "$LOG_FILE"; then
 	echo "TEST FAILED: OUTPUT DOES NOT CONTAIN '$1'"
 	echo "____________________________________"
-	cat "$OUT_DIR/sql_res.$TEST_NAME.log"
+	cat "$LOG_FILE"
 	echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 	exit 1
 fi

--- a/tests/integration_tests/_utils/check_not_contains
+++ b/tests/integration_tests/_utils/check_not_contains
@@ -2,11 +2,12 @@
 
 set -eu
 OUT_DIR=/tmp/tidb_cdc_test
+LOG_FILE="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
 
-if grep -Fq "$1" "$OUT_DIR/sql_res.$TEST_NAME.log"; then
+if grep -Fq "$1" "$LOG_FILE"; then
 	echo "TEST FAILED: OUTPUT CONTAINS '$1'"
 	echo "____________________________________"
-	cat "$OUT_DIR/sql_res.$TEST_NAME.log"
+	cat "$LOG_FILE"
 	echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 	exit 1
 fi

--- a/tests/integration_tests/_utils/run_sql
+++ b/tests/integration_tests/_utils/run_sql
@@ -35,7 +35,7 @@ if [ -n "$TEST_NAME" ] && [[ "$OUT_DIR" == *"/$TEST_NAME"* ]]; then
 fi
 
 echo "OUT_DIR: $ADJUSTED_OUT_DIR"
-log_file="$ADJUSTED_OUT_DIR/sql_res.$TEST_NAME.log"
+log_file="$ADJUSTED_OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
 
 echo "[$(date)] Executing SQL: ${sql}" >>"$log_file"
 

--- a/tests/integration_tests/_utils/run_sql
+++ b/tests/integration_tests/_utils/run_sql
@@ -27,7 +27,8 @@ fi
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-log_file="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
+echo "OUT_DIR: $OUT_DIR"
+log_file="$OUT_DIR/sql_res.$TEST_NAME.log"
 
 echo "[$(date)] Executing SQL: ${sql}" >>"$log_file"
 

--- a/tests/integration_tests/_utils/run_sql
+++ b/tests/integration_tests/_utils/run_sql
@@ -27,7 +27,9 @@ fi
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-echo "[$(date)] Executing SQL: ${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+log_file="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
 
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+echo "[$(date)] Executing SQL: ${sql}" >>"$log_file"
+
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >>"$log_file"
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >>"$log_file"

--- a/tests/integration_tests/_utils/run_sql
+++ b/tests/integration_tests/_utils/run_sql
@@ -27,8 +27,15 @@ fi
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-echo "OUT_DIR: $OUT_DIR"
-log_file="$OUT_DIR/sql_res.$TEST_NAME.log"
+
+# Check if OUT_DIR contains TEST_NAME, if so, truncate OUT_DIR to the parent directory
+ADJUSTED_OUT_DIR="$OUT_DIR"
+if [ -n "$TEST_NAME" ] && [[ "$OUT_DIR" == *"/$TEST_NAME"* ]]; then
+    ADJUSTED_OUT_DIR="${OUT_DIR%/$TEST_NAME}"
+fi
+
+echo "OUT_DIR: $ADJUSTED_OUT_DIR"
+log_file="$ADJUSTED_OUT_DIR/sql_res.$TEST_NAME.log"
 
 echo "[$(date)] Executing SQL: ${sql}" >>"$log_file"
 

--- a/tests/integration_tests/_utils/run_sql_file
+++ b/tests/integration_tests/_utils/run_sql_file
@@ -13,7 +13,7 @@ if [ -n "$TEST_NAME" ] && [[ "$OUT_DIR" == *"/$TEST_NAME"* ]]; then
     ADJUSTED_OUT_DIR="${OUT_DIR%/$TEST_NAME}"
 fi
 
-log_file="$ADJUSTED_OUT_DIR/sql_res.$TEST_NAME.log"
+log_file="$ADJUSTED_OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
 
 echo "[$(date)] Executing SQL: $1" >>"$log_file"
 mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -E -e "${prepare}" >>"$log_file"

--- a/tests/integration_tests/_utils/run_sql_file
+++ b/tests/integration_tests/_utils/run_sql_file
@@ -7,6 +7,8 @@ set -eu
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-echo "[$(date)] Executing SQL: $1" >"$OUT_DIR/sql_res.$TEST_NAME.log"
-mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
-mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -vv <"$1" >>"$OUT_DIR/sql_res.$TEST_NAME.log"
+log_file="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
+
+echo "[$(date)] Executing SQL: $1" >>"$log_file"
+mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -E -e "${prepare}" >>"$log_file"
+mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -vv <"$1" >>"$log_file"

--- a/tests/integration_tests/_utils/run_sql_file
+++ b/tests/integration_tests/_utils/run_sql_file
@@ -7,7 +7,13 @@ set -eu
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-log_file="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
+# Check if OUT_DIR contains TEST_NAME, if so, truncate OUT_DIR to the parent directory
+ADJUSTED_OUT_DIR="$OUT_DIR"
+if [ -n "$TEST_NAME" ] && [[ "$OUT_DIR" == *"/$TEST_NAME"* ]]; then
+    ADJUSTED_OUT_DIR="${OUT_DIR%/$TEST_NAME}"
+fi
+
+log_file="$ADJUSTED_OUT_DIR/sql_res.$TEST_NAME.log"
 
 echo "[$(date)] Executing SQL: $1" >>"$log_file"
 mysql -uroot -h$2 -P$3 --default-character-set utf8mb4 -E -e "${prepare}" >>"$log_file"

--- a/tests/integration_tests/_utils/run_sql_ignore_error
+++ b/tests/integration_tests/_utils/run_sql_ignore_error
@@ -31,7 +31,7 @@ if [ -n "$TEST_NAME" ] && [[ "$OUT_DIR" == *"/$TEST_NAME"* ]]; then
     ADJUSTED_OUT_DIR="${OUT_DIR%/$TEST_NAME}"
 fi
 
-log_file="$ADJUSTED_OUT_DIR/sql_res.$TEST_NAME.log"
+log_file="$ADJUSTED_OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
 
 echo "[$(date)] Executing SQL: ${sql}" >>"$log_file"
 

--- a/tests/integration_tests/_utils/run_sql_ignore_error
+++ b/tests/integration_tests/_utils/run_sql_ignore_error
@@ -25,7 +25,13 @@ fi
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-log_file="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
+# Check if OUT_DIR contains TEST_NAME, if so, truncate OUT_DIR to the parent directory
+ADJUSTED_OUT_DIR="$OUT_DIR"
+if [ -n "$TEST_NAME" ] && [[ "$OUT_DIR" == *"/$TEST_NAME"* ]]; then
+    ADJUSTED_OUT_DIR="${OUT_DIR%/$TEST_NAME}"
+fi
+
+log_file="$ADJUSTED_OUT_DIR/sql_res.$TEST_NAME.log"
 
 echo "[$(date)] Executing SQL: ${sql}" >>"$log_file"
 

--- a/tests/integration_tests/_utils/run_sql_ignore_error
+++ b/tests/integration_tests/_utils/run_sql_ignore_error
@@ -25,7 +25,9 @@ fi
 
 prepare="set global tidb_enable_clustered_index = 'int_only';"
 
-echo "[$(date)] Executing SQL: ${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+log_file="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
 
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
-mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >"$OUT_DIR/sql_res.$TEST_NAME.log"
+echo "[$(date)] Executing SQL: ${sql}" >>"$log_file"
+
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${prepare}" >>"$log_file"
+mysql -uroot -h${host} -P${port} ${other} --default-character-set utf8mb4 -E -e "${sql}" >>"$log_file"

--- a/tests/integration_tests/_utils/start_tidb_cluster
+++ b/tests/integration_tests/_utils/start_tidb_cluster
@@ -13,6 +13,8 @@ tikv_config=
 retry_times=3
 multiple_upstream_pd="false"
 
+LOG_DIR=
+
 while [[ ${1} ]]; do
 	case "${1}" in
 	--workdir)

--- a/tests/integration_tests/region_merge/run.sh
+++ b/tests/integration_tests/region_merge/run.sh
@@ -62,8 +62,8 @@ EOF
 	pulsar) run_pulsar_consumer --upstream-uri $SINK_URI --ca "${WORK_DIR}/ca.cert.pem" --auth-tls-private-key-path "${WORK_DIR}/broker_client.key-pk8.pem" --auth-tls-certificate-path="${WORK_DIR}/broker_client.cert.pem" ;;
 	esac
 
-	# set max_execution_time to 30s, because split region could block even region has been split.
-	run_sql "SET @@global.MAX_EXECUTION_TIME = 30000;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	# set max_execution_time to 90s, because split region could block even region has been split.
+	run_sql "SET @@global.MAX_EXECUTION_TIME = 90000;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "CREATE DATABASE region_merge;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "CREATE TABLE region_merge.t1 (id bigint primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 

--- a/tests/integration_tests/region_merge/run.sh
+++ b/tests/integration_tests/region_merge/run.sh
@@ -5,6 +5,7 @@ set -eu
 CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source $CUR/../_utils/test_prepare
 WORK_DIR=$OUT_DIR/$TEST_NAME
+LOG_FILE="$WORK_DIR/sql_res.$TEST_NAME.log"
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
@@ -14,7 +15,7 @@ function split_and_random_merge() {
 	echo "split_and_random_merge scale: $scale"
 	run_sql "SPLIT TABLE region_merge.t1 BETWEEN (-9223372036854775808) AND (9223372036854775807) REGIONS $scale;" ${UP_TIDB_HOST} ${UP_TIDB_PORT} || true
 	run_sql "SELECT count(distinct region_id) from information_schema.tikv_region_status where db_name = 'region_merge' and table_name = 't1';" &&
-		cat $OUT_DIR/sql_res.region_merge.log
+		cat $LOG_FILE
 	run_sql "insert into region_merge.t1 values (-9223372036854775808),(0),(1),(9223372036854775807);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "delete from region_merge.t1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	# sleep 5s to wait some region merge

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -29,37 +29,37 @@ group_num=${group#G}
 
 mysql_groups=(
 	# G00
-	'generate_column many_pk_or_uk'
+	'region_merge'
 	# G01
-	'api_v2'
+	'region_merge'
 	# G02
-	'availability'
+	'region_merge'
 	# G03
-	'multi_source'
+	'region_merge'
 	# G04
-	'syncpoint'
+	'region_merge'
 	# G05
-	'move_table'
+	'region_merge'
 	# G06
-	'cdc'
+	'region_merge'
 	# G07
-	'resolve_lock'
+	'region_merge'
 	# G08
-	'bank'
+	'region_merge'
 	# G09
-	'drop_many_tables'
+	'region_merge'
 	# G10
-	'default_value http_proxies'
+	'region_merge'
 	# G11
-	'ddl_reentrant force_replicate_table'
+	'region_merge'
 	# G12
-	'tidb_mysql_test'
+	'region_merge'
 	# G13
-	'fail_over' 'region_merge'
+	'region_merge'
 	# G14
-	'fail_over_ddl_mix'
+	'region_merge'
 	# G15
-	'fail_over_ddl_mix_with_syncpoint'
+	'region_merge'
 )
 
 kafka_groups=(

--- a/tests/integration_tests/syncpoint_check_ts/run.sh
+++ b/tests/integration_tests/syncpoint_check_ts/run.sh
@@ -12,6 +12,7 @@ set -eu
 CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source $CUR/../_utils/test_prepare
 WORK_DIR=$OUT_DIR/$TEST_NAME
+LOG_FILE="$WORK_DIR/sql_res.$TEST_NAME.log"
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
@@ -44,8 +45,8 @@ function run() {
 
 	run_sql "SELECT primary_ts, secondary_ts FROM tidb_cdc.syncpoint_v1 order by primary_ts limit 1;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	echo "____________________________________"
-	cat "$OUT_DIR/sql_res.$TEST_NAME.log"
-	primary_ts=($(grep primary_ts $OUT_DIR/sql_res.$TEST_NAME.log | awk -F ": " '{print $2}'))
+	cat "$LOG_FILE"
+	primary_ts=($(grep primary_ts $LOG_FILE | awk -F ": " '{print $2}'))
 	echo "primary_ts is " $primary_ts "start_ts is " $start_ts
 
 	shifted_primary_ts=$(($primary_ts >> 18))


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1119 

### What is changed and how it works?

1. Increase the value of `@@global.MAX_EXECUTION_TIME` from 30 seconds to 90 seconds to ensure that SQL execution does not time out.
2. Improve some shell scripts related to tests. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
