### PR TITLE
dispatcher: fix bug in wakeCallback

### DIFF
--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -360,8 +360,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 }
 
 func (d *Dispatcher) AddDMLEventsToSink(events []*commonEvent.DMLEvent) {
-	// for one batch events, we need to add all them in table progress first,
-	// then add them to sink
+	// for one batch events, we need to add all them in table progress first, then add them to sink
 	// because we need to ensure the wakeCallback only will be called when
 	// all these events are flushed to downstream successfully
 	for _, event := range events {
@@ -372,15 +371,6 @@ func (d *Dispatcher) AddDMLEventsToSink(events []*commonEvent.DMLEvent) {
 		failpoint.Inject("BlockAddDMLEvents", nil)
 	}
 }
-
-// func (d *Dispatcher) AddDMLEventToSink(event *commonEvent.DMLEvent) {
-// 	// for one batch events, we need to add all them in table progress first,
-// 	// then add them to sink
-// 	// because we need to ensure the wakeCallback only will be called when
-// 	// all these events are flushed to downstream successfully
-// 	d.tableProgress.Add(event)
-// 	d.sink.AddDMLEvent(event)
-// }
 
 func (d *Dispatcher) AddBlockEventToSink(event commonEvent.BlockEvent) error {
 	d.tableProgress.Add(event)

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -244,6 +244,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 	// Only return false when all events are resolvedTs Event.
 	block = false
 	dmlWakeOnce := &sync.Once{}
+	dmlEvents := make([]*commonEvent.DMLEvent, 0, len(dispatcherEvents))
 	// Dispatcher is ready, handle the events
 	for _, dispatcherEvent := range dispatcherEvents {
 		log.Debug("dispatcher receive all event",
@@ -291,7 +292,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 					dmlWakeOnce.Do(wakeCallback)
 				}
 			})
-			d.AddDMLEventToSink(dml)
+			dmlEvents = append(dmlEvents, dml)
 		case commonEvent.TypeDDLEvent:
 			if len(dispatcherEvents) != 1 {
 				log.Panic("ddl event should only be singly handled",
@@ -349,12 +350,23 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 				zap.Uint64("commitTs", event.GetCommitTs()))
 		}
 	}
+	if len(dmlEvents) > 0 {
+		d.AddDMLEventsToSink(dmlEvents)
+	}
 	return block
 }
 
