### PR TITLE
codec: fix the open protocol flag

### DIFF
--- a/pkg/sink/codec/open/codec.go
+++ b/pkg/sink/codec/open/codec.go
@@ -58,7 +58,6 @@ func encodeRowChangedEvent(
 			keyWriter.WriteStringField("ccl", claimCheckLocationName)
 		}
 	})
-
 	var err error
 	if e.IsDelete() {
 		onlyHandleKeyColumns := config.DeleteOnlyHandleKeyColumns || largeMessageOnlyHandleKeyColumns

--- a/pkg/sink/codec/open/codec.go
+++ b/pkg/sink/codec/open/codec.go
@@ -30,7 +30,13 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 )
 
-func encodeRowChangedEvent(e *commonEvent.RowEvent, config *common.Config, largeMessageOnlyHandleKeyColumns bool, claimCheckLocationName string) ([]byte, []byte, int, error) {
+func encodeRowChangedEvent(
+	e *commonEvent.RowEvent,
+	columnFlags map[string]uint64,
+	config *common.Config,
+	largeMessageOnlyHandleKeyColumns bool,
+	claimCheckLocationName string,
+) ([]byte, []byte, int, error) {
 	var (
 		keyBuf   bytes.Buffer
 		valueBuf bytes.Buffer
@@ -52,35 +58,36 @@ func encodeRowChangedEvent(e *commonEvent.RowEvent, config *common.Config, large
 			keyWriter.WriteStringField("ccl", claimCheckLocationName)
 		}
 	})
+
 	var err error
 	if e.IsDelete() {
 		onlyHandleKeyColumns := config.DeleteOnlyHandleKeyColumns || largeMessageOnlyHandleKeyColumns
 		valueWriter.WriteObject(func() {
 			valueWriter.WriteObjectField("d", func() {
-				err = writeColumnFieldValues(valueWriter, e.GetPreRows(), e.TableInfo, e.ColumnSelector, onlyHandleKeyColumns)
+				err = writeColumnFieldValues(valueWriter, e.GetPreRows(), e.TableInfo, columnFlags, e.ColumnSelector, onlyHandleKeyColumns)
 			})
 		})
 	} else if e.IsInsert() {
 		valueWriter.WriteObject(func() {
 			valueWriter.WriteObjectField("u", func() {
-				err = writeColumnFieldValues(valueWriter, e.GetRows(), e.TableInfo, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
+				err = writeColumnFieldValues(valueWriter, e.GetRows(), e.TableInfo, columnFlags, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
 			})
 		})
 	} else if e.IsUpdate() {
 		valueWriter.WriteObject(func() {
 			valueWriter.WriteObjectField("u", func() {
-				err = writeColumnFieldValues(valueWriter, e.GetRows(), e.TableInfo, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
+				err = writeColumnFieldValues(valueWriter, e.GetRows(), e.TableInfo, columnFlags, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
 			})
 			if err != nil {
 				return
 			}
 			if !config.OnlyOutputUpdatedColumns {
 				valueWriter.WriteObjectField("p", func() {
-					err = writeColumnFieldValues(valueWriter, e.GetPreRows(), e.TableInfo, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
+					err = writeColumnFieldValues(valueWriter, e.GetPreRows(), e.TableInfo, columnFlags, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
 				})
 			} else {
 				valueWriter.WriteObjectField("p", func() {
-					writeUpdatedColumnFieldValues(valueWriter, e.GetPreRows(), e.GetRows(), e.TableInfo, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
+					writeUpdatedColumnFieldValues(valueWriter, e.GetPreRows(), e.GetRows(), e.TableInfo, columnFlags, e.ColumnSelector, largeMessageOnlyHandleKeyColumns)
 				})
 			}
 		})
@@ -163,26 +170,24 @@ func writeColumnFieldValue(
 	col *model.ColumnInfo,
 	row *chunk.Row,
 	idx int,
-	tableInfo *commonType.TableInfo,
+	isHandle bool,
+	columnFlag uint64,
 ) {
-	colType := col.GetType()
-	flag := col.GetFlag()
-	whereHandle := tableInfo.IsHandleKey(col.ID)
-
-	writer.WriteIntField("t", int(colType))
-	if whereHandle {
-		writer.WriteBoolField("h", whereHandle)
+	fieldType := col.FieldType
+	writer.WriteIntField("t", int(fieldType.GetType()))
+	if isHandle {
+		writer.WriteBoolField("h", isHandle)
 	}
-	writer.WriteUint64Field("f", uint64(flag))
+	writer.WriteUint64Field("f", columnFlag)
 
 	if row.IsNull(idx) {
 		writer.WriteNullField("v")
 		return
 	}
 
-	switch col.GetType() {
+	switch fieldType.GetType() {
 	case mysql.TypeBit:
-		d := row.GetDatum(idx, &col.FieldType)
+		d := row.GetDatum(idx, &fieldType)
 		if d.IsNull() {
 			writer.WriteNullField("v")
 		} else {
@@ -203,7 +208,7 @@ func writeColumnFieldValue(
 		if len(value) == 0 {
 			writer.WriteNullField("v")
 		} else {
-			if mysql.HasBinaryFlag(flag) {
+			if mysql.HasBinaryFlag(fieldType.GetFlag()) {
 				str := string(value)
 				str = strconv.Quote(str)
 				str = str[1 : len(str)-1]
@@ -248,7 +253,7 @@ func writeColumnFieldValue(
 			writer.WriteStringField("v", value.String())
 		}
 	default:
-		d := row.GetDatum(idx, &col.FieldType)
+		d := row.GetDatum(idx, &fieldType)
 		// NOTICE: GetValue() may return some types that go sql not support, which will cause sink DML fail
 		// Make specified convert upper if you need
 		// Go sql support type ref to: https://github.com/golang/go/blob/go1.17.4/src/database/sql/driver/types.go#L236
@@ -261,25 +266,25 @@ func writeColumnFieldValues(
 	jWriter *util.JSONWriter,
 	row *chunk.Row,
 	tableInfo *commonType.TableInfo,
+	columnFlags map[string]uint64,
 	selector columnselector.Selector,
 	onlyHandleKeyColumns bool,
 ) error {
-	flag := false // flag to check if any column is written
-
+	var encoded bool
 	colInfo := tableInfo.GetColumns()
-
 	for idx, col := range colInfo {
 		if selector.Select(col) {
-			if onlyHandleKeyColumns && !tableInfo.IsHandleKey(col.ID) {
+			isHandle := tableInfo.IsHandleKey(col.ID)
+			if onlyHandleKeyColumns && !isHandle {
 				continue
 			}
-			flag = true
+			encoded = true
 			jWriter.WriteObjectField(col.Name.O, func() {
-				writeColumnFieldValue(jWriter, col, row, idx, tableInfo)
+				writeColumnFieldValue(jWriter, col, row, idx, isHandle, columnFlags[col.Name.O])
 			})
 		}
 	}
-	if !flag {
+	if !encoded {
 		return errors.ErrOpenProtocolCodecInvalidData.GenWithStack("not found handle key columns for the delete event")
 	}
 	return nil
@@ -290,6 +295,7 @@ func writeUpdatedColumnFieldValues(
 	preRow *chunk.Row,
 	row *chunk.Row,
 	tableInfo *commonType.TableInfo,
+	columnFlags map[string]uint64,
 	selector columnselector.Selector,
 	onlyHandleKeyColumns bool,
 ) {
@@ -299,10 +305,11 @@ func writeUpdatedColumnFieldValues(
 
 	for idx, col := range colInfo {
 		if selector.Select(col) {
-			if onlyHandleKeyColumns && !tableInfo.IsHandleKey(col.ID) {
+			isHandle := tableInfo.IsHandleKey(col.ID)
+			if onlyHandleKeyColumns && !isHandle {
 				continue
 			}
-			writeColumnFieldValueIfUpdated(jWriter, col, preRow, row, idx, tableInfo)
+			writeColumnFieldValueIfUpdated(jWriter, col, preRow, row, idx, isHandle, columnFlags[col.Name.O])
 		}
 	}
 }
@@ -313,17 +320,17 @@ func writeColumnFieldValueIfUpdated(
 	preRow *chunk.Row,
 	row *chunk.Row,
 	idx int,
-	tableInfo *commonType.TableInfo,
+	isHandle bool,
+	columnFlag uint64,
 ) {
 	colType := col.GetType()
 	flag := col.GetFlag()
-	whereHandle := tableInfo.IsHandleKey(col.ID)
 
 	writeFunc := func(writeColumnValue func()) {
 		writer.WriteObjectField(col.Name.O, func() {
 			writer.WriteIntField("t", int(colType))
-			if whereHandle {
-				writer.WriteBoolField("h", whereHandle)
+			if isHandle {
+				writer.WriteBoolField("h", isHandle)
 			}
 			writer.WriteUint64Field("f", uint64(flag))
 			writeColumnValue()
@@ -338,7 +345,7 @@ func writeColumnFieldValueIfUpdated(
 		return
 	}
 	if !preRow.IsNull(idx) && row.IsNull(idx) {
-		writeColumnFieldValue(writer, col, preRow, idx, tableInfo)
+		writeColumnFieldValue(writer, col, preRow, idx, isHandle, columnFlag)
 		return
 	}
 

--- a/pkg/sink/codec/open/decoder.go
+++ b/pkg/sink/codec/open/decoder.go
@@ -251,7 +251,7 @@ func buildColumns(
 			Value: value,
 		}
 		if _, ok := handleKeyColumns[name]; ok {
-			col.Flag = mysql.PriKeyFlag
+			col.Flag |= binaryFlag
 		}
 		result[name] = col
 	}
@@ -379,15 +379,15 @@ func newTiColumns(rawColumns map[string]column) []*timodel.ColumnInfo {
 		col.Name = pmodel.NewCIStr(name)
 		col.FieldType = *types.NewFieldType(raw.Type)
 
-		if mysql.HasPriKeyFlag(raw.Flag) {
+		if isPrimary(raw.Flag) {
 			col.AddFlag(mysql.PriKeyFlag)
 			col.AddFlag(mysql.UniqueKeyFlag)
 			col.AddFlag(mysql.NotNullFlag)
 		}
-		if mysql.HasUnsignedFlag(raw.Flag) {
+		if isUnsigned(raw.Flag) {
 			col.AddFlag(mysql.UnsignedFlag)
 		}
-		if mysql.HasBinaryFlag(raw.Flag) {
+		if isBinary(raw.Flag) {
 			col.AddFlag(mysql.BinaryFlag)
 		}
 

--- a/pkg/sink/codec/open/decoder.go
+++ b/pkg/sink/codec/open/decoder.go
@@ -389,16 +389,14 @@ func newTiColumns(rawColumns map[string]column) []*timodel.ColumnInfo {
 		}
 		if isBinary(raw.Flag) {
 			col.AddFlag(mysql.BinaryFlag)
+			col.SetCharset("binary")
+			col.SetCollate("binary")
 		}
 
 		switch col.GetType() {
 		case mysql.TypeVarchar, mysql.TypeString,
 			mysql.TypeTinyBlob, mysql.TypeBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
-			if mysql.HasBinaryFlag(col.GetFlag()) {
-				col.AddFlag(mysql.BinaryFlag)
-				col.SetCharset("binary")
-				col.SetCollate("binary")
-			} else {
+			if !mysql.HasBinaryFlag(col.GetFlag()) {
 				col.SetCharset("utf8mb4")
 				col.SetCollate("utf8mb4_bin")
 			}

--- a/pkg/sink/codec/open/encoder.go
+++ b/pkg/sink/codec/open/encoder.go
@@ -67,8 +67,8 @@ func (d *batchEncoder) Clean() {
 func (d *batchEncoder) fetchColumnFlags(e *commonEvent.RowEvent) map[string]uint64 {
 	result, ok := d.columnFlagsCache[e.GetTableID()]
 	if !ok {
-		result = make(map[string]uint64)
-		d.columnFlagsCache[e.GetTableID()] = initColumnFlags(e.TableInfo)
+		result = initColumnFlags(e.TableInfo)
+		d.columnFlagsCache[e.GetTableID()] = result
 	}
 	return result
 }

--- a/pkg/sink/codec/open/encoder.go
+++ b/pkg/sink/codec/open/encoder.go
@@ -40,6 +40,8 @@ type batchEncoder struct {
 
 	claimCheck *claimcheck.ClaimCheck
 
+	columnFlagsCache map[int64]map[string]uint64
+
 	config *common.Config
 }
 
@@ -50,8 +52,9 @@ func NewBatchEncoder(ctx context.Context, config *common.Config) (common.EventEn
 		return nil, errors.Trace(err)
 	}
 	return &batchEncoder{
-		config:     config,
-		claimCheck: claimCheck,
+		config:           config,
+		claimCheck:       claimCheck,
+		columnFlagsCache: make(map[int64]map[string]uint64, 32),
 	}, nil
 }
 
@@ -61,13 +64,23 @@ func (d *batchEncoder) Clean() {
 	}
 }
 
+func (d *batchEncoder) fetchColumnFlags(e *commonEvent.RowEvent) map[string]uint64 {
+	result, ok := d.columnFlagsCache[e.GetTableID()]
+	if !ok {
+		result = make(map[string]uint64)
+		d.columnFlagsCache[e.GetTableID()] = initColumnFlags(e.TableInfo)
+	}
+	return result
+}
+
 // AppendRowChangedEvent implements the RowEventEncoder interface
 func (d *batchEncoder) AppendRowChangedEvent(
 	ctx context.Context,
 	_ string,
 	e *commonEvent.RowEvent,
 ) error {
-	key, value, length, err := encodeRowChangedEvent(e, d.config, false, "")
+	columnFlags := d.fetchColumnFlags(e)
+	key, value, length, err := encodeRowChangedEvent(e, columnFlags, d.config, false, "")
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -93,7 +106,7 @@ func (d *batchEncoder) AppendRowChangedEvent(
 				return errors.Trace(err)
 			}
 
-			key, value, length, err = encodeRowChangedEvent(e, d.config, true, d.claimCheck.FileNameWithPrefix(claimCheckFileName))
+			key, value, length, err = encodeRowChangedEvent(e, columnFlags, d.config, true, d.claimCheck.FileNameWithPrefix(claimCheckFileName))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -110,7 +123,7 @@ func (d *batchEncoder) AppendRowChangedEvent(
 
 		if d.config.LargeMessageHandle.HandleKeyOnly() {
 			// it must that `LargeMessageHandle == LargeMessageHandleOnlyHandleKeyColumns` here.
-			key, value, length, err = encodeRowChangedEvent(e, d.config, true, "")
+			key, value, length, err = encodeRowChangedEvent(e, columnFlags, d.config, true, "")
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -211,6 +224,7 @@ func enhancedKeyValue(key, value []byte) ([]byte, []byte) {
 }
 
 func (d *batchEncoder) EncodeDDLEvent(e *commonEvent.DDLEvent) (*common.Message, error) {
+	delete(d.columnFlagsCache, e.TableID)
 	key, value, err := encodeDDLEvent(e, d.config)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/sink/codec/open/message.go
+++ b/pkg/sink/codec/open/message.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/pingcap/log"
+	commonType "github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
@@ -205,4 +206,94 @@ func (m *messageRow) decode(data []byte) {
 	if err != nil {
 		log.Panic("decode message row failed", zap.Any("data", data), zap.Error(err))
 	}
+}
+
+const (
+	// binaryFlag means the column charset is binary
+	binaryFlag uint64 = 1 << iota
+
+	// handleKeyFlag means the column is selected as the handle key
+	// The handleKey is chosen by the following rules in the order:
+	// 1. if the table has primary key, it's the handle key.
+	// 2. If the table has not null unique key, it's the handle key.
+	// 3. If the table has no primary key and no not null unique key, it has no handleKey.
+	handleKeyFlag
+
+	// generatedColumnFlag means the column is a generated column
+	generatedColumnFlag
+
+	// primaryKeyFlag means the column is primary key
+	primaryKeyFlag
+
+	// uniqueKeyFlag means the column is unique key
+	uniqueKeyFlag
+
+	// multipleKeyFlag means the column is multiple key
+	multipleKeyFlag
+
+	// nullableFlag means the column is nullable
+	nullableFlag
+
+	// unsignedFlag means the column stores an unsigned integer
+	unsignedFlag
+)
+
+func initColumnFlags(tableInfo *commonType.TableInfo) map[string]uint64 {
+	result := make(map[string]uint64, len(tableInfo.GetColumns()))
+	for _, col := range tableInfo.GetColumns() {
+		var flag uint64
+		if col.GetCharset() == "binary" {
+			flag |= binaryFlag
+		}
+		origin := col.GetFlag()
+		if col.IsGenerated() {
+			flag |= generatedColumnFlag
+		}
+		if mysql.HasUniKeyFlag(origin) {
+			flag |= uniqueKeyFlag
+		}
+		if mysql.HasPriKeyFlag(origin) {
+			flag |= primaryKeyFlag
+			if tableInfo.PKIsHandle() {
+				flag |= handleKeyFlag
+			}
+		}
+		if !mysql.HasNotNullFlag(origin) {
+			flag |= nullableFlag
+		}
+		if mysql.HasMultipleKeyFlag(origin) {
+			flag |= multipleKeyFlag
+		}
+		if mysql.HasUnsignedFlag(origin) {
+			flag |= unsignedFlag
+		}
+		result[col.Name.O] = flag
+	}
+
+	// In TiDB, just as in MySQL, only the first column of an index can be marked as "multiple key" or "unique key",
+	// and only the first column of a unique index may be marked as "unique key".
+	// See https://dev.mysql.com/doc/refman/5.7/en/show-columns.html.
+	// Yet if an index has multiple columns, we would like to easily determine that all those columns are indexed,
+	// which is crucial for the completeness of the information we pass to the downstream.
+	// Therefore, instead of using the MySQL standard,
+	// we made our own decision to mark all columns in an index with the appropriate flag(s).
+	for _, idxInfo := range tableInfo.GetIndices() {
+		for _, idxCol := range idxInfo.Columns {
+			flag := result[idxCol.Name.O]
+			if idxInfo.Primary {
+				flag |= primaryKeyFlag
+			} else if idxInfo.Unique {
+				flag |= uniqueKeyFlag
+			}
+			if len(idxInfo.Columns) > 1 {
+				flag |= multipleKeyFlag
+			}
+			colID := tableInfo.ForceGetColumnIDByName(idxCol.Name.O)
+			if tableInfo.IsHandleKey(colID) {
+				flag |= handleKeyFlag
+			}
+			result[idxCol.Name.O] = flag
+		}
+	}
+	return result
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1227 

### What is changed and how it works?

* Changing the column Flag type from uint to uint64 and updating related flag-check calls to use new helper functions (e.g. isBinary, isUnsigned, isPrimary).
* Introducing a column flags caching mechanism in the batch encoder to improve flag calculation efficiency.
* Adjusting encoding and decoding logic to properly pass the computed column flags.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
