### PR TITLE
fix some bugs in dispatcher and add test for random ddl with random moving dispatchers in the splitted tables

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -61,6 +61,7 @@ func RegisterOpenAPIV2Routes(router *gin.Engine, api OpenAPIV2) {
 
 	// internal APIs
 	changefeedGroup.POST("/:changefeed_id/move_table", authenticateMiddleware, api.MoveTable)
+	changefeedGroup.POST("/:changefeed_id/move_split_table", authenticateMiddleware, api.MoveSplitTable)
 	changefeedGroup.GET("/:changefeed_id/get_dispatcher_count", api.getDispatcherCount)
 	changefeedGroup.GET("/:changefeed_id/tables", api.ListTables)
 

--- a/cmd/cdc/cli/cli_changefeed.go
+++ b/cmd/cdc/cli/cli_changefeed.go
@@ -35,6 +35,7 @@ func newCmdChangefeed(f factory.Factory) *cobra.Command {
 	cmds.AddCommand(newCmdRemoveChangefeed(f))
 	cmds.AddCommand(newCmdResumeChangefeed(f))
 	cmds.AddCommand(newCmdMoveTable(f))
+	cmds.AddCommand(newCmdMoveSplitTable(f))
 
 	return cmds
 }

--- a/cmd/cdc/cli/cli_changefeed_move_split_table.go
+++ b/cmd/cdc/cli/cli_changefeed_move_split_table.go
@@ -1,0 +1,97 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/pingcap/ticdc/cmd/cdc/factory"
+	"github.com/pingcap/ticdc/cmd/util"
+	apiv2client "github.com/pingcap/ticdc/pkg/api/v2"
+	"github.com/spf13/cobra"
+)
+
+// moveTableChangefeedOptions defines common flags for the `cli changefeed move table` command.
+type moveSplitTableChangefeedOptions struct {
+	apiClientV2 apiv2client.APIV2Interface
+
+	changefeedID string
+	namespace    string
+	tableId      int64
+	targetNodeID string
+}
+
+// newCreateChangefeedOptions creates new options for the `cli changefeed create` command.
+func newMoveSplitTableChangefeedOptions() *moveSplitTableChangefeedOptions {
+	return &moveSplitTableChangefeedOptions{}
+}
+
+// addFlags receives a *cobra.Command reference and binds
+// flags related to template printing to it.
+func (o *moveSplitTableChangefeedOptions) addFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&o.namespace, "namespace", "n", "default", "Replication task (changefeed) Namespace")
+	cmd.PersistentFlags().StringVarP(&o.changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
+	cmd.PersistentFlags().Int64VarP(&o.tableId, "table-id", "t", 0, "the id of table to move")
+	cmd.PersistentFlags().StringVarP(&o.targetNodeID, "target-node-id", "d", "", "the dest for the table to move")
+	_ = cmd.MarkPersistentFlagRequired("changefeed-id")
+	_ = cmd.MarkPersistentFlagRequired("table-id")
+	_ = cmd.MarkPersistentFlagRequired("target-node-id")
+}
+
+// complete adapts from the command line args to the data and client required.
+func (o *moveSplitTableChangefeedOptions) complete(f factory.Factory) error {
+	clientV2, err := f.APIV2Client()
+	if err != nil {
+		return err
+	}
+	o.apiClientV2 = clientV2
+	return nil
+}
+
+// run the `cli changefeed move table` command.
+// return success or error message.
+func (o *moveSplitTableChangefeedOptions) run(cmd *cobra.Command) error {
+	ctx := context.Background()
+
+	err := o.apiClientV2.Changefeeds().MoveSplitTable(ctx, o.namespace, o.changefeedID, o.tableId, o.targetNodeID)
+	var errStr string
+	if err != nil {
+		errStr = err.Error()
+	}
+	response := &response{
+		Success: err == nil,
+		Error:   errStr,
+	}
+	return util.JSONPrint(cmd, response)
+}
+
+// newCmdMoveSplitTable creates the `cli changefeed move split table` command.
+// `cli changefeed move split table` command is just for inner test use, not public use.
+func newCmdMoveSplitTable(f factory.Factory) *cobra.Command {
+	o := newMoveSplitTableChangefeedOptions()
+
+	command := &cobra.Command{
+		Use:   "move-split-table",
+		Short: "move split table in a changefeed",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.complete(f))
+			util.CheckErr(o.run(cmd))
+		},
+	}
+
+	o.addFlags(command)
+
+	return command
+}

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -408,6 +408,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 					d.tableSchemaStore.AddEvent(ddl)
 				}
 				wakeCallback()
