### PR TITLE
mysql: rename some struct to make it less verbose

### DIFF
--- a/downstreamadapter/sink/conflictdetector/helper.go
+++ b/downstreamadapter/sink/conflictdetector/helper.go
@@ -51,7 +51,7 @@ func ConflictKeys(event *commonEvent.DMLEvent) []uint64 {
 		}
 	}
 
-	event.FinishGetRow()
+	event.Rewind()
 
 	keys := make([]uint64, 0, len(hashRes))
 	for key := range hashRes {
@@ -121,7 +121,7 @@ func genKeyList(
 	}
 	tableKey := make([]byte, 16)
 	binary.BigEndian.PutUint64(tableKey[:8], uint64(iIdx))
-	binary.BigEndian.PutUint64(tableKey[8:], uint64(dispatcherID.GetLow()))
+	binary.BigEndian.PutUint64(tableKey[8:], dispatcherID.GetLow())
 	key = append(key, tableKey...)
 	return key
 }

--- a/downstreamadapter/sink/mysql_sink.go
+++ b/downstreamadapter/sink/mysql_sink.go
@@ -91,7 +91,7 @@ func newMysqlSinkWithDBAndConfig(
 	ctx context.Context,
 	changefeedID common.ChangeFeedID,
 	workerCount int,
-	cfg *mysql.MysqlConfig,
+	cfg *mysql.Config,
 	db *sql.DB,
 ) *MysqlSink {
 	stat := metrics.NewStatistics(changefeedID, "TxnSink")

--- a/downstreamadapter/worker/mysql_worker.go
+++ b/downstreamadapter/worker/mysql_worker.go
@@ -34,7 +34,7 @@ type MysqlDMLWorker struct {
 	changefeedID common.ChangeFeedID
 
 	eventChan   <-chan *commonEvent.DMLEvent
-	mysqlWriter *mysql.MysqlWriter
+	mysqlWriter *mysql.Writer
 	id          int
 
 	maxRows int
@@ -43,7 +43,7 @@ type MysqlDMLWorker struct {
 func NewMysqlDMLWorker(
 	ctx context.Context,
 	db *sql.DB,
-	config *mysql.MysqlConfig,
+	config *mysql.Config,
 	id int,
 	changefeedID common.ChangeFeedID,
 	statistics *metrics.Statistics,
@@ -142,13 +142,13 @@ func (w *MysqlDMLWorker) Close() {
 // MysqlDDLWorker is use to flush the ddl event and sync point eventdownstream
 type MysqlDDLWorker struct {
 	changefeedID common.ChangeFeedID
-	mysqlWriter  *mysql.MysqlWriter
+	mysqlWriter  *mysql.Writer
 }
 
 func NewMysqlDDLWorker(
 	ctx context.Context,
 	db *sql.DB,
-	config *mysql.MysqlConfig,
+	config *mysql.Config,
 	changefeedID common.ChangeFeedID,
 	statistics *metrics.Statistics,
 	formatVectorType bool,

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -161,10 +161,8 @@ func (t *DMLEvent) AddPostFlushFunc(f func()) {
 	t.PostTxnFlushed = append(t.PostTxnFlushed, f)
 }
 
-// The function if called after call all the GetNextRow to get all rows.
-// It will reset the offset to 0
-// So that the next GetNextRow will return the first row
-func (t *DMLEvent) FinishGetRow() {
+// Rewind reset the offset to 0, So that the next GetNextRow will return the first row
+func (t *DMLEvent) Rewind() {
 	t.offset = 0
 }
 

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -98,9 +98,9 @@ const (
 
 // ToRedoLog converts row changed event to redo log
 func (r *DMLEvent) ToRedoLog() *RedoLog {
-	r.FinishGetRow()
+	r.Rewind()
 	row, valid := r.GetNextRow()
-	r.FinishGetRow()
+	r.Rewind()
 
 	redoLog := &RedoLog{
 		RedoRow: RedoDMLEvent{

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -859,8 +859,8 @@ func TestEncodeDDLEvent(t *testing.T) {
 			compression.Snappy,
 			compression.LZ4,
 		} {
-			insertEvent.FinishGetRow()
-			insertEvent2.FinishGetRow()
+			insertEvent.Rewind()
+			insertEvent2.Rewind()
 			codecConfig.LargeMessageHandle.LargeMessageHandleCompression = compressionType
 			enc, err := NewEncoder(ctx, codecConfig)
 			require.NoError(t, err)
@@ -1095,8 +1095,8 @@ func TestEncodeIntegerTypes(t *testing.T) {
 		common.EncodingFormatAvro,
 		common.EncodingFormatJSON,
 	} {
-		minValues.FinishGetRow()
-		maxValues.FinishGetRow()
+		minValues.Rewind()
+		maxValues.Rewind()
 		codecConfig.EncodingFormat = format
 		enc, err := NewEncoder(ctx, codecConfig)
 		require.NoError(t, err)
@@ -1179,7 +1179,7 @@ func TestEncoderOtherTypes(t *testing.T) {
 		common.EncodingFormatAvro,
 		common.EncodingFormatJSON,
 	} {
-		event.FinishGetRow()
+		event.Rewind()
 		codecConfig.EncodingFormat = format
 		enc, err := NewEncoder(ctx, codecConfig)
 		require.NoError(t, err)
@@ -1271,9 +1271,9 @@ func TestEncoderOtherTypes(t *testing.T) {
 
 // 		codecConfig.EncodingFormat = format
 // 		for _, event := range events {
-// 			insertEvent.FinishGetRow()
-// 			insertEvent1.FinishGetRow()
-// 			insertEvent2.FinishGetRow()
+// 			insertEvent.Rewind()
+// 			insertEvent1.Rewind()
+// 			insertEvent2.Rewind()
 // 			row, ok := event.GetNextRow()
 // 			require.True(t, ok)
 // 			err = enc.AppendRowChangedEvent(ctx, "", &commonEvent.RowEvent{
@@ -1418,7 +1418,7 @@ func TestEncodeBootstrapEvent(t *testing.T) {
 			compression.Snappy,
 			compression.LZ4,
 		} {
-			dmlEvent.FinishGetRow()
+			dmlEvent.Rewind()
 			codecConfig.LargeMessageHandle.LargeMessageHandleCompression = compressionType
 			enc, err := NewEncoder(ctx, codecConfig)
 			require.NoError(t, err)

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -87,7 +87,7 @@ const (
 	defaultHasVectorType = false
 )
 
-type MysqlConfig struct {
+type Config struct {
 	sinkURI                *url.URL
 	WorkerCount            int
 	MaxTxnRow              int
@@ -133,8 +133,8 @@ type MysqlConfig struct {
 }
 
 // NewConfig returns the default mysql backend config.
-func NewMysqlConfig() *MysqlConfig {
-	return &MysqlConfig{
+func NewMysqlConfig() *Config {
+	return &Config{
 		WorkerCount:            DefaultWorkerCount,
 		MaxTxnRow:              DefaultMaxTxnRow,
 		MaxMultiUpdateRowCount: defaultMaxMultiUpdateRowCount,
@@ -153,7 +153,7 @@ func NewMysqlConfig() *MysqlConfig {
 	}
 }
 
-func (c *MysqlConfig) Apply(
+func (c *Config) Apply(
 	sinkURI *url.URL,
 	changefeedID common.ChangeFeedID,
 	cfg *config.ChangefeedConfig,
@@ -227,7 +227,7 @@ func (c *MysqlConfig) Apply(
 	return nil
 }
 
-func NewMySQLConfig(changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig) (*MysqlConfig, error) {
+func NewMySQLConfig(changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig) (*Config, error) {
 	cfg := NewMysqlConfig()
 	err := cfg.Apply(sinkURI, changefeedID, config)
 	if err != nil {
@@ -236,7 +236,7 @@ func NewMySQLConfig(changefeedID common.ChangeFeedID, sinkURI *url.URL, config *
 	return cfg, nil
 }
 
-func NewMysqlConfigAndDB(ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig) (*MysqlConfig, *sql.DB, error) {
+func NewMysqlConfigAndDB(ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig) (*Config, *sql.DB, error) {
 	log.Info("create db connection", zap.String("sinkURI", sinkURI.String()))
 	// create db connection
 	cfg, err := NewMySQLConfig(changefeedID, sinkURI, config)

--- a/pkg/sink/mysql/config_test.go
+++ b/pkg/sink/mysql/config_test.go
@@ -221,30 +221,30 @@ func TestParseSinkURIOverride(t *testing.T) {
 
 	cases := []struct {
 		uri     string
-		checker func(*MysqlConfig)
+		checker func(*Config)
 	}{{
 		uri: "mysql://127.0.0.1:3306/?worker-count=2147483648", // int32 max
-		checker: func(sp *MysqlConfig) {
+		checker: func(sp *Config) {
 			require.EqualValues(t, sp.WorkerCount, maxWorkerCount)
 		},
 	}, {
 		uri: "mysql://127.0.0.1:3306/?max-txn-row=2147483648", // int32 max
-		checker: func(sp *MysqlConfig) {
+		checker: func(sp *Config) {
 			require.EqualValues(t, sp.MaxTxnRow, maxMaxTxnRow)
 		},
 	}, {
 		uri: "mysql://127.0.0.1:3306/?max-multi-update-row=2147483648", // int32 max
-		checker: func(sp *MysqlConfig) {
+		checker: func(sp *Config) {
 			require.EqualValues(t, sp.MaxMultiUpdateRowCount, maxMaxMultiUpdateRowCount)
 		},
 	}, {
 		uri: "mysql://127.0.0.1:3306/?max-multi-update-row-size=2147483648", // int32 max
-		checker: func(sp *MysqlConfig) {
+		checker: func(sp *Config) {
 			require.EqualValues(t, sp.MaxMultiUpdateRowSize, maxMaxMultiUpdateRowSize)
 		},
 	}, {
 		uri: "mysql://127.0.0.1:3306/?tidb-txn-mode=badmode",
-		checker: func(sp *MysqlConfig) {
+		checker: func(sp *Config) {
 			require.EqualValues(t, sp.tidbTxnMode, defaultTiDBTxnMode)
 		},
 	}}

--- a/pkg/sink/mysql/helper.go
+++ b/pkg/sink/mysql/helper.go
@@ -87,7 +87,7 @@ func CheckIsTiDB(ctx context.Context, db *sql.DB) bool {
 }
 
 // GenBasicDSN generates a basic DSN from the given config.
-func GenBasicDSN(cfg *MysqlConfig) (*dmysql.Config, error) {
+func GenBasicDSN(cfg *Config) (*dmysql.Config, error) {
 	// dsn format of the driver:
 	// [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
 	username := cfg.sinkURI.User.Username()
@@ -128,7 +128,7 @@ func GenBasicDSN(cfg *MysqlConfig) (*dmysql.Config, error) {
 	return dsn, nil
 }
 
-func setDryRunConfig(cfg *MysqlConfig) {
+func setDryRunConfig(cfg *Config) {
 	dryRun := cfg.sinkURI.Query().Get("dry-run")
 	if dryRun == "true" {
 		log.Info("dry-run mode is enabled, will not write data to downstream")
@@ -198,7 +198,7 @@ func checkTiDBVariable(db *sql.DB, variableName, defaultValue string) (string, e
 
 func generateDSNByConfig(
 	dsnCfg *dmysql.Config,
-	cfg *MysqlConfig,
+	cfg *Config,
 	testDB *sql.DB,
 ) (string, error) {
 	if dsnCfg.Params == nil {
@@ -296,7 +296,7 @@ func checkCharsetSupport(db *sql.DB, charsetName string) (bool, error) {
 }
 
 // return dsn
-func GenerateDSN(cfg *MysqlConfig) (string, error) {
+func GenerateDSN(cfg *Config) (string, error) {
 	dsn, err := GenBasicDSN(cfg)
 	if err != nil {
 		return "", err
@@ -368,7 +368,7 @@ func needSwitchDB(event *commonEvent.DDLEvent) bool {
 // SetWriteSource sets write source for the transaction.
 // When this variable is set to a value other than 0, data written in this session is considered to be written by TiCDC.
 // DDLs executed in a PRIMARY cluster can be replicated to a SECONDARY cluster by TiCDC.
-func SetWriteSource(ctx context.Context, cfg *MysqlConfig, txn *sql.Tx) error {
+func SetWriteSource(ctx context.Context, cfg *Config, txn *sql.Tx) error {
 	// we only set write source when donwstream is TiDB and write source is existed.
 	if !cfg.IsWriteSourceExisted {
 		return nil
@@ -389,7 +389,7 @@ func SetWriteSource(ctx context.Context, cfg *MysqlConfig, txn *sql.Tx) error {
 }
 
 // ShouldFormatVectorType return true if vector type should be converted to longtext.
-func ShouldFormatVectorType(db *sql.DB, cfg *MysqlConfig) bool {
+func ShouldFormatVectorType(db *sql.DB, cfg *Config) bool {
 	if !cfg.HasVectorType {
 		log.Warn("please set `has-vector-type` to be true if a column is vector type when the downstream is not TiDB or TiDB version less than specify version",
 			zap.Any("hasVectorType", cfg.HasVectorType), zap.Any("supportVectorVersion", defaultSupportVectorVersion))

--- a/pkg/sink/mysql/mysql_writer_for_syncpoint.go
+++ b/pkg/sink/mysql/mysql_writer_for_syncpoint.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (w *MysqlWriter) createSyncTable() error {
+func (w *Writer) createSyncTable() error {
 	database := filter.TiCDCSystemSchema
 	query := `CREATE TABLE IF NOT EXISTS %s
 	(
@@ -45,7 +45,7 @@ func (w *MysqlWriter) createSyncTable() error {
 	return w.createTable(database, filter.SyncPointTable, query)
 }
 
-func (w *MysqlWriter) SendSyncPointEvent(event *commonEvent.SyncPointEvent) error {
+func (w *Writer) SendSyncPointEvent(event *commonEvent.SyncPointEvent) error {
 	tx, err := w.db.BeginTx(w.ctx, nil)
 	if err != nil {
 		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, "sync table: begin Tx fail;"))

--- a/pkg/sink/mysql/mysql_writer_test.go
+++ b/pkg/sink/mysql/mysql_writer_test.go
@@ -31,11 +31,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestMysqlWriter(t *testing.T) (*MysqlWriter, *sql.DB, sqlmock.Sqlmock) {
+func newTestMysqlWriter(t *testing.T) (*Writer, *sql.DB, sqlmock.Sqlmock) {
 	db, mock := newTestMockDB(t)
 
 	ctx := context.Background()
-	cfg := &MysqlConfig{
+	cfg := &Config{
 		MaxAllowedPacket:   int64(variable.DefMaxAllowedPacket),
 		SyncPointRetention: 100 * time.Second,
 		MaxTxnRow:          256,
@@ -47,11 +47,11 @@ func newTestMysqlWriter(t *testing.T) (*MysqlWriter, *sql.DB, sqlmock.Sqlmock) {
 	return writer, db, mock
 }
 
-func newTestMysqlWriterForTiDB(t *testing.T) (*MysqlWriter, *sql.DB, sqlmock.Sqlmock) {
+func newTestMysqlWriterForTiDB(t *testing.T) (*Writer, *sql.DB, sqlmock.Sqlmock) {
 	db, mock := newTestMockDB(t)
 
 	ctx := context.Background()
-	cfg := &MysqlConfig{
+	cfg := &Config{
 		MaxAllowedPacket:   int64(variable.DefMaxAllowedPacket),
 		SyncPointRetention: 100 * time.Second,
 		IsTiDB:             true,

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -64,7 +64,7 @@ func (d *preparedDMLs) reset() {
 	d.approximateSize = 0
 }
 
-// prepareReplace builds a parametrics REPLACE statement as following
+// prepareReplace builds a parametric REPLACE statement as following
 // sql: `REPLACE INTO `test`.`t` VALUES (?,?,?)`
 func buildInsert(
 	tableInfo *common.TableInfo,


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1215 

### What is changed and how it works?

* Renaming from FinishGetRow to Rewind provides a clearer description of the function's purpose. Ensure that documentation and any external references are updated accordingly.
* remove the prefix mysql from some structs

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
