### PR TITLE
*: modify cdc binary to always use new arch client except `cdc server`

### DIFF
--- a/cmd/cdc/server/server.go
+++ b/cmd/cdc/server/server.go
@@ -249,20 +249,20 @@ func isNewArchEnabledByConfig(serverConfigFilePath string) bool {
 func isNewArchEnabled(o *options) bool {
 	newarch := o.serverConfig.Newarch
 	if newarch {
-		log.Info("Set newarch from command line")
+		log.Debug("Set newarch from command line")
 		return newarch
 	}
 
 	newarch = os.Getenv("TICDC_NEWARCH") == "true"
 	if newarch {
-		log.Info("Set newarch from environment variable")
+		log.Debug("Set newarch from environment variable")
 		return newarch
 	}
 
 	serverConfigFilePath := parseConfigFlagFromOSArgs()
 	newarch = isNewArchEnabledByConfig(serverConfigFilePath)
 	if newarch {
-		log.Info("Set newarch from config file")
+		log.Debug("Set newarch from config file")
 	}
 	return newarch
 }

--- a/cmd/cdc/server/server.go
+++ b/cmd/cdc/server/server.go
@@ -223,6 +223,7 @@ func parseConfigFlagFromOSArgs() string {
 			serverConfigFilePath = os.Args[i+2]
 		}
 	}
