### PR TITLE
sink: simplify the event router method interface

### DIFF
--- a/downstreamadapter/sink/eventrouter/event_router.go
+++ b/downstreamadapter/sink/eventrouter/event_router.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/eventrouter/partition"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/eventrouter/topic"
-	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
@@ -38,8 +37,9 @@ type EventRouter struct {
 }
 
 // NewEventRouter creates a new EventRouter.
-func NewEventRouter(sinkConfig *config.SinkConfig, defaultTopic string,
-	isPulsar bool, isAvro bool) (*EventRouter, error) {
+func NewEventRouter(
+	sinkConfig *config.SinkConfig, defaultTopic string, isPulsar bool, isAvro bool,
+) (*EventRouter, error) {
 	// If an event does not match any dispatching rules in the config file,
 	// it will be dispatched by the default partition dispatcher and
 	// static topic dispatcher because it matches *.* rule.
@@ -50,7 +50,6 @@ func NewEventRouter(sinkConfig *config.SinkConfig, defaultTopic string,
 	})
 
 	rules := make([]Rule, 0, len(ruleConfigs))
-
 	for _, ruleConfig := range ruleConfigs {
 		f, err := tableFilter.Parse(ruleConfig.Matcher)
 		if err != nil {
@@ -74,9 +73,9 @@ func NewEventRouter(sinkConfig *config.SinkConfig, defaultTopic string,
 }
 
 // GetTopicForRowChange returns the target topic for row changes.
-func (s *EventRouter) GetTopicForRowChange(tableInfo *common.TableInfo) string {
-	topicGenerator := s.matchTopicGenerator(tableInfo.TableName.Schema, tableInfo.TableName.Table)
-	return topicGenerator.Substitute(tableInfo.TableName.Schema, tableInfo.TableName.Table)
+func (s *EventRouter) GetTopicForRowChange(schema, table string) string {
+	topicGenerator := s.matchTopicGenerator(schema, table)
+	return topicGenerator.Substitute(schema, table)
 }
 
 // GetTopicForDDL returns the target topic for DDL.
@@ -104,7 +103,7 @@ func (s *EventRouter) GetTopicForDDL(ddl *commonEvent.DDLEvent) string {
 // GetActiveTopics returns a list of the corresponding topics
 // for the tables that are actively synchronized.
 func (s *EventRouter) GetActiveTopics(activeTables []*commonEvent.SchemaTableName) []string {
-	topics := make([]string, 0)
+	topics := make([]string, 0, len(activeTables))
 	topicsMap := make(map[string]bool, len(activeTables))
 	for _, tableName := range activeTables {
 		topicDispatcher := s.matchTopicGenerator(tableName.SchemaName, tableName.TableName)

--- a/downstreamadapter/sink/eventrouter/event_router.go
+++ b/downstreamadapter/sink/eventrouter/event_router.go
@@ -38,7 +38,8 @@ type EventRouter struct {
 }
 
 // NewEventRouter creates a new EventRouter.
-func NewEventRouter(sinkConfig *config.SinkConfig, protocol config.Protocol, defaultTopic, scheme string) (*EventRouter, error) {
+func NewEventRouter(sinkConfig *config.SinkConfig, defaultTopic string,
+	isPulsar bool, isAvro bool) (*EventRouter, error) {
 	// If an event does not match any dispatching rules in the config file,
 	// it will be dispatched by the default partition dispatcher and
 	// static topic dispatcher because it matches *.* rule.
@@ -58,10 +59,8 @@ func NewEventRouter(sinkConfig *config.SinkConfig, protocol config.Protocol, def
 		if !sinkConfig.CaseSensitive {
 			f = tableFilter.CaseInsensitive(f)
 		}
-
-		d := partition.GetPartitionGenerator(ruleConfig.PartitionRule, scheme, ruleConfig.IndexName, ruleConfig.Columns)
-
-		topicGenerator, err := topic.GetTopicGenerator(ruleConfig.TopicRule, defaultTopic, protocol, scheme)
+		d := partition.GetPartitionGenerator(ruleConfig.PartitionRule, isPulsar, ruleConfig.IndexName, ruleConfig.Columns)
+		topicGenerator, err := topic.GetTopicGenerator(ruleConfig.TopicRule, defaultTopic, isPulsar, isAvro)
 		if err != nil {
 			return nil, err
 		}

--- a/downstreamadapter/sink/eventrouter/event_router_test.go
+++ b/downstreamadapter/sink/eventrouter/event_router_test.go
@@ -14,7 +14,6 @@
 package eventrouter
 
 import (
-	cmdUtil "github.com/pingcap/ticdc/cmd/util"
 	"testing"
 
 	"github.com/pingcap/ticdc/downstreamadapter/sink/eventrouter/partition"
@@ -70,19 +69,6 @@ func newSinkConfig4Test() *config.SinkConfig {
 			},
 		},
 	}
-}
-
-func TestPartitionDispatcherMatch(t *testing.T) {
-	configFile := "/Users/edison/go/ticdc/tests/integration_tests/mq_sink_dispatcher/conf/new_changefeed.toml"
-	replicaConfig := config.GetDefaultReplicaConfig()
-	err := cmdUtil.StrictDecodeFile(configFile, "replica-config", &replicaConfig)
-	require.NoError(t, err)
-
-	router, err := NewEventRouter(replicaConfig.Sink, "test", false, false)
-	require.NoError(t, err)
-
-	partitionDispatcher := router.GetPartitionGenerator("dispatcher", "index")
-	require.IsType(t, &partition.IndexValuePartitionGenerator{}, partitionDispatcher)
 }
 
 func TestEventRouter(t *testing.T) {
@@ -179,29 +165,19 @@ func TestGetTopicForRowChange(t *testing.T) {
 	d, err := NewEventRouter(sinkConfig, "test", false, false)
 	require.NoError(t, err)
 
-	topicName := d.GetTopicForRowChange(&common.TableInfo{
-		TableName: common.TableName{Schema: "test_default1", Table: "table"},
-	})
+	topicName := d.GetTopicForRowChange("test_default1", "table")
 	require.Equal(t, "test", topicName)
 
-	topicName = d.GetTopicForRowChange(&common.TableInfo{
-		TableName: common.TableName{Schema: "test_default2", Table: "table"},
-	})
+	topicName = d.GetTopicForRowChange("test_default2", "table")
 	require.Equal(t, "test", topicName)
 
-	topicName = d.GetTopicForRowChange(&common.TableInfo{
-		TableName: common.TableName{Schema: "test_table", Table: "table"},
-	})
+	topicName = d.GetTopicForRowChange("test_table", "table")
 	require.Equal(t, "hello_test_table_world", topicName)
 
-	topicName = d.GetTopicForRowChange(&common.TableInfo{
-		TableName: common.TableName{Schema: "test_index_value", Table: "table"},
-	})
+	topicName = d.GetTopicForRowChange("test_index_value", "table")
 	require.Equal(t, "test_index_value_world", topicName)
 
-	topicName = d.GetTopicForRowChange(&common.TableInfo{
-		TableName: common.TableName{Schema: "a", Table: "table"},
-	})
+	topicName = d.GetTopicForRowChange("a", "table")
 	require.Equal(t, "a_table", topicName)
 }
 

--- a/downstreamadapter/sink/eventrouter/partition/generator.go
+++ b/downstreamadapter/sink/eventrouter/partition/generator.go
@@ -47,7 +47,7 @@ func GetPartitionGenerator(rule string, isPulsar bool, indexName string, columns
 	if isPulsar {
 		return newKeyPartitionGenerator(rule)
 	}
-	
+
 	log.Warn("the partition dispatch rule is not default/ts/table/index-value/columns,"+
 		" use the default rule instead.", zap.String("rule", rule))
 	return newTablePartitionGenerator()

--- a/downstreamadapter/sink/eventrouter/partition/generator.go
+++ b/downstreamadapter/sink/eventrouter/partition/generator.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/log"
-	"github.com/pingcap/ticdc/downstreamadapter/sink/helper"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"go.uber.org/zap"
@@ -29,7 +28,7 @@ type PartitionGenerator interface {
 	GeneratePartitionIndexAndKey(row *commonEvent.RowChange, partitionNum int32, tableInfo *common.TableInfo, commitTs uint64) (int32, string, error)
 }
 
-func GetPartitionGenerator(rule string, scheme string, indexName string, columns []string) PartitionGenerator {
+func GetPartitionGenerator(rule string, isPulsar bool, indexName string, columns []string) PartitionGenerator {
 	switch strings.ToLower(rule) {
 	case "default", "table":
 		return newTablePartitionGenerator()
@@ -45,10 +44,10 @@ func GetPartitionGenerator(rule string, scheme string, indexName string, columns
 	default:
 	}
 
-	if helper.IsPulsarScheme(scheme) {
+	if isPulsar {
 		return newKeyPartitionGenerator(rule)
 	}
-
+	
 	log.Warn("the partition dispatch rule is not default/ts/table/index-value/columns,"+
 		" use the default rule instead.", zap.String("rule", rule))
 	return newTablePartitionGenerator()

--- a/downstreamadapter/sink/eventrouter/topic/expression.go
+++ b/downstreamadapter/sink/eventrouter/topic/expression.go
@@ -83,7 +83,7 @@ func (e Expression) validateForAvro() error {
 }
 
 // PulsarValidate checks whether a pulsar topic name is valid or not.
-func (e Expression) validateForpulsar() error {
+func (e Expression) validateForPulsar() error {
 	// validate the topic expression
 	topicName := string(e)
 
@@ -142,7 +142,7 @@ func isHardCode(topicName string) bool {
 
 func validateTopicExpression(expr Expression, isPulsar, isAvro bool) error {
 	if isPulsar {
-		return expr.validateForpulsar()
+		return expr.validateForPulsar()
 	}
 	if isAvro {
 		return expr.validateForAvro()

--- a/downstreamadapter/sink/eventrouter/topic/expression.go
+++ b/downstreamadapter/sink/eventrouter/topic/expression.go
@@ -17,8 +17,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pingcap/ticdc/downstreamadapter/sink/helper"
-	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 )
 
@@ -142,16 +140,12 @@ func isHardCode(topicName string) bool {
 	return hardCodeTopicNameRe.MatchString(topicName)
 }
 
-func validateTopicExpression(expr Expression, scheme string, protocol config.Protocol) error {
-	if helper.IsPulsarScheme(scheme) {
+func validateTopicExpression(expr Expression, isPulsar, isAvro bool) error {
+	if isPulsar {
 		return expr.validateForpulsar()
 	}
-
-	switch protocol {
-	case config.ProtocolAvro:
+	if isAvro {
 		return expr.validateForAvro()
-	default:
 	}
-
 	return expr.validate()
 }

--- a/downstreamadapter/sink/eventrouter/topic/topic.go
+++ b/downstreamadapter/sink/eventrouter/topic/topic.go
@@ -13,10 +13,6 @@
 
 package topic
 
-import (
-	"github.com/pingcap/ticdc/pkg/config"
-)
-
 type TopicGeneratorType int
 
 const (
@@ -72,7 +68,7 @@ func (d *DynamicTopicGenerator) TopicGeneratorType() TopicGeneratorType {
 }
 
 func GetTopicGenerator(
-	rule string, defaultTopic string, protocol config.Protocol, scheme string,
+	rule string, defaultTopic string, isPulsar bool, isAvro bool,
 ) (TopicGenerator, error) {
 	if rule == "" {
 		return newStaticTopic(defaultTopic), nil
@@ -84,7 +80,7 @@ func GetTopicGenerator(
 
 	// check if this rule is a valid topic expression
 	topicExpr := Expression(rule)
-	err := validateTopicExpression(topicExpr, scheme, protocol)
+	err := validateTopicExpression(topicExpr, isPulsar, isAvro)
 	if err != nil {
 		return nil, err
 	}

--- a/downstreamadapter/sink/kafka/helper.go
+++ b/downstreamadapter/sink/kafka/helper.go
@@ -102,8 +102,8 @@ func newKafkaSinkComponentWithFactory(ctx context.Context,
 		kafkaComponent.adminClient,
 	)
 
-	scheme := helper.GetScheme(sinkURI)
-	kafkaComponent.eventRouter, err = eventrouter.NewEventRouter(sinkConfig, protocol, topic, scheme)
+	kafkaComponent.eventRouter, err = eventrouter.NewEventRouter(
+		sinkConfig, topic, false, protocol == config.ProtocolAvro)
 	if err != nil {
 		return kafkaComponent, protocol, errors.Trace(err)
 	}

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -197,14 +197,14 @@ func (s *sink) calculateKeyPartitions(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
 		case event := <-s.eventChan:
-			topic := s.comp.eventRouter.GetTopicForRowChange(event.TableInfo)
+			schema := event.TableInfo.GetSchemaName()
+			table := event.TableInfo.GetTableName()
+			topic := s.comp.eventRouter.GetTopicForRowChange(schema, table)
 			partitionNum, err := s.comp.topicManager.GetPartitionNum(ctx, topic)
 			if err != nil {
 				return err
 			}
 
-			schema := event.TableInfo.GetSchemaName()
-			table := event.TableInfo.GetTableName()
 			partitionGenerator := s.comp.eventRouter.GetPartitionGenerator(schema, table)
 			selector := s.comp.columnSelector.GetSelector(schema, table)
 			toRowCallback := func(postTxnFlushed []func(), totalCount uint64) func() {

--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -101,8 +101,7 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 
-	scheme := helper.GetScheme(sinkURI)
-	pulsarComponent.eventRouter, err = eventrouter.NewEventRouter(sinkConfig, protocol, topic, scheme)
+	pulsarComponent.eventRouter, err = eventrouter.NewEventRouter(sinkConfig, topic, true, false)
 	if err != nil {
 		return pulsarComponent, protocol, errors.Trace(err)
 	}

--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -101,6 +101,7 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 
+	// pulsar only support canal-json, so we don't need to check the protocol
 	pulsarComponent.eventRouter, err = eventrouter.NewEventRouter(sinkConfig, topic, true, false)
 	if err != nil {
 		return pulsarComponent, protocol, errors.Trace(err)

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -290,14 +290,14 @@ func (s *sink) calculateKeyPartitions(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
 		case event := <-s.eventChan:
-			topic := s.comp.eventRouter.GetTopicForRowChange(event.TableInfo)
+			schema := event.TableInfo.GetSchemaName()
+			table := event.TableInfo.GetTableName()
+			topic := s.comp.eventRouter.GetTopicForRowChange(schema, table)
 			partitionNum, err := s.comp.topicManager.GetPartitionNum(ctx, topic)
 			if err != nil {
 				return errors.Trace(err)
 			}
 
-			schema := event.TableInfo.GetSchemaName()
-			table := event.TableInfo.GetTableName()
 			partitionGenerator := s.comp.eventRouter.GetPartitionGenerator(schema, table)
 			selector := s.comp.columnSelector.GetSelector(schema, table)
 			toRowCallback := func(postTxnFlushed []func(), totalCount uint64) func() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1289 

### What is changed and how it works?

* Updating the NewEventRouter, GetTopicForRowChange, and GetPartitionGenerator interfaces to accept explicit parameters.
* Refactoring both Pulsar and Kafka sinks to use the simplified event router interface.
* Adjusting test cases to align with the new method signatures.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