-func (d *Dispatcher) AddDMLEventToSink(event *commonEvent.DMLEvent) {
-	d.tableProgress.Add(event)
-	d.sink.AddDMLEvent(event)
+func (d *Dispatcher) AddDMLEventsToSink(events []*commonEvent.DMLEvent) {
+	// for one batch events, we need to add all them in table progress first,
+	// then add them to sink
+	// because we need to ensure the wakeCallback only will be called when
+	// all these events are flushed to downstream successfully
+	for _, event := range events {
+		d.tableProgress.Add(event)
+	}
+	for _, event := range events {
+		d.sink.AddDMLEvent(event)
+	}
 }
 
 func (d *Dispatcher) AddBlockEventToSink(event commonEvent.BlockEvent) error {

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -366,8 +366,18 @@ func (d *Dispatcher) AddDMLEventsToSink(events []*commonEvent.DMLEvent) {
 	}
 	for _, event := range events {
 		d.sink.AddDMLEvent(event)
+		failpoint.Inject("BlockAddDMLEvents", nil)
 	}
 }
+
+// func (d *Dispatcher) AddDMLEventToSink(event *commonEvent.DMLEvent) {
+// 	// for one batch events, we need to add all them in table progress first,
+// 	// then add them to sink
+// 	// because we need to ensure the wakeCallback only will be called when
+// 	// all these events are flushed to downstream successfully
+// 	d.tableProgress.Add(event)
+// 	d.sink.AddDMLEvent(event)
+// }
 
 func (d *Dispatcher) AddBlockEventToSink(event commonEvent.BlockEvent) error {
 	d.tableProgress.Add(event)

--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -240,6 +240,9 @@ func (d *Dispatcher) InitializeTableSchemaStore(schemaInfo []*heartbeatpb.Schema
 // We ensure we only will receive one event when it's ddl event or sync point event
 // by setting them with different event types in DispatcherEventsHandler.GetType
 // When we handle events, we don't have any previous events still in sink.
+//
+// wakeCallback is used to wake the dynamic stream to handle the next batch events.
+// It will be called when all the events are flushed to downstream successfully.
 func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallback func()) (block bool) {
 	// Only return false when all events are resolvedTs Event.
 	block = false

--- a/downstreamadapter/dispatcher/dispatcher_test.go
+++ b/downstreamadapter/dispatcher/dispatcher_test.go
@@ -702,14 +702,14 @@ func TestBatchDMLEventsPartialFlush(t *testing.T) {
 		require.Equal(t, true, block)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	require.Equal(t, 1, len(mockSink.GetDMLs()))
 	mockSink.FlushDMLs()
 	require.False(t, callbackCalled)
 
 	failpoint.Disable("github.com/pingcap/ticdc/downstreamadapter/dispatcher/BlockAddDMLEvents")
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	require.Equal(t, 2, len(mockSink.GetDMLs()))
 	mockSink.FlushDMLs()
 	// Now the callback should be called after all events are flushed

--- a/downstreamadapter/dispatcher/dispatcher_test.go
+++ b/downstreamadapter/dispatcher/dispatcher_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/downstreamadapter/sink"
 	"github.com/pingcap/ticdc/downstreamadapter/syncpoint"
 	"github.com/pingcap/ticdc/heartbeatpb"
@@ -647,4 +648,73 @@ func TestDispatcherClose(t *testing.T) {
 		require.Equal(t, uint64(1), watermark.CheckpointTs)
 		require.Equal(t, uint64(0), watermark.ResolvedTs)
 	}
+}
+
+// TestBatchDMLEventsPartialFlush tests that wakeCallback is called correctly
+// when DML events are flushed partially in multiple batches.
+func TestBatchDMLEventsPartialFlush(t *testing.T) {
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	ddlJob := helper.DDL2Job("create table t(id int primary key, v int)")
+	require.NotNil(t, ddlJob)
+
+	// Create multiple DML events with different commit timestamps
+	dmlEvent1 := helper.DML2Event("test", "t", "insert into t values(1, 1)")
+	require.NotNil(t, dmlEvent1)
+	dmlEvent1.CommitTs = 10
+	dmlEvent1.Length = 1
+
+	dmlEvent2 := helper.DML2Event("test", "t", "insert into t values(2, 2)")
+	require.NotNil(t, dmlEvent2)
+	dmlEvent2.CommitTs = 11
+	dmlEvent2.Length = 1
+
+	dmlEvent3 := helper.DML2Event("test", "t", "insert into t values(3, 3)")
+	require.NotNil(t, dmlEvent3)
+	dmlEvent3.CommitTs = 12
+	dmlEvent3.Length = 1
+
+	mockSink := sink.NewMockSink(common.MysqlSinkType)
+	tableSpan := getCompleteTableSpan()
+	dispatcher := newDispatcherForTest(mockSink, tableSpan)
+
+	// Create a callback that records when it's called
+	var callbackCalled bool
+	wakeCallback := func() {
+		callbackCalled = true
+	}
+
+	nodeID := node.NewID()
+
+	// Create dispatcher events for all three DML events
+	dispatcherEvents := []DispatcherEvent{
+		NewDispatcherEvent(&nodeID, dmlEvent1),
+		NewDispatcherEvent(&nodeID, dmlEvent2),
+		NewDispatcherEvent(&nodeID, dmlEvent3),
+	}
+
+	failpoint.Enable("github.com/pingcap/ticdc/downstreamadapter/dispatcher/BlockAddDMLEvents", `pause`)
+
+	go func() {
+		block := dispatcher.HandleEvents(dispatcherEvents, wakeCallback)
+		require.Equal(t, true, block)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, len(mockSink.GetDMLs()))
+	mockSink.FlushDMLs()
+	require.False(t, callbackCalled)
+
+	failpoint.Disable("github.com/pingcap/ticdc/downstreamadapter/dispatcher/BlockAddDMLEvents")
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 2, len(mockSink.GetDMLs()))
+	mockSink.FlushDMLs()
+	// Now the callback should be called after all events are flushed
+	require.True(t, callbackCalled)
+
+	// Verify that all events were actually flushed
+	require.Equal(t, 0, len(mockSink.GetDMLs()))
 }

--- a/downstreamadapter/sink/mock_sink.go
+++ b/downstreamadapter/sink/mock_sink.go
@@ -15,6 +15,7 @@ package sink
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
@@ -22,12 +23,15 @@ import (
 )
 
 type mockSink struct {
+	mu       sync.Mutex
 	dmls     []*commonEvent.DMLEvent
 	isNormal bool
 	sinkType common.SinkType
 }
 
 func (s *mockSink) AddDMLEvent(event *commonEvent.DMLEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.dmls = append(s.dmls, event)
 }
 
@@ -61,6 +65,8 @@ func (s *mockSink) SetIsNormal(isNormal bool) {
 }
 
 func (s *mockSink) FlushDMLs() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, dml := range s.dmls {
 		dml.PostFlush()
 	}
@@ -68,6 +74,8 @@ func (s *mockSink) FlushDMLs() {
 }
 
 func (s *mockSink) GetDMLs() []*commonEvent.DMLEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.dmls
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
when dispatcher receive a batch dml events, we need to add these all dml events into tableProgress first, and then add them to sink, in order to ensure the wakeCallback only happen when all these events flushed successfully.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
