### PR TITLE
ci: fix extra region_merge in G13

### DIFF
--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -55,7 +55,7 @@ mysql_groups=(
 	# G12
 	'tidb_mysql_test'
 	# G13
-	'fail_over' 'region_merge'
+	'fail_over region_merge'
 	# G14
 	'fail_over_ddl_mix'
 	# G15


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1147

### What is changed and how it works?

This PR fixes an issue in run_heavy_it_in_ci.sh where fail_over_ddl_mix_with_syncpoint was not executed due to G13 containing an extra region_merge group.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
