### PR TITLE
mysql: extract col value meet error then panic immediately

### DIFF
--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -350,18 +350,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 					wakeCallback()
 				}
 			})
-			err := d.AddDMLEventToSink(dml)
-			if err != nil {
-				select {
-				case d.errCh <- err:
-				default:
-					log.Error("error channel is full, discard error",
-						zap.Stringer("changefeedID", d.changefeedID),
-						zap.Stringer("dispatcherID", d.id),
-						zap.Error(err))
-				}
-				return
-			}
+			d.AddDMLEventToSink(dml)
 		case commonEvent.TypeDDLEvent:
 			if len(dispatcherEvents) != 1 {
 				log.Panic("ddl event should only be singly handled",
@@ -431,9 +420,9 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 	return block
 }
 
-func (d *Dispatcher) AddDMLEventToSink(event *commonEvent.DMLEvent) error {
+func (d *Dispatcher) AddDMLEventToSink(event *commonEvent.DMLEvent) {
 	d.tableProgress.Add(event)
-	return d.sink.AddDMLEvent(event)
+	d.sink.AddDMLEvent(event)
 }
 
 func (d *Dispatcher) AddBlockEventToSink(event commonEvent.BlockEvent) error {

--- a/downstreamadapter/dispatcher/dispatcher_test.go
+++ b/downstreamadapter/dispatcher/dispatcher_test.go
@@ -37,9 +37,8 @@ type mockSink struct {
 	sinkType common.SinkType
 }
 
-func (s *mockSink) AddDMLEvent(event *commonEvent.DMLEvent) error {
+func (s *mockSink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	s.dmls = append(s.dmls, event)
-	return nil
 }
 
 func (s *mockSink) WriteBlockEvent(event commonEvent.BlockEvent) error {

--- a/downstreamadapter/sink/blackhole.go
+++ b/downstreamadapter/sink/blackhole.go
@@ -43,14 +43,13 @@ func (s *BlackHoleSink) SinkType() common.SinkType {
 func (s *BlackHoleSink) SetTableSchemaStore(tableSchemaStore *util.TableSchemaStore) {
 }
 
-func (s *BlackHoleSink) AddDMLEvent(event *commonEvent.DMLEvent) error {
+func (s *BlackHoleSink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	// NOTE: don't change the log, integration test `lossy_ddl` depends on it.
 	// ref: https://github.com/pingcap/ticdc/blob/da834db76e0662ff15ef12645d1f37bfa6506d83/tests/integration_tests/lossy_ddl/run.sh#L23
 	log.Debug("BlackHoleSink: WriteEvents", zap.Any("dml", event))
 	for _, callback := range event.PostTxnFlushed {
 		callback()
 	}
-	return nil
 }
 
 func (s *BlackHoleSink) PassBlockEvent(event commonEvent.BlockEvent) {

--- a/downstreamadapter/sink/cloudstorage.go
+++ b/downstreamadapter/sink/cloudstorage.go
@@ -146,9 +146,8 @@ func (s *CloudStorageSink) IsNormal() bool {
 	return atomic.LoadUint32(&s.isNormal) == 1
 }
 
-func (s *CloudStorageSink) AddDMLEvent(event *commonEvent.DMLEvent) error {
+func (s *CloudStorageSink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	s.dmlWorker.AddDMLEvent(event)
-	return nil
 }
 
 func (s *CloudStorageSink) PassBlockEvent(event commonEvent.BlockEvent) {

--- a/downstreamadapter/sink/cloudstorage_test.go
+++ b/downstreamadapter/sink/cloudstorage_test.go
@@ -108,8 +108,7 @@ func TestCloudStorageSinkBasicFunctionality(t *testing.T) {
 	err = sink.WriteBlockEvent(ddlEvent)
 	require.NoError(t, err)
 
-	err = sink.AddDMLEvent(dmlEvent)
-	require.NoError(t, err)
+	sink.AddDMLEvent(dmlEvent)
 
 	time.Sleep(5 * time.Second)
 

--- a/downstreamadapter/sink/conflictdetector/conflict_detector.go
+++ b/downstreamadapter/sink/conflictdetector/conflict_detector.go
@@ -16,11 +16,9 @@ package conflictdetector
 import (
 	"sync"
 
-	"github.com/pingcap/log"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/utils/chann"
 	"go.uber.org/atomic"
-	"go.uber.org/zap"
 )
 
 // ConflictDetector implements a logic that dispatches transaction
@@ -90,11 +88,8 @@ func (d *ConflictDetector) runBackgroundTasks() {
 //
 // NOTE: if multiple threads access this concurrently,
 // ConflictKeys must be sorted by the slot index.
-func (d *ConflictDetector) Add(event *commonEvent.DMLEvent) error {
-	hashes, err := ConflictKeys(event)
-	if err != nil {
-		return err
-	}
+func (d *ConflictDetector) Add(event *commonEvent.DMLEvent) {
+	hashes := ConflictKeys(event)
 	node := d.slots.AllocNode(hashes)
 
 	event.AddPostFlushFunc(func() {
@@ -108,8 +103,6 @@ func (d *ConflictDetector) Add(event *commonEvent.DMLEvent) error {
 	node.RandCacheID = func() int64 { return d.nextCacheID.Add(1) % int64(len(d.resolvedTxnCaches)) }
 	node.OnNotified = func(callback func()) { d.notifiedNodes.In() <- callback }
 	d.slots.Add(node)
-
-	return nil
 }
 
 // Close closes the ConflictDetector.
@@ -119,10 +112,6 @@ func (d *ConflictDetector) Close() {
 
 // sendToCache should not call txn.Callback if it returns an error.
 func (d *ConflictDetector) sendToCache(event *commonEvent.DMLEvent, id int64) bool {
-	if id < 0 {
-		log.Panic("must assign with a valid cacheID", zap.Int64("cacheID", id))
-	}
-
 	cache := d.resolvedTxnCaches[id]
 	ok := cache.add(event)
 	return ok
@@ -131,8 +120,5 @@ func (d *ConflictDetector) sendToCache(event *commonEvent.DMLEvent, id int64) bo
 // GetOutChByCacheID returns the output channel by cacheID.
 // Note txns in single cache should be executed sequentially.
 func (d *ConflictDetector) GetOutChByCacheID(id int64) <-chan *commonEvent.DMLEvent {
-	if id < 0 {
-		log.Panic("must assign with a valid cacheID", zap.Int64("cacheID", id))
-	}
 	return d.resolvedTxnCaches[id].out()
 }

--- a/downstreamadapter/sink/conflictdetector/helper.go
+++ b/downstreamadapter/sink/conflictdetector/helper.go
@@ -102,8 +102,7 @@ func genKeyList(
 		if columnInfos[i] == nil || tableInfo.GetColumnFlags()[columnInfos[i].ID].IsGeneratedColumn() {
 			return nil
 		}
-		ft := columnInfos[i].FieldType
-		value := common.ExtractColVal(row, ft, i)
+		value := common.ExtractColVal(row, columnInfos[i], i)
 		// if a column value is null, we can ignore this index
 		if value == nil {
 			return nil

--- a/downstreamadapter/sink/conflictdetector/helper.go
+++ b/downstreamadapter/sink/conflictdetector/helper.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
-	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tiflow/cdc/model"
@@ -29,9 +28,9 @@ import (
 )
 
 // ConflictKeys implements causality.txnEvent interface.
-func ConflictKeys(event *commonEvent.DMLEvent) ([]uint64, error) {
+func ConflictKeys(event *commonEvent.DMLEvent) []uint64 {
 	if event.Len() == 0 {
-		return nil, nil
+		return nil
 	}
 
 	hashRes := make(map[uint64]struct{}, event.Len())
@@ -42,10 +41,7 @@ func ConflictKeys(event *commonEvent.DMLEvent) ([]uint64, error) {
 		if !ok {
 			break
 		}
-		keys, err := genRowKeys(row, event.TableInfo, event.DispatcherID)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+		keys := genRowKeys(row, event.TableInfo, event.DispatcherID)
 		for _, key := range keys {
 			if n, err := hasher.Write(key); n != len(key) || err != nil {
 				log.Panic("transaction key hash fail")
@@ -61,18 +57,15 @@ func ConflictKeys(event *commonEvent.DMLEvent) ([]uint64, error) {
 	for key := range hashRes {
 		keys = append(keys, key)
 	}
-	return keys, nil
+	return keys
 }
 
-func genRowKeys(row commonEvent.RowChange, tableInfo *common.TableInfo, dispatcherID common.DispatcherID) ([][]byte, error) {
+func genRowKeys(row commonEvent.RowChange, tableInfo *common.TableInfo, dispatcherID common.DispatcherID) [][]byte {
 	var keys [][]byte
 
 	if !row.Row.IsEmpty() {
 		for iIdx, idxCol := range tableInfo.GetIndexColumnsOffset() {
-			key, err := genKeyList(&row.Row, iIdx, idxCol, dispatcherID, tableInfo)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
+			key := genKeyList(&row.Row, iIdx, idxCol, dispatcherID, tableInfo)
 			if len(key) == 0 {
 				continue
 			}
@@ -81,10 +74,7 @@ func genRowKeys(row commonEvent.RowChange, tableInfo *common.TableInfo, dispatch
 	}
 	if !row.PreRow.IsEmpty() {
 		for iIdx, idxCol := range tableInfo.GetIndexColumnsOffset() {
-			key, err := genKeyList(&row.PreRow, iIdx, idxCol, dispatcherID, tableInfo)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
+			key := genKeyList(&row.PreRow, iIdx, idxCol, dispatcherID, tableInfo)
 			if len(key) == 0 {
 				continue
 			}
@@ -99,27 +89,32 @@ func genRowKeys(row commonEvent.RowChange, tableInfo *common.TableInfo, dispatch
 		binary.BigEndian.PutUint64(tableKey, uint64(dispatcherID.GetLow()))
 		keys = [][]byte{tableKey}
 	}
-	return keys, nil
+	return keys
 }
 
 func genKeyList(
 	row *chunk.Row, iIdx int, colIdx []int, dispatcherID common.DispatcherID, tableInfo *common.TableInfo,
-) ([]byte, error) {
+) []byte {
 	var key []byte
 	columnInfos := tableInfo.GetColumns()
 	for _, i := range colIdx {
 		// If the index contain generated column, we can't use this key to detect conflict with other DML,
 		if columnInfos[i] == nil || tableInfo.GetColumnFlags()[columnInfos[i].ID].IsGeneratedColumn() {
-			return nil, nil
+			return nil
 		}
 
+<<<<<<< Updated upstream
 		value, err := common.ExtractColVal(row, columnInfos[i], i)
 		if err != nil {
 			return nil, err
 		}
+=======
+		ft := columnInfos[i].FieldType
+		value := common.ExtractColVal(row, ft, i)
+>>>>>>> Stashed changes
 		// if a column value is null, we can ignore this index
 		if value == nil {
-			return nil, nil
+			return nil
 		}
 
 		val := model.ColumnValueString(value)
@@ -131,13 +126,13 @@ func genKeyList(
 		key = append(key, 0)
 	}
 	if len(key) == 0 {
-		return nil, nil
+		return nil
 	}
 	tableKey := make([]byte, 16)
 	binary.BigEndian.PutUint64(tableKey[:8], uint64(iIdx))
 	binary.BigEndian.PutUint64(tableKey[8:], uint64(dispatcherID.GetLow()))
 	key = append(key, tableKey...)
-	return key, nil
+	return key
 }
 
 func columnNeeds2LowerCase(mysqlType byte, collation string) bool {

--- a/downstreamadapter/sink/conflictdetector/helper.go
+++ b/downstreamadapter/sink/conflictdetector/helper.go
@@ -102,16 +102,8 @@ func genKeyList(
 		if columnInfos[i] == nil || tableInfo.GetColumnFlags()[columnInfos[i].ID].IsGeneratedColumn() {
 			return nil
 		}
-
-<<<<<<< Updated upstream
-		value, err := common.ExtractColVal(row, columnInfos[i], i)
-		if err != nil {
-			return nil, err
-		}
-=======
 		ft := columnInfos[i].FieldType
 		value := common.ExtractColVal(row, ft, i)
->>>>>>> Stashed changes
 		// if a column value is null, we can ignore this index
 		if value == nil {
 			return nil

--- a/downstreamadapter/sink/helper/eventrouter/partition/columns.go
+++ b/downstreamadapter/sink/helper/eventrouter/partition/columns.go
@@ -66,7 +66,7 @@ func (r *ColumnsPartitionGenerator) GeneratePartitionIndexAndKey(row *commonEven
 
 	for idx := 0; idx < len(r.Columns); idx++ {
 		colInfo := tableInfo.GetColumns()[offsets[idx]]
-		value := common.ExtractColVal(&rowData, colInfo.FieldType, idx)
+		value := common.ExtractColVal(&rowData, colInfo, idx)
 		if value == nil {
 			continue
 		}

--- a/downstreamadapter/sink/helper/eventrouter/partition/columns.go
+++ b/downstreamadapter/sink/helper/eventrouter/partition/columns.go
@@ -66,11 +66,7 @@ func (r *ColumnsPartitionGenerator) GeneratePartitionIndexAndKey(row *commonEven
 
 	for idx := 0; idx < len(r.Columns); idx++ {
 		colInfo := tableInfo.GetColumns()[offsets[idx]]
-		value, err := common.ExtractColVal(&rowData, colInfo, idx)
-		if err != nil {
-			// FIXME:
-			log.Panic("ExtractColVal failed", zap.Error(err))
-		}
+		value := common.ExtractColVal(&rowData, colInfo.FieldType, idx)
 		if value == nil {
 			continue
 		}

--- a/downstreamadapter/sink/helper/eventrouter/partition/index_value.go
+++ b/downstreamadapter/sink/helper/eventrouter/partition/index_value.go
@@ -62,11 +62,7 @@ func (r *IndexValuePartitionGenerator) GeneratePartitionIndexAndKey(row *commonE
 				continue
 			}
 			if tableInfo.GetColumnFlags()[col.ID].IsHandleKey() {
-				value, err := common.ExtractColVal(&rowData, col, idx)
-				if err != nil {
-					// FIXME:
-					log.Panic("ExtractColVal failed", zap.Error(err))
-				}
+				value := common.ExtractColVal(&rowData, col.FieldType, idx)
 				r.hasher.Write([]byte(col.Name.O), []byte(model.ColumnValueString(value)))
 			}
 		}
@@ -81,11 +77,7 @@ func (r *IndexValuePartitionGenerator) GeneratePartitionIndexAndKey(row *commonE
 		}
 		for idx := 0; idx < len(names); idx++ {
 			colInfo := tableInfo.GetColumns()[offsets[idx]]
-			value, err := common.ExtractColVal(&rowData, colInfo, idx)
-			if err != nil {
-				// FIXME:
-				log.Panic("ExtractColVal failed", zap.Error(err))
-			}
+			value := common.ExtractColVal(&rowData, colInfo.FieldType, idx)
 			if value == nil {
 				continue
 			}

--- a/downstreamadapter/sink/helper/eventrouter/partition/index_value.go
+++ b/downstreamadapter/sink/helper/eventrouter/partition/index_value.go
@@ -62,7 +62,7 @@ func (r *IndexValuePartitionGenerator) GeneratePartitionIndexAndKey(row *commonE
 				continue
 			}
 			if tableInfo.GetColumnFlags()[col.ID].IsHandleKey() {
-				value := common.ExtractColVal(&rowData, col.FieldType, idx)
+				value := common.ExtractColVal(&rowData, col, idx)
 				r.hasher.Write([]byte(col.Name.O), []byte(model.ColumnValueString(value)))
 			}
 		}
@@ -77,7 +77,7 @@ func (r *IndexValuePartitionGenerator) GeneratePartitionIndexAndKey(row *commonE
 		}
 		for idx := 0; idx < len(names); idx++ {
 			colInfo := tableInfo.GetColumns()[offsets[idx]]
-			value := common.ExtractColVal(&rowData, colInfo.FieldType, idx)
+			value := common.ExtractColVal(&rowData, colInfo, idx)
 			if value == nil {
 				continue
 			}

--- a/downstreamadapter/sink/kafka_sink.go
+++ b/downstreamadapter/sink/kafka_sink.go
@@ -147,9 +147,8 @@ func (s *KafkaSink) IsNormal() bool {
 	return atomic.LoadUint32(&s.isNormal) == 1
 }
 
-func (s *KafkaSink) AddDMLEvent(event *commonEvent.DMLEvent) error {
+func (s *KafkaSink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	s.dmlWorker.AddDMLEvent(event)
-	return nil
 }
 
 func (s *KafkaSink) PassBlockEvent(event commonEvent.BlockEvent) {

--- a/downstreamadapter/sink/kafka_sink_test.go
+++ b/downstreamadapter/sink/kafka_sink_test.go
@@ -147,8 +147,7 @@ func TestKafkaSinkBasicFunctionality(t *testing.T) {
 	err = sink.WriteBlockEvent(ddlEvent)
 	require.NoError(t, err)
 
-	err = sink.AddDMLEvent(dmlEvent)
-	require.NoError(t, err)
+	sink.AddDMLEvent(dmlEvent)
 
 	time.Sleep(1 * time.Second)
 

--- a/downstreamadapter/sink/mysql_sink.go
+++ b/downstreamadapter/sink/mysql_sink.go
@@ -142,14 +142,8 @@ func (s *MysqlSink) SetTableSchemaStore(tableSchemaStore *util.TableSchemaStore)
 	s.ddlWorker.SetTableSchemaStore(tableSchemaStore)
 }
 
-<<<<<<< Updated upstream:downstreamadapter/sink/mysql_sink.go
-func (s *MysqlSink) AddDMLEvent(event *commonEvent.DMLEvent) error {
-	return s.conflictDetector.Add(event)
-
-=======
-func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
+func (s *MysqlSink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	s.conflictDetector.Add(event)
->>>>>>> Stashed changes:downstreamadapter/sink/mysql/mysql_sink.go
 	// // We use low value of dispatcherID to divide different tables into different workers.
 	// // And ensure the same table always goes to the same worker.
 	// index := event.GetDispatcherID().GetLow() % uint64(s.workerCount)

--- a/downstreamadapter/sink/mysql_sink.go
+++ b/downstreamadapter/sink/mysql_sink.go
@@ -142,9 +142,14 @@ func (s *MysqlSink) SetTableSchemaStore(tableSchemaStore *util.TableSchemaStore)
 	s.ddlWorker.SetTableSchemaStore(tableSchemaStore)
 }
 
+<<<<<<< Updated upstream:downstreamadapter/sink/mysql_sink.go
 func (s *MysqlSink) AddDMLEvent(event *commonEvent.DMLEvent) error {
 	return s.conflictDetector.Add(event)
 
+=======
+func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
+	s.conflictDetector.Add(event)
+>>>>>>> Stashed changes:downstreamadapter/sink/mysql/mysql_sink.go
 	// // We use low value of dispatcherID to divide different tables into different workers.
 	// // And ensure the same table always goes to the same worker.
 	// index := event.GetDispatcherID().GetLow() % uint64(s.workerCount)

--- a/downstreamadapter/sink/pulsar_sink.go
+++ b/downstreamadapter/sink/pulsar_sink.go
@@ -125,9 +125,8 @@ func (s *PulsarSink) IsNormal() bool {
 	return atomic.LoadUint32(&s.isNormal) == 1
 }
 
-func (s *PulsarSink) AddDMLEvent(event *commonEvent.DMLEvent) error {
+func (s *PulsarSink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	s.dmlWorker.AddDMLEvent(event)
-	return nil
 }
 
 func (s *PulsarSink) PassBlockEvent(event commonEvent.BlockEvent) {

--- a/downstreamadapter/sink/pulsar_sink_test.go
+++ b/downstreamadapter/sink/pulsar_sink_test.go
@@ -134,8 +134,7 @@ func TestPulsarSinkBasicFunctionality(t *testing.T) {
 	err = sink.WriteBlockEvent(ddlEvent)
 	require.NoError(t, err)
 
-	err = sink.AddDMLEvent(dmlEvent)
-	require.NoError(t, err)
+	sink.AddDMLEvent(dmlEvent)
 	time.Sleep(1 * time.Second)
 
 	sink.PassBlockEvent(ddlEvent2)

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -29,7 +29,7 @@ type Sink interface {
 	SinkType() common.SinkType
 	IsNormal() bool
 
-	AddDMLEvent(event *commonEvent.DMLEvent) error
+	AddDMLEvent(event *commonEvent.DMLEvent)
 	WriteBlockEvent(event commonEvent.BlockEvent) error
 	PassBlockEvent(event commonEvent.BlockEvent)
 	AddCheckpointTs(ts uint64)

--- a/pkg/common/event/mounter_test.go
+++ b/pkg/common/event/mounter_test.go
@@ -681,25 +681,25 @@ func TestNullColumn(t *testing.T) {
 	require.NotNil(t, tableInfo)
 
 	// column b is the 2th column
-	colValue := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[1].FieldType, 1)
+	colValue := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[1], 1)
 	require.Equal(t, nil, colValue)
 	// column d is the 4th column
-	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[3].FieldType, 3)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[3], 3)
 	require.Equal(t, nil, colValue)
 	// column f is the 6th column
-	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[5].FieldType, 5)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[5], 5)
 	require.Equal(t, nil, colValue)
 	// column h is the 8th column
-	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[7].FieldType, 7)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[7], 7)
 	require.Equal(t, nil, colValue)
 	// column j is the 10th column
-	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[9].FieldType, 9)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[9], 9)
 	require.Equal(t, nil, colValue)
 	// column l is the 12th column
-	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[11].FieldType, 11)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[11], 11)
 	require.Equal(t, nil, colValue)
 	// column ah is the 34th column
-	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[33].FieldType, 33)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[33], 33)
 	require.Equal(t, nil, colValue)
 }
 
@@ -717,7 +717,7 @@ func TestBinary(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, RowTypeInsert, row.RowType)
 	tableInfo := helper.GetTableInfo(job)
-	v := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[0].FieldType, 0)
+	v := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[0], 0)
 	binaryFormat := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A}
 	require.Equal(t, binaryFormat, v)
 }

--- a/pkg/common/event/mounter_test.go
+++ b/pkg/common/event/mounter_test.go
@@ -681,32 +681,25 @@ func TestNullColumn(t *testing.T) {
 	require.NotNil(t, tableInfo)
 
 	// column b is the 2th column
-	colValue, err := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[1], 1)
-	require.NoError(t, err)
+	colValue := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[1].FieldType, 1)
 	require.Equal(t, nil, colValue)
 	// column d is the 4th column
-	colValue, err = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[3], 3)
-	require.NoError(t, err)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[3].FieldType, 3)
 	require.Equal(t, nil, colValue)
 	// column f is the 6th column
-	colValue, err = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[5], 5)
-	require.NoError(t, err)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[5].FieldType, 5)
 	require.Equal(t, nil, colValue)
 	// column h is the 8th column
-	colValue, err = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[7], 7)
-	require.NoError(t, err)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[7].FieldType, 7)
 	require.Equal(t, nil, colValue)
 	// column j is the 10th column
-	colValue, err = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[9], 9)
-	require.NoError(t, err)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[9].FieldType, 9)
 	require.Equal(t, nil, colValue)
 	// column l is the 12th column
-	colValue, err = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[11], 11)
-	require.NoError(t, err)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[11].FieldType, 11)
 	require.Equal(t, nil, colValue)
 	// column ah is the 34th column
-	colValue, err = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[33], 33)
-	require.NoError(t, err)
+	colValue = common.ExtractColVal(&row.Row, tableInfo.GetColumns()[33].FieldType, 33)
 	require.Equal(t, nil, colValue)
 }
 
@@ -724,8 +717,7 @@ func TestBinary(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, RowTypeInsert, row.RowType)
 	tableInfo := helper.GetTableInfo(job)
-	v, err := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[0], 0)
-	require.NoError(t, err)
+	v := common.ExtractColVal(&row.Row, tableInfo.GetColumns()[0].FieldType, 0)
 	binaryFormat := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A}
 	require.Equal(t, binaryFormat, v)
 }

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/util/chunk"
-	"go.uber.org/zap"
 )
 
 //go:generate msgp
@@ -211,10 +210,7 @@ func (r RedoDMLEvent) IsUpdate() bool {
 }
 
 func parseColumnValue(row *chunk.Row, column *model.ColumnInfo, i int) RedoColumnValue {
-	v, err := common.ExtractColVal(row, column, i)
-	if err != nil {
-		log.Panic("ExtractColVal fail", zap.Error(err))
-	}
+	v := common.ExtractColVal(row, column.FieldType, i)
 	rrv := RedoColumnValue{Value: v}
 	switch t := rrv.Value.(type) {
 	case []byte:

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -210,7 +210,7 @@ func (r RedoDMLEvent) IsUpdate() bool {
 }
 
 func parseColumnValue(row *chunk.Row, column *model.ColumnInfo, i int) RedoColumnValue {
-	v := common.ExtractColVal(row, column.FieldType, i)
+	v := common.ExtractColVal(row, column, i)
 	rrv := RedoColumnValue{Value: v}
 	switch t := rrv.Value.(type) {
 	case []byte:

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -15,6 +15,7 @@ package common
 
 import (
 	"fmt"
+	"go.uber.org/zap"
 	"math"
 	"unsafe"
 
@@ -28,34 +29,43 @@ import (
 
 var EmptyBytes = make([]byte, 0)
 
+<<<<<<< Updated upstream
 // ExtractColVal returns the column value in the row
 func ExtractColVal(row *chunk.Row, col *model.ColumnInfo, idx int) (
 	value interface{}, err error,
 ) {
+=======
+// ExtractColVal returns the value in the row
+func ExtractColVal(row *chunk.Row, ft types.FieldType, idx int) interface{} {
+>>>>>>> Stashed changes
 	if row.IsNull(idx) {
-		return nil, nil
+		return nil
 	}
 	switch col.GetType() {
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeNewDate, mysql.TypeTimestamp:
-		return row.GetTime(idx).String(), nil
+		return row.GetTime(idx).String()
 	case mysql.TypeDuration:
-		return row.GetDuration(idx, 0).String(), nil
+		return row.GetDuration(idx, 0).String()
 	case mysql.TypeJSON:
-		return row.GetJSON(idx).String(), nil
+		return row.GetJSON(idx).String()
 	case mysql.TypeNewDecimal:
 		d := row.GetMyDecimal(idx)
 		if d == nil {
 			// nil takes 0 byte.
-			return nil, nil
+			return nil
 		}
-		return d.String(), nil
+		return d.String()
 	case mysql.TypeEnum, mysql.TypeSet:
-		return row.GetEnum(idx).Value, nil
+		return row.GetEnum(idx).Value
 	case mysql.TypeBit:
 		d := row.GetDatum(idx, &col.FieldType)
 		dp := &d
 		// Encode bits as integers to avoid pingcap/tidb#10988 (which also affects MySQL itself)
-		return dp.GetBinaryLiteral().ToInt(types.DefaultStmtNoWarningContext)
+		result, err := dp.GetBinaryLiteral().ToInt(types.DefaultStmtNoWarningContext)
+		if err != nil {
+			log.Panic("extract bit value failed", zap.Any("bit", dp.GetBinaryLiteral()), zap.Error(err))
+		}
+		return result
 	case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar,
 		mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob:
 		b := row.GetBytes(idx)
@@ -68,11 +78,11 @@ func ExtractColVal(row *chunk.Row, col *model.ColumnInfo, idx int) (
 		// See https://github.com/go-sql-driver/mysql/blob/ce134bfc/connection.go#L267
 		if col.GetCharset() != "" && col.GetCharset() != charset.CharsetBin {
 			if len(b) == 0 {
-				return "", nil
+				return ""
 			}
-			return unsafe.String(&b[0], len(b)), nil
+			return unsafe.String(&b[0], len(b))
 		}
-		return b, nil
+		return b
 	case mysql.TypeFloat:
 		b := row.GetFloat32(idx)
 		if math.IsNaN(float64(b)) || math.IsInf(float64(b), 1) || math.IsInf(float64(b), -1) {
@@ -80,7 +90,7 @@ func ExtractColVal(row *chunk.Row, col *model.ColumnInfo, idx int) (
 			log.Warn(warn)
 			b = 0
 		}
-		return b, nil
+		return b
 	case mysql.TypeDouble:
 		b := row.GetFloat64(idx)
 		if math.IsNaN(b) || math.IsInf(b, 1) || math.IsInf(b, -1) {
@@ -88,15 +98,15 @@ func ExtractColVal(row *chunk.Row, col *model.ColumnInfo, idx int) (
 			log.Warn(warn)
 			b = 0
 		}
-		return b, nil
+		return b
 	case mysql.TypeTiDBVectorFloat32:
 		b := row.GetVectorFloat32(idx).String()
-		return b, nil
+		return b
 	default:
 		d := row.GetDatum(idx, &col.FieldType)
 		// NOTICE: GetValue() may return some types that go sql not support, which will cause sink DML fail
 		// Make specified convert upper if you need
 		// Go sql support type ref to: https://github.com/golang/go/blob/go1.17.4/src/database/sql/driver/types.go#L236
-		return d.GetValue(), nil
+		return d.GetValue()
 	}
 }

--- a/pkg/sink/mysql/mysql_writer.go
+++ b/pkg/sink/mysql/mysql_writer.go
@@ -200,10 +200,7 @@ func (w *MysqlWriter) FlushSyncPointEvent(event *commonEvent.SyncPointEvent) err
 }
 
 func (w *MysqlWriter) Flush(events []*commonEvent.DMLEvent) error {
-	dmls, err := w.prepareDMLs(events)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	dmls := w.prepareDMLs(events)
 	defer dmlsPool.Put(dmls) // Return dmls to pool after use
 
 	if dmls.rowCount == 0 {
@@ -211,12 +208,12 @@ func (w *MysqlWriter) Flush(events []*commonEvent.DMLEvent) error {
 	}
 
 	if !w.cfg.DryRun {
-		if err = w.execDMLWithMaxRetries(dmls); err != nil {
+		if err := w.execDMLWithMaxRetries(dmls); err != nil {
 			return errors.Trace(err)
 		}
 	} else {
 		w.tryDryRunBlock()
-		if err = w.statistics.RecordBatchExecution(func() (int, int64, error) {
+		if err := w.statistics.RecordBatchExecution(func() (int, int64, error) {
 			return dmls.rowCount, dmls.approximateSize, nil
 		}); err != nil {
 			return errors.Trace(err)

--- a/pkg/sink/mysql/mysql_writer_helper.go
+++ b/pkg/sink/mysql/mysql_writer_helper.go
@@ -54,7 +54,7 @@ func genKeyList(row *chunk.Row, colIdx []int, tableInfo *common.TableInfo) []byt
 			return nil
 		}
 
-		value := common.ExtractColVal(row, columnInfos[i].FieldType, i)
+		value := common.ExtractColVal(row, columnInfos[i], i)
 		// if a column value is null, we can ignore this index
 		if value == nil {
 			return nil

--- a/pkg/sink/mysql/mysql_writer_helper.go
+++ b/pkg/sink/mysql/mysql_writer_helper.go
@@ -18,7 +18,6 @@ import (
 	"hash/fnv"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -31,13 +30,10 @@ func compareKeys(firstKey, secondKey []byte) bool {
 	return bytes.Equal(firstKey, secondKey)
 }
 
-func genKeyAndHash(row *chunk.Row, tableInfo *common.TableInfo) (uint64, []byte, error) {
+func genKeyAndHash(row *chunk.Row, tableInfo *common.TableInfo) (uint64, []byte) {
 	idxCol := tableInfo.GetPKIndexOffset()
 	// log.Info("genKeyAndHash", zap.Any("idxCol", idxCol), zap.Any("iIdx", iIdx))
-	key, err := genKeyList(row, idxCol, tableInfo)
-	if err != nil {
-		return 0, nil, errors.Trace(err)
-	}
+	key := genKeyList(row, idxCol, tableInfo)
 	if len(key) == 0 {
 		log.Panic("the table has no primary key", zap.Any("tableinfo", tableInfo))
 	}
@@ -47,24 +43,21 @@ func genKeyAndHash(row *chunk.Row, tableInfo *common.TableInfo) (uint64, []byte,
 		log.Panic("transaction key hash fail")
 	}
 
-	return uint64(hasher.Sum32()), key, nil
+	return uint64(hasher.Sum32()), key
 }
 
-func genKeyList(row *chunk.Row, colIdx []int, tableInfo *common.TableInfo) ([]byte, error) {
+func genKeyList(row *chunk.Row, colIdx []int, tableInfo *common.TableInfo) []byte {
 	var key []byte
 	columnInfos := tableInfo.GetColumns()
 	for _, i := range colIdx {
 		if columnInfos[i] == nil {
-			return nil, nil
+			return nil
 		}
 
-		value, err := common.ExtractColVal(row, columnInfos[i], i)
-		if err != nil {
-			return nil, err
-		}
+		value := common.ExtractColVal(row, columnInfos[i].FieldType, i)
 		// if a column value is null, we can ignore this index
 		if value == nil {
-			return nil, nil
+			return nil
 		}
 
 		val := model.ColumnValueString(value)
@@ -76,9 +69,9 @@ func genKeyList(row *chunk.Row, colIdx []int, tableInfo *common.TableInfo) ([]by
 		key = append(key, 0)
 	}
 	if len(key) == 0 {
-		return nil, nil
+		return nil
 	}
-	return key, nil
+	return key
 }
 
 func columnNeeds2LowerCase(mysqlType byte, collation string) bool {

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -165,7 +165,7 @@ func getArgs(row *chunk.Row, tableInfo *common.TableInfo, enableGeneratedColumn 
 		if col == nil || (tableInfo.GetColumnFlags()[col.ID].IsGeneratedColumn() && !enableGeneratedColumn) {
 			continue
 		}
-		v := common.ExtractColVal(row, col.FieldType, i)
+		v := common.ExtractColVal(row, col, i)
 		args = append(args, v)
 	}
 	return args
@@ -181,7 +181,7 @@ func whereSlice(row *chunk.Row, tableInfo *common.TableInfo, forceReplicate bool
 			continue
 		}
 		colNames = append(colNames, col.Name.O)
-		v := common.ExtractColVal(row, col.FieldType, i)
+		v := common.ExtractColVal(row, col, i)
 		args = append(args, v)
 	}
 
@@ -189,7 +189,7 @@ func whereSlice(row *chunk.Row, tableInfo *common.TableInfo, forceReplicate bool
 	if len(colNames) == 0 && forceReplicate {
 		for i, col := range tableInfo.GetColumns() {
 			colNames = append(colNames, col.Name.O)
-			v := common.ExtractColVal(row, col.FieldType, i)
+			v := common.ExtractColVal(row, col, i)
 			args = append(args, v)
 		}
 	}

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
@@ -71,13 +70,10 @@ func buildInsert(
 	tableInfo *common.TableInfo,
 	row commonEvent.RowChange,
 	translateToInsert bool,
-) (string, []interface{}, error) {
-	args, err := getArgs(&row.Row, tableInfo, false)
-	if err != nil {
-		return "", nil, errors.Trace(err)
-	}
+) (string, []interface{}) {
+	args := getArgs(&row.Row, tableInfo, false)
 	if len(args) == 0 {
-		return "", nil, nil
+		return "", nil
 	}
 
 	var sql string
@@ -91,24 +87,21 @@ func buildInsert(
 		log.Panic("PreInsertSQL should not be empty")
 	}
 
-	return sql, args, nil
+	return sql, args
 }
 
 // prepareDelete builds a parametric DELETE statement as following
 // sql: `DELETE FROM `test`.`t` WHERE x = ? AND y >= ? LIMIT 1`
-func buildDelete(tableInfo *common.TableInfo, row commonEvent.RowChange, forceReplicate bool) (string, []interface{}, error) {
+func buildDelete(tableInfo *common.TableInfo, row commonEvent.RowChange, forceReplicate bool) (string, []interface{}) {
 	var builder strings.Builder
 	quoteTable := tableInfo.TableName.QuoteString()
 	builder.WriteString("DELETE FROM ")
 	builder.WriteString(quoteTable)
 	builder.WriteString(" WHERE ")
 
-	colNames, whereArgs, err := whereSlice(&row.PreRow, tableInfo, forceReplicate)
-	if err != nil {
-		return "", nil, errors.Trace(err)
-	}
+	colNames, whereArgs := whereSlice(&row.PreRow, tableInfo, forceReplicate)
 	if len(whereArgs) == 0 {
-		return "", nil, nil
+		return "", nil
 	}
 	args := make([]interface{}, 0, len(whereArgs))
 	for i := 0; i < len(colNames); i++ {
@@ -126,30 +119,24 @@ func buildDelete(tableInfo *common.TableInfo, row commonEvent.RowChange, forceRe
 	}
 	builder.WriteString(" LIMIT 1")
 	sql := builder.String()
-	return sql, args, nil
+	return sql, args
 }
 
-func buildUpdate(tableInfo *common.TableInfo, row commonEvent.RowChange, forceReplicate bool) (string, []interface{}, error) {
+func buildUpdate(tableInfo *common.TableInfo, row commonEvent.RowChange, forceReplicate bool) (string, []interface{}) {
 	var builder strings.Builder
 	if tableInfo.GetPreUpdateSQL() == "" {
 		log.Panic("PreUpdateSQL should not be empty")
 	}
 	builder.WriteString(tableInfo.GetPreUpdateSQL())
 
-	args, err := getArgs(&row.Row, tableInfo, false)
-	if err != nil {
-		return "", nil, errors.Trace(err)
-	}
+	args := getArgs(&row.Row, tableInfo, false)
 	if len(args) == 0 {
-		return "", nil, nil
+		return "", nil
 	}
 
-	whereColNames, whereArgs, err := whereSlice(&row.PreRow, tableInfo, forceReplicate)
-	if err != nil {
-		return "", nil, errors.Trace(err)
-	}
+	whereColNames, whereArgs := whereSlice(&row.PreRow, tableInfo, forceReplicate)
 	if len(whereArgs) == 0 {
-		return "", nil, nil
+		return "", nil
 	}
 
 	builder.WriteString(" WHERE ")
@@ -169,26 +156,23 @@ func buildUpdate(tableInfo *common.TableInfo, row commonEvent.RowChange, forceRe
 
 	builder.WriteString(" LIMIT 1")
 	sql := builder.String()
-	return sql, args, nil
+	return sql, args
 }
 
-func getArgs(row *chunk.Row, tableInfo *common.TableInfo, enableGeneratedColumn bool) ([]interface{}, error) {
+func getArgs(row *chunk.Row, tableInfo *common.TableInfo, enableGeneratedColumn bool) []interface{} {
 	args := make([]interface{}, 0, len(tableInfo.GetColumns()))
 	for i, col := range tableInfo.GetColumns() {
 		if col == nil || (tableInfo.GetColumnFlags()[col.ID].IsGeneratedColumn() && !enableGeneratedColumn) {
 			continue
 		}
-		v, err := common.ExtractColVal(row, col, i)
-		if err != nil {
-			return nil, err
-		}
+		v := common.ExtractColVal(row, col.FieldType, i)
 		args = append(args, v)
 	}
-	return args, nil
+	return args
 }
 
 // whereSlice returns the column names and values for the WHERE clause
-func whereSlice(row *chunk.Row, tableInfo *common.TableInfo, forceReplicate bool) ([]string, []interface{}, error) {
+func whereSlice(row *chunk.Row, tableInfo *common.TableInfo, forceReplicate bool) ([]string, []interface{}) {
 	args := make([]interface{}, 0, len(tableInfo.GetColumns()))
 	colNames := make([]string, 0, len(tableInfo.GetColumns()))
 	// Try to use unique key values when available
@@ -197,10 +181,7 @@ func whereSlice(row *chunk.Row, tableInfo *common.TableInfo, forceReplicate bool
 			continue
 		}
 		colNames = append(colNames, col.Name.O)
-		v, err := common.ExtractColVal(row, col, i)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
+		v := common.ExtractColVal(row, col.FieldType, i)
 		args = append(args, v)
 	}
 
@@ -208,12 +189,9 @@ func whereSlice(row *chunk.Row, tableInfo *common.TableInfo, forceReplicate bool
 	if len(colNames) == 0 && forceReplicate {
 		for i, col := range tableInfo.GetColumns() {
 			colNames = append(colNames, col.Name.O)
-			v, err := common.ExtractColVal(row, col, i)
-			if err != nil {
-				return nil, nil, errors.Trace(err)
-			}
+			v := common.ExtractColVal(row, col.FieldType, i)
 			args = append(args, v)
 		}
 	}
-	return colNames, args, nil
+	return colNames, args
 }

--- a/pkg/sink/mysql/sql_builder_benchmark_test.go
+++ b/pkg/sink/mysql/sql_builder_benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkBuildInsert(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, _, _ = buildInsert(tableInfo, insert, false)
+			_, _ = buildInsert(tableInfo, insert, false)
 		}
 	})
 }
@@ -37,7 +37,7 @@ func BenchmarkBuildDelete(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, _, _ = buildDelete(tableInfo, delete, true)
+			_, _ = buildDelete(tableInfo, delete, true)
 		}
 	})
 }
@@ -50,7 +50,7 @@ func BenchmarkBuildUpdate(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, _, _ = buildUpdate(tableInfo, update, true)
+			_, _ = buildUpdate(tableInfo, update, true)
 		}
 	})
 }

--- a/pkg/sink/mysql/sql_builder_test.go
+++ b/pkg/sink/mysql/sql_builder_test.go
@@ -169,16 +169,14 @@ func TestBuildInsert(t *testing.T) {
 
 	// case 1: Convert to INSERT INTO
 	exportedSQL := "INSERT INTO `test`.`t` (`id`,`c_tinyint`,`c_smallint`,`c_mediumint`,`c_int`,`c_bigint`,`c_unsigned_tinyint`,`c_unsigned_smallint`,`c_unsigned_mediumint`,`c_unsigned_int`,`c_unsigned_bigint`,`c_float`,`c_double`,`c_decimal`,`c_decimal_2`,`c_unsigned_float`,`c_unsigned_double`,`c_unsigned_decimal`,`c_unsigned_decimal_2`,`c_date`,`c_datetime`,`c_timestamp`,`c_time`,`c_year`,`c_tinytext`,`c_text`,`c_mediumtext`,`c_longtext`,`c_tinyblob`,`c_blob`,`c_mediumblob`,`c_longblob`,`c_char`,`c_varchar`,`c_binary`,`c_varbinary`,`c_enum`,`c_set`,`c_bit`,`c_json`,`name`,`country`,`city`,`description`,`image`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
-	sql, args, err := buildInsert(tableInfo, insert, true)
-	require.NoError(t, err)
+	sql, args := buildInsert(tableInfo, insert, true)
 	require.Equal(t, exportedSQL, sql)
 	require.Len(t, args, 45)
 	require.Equal(t, exportedArgs, args)
 
 	// case 2: Convert to REPLACE INTO
 	exportedSQL = "REPLACE INTO `test`.`t` (`id`,`c_tinyint`,`c_smallint`,`c_mediumint`,`c_int`,`c_bigint`,`c_unsigned_tinyint`,`c_unsigned_smallint`,`c_unsigned_mediumint`,`c_unsigned_int`,`c_unsigned_bigint`,`c_float`,`c_double`,`c_decimal`,`c_decimal_2`,`c_unsigned_float`,`c_unsigned_double`,`c_unsigned_decimal`,`c_unsigned_decimal_2`,`c_date`,`c_datetime`,`c_timestamp`,`c_time`,`c_year`,`c_tinytext`,`c_text`,`c_mediumtext`,`c_longtext`,`c_tinyblob`,`c_blob`,`c_mediumblob`,`c_longblob`,`c_char`,`c_varchar`,`c_binary`,`c_varbinary`,`c_enum`,`c_set`,`c_bit`,`c_json`,`name`,`country`,`city`,`description`,`image`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
-	sql, args, err = buildInsert(tableInfo, insert, false)
-	require.NoError(t, err)
+	sql, args = buildInsert(tableInfo, insert, false)
 	require.Equal(t, exportedSQL, sql)
 	require.Len(t, args, 45)
 	require.Equal(t, exportedArgs, args)
@@ -209,8 +207,7 @@ func TestBuildDelete(t *testing.T) {
 	expectedSQL := "DELETE FROM `test`.`t` WHERE `id` = ? LIMIT 1"
 	expectedArgs := []interface{}{int64(1)}
 
-	sql, args, err := buildDelete(event.TableInfo, row, true)
-	require.NoError(t, err)
+	sql, args := buildDelete(event.TableInfo, row, true)
 	require.Equal(t, expectedSQL, sql)
 	require.Len(t, args, 1)
 	require.Equal(t, expectedArgs, args)
@@ -231,8 +228,7 @@ func TestBuildDelete(t *testing.T) {
 	expectedSQL = "DELETE FROM `test`.`t2` WHERE `id` = ? LIMIT 1"
 	expectedArgs = []interface{}{int64(1)}
 
-	sql, args, err = buildDelete(event.TableInfo, row, true)
-	require.NoError(t, err)
+	sql, args = buildDelete(event.TableInfo, row, true)
 	require.Equal(t, expectedSQL, sql)
 	require.Len(t, args, 1)
 	require.Equal(t, expectedArgs, args)
@@ -254,8 +250,7 @@ func TestBuildDelete(t *testing.T) {
 	expectedSQL = "DELETE FROM `test`.`t3` WHERE `id` = ? AND `name` = ? LIMIT 1"
 	expectedArgs = []interface{}{int64(1), "test"}
 
-	sql, args, err = buildDelete(event.TableInfo, row, true)
-	require.NoError(t, err)
+	sql, args = buildDelete(event.TableInfo, row, true)
 	require.Equal(t, expectedSQL, sql)
 	require.Len(t, args, 2)
 	require.Equal(t, expectedArgs, args)
@@ -277,8 +272,7 @@ func TestBuildDelete(t *testing.T) {
 	expectedSQL = "DELETE FROM `test`.`t4` WHERE `name` = ? AND `age` = ? LIMIT 1"
 	expectedArgs = []interface{}{"test", int64(20)}
 
-	sql, args, err = buildDelete(event.TableInfo, row, true)
-	require.NoError(t, err)
+	sql, args = buildDelete(event.TableInfo, row, true)
 	require.Equal(t, expectedSQL, sql)
 	require.Len(t, args, 2)
 	require.Equal(t, expectedArgs, args)
@@ -300,8 +294,7 @@ func TestBuildDelete(t *testing.T) {
 	expectedSQL = "DELETE FROM `test`.`t5` WHERE `id` = ? AND `name` = ? AND `age` = ? LIMIT 1"
 	expectedArgs = []interface{}{int64(1), "test", int64(20)}
 
-	sql, args, err = buildDelete(event.TableInfo, row, true)
-	require.NoError(t, err)
+	sql, args = buildDelete(event.TableInfo, row, true)
 	require.Equal(t, expectedSQL, sql)
 	require.Len(t, args, 3)
 	require.Equal(t, expectedArgs, args)
@@ -336,8 +329,7 @@ func TestBuildUpdate(t *testing.T) {
 
 	expectedSQL := "UPDATE `test`.`t` SET `id` = ?,`name` = ? WHERE `id` = ? LIMIT 1"
 	expectedArgs := []interface{}{int64(1), "test2", int64(1)}
-	sql, args, err := buildUpdate(event.TableInfo, row, true)
-	require.NoError(t, err)
+	sql, args := buildUpdate(event.TableInfo, row, true)
 	require.Equal(t, expectedSQL, sql)
 	require.Len(t, args, 3)
 	require.Equal(t, expectedArgs, args)
@@ -365,8 +357,7 @@ func TestBuildUpdate(t *testing.T) {
 
 	expectedSQL = "UPDATE `test`.`t2` SET `id` = ?,`name` = ?,`age` = ? WHERE `name` = ? AND `age` = ? LIMIT 1"
 	expectedArgs = []interface{}{int64(1), "test2", int64(20), "test", int64(20)}
-	sql, args, err = buildUpdate(event.TableInfo, row, true)
-	require.NoError(t, err)
+	sql, args = buildUpdate(event.TableInfo, row, true)
 	require.Equal(t, expectedSQL, sql)
 	require.Len(t, args, 5)
 	require.Equal(t, expectedArgs, args)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1205

### What is changed and how it works?

* Removed error propagation from helper functions (e.g. getArgs, whereSlice, ExtractColVal) so that errors trigger a panic immediately.
* Updated API signatures (e.g. AddDMLEvent, generate* functions) by eliminating error returns, with corresponding updates in call sites.
* Adjusted unit tests to remove error checking on extraction functions.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