+				log.Info("dispatcher ddl event wake callback", zap.Any("dispatcher", d.id), zap.Any("commitTs", event.GetCommitTs()))
 			})
 			d.dealWithBlockEvent(ddl)
 		case commonEvent.TypeSyncPointEvent:

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -321,6 +321,7 @@ func (d *Dispatcher) HandleDispatcherStatus(dispatcherStatus *heartbeatpb.Dispat
 func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallback func()) (block bool) {
 	// Only return false when all events are resolvedTs Event.
 	block = false
+	log.Info("dispatcher handle events", zap.Any("dispatcher", d.id), zap.Any("events len", len(dispatcherEvents)))
 	// Dispatcher is ready, handle the events
 	for _, dispatcherEvent := range dispatcherEvents {
 		log.Debug("dispatcher receive all event",

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -322,7 +322,6 @@ func (d *Dispatcher) HandleDispatcherStatus(dispatcherStatus *heartbeatpb.Dispat
 func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallback func()) (block bool) {
 	// Only return false when all events are resolvedTs Event.
 	block = false
-	log.Info("dispatcher handle events", zap.Any("dispatcher", d.id), zap.Any("events len", len(dispatcherEvents)))
 	dmlWakeOnce := &sync.Once{}
 	// Dispatcher is ready, handle the events
 	for _, dispatcherEvent := range dispatcherEvents {
@@ -370,7 +369,6 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 				// and wake dynamic stream to handle the next events.
 				if d.tableProgress.Empty() {
 					dmlWakeOnce.Do(wakeCallback)
-					log.Info("dispatcher dml event wake callback", zap.Any("dispatcher", d.id), zap.Any("commitTs", event.GetCommitTs()))
 				}
 			})
 			d.AddDMLEventToSink(dml)
@@ -411,7 +409,6 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 					d.tableSchemaStore.AddEvent(ddl)
 				}
 				wakeCallback()
-				log.Info("dispatcher ddl event wake callback", zap.Any("dispatcher", d.id), zap.Any("commitTs", event.GetCommitTs()))
 			})
 			d.dealWithBlockEvent(ddl)
 		case commonEvent.TypeSyncPointEvent:

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -368,6 +368,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 				// and wake dynamic stream to handle the next events.
 				if d.tableProgress.Empty() {
 					wakeCallback()
+					log.Info("dispatcher dml event wake callback", zap.Any("dispatcher", d.id), zap.Any("commitTs", event.GetCommitTs()))
 				}
 			})
 			d.AddDMLEventToSink(dml)

--- a/maintainer/barrier_event.go
+++ b/maintainer/barrier_event.go
@@ -427,7 +427,7 @@ func (be *BarrierEvent) resend() []*messaging.TargetMessage {
 				zap.Stringer("node", stm.GetNodeID()),
 				zap.Uint64("commitTs", be.commitTs),
 				zap.Bool("isSyncPoint", be.isSyncPoint))
-			// TODO: select a new writer
+			// TODO: select a new writer 这个可以根据 block 信息重选一个
 			return nil
 		}
 

--- a/maintainer/barrier_event.go
+++ b/maintainer/barrier_event.go
@@ -427,7 +427,7 @@ func (be *BarrierEvent) resend() []*messaging.TargetMessage {
 				zap.Stringer("node", stm.GetNodeID()),
 				zap.Uint64("commitTs", be.commitTs),
 				zap.Bool("isSyncPoint", be.isSyncPoint))
-			// TODO: select a new writer 这个可以根据 block 信息重选一个
+			// TODO: select a new writer
 			return nil
 		}
 

--- a/maintainer/maintainer.go
+++ b/maintainer/maintainer.go
@@ -944,6 +944,11 @@ func (m *Maintainer) MoveTable(tableId int64, targetNode node.ID) error {
 	return m.controller.moveTable(tableId, targetNode)
 }
 
