### PR TITLE
sink: set `tidb_cdc_write_source` in dsn instead of set session variable seperately before each txn 

### DIFF
--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -107,9 +107,6 @@ type Config struct {
 	DMLMaxRetry uint64
 
 	IsTiDB bool // IsTiDB is true if the downstream is TiDB
-	// IsBDRModeSupported is true if the downstream is TiDB and write source is existed.
-	// write source exists when the downstream is TiDB and version is greater than or equal to v6.5.0.
-	IsWriteSourceExisted bool
 
 	// EnableDDLTs can be set in the sink URI to enable the DDL ts.
 	// it's default to true to make the mysql sink write DDL-ts
@@ -248,19 +245,12 @@ func NewMysqlConfigAndDB(
 		return nil, nil, err
 	}
 
-	dsnStr, err := GenerateDSN(cfg)
+	dsnStr, err := GenerateDSN(ctx, cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	db, err := CreateMysqlDBConn(dsnStr)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cfg.IsTiDB = CheckIsTiDB(ctx, db)
-
-	cfg.IsWriteSourceExisted, err = CheckIfBDRModeIsSupported(ctx, db)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sink/mysql/helper.go
+++ b/pkg/sink/mysql/helper.go
@@ -48,12 +48,8 @@ WHERE TABLE_ID = "%d"
 const checkRunningSQL = `SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, STATE, QUERY FROM information_schema.ddl_jobs 
 	WHERE CREATE_TIME >= "%s" AND QUERY = "%s";`
 
-// CheckIfBDRModeIsSupported checks if the downstream supports BDR mode.
+// CheckIfBDRModeIsSupported checks if the downstream supports set tidb_cdc_write_source variable
 func CheckIfBDRModeIsSupported(ctx context.Context, db *sql.DB) (bool, error) {
-	isTiDB := CheckIsTiDB(ctx, db)
-	if !isTiDB {
-		return false, nil
-	}
 	testSourceID := 1
 	// downstream is TiDB, set system variables.
 	// We should always try to set this variable, and ignore the error if
@@ -307,7 +303,7 @@ func checkCharsetSupport(db *sql.DB, charsetName string) (bool, error) {
 }
 
 // return dsn
-func GenerateDSN(cfg *Config) (string, error) {
+func GenerateDSN(ctx context.Context, cfg *Config) (string, error) {
 	dsn, err := GenBasicDSN(cfg)
 	if err != nil {
 		return "", err
@@ -344,6 +340,20 @@ func GenerateDSN(cfg *Config) (string, error) {
 		log.Warn("GBK charset is not supported by the downstream. "+
 			"Some types of DDLs may fail to execute",
 			zap.String("host", dsn.Addr))
+	}
+
+	cfg.IsTiDB = CheckIsTiDB(ctx, testDB)
+
+	if cfg.IsTiDB {
+		// check if tidb_cdc_write_source is supported
+		// only tidb downstream and version is greater than or equal to v6.5.0 supports this variable
+		bdrModeSupported, err := CheckIfBDRModeIsSupported(ctx, testDB)
+		if err != nil {
+			return "", err
+		}
+		if bdrModeSupported {
+			dsn.Params["tidb_cdc_write_source"] = "1"
+		}
 	}
 
 	return dsnStr, nil
@@ -385,29 +395,6 @@ func needWaitAsyncExecDone(t timodel.ActionType) bool {
 	default:
 		return true
 	}
-}
-
-// SetWriteSource sets write source for the transaction.
-// When this variable is set to a value other than 0, data written in this session is considered to be written by TiCDC.
-// DDLs executed in a PRIMARY cluster can be replicated to a SECONDARY cluster by TiCDC.
-func SetWriteSource(ctx context.Context, cfg *Config, txn *sql.Tx) error {
-	// we only set write source when donwstream is TiDB and write source is existed.
-	if !cfg.IsWriteSourceExisted {
-		return nil
-	}
-	// downstream is TiDB, set system variables.
-	// We should always try to set this variable, and ignore the error if
-	// downstream does not support this variable, it is by design.
-	query := fmt.Sprintf("SET SESSION %s = %d", "tidb_cdc_write_source", cfg.SourceID)
-	_, err := txn.ExecContext(ctx, query)
-	if err != nil {
-		if mysqlErr, ok := errors.Cause(err).(*dmysql.MySQLError); ok &&
-			mysqlErr.Number == mysql.ErrUnknownSystemVariable {
-			return nil
-		}
-		return err
-	}
-	return nil
 }
 
 // ShouldFormatVectorType return true if vector type should be converted to longtext.

--- a/pkg/sink/mysql/helper.go
+++ b/pkg/sink/mysql/helper.go
@@ -50,11 +50,9 @@ const checkRunningSQL = `SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE
 
 // CheckIfBDRModeIsSupported checks if the downstream supports set tidb_cdc_write_source variable
 func CheckIfBDRModeIsSupported(ctx context.Context, db *sql.DB) (bool, error) {
-	testSourceID := 1
-	// downstream is TiDB, set system variables.
 	// We should always try to set this variable, and ignore the error if
 	// downstream does not support this variable, it is by design.
-	query := fmt.Sprintf("SET SESSION tidb_cdc_write_source = %d", testSourceID)
+	query := fmt.Sprintf("SET SESSION tidb_cdc_write_source = %d", 1)
 	_, err := db.ExecContext(ctx, query)
 	if err != nil {
 		if mysqlErr, ok := errors.Cause(err).(*dmysql.MySQLError); ok &&

--- a/pkg/sink/mysql/mysql_writer_ddl.go
+++ b/pkg/sink/mysql/mysql_writer_ddl.go
@@ -76,16 +76,6 @@ func (w *Writer) execDDL(event *commonEvent.DDLEvent) error {
 		}
 	}
 
-	// we try to set cdc write source for the ddl
-	if err = SetWriteSource(ctx, w.cfg, tx); err != nil {
-		if rbErr := tx.Rollback(); rbErr != nil {
-			if errors.Cause(rbErr) != context.Canceled {
-				log.Error("Failed to rollback", zap.Error(err))
-			}
-		}
-		return err
-	}
-
 	query := event.GetDDLQuery()
 	_, err = tx.ExecContext(ctx, query)
 	if err != nil {

--- a/pkg/sink/mysql/mysql_writer_dml.go
+++ b/pkg/sink/mysql/mysql_writer_dml.go
@@ -575,22 +575,6 @@ func (w *Writer) execDMLWithMaxRetries(dmls *preparedDMLs) error {
 func (w *Writer) sequenceExecute(
 	dmls *preparedDMLs, tx *sql.Tx, writeTimeout time.Duration,
 ) error {
-	// Set session variables first and execution the txn.
-	// we try to set write source for each txn,
-	// so we can use it to trace the data source
-	setWriteSourceStart := time.Now()
-	if err := SetWriteSource(w.ctx, w.cfg, tx); err != nil {
-		log.Error("Failed to set write source", zap.Error(err))
-		if rbErr := tx.Rollback(); rbErr != nil {
-			if errors.Cause(rbErr) != context.Canceled {
-				log.Warn("failed to rollback txn", zap.Error(rbErr))
-			}
-		}
-		return err
-	}
-	setWriteSourceDuration := time.Since(setWriteSourceStart)
-	log.Debug("SetWriteSource timing", zap.Duration("duration", setWriteSourceDuration))
-
 	for i, query := range dmls.sqls {
 		args := dmls.values[i]
 		log.Debug("exec row", zap.String("sql", query), zap.Any("args", args))
@@ -633,19 +617,6 @@ func (w *Writer) sequenceExecute(
 	return nil
 }
 
-// SetWriteSource sets write source for the transaction.
-// When this variable is set to a value other than 0, data written in this session is considered to be written by TiCDC.
-// DDLs executed in a PRIMARY cluster can be replicated to a SECONDARY cluster by TiCDC.
-func setWriteSourceInSQL(cfg *Config, sql string) string {
-	if !cfg.IsWriteSourceExisted {
-		return sql
-	}
-
-	query := fmt.Sprintf("SET SESSION %s = %d;", "tidb_cdc_write_source", cfg.SourceID)
-	finalSql := query + sql
-	return finalSql
-}
-
 // execute SQLs in the multi statements way.
 func (w *Writer) multiStmtExecute(
 	dmls *preparedDMLs, tx *sql.Tx, writeTimeout time.Duration,
@@ -655,24 +626,20 @@ func (w *Writer) multiStmtExecute(
 		multiStmtArgs = append(multiStmtArgs, value...)
 	}
 	multiStmtSQL := strings.Join(dmls.sqls, ";")
-	// Set session variables first in the sql.
-	// we try to set write source for each txn,
-	// so we can use it to trace the data source
-	finalMultiStmtSQL := setWriteSourceInSQL(w.cfg, multiStmtSQL)
 
 	ctx, cancel := context.WithTimeout(w.ctx, writeTimeout)
 	defer cancel()
 
-	_, err := tx.ExecContext(ctx, finalMultiStmtSQL, multiStmtArgs...)
+	_, err := tx.ExecContext(ctx, multiStmtSQL, multiStmtArgs...)
 	if err != nil {
-		log.Error("ExecContext", zap.Error(err), zap.Any("multiStmtSQL", finalMultiStmtSQL), zap.Any("multiStmtArgs", multiStmtArgs))
+		log.Error("ExecContext", zap.Error(err), zap.Any("multiStmtSQL", multiStmtSQL), zap.Any("multiStmtArgs", multiStmtArgs))
 		if rbErr := tx.Rollback(); rbErr != nil {
 			if errors.Cause(rbErr) != context.Canceled {
 				log.Warn("failed to rollback txn", zap.Error(rbErr))
 			}
 		}
 		cancel()
-		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("Failed to execute DMLs, query info:%s, args:%v; ", finalMultiStmtSQL, multiStmtArgs)))
+		return cerror.WrapError(cerror.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("Failed to execute DMLs, query info:%s, args:%v; ", multiStmtSQL, multiStmtArgs)))
 	}
 	return nil
 }

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -14,7 +14,6 @@
 package mysql
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -509,16 +508,6 @@ func (w *Writer) createTable(dbName string, tableName string, createTableQuery s
 	tx, err := w.db.BeginTx(w.ctx, nil)
 	if err != nil {
 		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("create %s table: begin Tx fail;", tableName)))
-	}
-
-	// we try to set cdc write source for the ddl
-	if err = SetWriteSource(w.ctx, w.cfg, tx); err != nil {
-		if rbErr := tx.Rollback(); rbErr != nil {
-			if errors.Cause(rbErr) != context.Canceled {
-				log.Error("Failed to rollback", zap.Error(err))
-			}
-		}
-		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("create %s table: set write source fail;", tableName)))
 	}
 
 	_, err = tx.Exec("CREATE DATABASE IF NOT EXISTS " + dbName)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
