### PR TITLE
sink: move some helper method to the caller package

### DIFF
--- a/downstreamadapter/sink/cloudstorage/defragmenter_test.go
+++ b/downstreamadapter/sink/cloudstorage/defragmenter_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/ticdc/downstreamadapter/sink/helper"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/sink/cloudstorage"
 	"github.com/pingcap/ticdc/pkg/sink/codec"
-	"github.com/pingcap/ticdc/pkg/sink/util"
 	"github.com/pingcap/ticdc/utils/chann"
 	timodel "github.com/pingcap/tidb/pkg/meta/model"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -57,9 +57,9 @@ func TestDeframenter(t *testing.T) {
 
 	replicaConfig := config.GetDefaultReplicaConfig()
 	changefeedID := common.NewChangefeedID4Test("test", "table1")
-	encoderConfig, err := util.GetEncoderConfig(changefeedID, sinkURI, config.ProtocolCsv,
+	encoderConfig, err := helper.GetEncoderConfig(changefeedID, sinkURI, config.ProtocolCsv,
 		replicaConfig.Sink, config.DefaultMaxMessageBytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var seqNumbers []uint64
 	for i := 0; i < txnCnt; i++ {

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -76,7 +76,7 @@ func Verify(ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.
 	if err != nil {
 		return err
 	}
-	_, err = util.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, math.MaxInt)
+	_, err = helper.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, math.MaxInt)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func New(
 	ext := helper.GetFileExtension(protocol)
 	// the last param maxMsgBytes is mainly to limit the size of a single message for
 	// batch protocols in mq scenario. In cloud storage sink, we just set it to max int.
-	encoderConfig, err := util.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, math.MaxInt)
+	encoderConfig, err := helper.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, math.MaxInt)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/downstreamadapter/sink/kafka/helper.go
+++ b/downstreamadapter/sink/kafka/helper.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/sink/codec"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/sink/kafka"
-	"github.com/pingcap/ticdc/pkg/sink/util"
 	"github.com/pingcap/tidb/br/pkg/utils"
 )
 
@@ -108,12 +107,12 @@ func newKafkaSinkComponentWithFactory(ctx context.Context,
 		return kafkaComponent, protocol, errors.Trace(err)
 	}
 
-	kafkaComponent.columnSelector, err = columnselector.NewColumnSelectors(sinkConfig)
+	kafkaComponent.columnSelector, err = columnselector.New(sinkConfig)
 	if err != nil {
 		return kafkaComponent, protocol, errors.Trace(err)
 	}
 
-	encoderConfig, err := util.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, options.MaxMessageBytes)
+	encoderConfig, err := helper.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, options.MaxMessageBytes)
 	if err != nil {
 		return kafkaComponent, protocol, errors.Trace(err)
 	}

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -206,7 +206,7 @@ func (s *sink) calculateKeyPartitions(ctx context.Context) error {
 			}
 
 			partitionGenerator := s.comp.eventRouter.GetPartitionGenerator(schema, table)
-			selector := s.comp.columnSelector.GetSelector(schema, table)
+			selector := s.comp.columnSelector.Get(schema, table)
 			toRowCallback := func(postTxnFlushed []func(), totalCount uint64) func() {
 				var calledCount atomic.Uint64
 				// The callback of the last row will trigger the callback of the txn.

--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/sink/codec"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/sink/pulsar"
-	"github.com/pingcap/ticdc/pkg/sink/util"
 	putil "github.com/pingcap/ticdc/pkg/util"
 )
 
@@ -107,12 +106,12 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 
-	pulsarComponent.columnSelector, err = columnselector.NewColumnSelectors(sinkConfig)
+	pulsarComponent.columnSelector, err = columnselector.New(sinkConfig)
 	if err != nil {
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 
-	encoderConfig, err := util.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, config.DefaultMaxMessageBytes)
+	encoderConfig, err := helper.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, config.DefaultMaxMessageBytes)
 	if err != nil {
 		return pulsarComponent, protocol, errors.Trace(err)
 	}

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -299,7 +299,7 @@ func (s *sink) calculateKeyPartitions(ctx context.Context) error {
 			}
 
 			partitionGenerator := s.comp.eventRouter.GetPartitionGenerator(schema, table)
