### PR TITLE
schemastore: fix register partition table

### DIFF
--- a/logservice/schemastore/disk_format.go
+++ b/logservice/schemastore/disk_format.go
@@ -84,6 +84,18 @@ func tableInfoKey(ts uint64, tableID int64) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func partitionInfoKey(ts uint64, partitionID int64) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	buf.WriteString(snapshotPartitionKeyPrefix)
+	if err := binary.Write(buf, binary.BigEndian, ts); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, partitionID); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 func ddlJobKey(ts uint64) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteString(ddlKeyPrefix)
@@ -486,12 +498,18 @@ func addSchemaInfoToBatch(batch *pebble.Batch, ts uint64, info *model.DBInfo) {
 	batch.Set(schemaKey, schemaValue, pebble.NoSync)
 }
 
-func addTableInfoToBatch(batch *pebble.Batch, ts uint64, dbInfo *model.DBInfo, tableInfoValue []byte) (int64, string) {
-	tbNameInfo := model.TableNameInfo{}
-	if err := json.Unmarshal(tableInfoValue, &tbNameInfo); err != nil {
+func addTableInfoToBatch(
+	batch *pebble.Batch,
+	ts uint64,
+	dbInfo *model.DBInfo,
+	tableInfoValue []byte,
+) (int64, string, []int64) {
+	tableInfo := model.TableInfo{}
+	if err := json.Unmarshal(tableInfoValue, &tableInfo); err != nil {
 		log.Fatal("unmarshal table info failed", zap.Error(err))
 	}
-	tableKey, err := tableInfoKey(ts, tbNameInfo.ID)
+	// write table info to batch
+	tableKey, err := tableInfoKey(ts, tableInfo.ID)
 	if err != nil {
 		log.Fatal("generate table key failed", zap.Error(err))
 	}
@@ -505,16 +523,33 @@ func addTableInfoToBatch(batch *pebble.Batch, ts uint64, dbInfo *model.DBInfo, t
 		log.Fatal("marshal table info entry failed", zap.Error(err))
 	}
 	batch.Set(tableKey, tableInfoEntryValue, pebble.NoSync)
-	return tbNameInfo.ID, tbNameInfo.Name.O
+
+	// write partition info to batch if the table is a partition table
+	var partitionIDs []int64
+	if tableInfo.Partition != nil {
+		for _, partition := range tableInfo.Partition.Definitions {
+			partitionKey, err := partitionInfoKey(ts, partition.ID)
+			if err != nil {
+				log.Fatal("generate partition key failed", zap.Error(err))
+			}
+			valueBuf := new(bytes.Buffer)
+			if err := binary.Write(valueBuf, binary.BigEndian, tableInfo.ID); err != nil {
+				log.Fatal("generate partition value failed", zap.Error(err))
+			}
+			batch.Set(partitionKey, valueBuf.Bytes(), pebble.NoSync)
+			partitionIDs = append(partitionIDs, partition.ID)
+		}
+	}
+	return tableInfo.ID, tableInfo.Name.O, partitionIDs
 }
 
-// writeSchemaSnapshotAndMeta write database info and table info to disks.
-func writeSchemaSnapshotAndMeta(
+// persistSchemaSnapshot write database/table/partition info to disks.
+func persistSchemaSnapshot(
 	db *pebble.DB,
 	tiStore kv.Storage,
 	snapTs uint64,
-	needTableInfo bool,
-) (map[int64]*BasicDatabaseInfo, map[int64]*BasicTableInfo, error) {
+	collectMetaInfo bool,
+) (map[int64]*BasicDatabaseInfo, map[int64]*BasicTableInfo, map[int64]BasicPartitionInfo, error) {
 	meta := getSnapshotMeta(tiStore, snapTs)
 	start := time.Now()
 	dbInfos, err := meta.ListDatabases()
@@ -523,56 +558,62 @@ func writeSchemaSnapshotAndMeta(
 	}
 
 	var databaseMap map[int64]*BasicDatabaseInfo
-	var tablesInKVSnap map[int64]*BasicTableInfo
-	if needTableInfo {
+	var tableMap map[int64]*BasicTableInfo
+	var partitionMap map[int64]BasicPartitionInfo
+	if collectMetaInfo {
 		databaseMap = make(map[int64]*BasicDatabaseInfo)
-		tablesInKVSnap = make(map[int64]*BasicTableInfo)
+		tableMap = make(map[int64]*BasicTableInfo)
+		partitionMap = make(map[int64]BasicPartitionInfo)
 	}
 	for _, dbInfo := range dbInfos {
 		if filter.IsSysSchema(dbInfo.Name.O) {
 			continue
 		}
 		batch := db.NewBatch()
-
 		addSchemaInfoToBatch(batch, snapTs, dbInfo)
-
 		rawTables, err := meta.GetMetasByDBID(dbInfo.ID)
 		if err != nil {
 			log.Fatal("get tables failed", zap.Error(err))
 		}
-		var tables map[int64]bool
-		if needTableInfo {
-			tables = make(map[int64]bool)
+		var tablesInDB map[int64]bool
+		if collectMetaInfo {
+			tablesInDB = make(map[int64]bool)
 		}
 		for _, rawTable := range rawTables {
 			if !isTableRawKey(rawTable.Field) {
 				continue
 			}
-			tableID, tableName := addTableInfoToBatch(batch, snapTs, dbInfo, rawTable.Value)
-			if needTableInfo {
-				tablesInKVSnap[tableID] = &BasicTableInfo{
+			tableID, tableName, partitionIDs := addTableInfoToBatch(batch, snapTs, dbInfo, rawTable.Value)
+			if collectMetaInfo {
+				tableMap[tableID] = &BasicTableInfo{
 					SchemaID: dbInfo.ID,
 					Name:     tableName,
 				}
-				tables[tableID] = true
+				tablesInDB[tableID] = true
+				if len(partitionIDs) > 0 {
+					partitionMap[tableID] = make(BasicPartitionInfo)
+					for _, partitionID := range partitionIDs {
+						partitionMap[tableID].AddPartitionID(partitionID)
+					}
+				}
 			}
 			// 8M is arbitrary, we can adjust it later
 			if batch.Len() >= 8*1024*1024 {
 				if err := batch.Commit(pebble.NoSync); err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 				batch = db.NewBatch()
 			}
 		}
-		if needTableInfo {
+		if collectMetaInfo {
 			databaseInfo := &BasicDatabaseInfo{
 				Name:   dbInfo.Name.O,
-				Tables: tables,
+				Tables: tablesInDB,
 			}
 			databaseMap[dbInfo.ID] = databaseInfo
 		}
 		if err := batch.Commit(pebble.NoSync); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
@@ -580,7 +621,7 @@ func writeSchemaSnapshotAndMeta(
 
 	log.Info("finish write schema snapshot",
 		zap.Any("duration", time.Since(start).Seconds()))
-	return databaseMap, tablesInKVSnap, nil
+	return databaseMap, tableMap, partitionMap, nil
 }
 
 func cleanObsoleteData(db *pebble.DB, oldGcTs uint64, gcTs uint64) {

--- a/logservice/schemastore/disk_format.go
+++ b/logservice/schemastore/disk_format.go
@@ -46,11 +46,11 @@ import (
 //     and we will pull ddl job from `resolved_ts` at restart if the current gc ts is smaller than resolved_ts.
 
 const (
-	snapshotSchemaKeyPrefix = "ss_"
-	snapshotTableKeyPrefix  = "st_"
+	snapshotSchemaKeyPrefix    = "ss_"
+	snapshotTableKeyPrefix     = "st_"
+	snapshotPartitionKeyPrefix = "sp_"
+	ddlKeyPrefix               = "ds_"
 )
-
-const ddlKeyPrefix = "ds_"
 
 func gcTsKey() []byte {
 	return []byte("gc")

--- a/logservice/schemastore/disk_format.go
+++ b/logservice/schemastore/disk_format.go
@@ -632,7 +632,7 @@ func persistSchemaSnapshot(
 				if len(partitionIDs) > 0 {
 					partitionMap[tableID] = make(BasicPartitionInfo)
 					for _, partitionID := range partitionIDs {
-						partitionMap[tableID].AddPartitionID(partitionID)
+						partitionMap[tableID].AddPartitionIDs(partitionID)
 					}
 				}
 			}

--- a/logservice/schemastore/multi_version.go
+++ b/logservice/schemastore/multi_version.go
@@ -98,7 +98,8 @@ func (e *TableDeletedError) Error() string {
 	return "table deleted"
 }
 
-// return the table info with the largest version <= ts
+// if ts < deleteVersion, return the table info with the largest version <= ts
+// if ts >= deleteVersion, return nil table info and TableDeletedError
 func (v *versionedTableInfoStore) getTableInfo(ts uint64) (*common.TableInfo, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()

--- a/logservice/schemastore/multi_version_test_utils.go
+++ b/logservice/schemastore/multi_version_test_utils.go
@@ -74,24 +74,15 @@ func buildCreatePartitionTableEventForTest(schemaID, tableID int64, schemaName, 
 		SchemaName: schemaName,
 		TableName:  tableName,
 		TableInfo: &model.TableInfo{
-			ID:   tableID,
-			Name: pmodel.NewCIStr(tableName),
-			Partition: &model.PartitionInfo{
-				Definitions: partitionDefinitions,
-				Enable:      true,
-			},
+			ID:        tableID,
+			Name:      pmodel.NewCIStr(tableName),
+			Partition: buildPartitionDefinitionsForTest(partitionIDs),
 		},
 		FinishedTs: finishedTs,
 	}
 }
 
 func buildDropPartitionTableEventForTest(schemaID, tableID int64, schemaName, tableName string, partitionIDs []int64, finishedTs uint64) *PersistedDDLEvent {
-	partitionDefinitions := make([]model.PartitionDefinition, 0, len(partitionIDs))
-	for _, partitionID := range partitionIDs {
-		partitionDefinitions = append(partitionDefinitions, model.PartitionDefinition{
-			ID: partitionID,
-		})
-	}
 	return &PersistedDDLEvent{
 		Type:       byte(model.ActionDropTable),
 		SchemaID:   schemaID,
@@ -99,12 +90,9 @@ func buildDropPartitionTableEventForTest(schemaID, tableID int64, schemaName, ta
 		SchemaName: schemaName,
 		TableName:  tableName,
 		TableInfo: &model.TableInfo{
-			ID:   tableID,
-			Name: pmodel.NewCIStr(tableName),
-			Partition: &model.PartitionInfo{
-				Definitions: partitionDefinitions,
-				Enable:      true,
-			},
+			ID:        tableID,
+			Name:      pmodel.NewCIStr(tableName),
+			Partition: buildPartitionDefinitionsForTest(partitionIDs),
 		},
 		FinishedTs: finishedTs,
 	}
@@ -131,12 +119,6 @@ func buildTruncatePartitionTableEventForTest(
 	schemaName, tableName string,
 	newPartitionIDs []int64, finishedTs uint64,
 ) *PersistedDDLEvent {
-	partitionDefinitions := make([]model.PartitionDefinition, 0, len(newPartitionIDs))
-	for _, partitionID := range newPartitionIDs {
-		partitionDefinitions = append(partitionDefinitions, model.PartitionDefinition{
-			ID: partitionID,
-		})
-	}
 	return &PersistedDDLEvent{
 		Type:       byte(model.ActionTruncateTable),
 		SchemaID:   schemaID,
@@ -144,12 +126,9 @@ func buildTruncatePartitionTableEventForTest(
 		SchemaName: schemaName,
 		TableName:  tableName,
 		TableInfo: &model.TableInfo{
-			ID:   newTableID,
-			Name: pmodel.NewCIStr(tableName),
-			Partition: &model.PartitionInfo{
-				Definitions: partitionDefinitions,
-				Enable:      true,
-			},
+			ID:        newTableID,
+			Name:      pmodel.NewCIStr(tableName),
+			Partition: buildPartitionDefinitionsForTest(newPartitionIDs),
 		},
 		FinishedTs: finishedTs,
 	}
@@ -178,12 +157,6 @@ func buildExchangePartitionTableEventForTest(
 	normalSchemaName, normalTableName, partitionSchemaName, partitionTableName string,
 	oldPartitionIDs, newPartitionIDs []int64, finishedTs uint64,
 ) *PersistedDDLEvent {
-	partitionDefinitions := make([]model.PartitionDefinition, 0, len(newPartitionIDs))
-	for _, partitionID := range newPartitionIDs {
-		partitionDefinitions = append(partitionDefinitions, model.PartitionDefinition{
-			ID: partitionID,
-		})
-	}
 	return &PersistedDDLEvent{
 		Type:            byte(model.ActionExchangeTablePartition),
 		SchemaID:        normalSchemaID,
@@ -195,12 +168,9 @@ func buildExchangePartitionTableEventForTest(
 		ExtraSchemaName: partitionSchemaName,
 		ExtraTableName:  partitionTableName,
 		TableInfo: &model.TableInfo{
-			ID:   partitionTableID,
-			Name: pmodel.NewCIStr(partitionTableName),
-			Partition: &model.PartitionInfo{
-				Definitions: partitionDefinitions,
-				Enable:      true,
-			},
+			ID:        partitionTableID,
+			Name:      pmodel.NewCIStr(partitionTableName),
+			Partition: buildPartitionDefinitionsForTest(newPartitionIDs),
 		},
 		ExtraTableInfo: common.WrapTableInfo(normalSchemaName, &model.TableInfo{
 			ID:   normalTableID,

--- a/logservice/schemastore/multi_version_test_utils.go
+++ b/logservice/schemastore/multi_version_test_utils.go
@@ -211,7 +211,7 @@ func buildExchangePartitionTableEventForTest(
 	}
 }
 
-func buildPartitionDefinitions(partitionIDs []int64) *model.PartitionInfo {
+func buildPartitionDefinitionsForTest(partitionIDs []int64) *model.PartitionInfo {
 	partitionDefinitions := make([]model.PartitionDefinition, 0, len(partitionIDs))
 	for _, partitionID := range partitionIDs {
 		partitionDefinitions = append(partitionDefinitions, model.PartitionDefinition{

--- a/logservice/schemastore/multi_version_test_utils.go
+++ b/logservice/schemastore/multi_version_test_utils.go
@@ -210,3 +210,16 @@ func buildExchangePartitionTableEventForTest(
 		FinishedTs:     finishedTs,
 	}
 }
+
+func buildPartitionDefinitions(partitionIDs []int64) *model.PartitionInfo {
+	partitionDefinitions := make([]model.PartitionDefinition, 0, len(partitionIDs))
+	for _, partitionID := range partitionIDs {
+		partitionDefinitions = append(partitionDefinitions, model.PartitionDefinition{
+			ID: partitionID,
+		})
+	}
+	return &model.PartitionInfo{
+		Definitions: partitionDefinitions,
+		Enable:      true,
+	}
+}

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -1016,9 +1016,7 @@ func updateSchemaMetadataForNewTableDDL(args updateSchemaMetadataFuncArgs) {
 	}
 	if isPartitionTable(args.event.TableInfo) {
 		partitionInfo := make(BasicPartitionInfo)
-		for _, id := range getAllPartitionIDs(args.event.TableInfo) {
-			partitionInfo[id] = nil
-		}
+		partitionInfo.AddPartitionIDs(getAllPartitionIDs(args.event.TableInfo)...)
 		args.partitionMap[tableID] = partitionInfo
 	}
 }
@@ -1049,9 +1047,7 @@ func updateSchemaMetadataForTruncateTable(args updateSchemaMetadataFuncArgs) {
 	if isPartitionTable(args.event.TableInfo) {
 		delete(args.partitionMap, oldTableID)
 		partitionInfo := make(BasicPartitionInfo)
-		for _, id := range getAllPartitionIDs(args.event.TableInfo) {
-			partitionInfo[id] = nil
-		}
+		partitionInfo.AddPartitionIDs(getAllPartitionIDs(args.event.TableInfo)...)
 		args.partitionMap[newTableID] = partitionInfo
 	}
 }
@@ -1142,9 +1138,7 @@ func updateSchemaMetadataForCreateTables(args updateSchemaMetadataFuncArgs) {
 		}
 		if isPartitionTable(info) {
 			partitionInfo := make(BasicPartitionInfo)
-			for _, id := range getAllPartitionIDs(info) {
-				partitionInfo[id] = nil
-			}
+			partitionInfo.AddPartitionIDs((getAllPartitionIDs(info))...)
 			args.partitionMap[info.ID] = partitionInfo
 		}
 	}
@@ -1154,13 +1148,9 @@ func updateSchemaMetadataForReorganizePartition(args updateSchemaMetadataFuncArg
 	tableID := args.event.TableID
 	physicalIDs := getAllPartitionIDs(args.event.TableInfo)
 	droppedIDs := getDroppedIDs(args.event.PrevPartitions, physicalIDs)
-	for _, id := range droppedIDs {
-		delete(args.partitionMap[tableID], id)
-	}
+	args.partitionMap[tableID].RemovePartitionIDs(droppedIDs...)
 	newCreatedIDs := getCreatedIDs(args.event.PrevPartitions, physicalIDs)
-	for _, id := range newCreatedIDs {
-		args.partitionMap[tableID][id] = nil
-	}
+	args.partitionMap[tableID].AddPartitionIDs(newCreatedIDs...)
 }
 
 func updateSchemaMetadataForAlterTablePartitioning(args updateSchemaMetadataFuncArgs) {
@@ -1178,9 +1168,7 @@ func updateSchemaMetadataForAlterTablePartitioning(args updateSchemaMetadataFunc
 		Name:     args.event.TableName,
 	}
 	args.partitionMap[newTableID] = make(BasicPartitionInfo)
-	for _, id := range getAllPartitionIDs(args.event.TableInfo) {
-		args.partitionMap[newTableID][id] = nil
-	}
+	args.partitionMap[newTableID].AddPartitionIDs(getAllPartitionIDs(args.event.TableInfo)...)
 }
 
 func updateSchemaMetadataForRemovePartitioning(args updateSchemaMetadataFuncArgs) {

--- a/logservice/schemastore/persist_storage_test.go
+++ b/logservice/schemastore/persist_storage_test.go
@@ -2259,17 +2259,17 @@ func TestRegisterTable(t *testing.T) {
 				{
 					tableID: 201,
 					snapTs:  1029,
-					name:    "t4",
+					name:    "t1",
 				},
 				{
 					tableID: 202,
 					snapTs:  1029,
-					name:    "t4",
+					name:    "t1",
 				},
 				{
 					tableID: 203,
 					snapTs:  1029,
-					name:    "t4",
+					name:    "t1",
 				},
 				{
 					tableID: 201,

--- a/logservice/schemastore/persist_storage_test_utils.go
+++ b/logservice/schemastore/persist_storage_test_utils.go
@@ -126,13 +126,13 @@ func mockWriteKVSnapOnDisk(db *pebble.DB, snapTs uint64, dbInfos []mockDBInfo) {
 	batch := db.NewBatch()
 	defer batch.Close()
 	for _, dbInfo := range dbInfos {
-		writeSchemaInfoToBatch(batch, snapTs, dbInfo.dbInfo)
+		addSchemaInfoToBatch(batch, snapTs, dbInfo.dbInfo)
 		for _, tableInfo := range dbInfo.tables {
 			tableInfoValue, err := json.Marshal(tableInfo)
 			if err != nil {
 				log.Panic("marshal table info fail", zap.Error(err))
 			}
-			writeTableInfoToBatch(batch, snapTs, dbInfo.dbInfo, tableInfoValue)
+			addTableInfoToBatch(batch, snapTs, dbInfo.dbInfo, tableInfoValue)
 		}
 	}
 	if err := batch.Commit(pebble.NoSync); err != nil {

--- a/logservice/schemastore/types.go
+++ b/logservice/schemastore/types.go
@@ -116,6 +116,14 @@ type BasicTableInfo struct {
 
 type BasicPartitionInfo map[int64]interface{}
 
+func (b BasicPartitionInfo) AddPartitionID(id int64) {
+	b[id] = nil
+}
+
+func (b BasicPartitionInfo) RemovePartitionID(id int64) {
+	delete(b, id)
+}
+
 //msgp:ignore DDLJobWithCommitTs
 type DDLJobWithCommitTs struct {
 	Job *model.Job

--- a/logservice/schemastore/types.go
+++ b/logservice/schemastore/types.go
@@ -116,12 +116,16 @@ type BasicTableInfo struct {
 
 type BasicPartitionInfo map[int64]interface{}
 
-func (b BasicPartitionInfo) AddPartitionID(id int64) {
-	b[id] = nil
+func (info BasicPartitionInfo) AddPartitionIDs(ids ...int64) {
+	for _, id := range ids {
+		info[id] = nil
+	}
 }
 
-func (b BasicPartitionInfo) RemovePartitionID(id int64) {
-	delete(b, id)
+func (info BasicPartitionInfo) RemovePartitionIDs(ids ...int64) {
+	for _, id := range ids {
+		delete(info, id)
+	}
 }
 
 //msgp:ignore DDLJobWithCommitTs


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1142 

### What is changed and how it works?

When schema store starts, it will fetch a snapshot of table info from upstream. And these infos are stored on disk in the format `logical_table_id -> table_info`. 

When we receive a dispatcher register request, we only knows the physical table id of the dispatcher. And we cannot fetch the table info from disk using the physical table id for partition tables. So we need a way to get the logical table id of the physical table id.

This pr writes an entry for every physical partition in the format `physical_table_id -> logical_table_id`.

When we receive a dispatcher register request, we will fetch the table info in the following steps:
1. use the table id of the dispatcher to get the table info directly;
2. if fail to get table info, try use the table id as the key to get the logical table id, and if success, use the logical table id to get the table info; otherwise, return nil;


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