+// MoveSplitTable moves all the dispatchers in a split table to a specific node.
+func (m *Maintainer) MoveSplitTable(tableId int64, targetNode node.ID) error {
+	return m.controller.moveSplitTable(tableId, targetNode)
+}
+
 // GetTables returns all tables.
 func (m *Maintainer) GetTables() []*replica.SpanReplication {
 	return m.controller.replicationDB.GetAllTasks()

--- a/maintainer/maintainer_controller.go
+++ b/maintainer/maintainer_controller.go
@@ -606,7 +606,7 @@ func (c *Controller) moveSplitTable(tableId int64, targetNode node.ID) error {
 	opList := make([]pkgoperator.Operator[common.DispatcherID, *heartbeatpb.TableSpanStatus], 0, len(replications))
 	finishList := make([]bool, len(replications))
 	for _, replication := range replications {
-		if replication.GetNodeID() != targetNode {
+		if replication.GetNodeID() == targetNode {
 			continue
 		}
 		op := c.operatorController.NewMoveOperator(replication, replication.GetNodeID(), targetNode)

--- a/maintainer/maintainer_controller.go
+++ b/maintainer/maintainer_controller.go
@@ -613,8 +613,11 @@ func (c *Controller) moveSplitTable(tableId int64, targetNode node.ID) error {
 
 	replications := c.replicationDB.GetTasksByTableID(tableId)
 	opList := make([]pkgoperator.Operator[common.DispatcherID, *heartbeatpb.TableSpanStatus], 0, len(replications))
-	finishList := make([]bool, 0, len(replications))
+	finishList := make([]bool, len(replications))
 	for _, replication := range replications {
+		if replication.GetNodeID() != targetNode {
+			continue
+		}
 		op := c.operatorController.NewMoveOperator(replication, replication.GetNodeID(), targetNode)
 		c.operatorController.AddOperator(op)
 		opList = append(opList, op)

--- a/maintainer/scheduler/split.go
+++ b/maintainer/scheduler/split.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/maintainer/operator"
@@ -65,6 +66,10 @@ func NewSplitScheduler(
 }
 
 func (s *splitScheduler) Execute() time.Time {
+	failpoint.Inject("StopSplitScheduler", func() time.Time {
+		return time.Now().Add(s.checkInterval)
+	})
+
 	if s.splitter == nil {
 		return time.Time{}
 	}

--- a/pkg/api/v2/changefeed.go
+++ b/pkg/api/v2/changefeed.go
@@ -50,6 +50,8 @@ type ChangefeedInterface interface {
 	List(ctx context.Context, namespace string, state string) ([]v2.ChangefeedCommonInfo, error)
 	// Move Table to target node, it just for make test case now. **Not for public use.**
 	MoveTable(ctx context.Context, namespace string, name string, tableID int64, targetNode string) error
+	// Move dispatchers in a split Table to target node, it just for make test case now. **Not for public use.**
+	MoveSplitTable(ctx context.Context, namespace string, name string, tableID int64, targetNode string) error
 }
 
 // changefeeds implements ChangefeedInterface
@@ -166,6 +168,19 @@ func (c *changefeeds) MoveTable(ctx context.Context,
 	namespace string, name string, tableID int64, targetNode string,
 ) error {
 	url := fmt.Sprintf("changefeeds/%s/move_table?namespace=%s", name, namespace)
+	err := c.client.Post().
+		WithURI(url).
+		WithParam("tableID", strconv.FormatInt(tableID, 10)).
+		WithParam("targetNodeID", targetNode).
+		Do(ctx).Error()
+	return err
+}
+
+// move dispatchers in a split table to target node, it just for make test case now. **Not for public use.**
+func (c *changefeeds) MoveSplitTable(ctx context.Context,
+	namespace string, name string, tableID int64, targetNode string,
+) error {
+	url := fmt.Sprintf("changefeeds/%s/move_split_table?namespace=%s", name, namespace)
 	err := c.client.Post().
 		WithURI(url).
 		WithParam("tableID", strconv.FormatInt(tableID, 10)).

--- a/pkg/api/v2/mock/changefeed_mock.go
+++ b/pkg/api/v2/mock/changefeed_mock.go
@@ -146,6 +146,20 @@ func (mr *MockChangefeedInterfaceMockRecorder) MoveTable(ctx, namespace, name, t
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveTable", reflect.TypeOf((*MockChangefeedInterface)(nil).MoveTable), ctx, namespace, name, tableID, targetNode)
 }
 
+// MoveSplitTable mocks base method.
+func (m *MockChangefeedInterface) MoveSplitTable(ctx context.Context, namespace, name string, tableID int64, targetNode string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveSplitTable", ctx, namespace, name, tableID, targetNode)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MoveSplitTable indicates an expected call of MoveSplitTable.
+func (mr *MockChangefeedInterfaceMockRecorder) MoveSplitTable(ctx, namespace, name, tableID, targetNode interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveSplitTable", reflect.TypeOf((*MockChangefeedInterface)(nil).MoveSplitTable), ctx, namespace, name, tableID, targetNode)
+}
+
 // Pause mocks base method.
 func (m *MockChangefeedInterface) Pause(ctx context.Context, namespace, name string) error {
 	m.ctrl.T.Helper()

--- a/pkg/sink/mysql/helper.go
+++ b/pkg/sink/mysql/helper.go
@@ -38,7 +38,7 @@ import (
 )
 
 const checkRunningAddIndexSQL = `
-SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, STATE, QUERY
+SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, STATE
 FROM information_schema.ddl_jobs
 WHERE TABLE_ID = "%d"
     AND JOB_TYPE LIKE "add index%%"

--- a/tests/integration_tests/_utils/move_split_table_with_retry
+++ b/tests/integration_tests/_utils/move_split_table_with_retry
@@ -1,0 +1,38 @@
+#!/bin/bash
+# parameter 1: ip addr with port
+# parameter 2: table id
+# parameter 3: changefeed id
+# parameter 4: retry count
+
+set -ex
+
+ipAddr=${1}
+tableID=${2}
+changefeedID=${3}
+retryCount=${4}
+
+echo "move split table with retry"
+count=0
+
+while [[ $count -lt $retryCount ]]; do
+	ans=$(run_cdc_cli capture list)
+	node2ID=$(echo $ans | sed 's/ PASS.*//' | sed 's/^=== Command to ticdc(new arch). //' | jq -r ".[] | select(.address == \"$ipAddr\") | .id")
+	if [ -z "$node2ID" ]; then
+		echo "Failed to extract node2 ID"
+		continue
+	fi
+
+	# move table 1 to node2
+	result=$(run_cdc_cli changefeed move-split-table -c "$changefeedID" -t $tableID -d "$node2ID")
+	echo $result
+	success=$(echo $result | sed 's/ PASS.*//' | sed 's/^=== Command to ticdc(new arch). //' | jq -r '.success')
+
+	if [ "$success" == "true" ]; then
+		exit 0
+	fi
+
+	count=$((count + 1))
+done
+
+echo "move all dispatcher in table 1 to node2 failed after $retryCount retries"
+exit 1

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/changefeed.toml
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/changefeed.toml
@@ -1,0 +1,4 @@
+[scheduler]
+enable-table-across-nodes=true
+region-threshold=10
+region-count-per-span=10

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/diff_config.toml
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/diff_config.toml
@@ -1,0 +1,28 @@
+# diff Configuration.
+check-thread-count = 4
+
+export-fix-sql = true
+
+check-struct-only = false
+
+[task]
+output-dir = "/tmp/tidb_cdc_test/ddl_with_random_move_table/sync_diff/output"
+
+source-instances = ["mysql1"]
+
+target-instance = "tidb0"
+
+target-check-tables = ["test.*"]
+
+[data-sources]
+[data-sources.tidb0]
+host = "127.0.0.1"
+port = 4000
+user = "root"
+password = ""
+
+[data-sources.mysql1]
+host = "127.0.0.1"
+port = 3306
+user = "root"
+password = ""

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/diff_config.toml
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/diff_config.toml
@@ -6,7 +6,7 @@ export-fix-sql = true
 check-struct-only = false
 
 [task]
-output-dir = "/tmp/tidb_cdc_test/ddl_with_random_move_table/sync_diff/output"
+output-dir = "/tmp/tidb_cdc_test/ddl_for_split_tables_with_random_move_table/sync_diff/output"
 
 source-instances = ["mysql1"]
 

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/data/pre.sql
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/data/pre.sql
@@ -1,0 +1,14 @@
+drop database if exists `test`;
+create database `test`;
+use `test`;
+create table table_1 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
+create table table_2 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
+create table table_3 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
+create table table_4 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
+create table table_5 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
+
+split table test.table_1 between (1) and (100000) regions 50;
+split table test.table_2 between (1) and (100000) regions 50;
+split table test.table_3 between (1) and (100000) regions 50;
+split table test.table_4 between (1) and (100000) regions 50;
+split table test.table_5 between (1) and (100000) regions 50;

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
@@ -112,7 +112,7 @@ main() {
 
 	sleep 10
 
-	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 500
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 100
 
 	cleanup_process $CDC_BINARY
 }

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
@@ -100,7 +100,7 @@ main() {
 
 	for i in {1..5}; do
 		execute_dml $i &
-		pids+=("$!") 
+		pids+=("$!")
 	done
 
 	move_split_table &

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# This test is aimed to test the ddl execution for split tables when the table is scheduled to be moved.
+# 1. we start three TiCDC servers, and create a table with some data and multiple regions.
+# 2. we enable the split table param, and start a changefeed.
+# 2. one thread we execute ddl randomly(including add column, drop column, rename table, add index, drop index)
+# 3. one thread we execute dmls, and insert data to these table.
+# 4. one thread we randomly move the table(all related dispatchers) to other nodes.
+# finally, we check the data consistency between the upstream and downstream.
+
+set -eu
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+check_time=60
+
+function prepare() {
+	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+	start_tidb_cluster --workdir $WORK_DIR
+
+	cd $WORK_DIR
+
+	# record tso before we create tables to skip the system table DDLs
+	start_ts=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
+
+	export GO_FAILPOINTS='github.com/pingcap/ticdc/pkg/scheduler/StopBalanceScheduler=return(true);github.com/pingcap/ticdc/maintainer/scheduler/StopSplitScheduler=return(true)'
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "0" --addr "127.0.0.1:8300"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "2" --addr "127.0.0.1:8302"
+
+	run_sql_file $CUR/data/pre.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+	SINK_URI="mysql://root@127.0.0.1:3306/"
+	do_retry 5 3 run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c "test" --config="$CUR/conf/changefeed.toml"
+}
+
+function execute_ddls() {
+	while true; do
+		table_num=$((RANDOM % 5 + 1))
+		table_name="table_$table_num"
+
+		case $((RANDOM % 3)) in
+		0)
+			echo "DDL: Adding index and dropping index in $table_name..."
+			run_sql "CREATE INDEX idx_data ON test.$table_name (data);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+			sleep 0.5
+			run_sql "DROP INDEX idx_data ON test.$table_name;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+			;;
+		1)
+			echo "DDL: Renaming $table_name..."
+			new_table_name="table_$(($table_num + 100))"
+			run_sql "RENAME TABLE test.$table_name TO test.$new_table_name;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+			sleep 0.5
+			run_sql "RENAME TABLE test.$new_table_name TO test.$table_name;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+			;;
+		2)
+			echo "DDL: Adding column to $table_name..."
+			run_sql "ALTER TABLE test.$table_name ADD COLUMN new_col INT;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+			sleep 0.5
+			run_sql "ALTER TABLE test.$table_name DROP COLUMN new_col;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+			;;
+		esac
+
+		sleep 1
+	done
+}
+
+function execute_dml() {
+	table_name="table_$1"
+	echo "DML: Inserting data into $table_name..."
+	while true; do
+		run_sql_ignore_error "INSERT INTO test.$table_name (data) VALUES ('$(date +%s)');" ${UP_TIDB_HOST} ${UP_TIDB_PORT} || true
+	done
+}
+
+function move_split_table() {
+	while true; do
+		table_num=$((RANDOM % 5 + 1))
+		table_name="table_$table_num"
+		port=$((RANDOM % 3 + 8300))
+
+		# move table to a random node
+		table_id=$(get_table_id "test" "$table_name")
+		move_split_table_with_retry "127.0.0.1:$port" $table_id "test" 10 || true
+		sleep 1
+	done
+}
+
+main() {
+	prepare
+
+	execute_ddls &
+	NORMAL_TABLE_DDL_PID=$!
+
+	# do execute dml for 100 tables, and store the pid for each thread
+	declare -a pids=()
+
+	for i in {1..5}; do
+		execute_dml $i &
+		pids+=("$!") 
+	done
+
+	move_split_table &
+	MOVE_TABLE_PID=$!
+
+	sleep 500
+
+	kill -9 $NORMAL_TABLE_DDL_PID ${pids[@]} $MOVE_TABLE_PID
+
+	sleep 10
+
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 500
+
+	cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+main
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/ddl_with_random_move_table/run.sh
+++ b/tests/integration_tests/ddl_with_random_move_table/run.sh
@@ -116,7 +116,7 @@ main() {
 
 	for i in {1..10}; do
 		execute_dml $i &
-		pids+=("$!") # 将进程 PID 添加到数组
+		pids+=("$!")
 	done
 
 	move_table &

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -30,37 +30,53 @@ group_num=${group#G}
 # 12 CPU cores will be allocated to run each mysql heavy group in CI pipelines.
 mysql_groups=(
 	# G00
-	'generate_column many_pk_or_uk'
+	# 'generate_column many_pk_or_uk' 
+	'ddl_for_split_tables_with_random_move_table'
 	# G01
-	'api_v2'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'api_v2'
 	# G02
-	'availability'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'availability'
 	# G03
-	'multi_source'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'multi_source'
 	# G04
-	'syncpoint syncpoint_check_ts'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'syncpoint syncpoint_check_ts'
 	# G05
-	'move_table'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'move_table'
 	# G06
-	'cdc'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'cdc'
 	# G07
-	'resolve_lock'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'resolve_lock'
 	# G08
-	'bank'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'bank'
 	# G09
-	'drop_many_tables'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'drop_many_tables'
 	# G10
-	'default_value http_proxies'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'default_value http_proxies'
 	# G11
-	'ddl_reentrant force_replicate_table'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'ddl_reentrant force_replicate_table'
 	# G12
-	'tidb_mysql_test'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'tidb_mysql_test'
 	# G13
-	'fail_over region_merge'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'fail_over region_merge'
 	# G14
-	'fail_over_ddl_mix'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'fail_over_ddl_mix'
 	# G15
-	'fail_over_ddl_mix_with_syncpoint'
+	'ddl_for_split_tables_with_random_move_table'
+	# 'fail_over_ddl_mix_with_syncpoint'
 )
 
 kafka_groups=(

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -30,53 +30,37 @@ group_num=${group#G}
 # 12 CPU cores will be allocated to run each mysql heavy group in CI pipelines.
 mysql_groups=(
 	# G00
-	# 'generate_column many_pk_or_uk' 
-	'ddl_for_split_tables_with_random_move_table'
+	'generate_column many_pk_or_uk'
 	# G01
-	'ddl_for_split_tables_with_random_move_table'
-	# 'api_v2'
+	'api_v2' 'ddl_for_split_tables_with_random_move_table'
 	# G02
-	'ddl_for_split_tables_with_random_move_table'
-	# 'availability'
+	'availability'
 	# G03
-	'ddl_for_split_tables_with_random_move_table'
-	# 'multi_source'
+	'multi_source'
 	# G04
-	'ddl_for_split_tables_with_random_move_table'
-	# 'syncpoint syncpoint_check_ts'
+	'syncpoint syncpoint_check_ts'
 	# G05
-	'ddl_for_split_tables_with_random_move_table'
-	# 'move_table'
+	'move_table'
 	# G06
-	'ddl_for_split_tables_with_random_move_table'
-	# 'cdc'
+	'cdc'
 	# G07
-	'ddl_for_split_tables_with_random_move_table'
-	# 'resolve_lock'
+	'resolve_lock'
 	# G08
-	'ddl_for_split_tables_with_random_move_table'
-	# 'bank'
+	'bank'
 	# G09
-	'ddl_for_split_tables_with_random_move_table'
-	# 'drop_many_tables'
+	'drop_many_tables'
 	# G10
-	'ddl_for_split_tables_with_random_move_table'
-	# 'default_value http_proxies'
+	'default_value http_proxies'
 	# G11
-	'ddl_for_split_tables_with_random_move_table'
-	# 'ddl_reentrant force_replicate_table'
+	'ddl_reentrant force_replicate_table'
 	# G12
-	'ddl_for_split_tables_with_random_move_table'
-	# 'tidb_mysql_test'
+	'tidb_mysql_test' 'ddl_with_random_move_table'
 	# G13
-	'ddl_for_split_tables_with_random_move_table'
-	# 'fail_over region_merge'
+	'fail_over region_merge'
 	# G14
-	'ddl_for_split_tables_with_random_move_table'
-	# 'fail_over_ddl_mix'
+	'fail_over_ddl_mix'
 	# G15
-	'ddl_for_split_tables_with_random_move_table'
-	# 'fail_over_ddl_mix_with_syncpoint'
+	'fail_over_ddl_mix_with_syncpoint'
 )
 
 kafka_groups=(


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
1. add a move-split-table api to move all dispatchers in a split-table to a target node, which is useful in making test cases
2. make a test to ensure the ddl and dml can be correctly dealing with, under frequently scheduling actions of moving dispatchers.
3. fix a bug of querying downstream DDL execution status sql statement
4. fix a bug to ensure dml events will not go into dispatcher when the previous ddl event not finished.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