-			selector := s.comp.columnSelector.GetSelector(schema, table)
+			selector := s.comp.columnSelector.Get(schema, table)
 			toRowCallback := func(postTxnFlushed []func(), totalCount uint64) func() {
 				var calledCount atomic.Uint64
 				// The callback of the last row will trigger the callback of the txn.

--- a/maintainer/maintainer_controller.go
+++ b/maintainer/maintainer_controller.go
@@ -221,7 +221,7 @@ func (c *Controller) AddNewTable(table commonEvent.Table, startTs uint64) {
 //
 // Parameters:
 //   - allNodesResp: Bootstrap responses from all nodes containing their current state
-//   - isMysqlCompatibleBackend: Flag indicating if using MySQL-compatible backend
+//   - isMysqlCompatible: Flag indicating if using MySQL-compatible backend
 //
 // Returns:
 //   - *Barrier: Initialized barrier for consistency tracking

--- a/pkg/common/columnselector/column_selector.go
+++ b/pkg/common/columnselector/column_selector.go
@@ -14,10 +14,10 @@
 package columnselector
 
 import (
-	ticonfig "github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/tidb/pkg/meta/model"
-	filter "github.com/pingcap/tidb/pkg/util/table-filter"
+	"github.com/pingcap/tidb/pkg/util/table-filter"
 )
 
 type Selector interface {
@@ -40,7 +40,7 @@ type ColumnSelector struct {
 }
 
 func newColumnSelector(
-	rule *ticonfig.ColumnSelector, caseSensitive bool,
+	rule *config.ColumnSelector, caseSensitive bool,
 ) (*ColumnSelector, error) {
 	tableM, err := filter.Parse(rule.Matcher)
 	if err != nil {
@@ -78,7 +78,7 @@ type ColumnSelectors struct {
 }
 
 // New return a column selectors
-func NewColumnSelectors(sinkConfig *ticonfig.SinkConfig) (*ColumnSelectors, error) {
+func New(sinkConfig *config.SinkConfig) (*ColumnSelectors, error) {
 	selectors := make([]*ColumnSelector, 0, len(sinkConfig.ColumnSelectors))
 	for _, r := range sinkConfig.ColumnSelectors {
 		selector, err := newColumnSelector(r, sinkConfig.CaseSensitive)
@@ -93,7 +93,7 @@ func NewColumnSelectors(sinkConfig *ticonfig.SinkConfig) (*ColumnSelectors, erro
 	}, nil
 }
 
-func (c *ColumnSelectors) GetSelector(schema, table string) Selector {
+func (c *ColumnSelectors) Get(schema, table string) Selector {
 	for _, s := range c.selectors {
 		if s.match(schema, table) {
 			return s

--- a/pkg/common/columnselector/column_selector_test.go
+++ b/pkg/common/columnselector/column_selector_test.go
@@ -25,7 +25,7 @@ import (
 func TestNewColumnSelector(t *testing.T) {
 	// the column selector is not set
 	replicaConfig := config.GetDefaultReplicaConfig()
-	selectors, err := NewColumnSelectors(replicaConfig.Sink)
+	selectors, err := New(replicaConfig.Sink)
 	require.NoError(t, err)
 	require.NotNil(t, selectors)
 	require.Len(t, selectors.selectors, 0)
@@ -48,7 +48,7 @@ func TestNewColumnSelector(t *testing.T) {
 			Columns: []string{"co?1"},
 		},
 	}
-	selectors, err = NewColumnSelectors(replicaConfig.Sink)
+	selectors, err = New(replicaConfig.Sink)
 	require.NoError(t, err)
 	require.Len(t, selectors.selectors, 4)
 }
@@ -73,11 +73,11 @@ func TestColumnSelectorGetSelector(t *testing.T) {
 			Columns: []string{"co?1"},
 		},
 	}
-	selectors, err := NewColumnSelectors(replicaConfig.Sink)
+	selectors, err := New(replicaConfig.Sink)
 	require.NoError(t, err)
 
 	{
-		selector := selectors.GetSelector("test", "t1")
+		selector := selectors.Get("test", "t1")
 		columns := []*model.ColumnInfo{
 			{
 				Name: pmodel.NewCIStr("a"),
@@ -99,7 +99,7 @@ func TestColumnSelectorGetSelector(t *testing.T) {
 	}
 
 	{
-		selector := selectors.GetSelector("test1", "aaa")
+		selector := selectors.Get("test1", "aaa")
 		columns := []*model.ColumnInfo{
 			{
 				Name: pmodel.NewCIStr("a"),
@@ -121,7 +121,7 @@ func TestColumnSelectorGetSelector(t *testing.T) {
 	}
 
 	{
-		selector := selectors.GetSelector("test2", "t2")
+		selector := selectors.Get("test2", "t2")
 		columns := []*model.ColumnInfo{
 			{
 				Name: pmodel.NewCIStr("a"),
@@ -143,7 +143,7 @@ func TestColumnSelectorGetSelector(t *testing.T) {
 	}
 
 	{
-		selector := selectors.GetSelector("test3", "t3")
+		selector := selectors.Get("test3", "t3")
 		columns := []*model.ColumnInfo{
 			{
 				Name: pmodel.NewCIStr("a"),
@@ -165,7 +165,7 @@ func TestColumnSelectorGetSelector(t *testing.T) {
 	}
 
 	{
-		selector := selectors.GetSelector("test4", "t4")
+		selector := selectors.Get("test4", "t4")
 		columns := []*model.ColumnInfo{
 			{
 				Name: pmodel.NewCIStr("a"),

--- a/pkg/sink/codec/canal/canal_json_test.go
+++ b/pkg/sink/codec/canal/canal_json_test.go
@@ -471,14 +471,14 @@ func TestDMLEventWithColumnSelector(t *testing.T) {
 			Columns: []string{"a"},
 		},
 	}
-	selectors, err := columnselector.NewColumnSelectors(replicaConfig.Sink)
+	selectors, err := columnselector.New(replicaConfig.Sink)
 	require.NoError(t, err)
 
 	rowEvent := &commonEvent.RowEvent{
 		TableInfo:      tableInfo,
 		CommitTs:       1,
 		Event:          row,
-		ColumnSelector: selectors.GetSelector("test", "t"),
+		ColumnSelector: selectors.Get("test", "t"),
 		Callback:       func() {},
 	}
 

--- a/pkg/sink/codec/open/encoder_test.go
+++ b/pkg/sink/codec/open/encoder_test.go
@@ -884,14 +884,14 @@ func TestDMLEventWithColumnSelector(t *testing.T) {
 			Columns: []string{"a"},
 		},
 	}
-	selectors, err := columnselector.NewColumnSelectors(replicaConfig.Sink)
+	selectors, err := columnselector.New(replicaConfig.Sink)
 	require.NoError(t, err)
 
 	rowEvent := &commonEvent.RowEvent{
 		TableInfo:      tableInfo,
 		CommitTs:       1,
 		Event:          row,
-		ColumnSelector: selectors.GetSelector("test", "t"),
+		ColumnSelector: selectors.Get("test", "t"),
 		Callback:       func() {},
 	}
 

--- a/pkg/sink/util/helper.go
+++ b/pkg/sink/util/helper.go
@@ -22,45 +22,9 @@ import (
 	"github.com/pingcap/ticdc/heartbeatpb"
 	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
-	"github.com/pingcap/ticdc/pkg/config"
-	ticonfig "github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
-	"github.com/pingcap/ticdc/pkg/sink/codec/common"
-	"github.com/pingcap/ticdc/pkg/util"
 	"go.uber.org/zap"
 )
-
-// GetEncoderConfig returns the encoder config and validates the config.
-func GetEncoderConfig(
-	changefeedID commonType.ChangeFeedID,
-	sinkURI *url.URL,
-	protocol config.Protocol,
-	sinkConfig *ticonfig.SinkConfig,
-	maxMsgBytes int,
-) (*common.Config, error) {
-	encoderConfig := common.NewConfig(protocol)
-	if err := encoderConfig.Apply(sinkURI, sinkConfig); err != nil {
-		return nil, errors.WrapError(errors.ErrSinkInvalidConfig, err)
-	}
-	// Always set encoder's `MaxMessageBytes` equal to producer's `MaxMessageBytes`
-	// to prevent that the encoder generate batched message too large
-	// then cause producer meet `message too large`.
-	encoderConfig = encoderConfig.
-		WithMaxMessageBytes(maxMsgBytes).
-		WithChangefeedID(changefeedID)
-
-	tz, err := util.GetTimezone(config.GetGlobalServerConfig().TZ)
-	if err != nil {
-		return nil, errors.WrapError(errors.ErrSinkInvalidConfig, err)
-	}
-	encoderConfig.TimeZone = tz
-
-	if err = encoderConfig.Validate(); err != nil {
-		return nil, errors.WrapError(errors.ErrSinkInvalidConfig, err)
-	}
-
-	return encoderConfig, nil
-}
 
 // TableSchemaStore is store some schema info for dispatchers.
 // It is responsible for


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1291 

### What is changed and how it works?

* Moved the GetEncoderConfig function to downstreamadapter/sink/helper and updated all call sites.
* Refactored columnselector API calls from NewColumnSelectors/GetSelector to New/Get.
* Updated comment and variable naming related to MySQL compatibility.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
