### PR TITLE
ci: remove some unstable cases in pulsar and kafka to ensure CI stability

### DIFF
--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -84,9 +84,9 @@ kafka_groups=(
 	# G06
 	'open_protocol_handle_key_only'
 	# G07
-	'kafka_big_messages'
+	'multi_topics'
 	# G08
-	'kafka_big_messages_v2'
+	'multi_topics_v2'
 	# G09
 	'kafka_compression'
 	# G10
@@ -94,9 +94,9 @@ kafka_groups=(
 	# G11
 	'mq_sink_dispatcher'
 	# G12
-	'multi_topics'
+	''
 	# G13
-	'multi_topics_v2'
+	''
 	# G14
 	''
 	# G15
@@ -108,7 +108,7 @@ kafka_groups=(
 # 6 CPU, 32 Gi memory.
 pulsar_groups=(
 	# G00
-	'canal_json_basic'
+	'canal_json_storage_basic'
 	# G01
 	'canal_json_claim_check'
 	# G02
@@ -116,7 +116,7 @@ pulsar_groups=(
 	# G03
 	'canal_json_handle_key_only'
 	# G04
-	'canal_json_storage_basic'
+	''
 	# G05
 	''
 	# G06


### PR DESCRIPTION


<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1211

### What is changed and how it works?

This PR removes the following unstable test cases from the CI:
* kafka_big_messages
* kafka_big_messages_v2
* canal_json_basic

These cases are currently flaky and may fail randomly, causing unrelated PRs to be blocked. We’ll re-enable them once their issues are fixed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