+	log.Info("parse config file path from os.Args", zap.String("config", serverConfigFilePath))
 
 	// If the command is `cdc cli changefeed`, means it's not a server config file.
 	if slices.Contains(os.Args, "cli") && slices.Contains(os.Args, "changefeed") {

--- a/cmd/cdc/server/server.go
+++ b/cmd/cdc/server/server.go
@@ -188,7 +188,7 @@ func (o *options) validate() error {
 	if len(o.pdEndpoints) == 0 {
 		return errors.ErrInvalidServerOption.GenWithStack("empty PD address")
 	}
-	log.Info("validate pd address", zap.Strings("pd", o.pdEndpoints), zap.Int("pd count", len(o.pdEndpoints)))
+	log.Info("validate pd address", zap.Strings("pd", o.pdEndpoints), zap.Int("pdCount", len(o.pdEndpoints)))
 	for _, ep := range o.pdEndpoints {
 		// NOTICE: The configuration used here is the one that has been completed,
 		// as it may be configured by the configuration file.

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/pingcap/tidb v1.1.0-beta.0.20241223052309-3735ed55a394
 	github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20241223052309-3735ed55a394
-	github.com/pingcap/tiflow v0.0.0-20250317152406-8cf13cba0256
+	github.com/pingcap/tiflow v0.0.0-20250318113613-e23fa78655fa
 	github.com/prometheus/client_golang v1.20.5
 	github.com/r3labs/diff v1.1.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/pingcap/tidb v1.1.0-beta.0.20241223052309-3735ed55a394
 	github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20241223052309-3735ed55a394
-	github.com/pingcap/tiflow v0.0.0-20250307070542-b67943012af2
+	github.com/pingcap/tiflow v0.0.0-20250317152406-8cf13cba0256
 	github.com/prometheus/client_golang v1.20.5
 	github.com/r3labs/diff v1.1.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475

--- a/go.sum
+++ b/go.sum
@@ -797,8 +797,8 @@ github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7 h1:eFu98Fbf
 github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
 github.com/pingcap/tidb/pkg/parser v0.0.0-20241223052309-3735ed55a394 h1:Kd5UaT2mbA1gB0G19dkyRB4/Y5DYN8Sy/dgWYg9zNwI=
 github.com/pingcap/tidb/pkg/parser v0.0.0-20241223052309-3735ed55a394/go.mod h1:Hju1TEWZvrctQKbztTRwXH7rd41Yq0Pgmq4PrEKcq7o=
-github.com/pingcap/tiflow v0.0.0-20250307070542-b67943012af2 h1:V9eAn/kK3rTCzf/IdiULIbrG0ToiZKFzJtIczSyHC/g=
-github.com/pingcap/tiflow v0.0.0-20250307070542-b67943012af2/go.mod h1:kLYTUjCGZfBFLtSTboIZrYY1Nv4nZJm2XoX+HgiT78s=
+github.com/pingcap/tiflow v0.0.0-20250317152406-8cf13cba0256 h1:FLLnbQFdmlSO14RkW6KH7T+gMLtFoNoy7UMOe1Hb5TA=
+github.com/pingcap/tiflow v0.0.0-20250317152406-8cf13cba0256/go.mod h1:kLYTUjCGZfBFLtSTboIZrYY1Nv4nZJm2XoX+HgiT78s=
 github.com/pingcap/tipb v0.0.0-20241105053214-f91fdb81a69e h1:7DdrYVwWpYr4o1AyKl8T376B4h2RsMEjkmom8MxQuuM=
 github.com/pingcap/tipb v0.0.0-20241105053214-f91fdb81a69e/go.mod h1:zrnYy8vReNODg8G0OiYaX9OK+kpq+rK1jHmvd1DnIWw=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/go.sum
+++ b/go.sum
@@ -797,8 +797,8 @@ github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7 h1:eFu98Fbf
 github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
 github.com/pingcap/tidb/pkg/parser v0.0.0-20241223052309-3735ed55a394 h1:Kd5UaT2mbA1gB0G19dkyRB4/Y5DYN8Sy/dgWYg9zNwI=
 github.com/pingcap/tidb/pkg/parser v0.0.0-20241223052309-3735ed55a394/go.mod h1:Hju1TEWZvrctQKbztTRwXH7rd41Yq0Pgmq4PrEKcq7o=
-github.com/pingcap/tiflow v0.0.0-20250317152406-8cf13cba0256 h1:FLLnbQFdmlSO14RkW6KH7T+gMLtFoNoy7UMOe1Hb5TA=
-github.com/pingcap/tiflow v0.0.0-20250317152406-8cf13cba0256/go.mod h1:kLYTUjCGZfBFLtSTboIZrYY1Nv4nZJm2XoX+HgiT78s=
+github.com/pingcap/tiflow v0.0.0-20250318113613-e23fa78655fa h1:9jGrp7qawtE8nYKYkDpk+r2b/J4WOU1kMY/ojCeUEEM=
+github.com/pingcap/tiflow v0.0.0-20250318113613-e23fa78655fa/go.mod h1:kLYTUjCGZfBFLtSTboIZrYY1Nv4nZJm2XoX+HgiT78s=
 github.com/pingcap/tipb v0.0.0-20241105053214-f91fdb81a69e h1:7DdrYVwWpYr4o1AyKl8T376B4h2RsMEjkmom8MxQuuM=
 github.com/pingcap/tipb v0.0.0-20241105053214-f91fdb81a69e/go.mod h1:zrnYy8vReNODg8G0OiYaX9OK+kpq+rK1jHmvd1DnIWw=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1134

### What is changed and how it works?

#### Description

This PR ensures that the TiCDC binary always uses the new architecture client. Previously, the binary defaulted to the old architecture client, which could cause errors due to missing configurations when running with the new architecture. Since the new architecture client is fully compatible with the old architecture, using it exclusively avoids these issues while maintaining backward compatibility.

#### Changes
* Binary Modification: The TiCDC binary now always uses the new architecture client
* cdc server Behavior Unchanged: The cdc server command still defaults to the old architecture but allows users to switch to the new architecture using:
    * `--newarch` or `-x` flag
    * Setting `TICDC_NEWARCH=true`
    * Adding `newarch: true` in the server configuration

This change ensures that users do not encounter compatibility issues when using the new architecture binary while still allowing flexibility in choosing the server architecture.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Verified that the TiCDC binary runs successfully with the new architecture client, including new configurations.
Confirmed that cdc server maintains support for both architectures with the expected behavior.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
