### PR TITLE
eventboker: send data events immediately after handshake event

### DIFF
--- a/downstreamadapter/eventcollector/event_collector_test.go
+++ b/downstreamadapter/eventcollector/event_collector_test.go
@@ -156,7 +156,7 @@ func TestProcessMessage(t *testing.T) {
 	c.AddDispatcher(d, config.GetDefaultReplicaConfig().MemoryQuota)
 
 	ch <- newMessage(node.ID, &readyEvent)
-	ch <- newMessage(node.ID, handshakeEvent)
+	ch <- newMessage(node.ID, &handshakeEvent)
 	ch <- newMessage(node.ID, ddl)
 	ch <- newMessage(node.ID, dmls)
 

--- a/pkg/common/event/handshake_event.go
+++ b/pkg/common/event/handshake_event.go
@@ -38,8 +38,8 @@ type HandshakeEvent struct {
 	TableInfo    *common.TableInfo   `json:"table_info"`
 }
 
-func NewHandshakeEvent(dispatcherID common.DispatcherID, resolvedTs common.Ts, seq uint64, tableInfo *common.TableInfo) *HandshakeEvent {
-	return &HandshakeEvent{
+func NewHandshakeEvent(dispatcherID common.DispatcherID, resolvedTs common.Ts, seq uint64, tableInfo *common.TableInfo) HandshakeEvent {
+	return HandshakeEvent{
 		Version:      HandshakeEventVersion,
 		ResolvedTs:   uint64(resolvedTs),
 		Seq:          seq,

--- a/pkg/common/event/handshake_event_test.go
+++ b/pkg/common/event/handshake_event_test.go
@@ -37,5 +37,5 @@ func TestHandshakeEvent(t *testing.T) {
 	e2 := &HandshakeEvent{}
 	err = e2.Unmarshal(data)
 	require.NoError(t, err)
-	require.Equal(t, e, e2)
+	require.Equal(t, &e, e2)
 }

--- a/pkg/eventservice/dispatcher_stat.go
+++ b/pkg/eventservice/dispatcher_stat.go
@@ -73,7 +73,7 @@ type dispatcherStat struct {
 	// If the dispatcher is reset, the seq should be set to 1.
 	seq atomic.Uint64
 
-	// isReadyRecevingData is used to indicate whether the dispatcher is ready to receive data.
+	// isReadyRecevingData is used to indicate whether the dispatcher is ready to receive data events.
 	// It will be set to false, after it receives the pause event from the dispatcher.
 	// It will be set to true, after it receives the register/resume/reset event from the dispatcher.
 	isReadyRecevingData atomic.Bool

--- a/pkg/eventservice/dispatcher_stat.go
+++ b/pkg/eventservice/dispatcher_stat.go
@@ -73,10 +73,10 @@ type dispatcherStat struct {
 	// If the dispatcher is reset, the seq should be set to 1.
 	seq atomic.Uint64
 
-	// isRunning is used to indicate whether the dispatcher is running.
+	// isReadyRecevingData is used to indicate whether the dispatcher is ready to receive data.
 	// It will be set to false, after it receives the pause event from the dispatcher.
 	// It will be set to true, after it receives the register/resume/reset event from the dispatcher.
-	isRunning atomic.Bool
+	isReadyRecevingData atomic.Bool
 	// isHandshaked is used to indicate whether the dispatcher is ready to send data.
 	// It will be set to true, after it sends the handshake event to the dispatcher.
 	// It will be set to false, after it receives the reset event from the dispatcher.
@@ -139,7 +139,7 @@ func newDispatcherStat(
 	dispStat.eventStoreResolvedTs.Store(startTs)
 	dispStat.checkpointTs.Store(startTs)
 	dispStat.sentResolvedTs.Store(startTs)
-	dispStat.isRunning.Store(true)
+	dispStat.isReadyRecevingData.Store(true)
 	dispStat.resetScanLimit()
 
 	now := time.Now()
@@ -150,7 +150,7 @@ func newDispatcherStat(
 }
 
 func (a *dispatcherStat) getEventSenderState() pevent.EventSenderState {
-	if a.IsRunning() {
+	if a.IsReadyRecevingData() {
 		return pevent.EventSenderStateNormal
 	}
 	return pevent.EventSenderStatePaused
@@ -180,7 +180,7 @@ func (a *dispatcherStat) resetState(resetTs uint64) {
 
 	a.isTaskScanning.Store(false)
 
-	a.isRunning.Store(true)
+	a.isReadyRecevingData.Store(true)
 	a.lastReceivedHeartbeatTime.Store(time.Now().UnixNano())
 }
 
@@ -224,8 +224,8 @@ func (a *dispatcherStat) getDataRange() (common.DataRange, bool) {
 	return r, true
 }
 
-func (a *dispatcherStat) IsRunning() bool {
-	return a.isRunning.Load() && a.changefeedStat.isRunning.Load()
+func (a *dispatcherStat) IsReadyRecevingData() bool {
+	return a.isReadyRecevingData.Load() && a.changefeedStat.isReadyRecevingData.Load()
 }
 
 // getCurrentScanLimitInBytes returns the current scan limit in bytes.
@@ -310,6 +310,14 @@ func (w *wrapEvent) getDispatcherID() common.DispatcherID {
 	return e.GetDispatcherID()
 }
 
+func newWrapHandshakeEvent(serverID node.ID, e pevent.HandshakeEvent) *wrapEvent {
+	w := getWrapEvent()
+	w.serverID = serverID
+	w.e = &e
+	w.msgType = pevent.TypeHandshakeEvent
+	return w
+}
+
 func newWrapReadyEvent(serverID node.ID, e pevent.ReadyEvent) *wrapEvent {
 	w := getWrapEvent()
 	w.serverID = serverID
@@ -392,10 +400,10 @@ func (c *resolvedTsCache) reset() {
 
 type changefeedStatus struct {
 	changefeedID common.ChangeFeedID
-	// isRunning is used to indicate whether the changefeed is running.
+	// isReadyRecevingData is used to indicate whether the changefeed is running.
 	// It will be set to false, after it receives the pause event from the dispatcher.
 	// It will be set to true, after it receives the register/resume/reset event from the dispatcher.
-	isRunning atomic.Bool
+	isReadyRecevingData atomic.Bool
 	// dispatcherCount is the number of the dispatchers that belong to this changefeed.
 	dispatcherCount atomic.Uint64
 
@@ -404,10 +412,10 @@ type changefeedStatus struct {
 
 func newChangefeedStatus(changefeedID common.ChangeFeedID) *changefeedStatus {
 	stat := &changefeedStatus{
-		changefeedID: changefeedID,
-		isRunning:    atomic.Bool{},
+		changefeedID:        changefeedID,
+		isReadyRecevingData: atomic.Bool{},
 	}
-	stat.isRunning.Store(true)
+	stat.isReadyRecevingData.Store(true)
 	return stat
 }
 

--- a/pkg/eventservice/dispatcher_stat_test.go
+++ b/pkg/eventservice/dispatcher_stat_test.go
@@ -47,7 +47,7 @@ func TestNewDispatcherStat(t *testing.T) {
 	require.Equal(t, startTs, stat.eventStoreResolvedTs.Load())
 	require.Equal(t, startTs, stat.checkpointTs.Load())
 	require.Equal(t, startTs, stat.sentResolvedTs.Load())
-	require.True(t, stat.isRunning.Load())
+	require.True(t, stat.isReadyRecevingData.Load())
 	require.False(t, stat.enableSyncPoint)
 	require.Equal(t, info.GetSyncPointTs(), stat.nextSyncPoint)
 	require.Equal(t, info.GetSyncPointInterval(), stat.syncPointInterval)

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -237,16 +237,6 @@ func (c *eventBroker) sendResolvedTs(
 	metricEventServiceSendResolvedTsCount.Inc()
 }
 
-func (c *eventBroker) sendReadyEvent(
-	server node.ID,
-	d *dispatcherStat,
-) {
-	event := pevent.NewReadyEvent(d.info.GetID())
-	wrapEvent := newWrapReadyEvent(server, event)
-	c.getMessageCh(d.messageWorkerIndex) <- wrapEvent
-	metricEventServiceSendCommandCount.Inc()
-}
-
 func (c *eventBroker) sendNotReusableEvent(
 	server node.ID,
 	d *dispatcherStat,
@@ -289,9 +279,7 @@ func (c *eventBroker) tickTableTriggerDispatchers(ctx context.Context) error {
 				if !c.checkAndSendReady(dispatcherStat) {
 					return true
 				}
-				if !c.checkAndSendHandshake(dispatcherStat) {
-					return true
-				}
+				c.sendHandshakeIfNeed(dispatcherStat)
 				startTs := dispatcherStat.sentResolvedTs.Load()
 				remoteID := node.ID(dispatcherStat.info.GetServerID())
 				// TODO: maybe limit 1 is enough.
@@ -340,31 +328,13 @@ func (c *eventBroker) logUnresetDispatchers(ctx context.Context) error {
 	}
 }
 
-// checkNeedScan checks if the dispatcher needs to scan the event store.
-// If the dispatcher needs to scan the event store, it returns true.
-// If the dispatcher does not need to scan the event store, it send the watermark to the dispatcher
-func (c *eventBroker) checkNeedScan(task scanTask, mustCheck bool) (bool, common.DataRange) {
-	if !mustCheck && task.isTaskScanning.Load() {
-		return false, common.DataRange{}
-	}
-
-	// If the dispatcher is not ready, we don't need to scan the event store.
-	if !c.checkAndSendReady(task) {
-		return false, common.DataRange{}
-	}
-
-	if !c.checkAndSendHandshake(task) {
-		return false, common.DataRange{}
-	}
-
-	// Only check scan when the dispatcher is running.
-	if !task.IsRunning() {
-		// If the dispatcher is not running, we also need to send the watermark to the dispatcher.
-		// And the resolvedTs should be the last sent watermark.
-		resolvedTs := task.sentResolvedTs.Load()
-		remoteID := node.ID(task.info.GetServerID())
-
-		c.sendResolvedTs(remoteID, task, resolvedTs)
+// getScanTaskDataRange determines the valid data range for scanning a given task.
+// It checks various conditions (dispatcher status, DDL state, max commit ts of dml event)
+// to decide whether scanning is needed and returns the appropriate time range.
+// If no valid range is found, it returns an empty DataRange.
+func (c *eventBroker) getScanTaskDataRange(task scanTask) (bool, common.DataRange) {
+	// Only do scan when the dispatcher is ready to receive data.
+	if !task.IsReadyRecevingData() {
 		return false, common.DataRange{}
 	}
 
@@ -379,62 +349,94 @@ func (c *eventBroker) checkNeedScan(task scanTask, mustCheck bool) (bool, common
 	ddlState := c.schemaStore.GetTableDDLEventState(task.info.GetTableSpan().TableID)
 	dataRange.EndTs = min(dataRange.EndTs, ddlState.ResolvedTs)
 
-	if ddlState.ResolvedTs <= dataRange.StartTs {
-		metricEventServiceSkipResolvedTsCount.Inc()
-		return false, common.DataRange{}
-	}
-
-	// Note: Maybe we should still send a resolvedTs to downstream to tell that
-	// the dispatcher is alive?
 	if dataRange.EndTs <= dataRange.StartTs {
 		metricEventServiceSkipResolvedTsCount.Inc()
 		return false, common.DataRange{}
 	}
 
-	// target ts range: (dataRange.StartTs, dataRange.EndTs]
+	// 3. Check whether there is any events in the data range
+	// Note: target range is (dataRange.StartTs, dataRange.EndTs]
 	if dataRange.StartTs >= task.latestCommitTs.Load() &&
 		dataRange.StartTs >= ddlState.MaxEventCommitTs {
-		// The dispatcher has no new events. In such case, we don't need to scan the event store.
-		// We just send the watermark to the dispatcher.
-		remoteID := node.ID(task.info.GetServerID())
-		c.sendResolvedTs(remoteID, task, dataRange.EndTs)
 		return false, common.DataRange{}
 	}
-
 	return true, dataRange
 }
 
-func (c *eventBroker) checkAndSendReady(task scanTask) bool {
-	if task.resetTs.Load() == 0 {
+// checkNeedScan checks if the dispatcher needs to scan the event store/schema store.
+// If the dispatcher needs to scan the event store/schema store, it returns true.
+// If the dispatcher does not need to scan the event store, it send the watermark to the dispatcher.
+//
+// Note: A true return value only indicates potential scanning need,
+// final determination occurs when the scanTask is actully processed.
+func (c *eventBroker) checkNeedScan(task scanTask) bool {
+	// If there is already a scan task running, skip this one.
+	if task.isTaskScanning.Load() {
+		return false
+	}
+
+	// If the dispatcher is not ready, we don't need do the scan.
+	if !c.checkAndSendReady(task) {
+		return false
+	}
+
+	c.sendHandshakeIfNeed(task)
+
+	doSendResolvedTs := func() {
+		resolvedTs := task.sentResolvedTs.Load()
 		remoteID := node.ID(task.info.GetServerID())
-		c.sendReadyEvent(remoteID, task)
+		c.sendResolvedTs(remoteID, task, resolvedTs)
+	}
+
+	// Only check scan when the dispatcher is ready to receive data event.
+	if !task.IsReadyRecevingData() {
+		// If the dispatcher is not ready to receive data event,
+		// we still need to send the last resolvedTs to the dispatcher.
+		doSendResolvedTs()
+		return false
+	}
+
+	ok, _ := c.getScanTaskDataRange(task)
+	if !ok {
+		// If there is no valid data range for scanning,
+		// we still need to send the last resolvedTs to the dispatcher.
+		doSendResolvedTs()
 		return false
 	}
 	return true
 }
 
-func (c *eventBroker) checkAndSendHandshake(task scanTask) bool {
+func (c *eventBroker) checkAndSendReady(task scanTask) bool {
+	if task.resetTs.Load() == 0 {
+		remoteID := node.ID(task.info.GetServerID())
+		event := pevent.NewReadyEvent(task.info.GetID())
+		wrapEvent := newWrapReadyEvent(remoteID, event)
+		c.getMessageCh(task.messageWorkerIndex) <- wrapEvent
+		metricEventServiceSendCommandCount.Inc()
+		return false
+	}
+	return true
+}
+
+func (c *eventBroker) sendHandshakeIfNeed(task scanTask) {
 	if task.isHandshaked.Load() {
-		return true
+		return
+	}
+	if !task.isHandshaked.CompareAndSwap(false, true) {
+		log.Panic("should not happen: sendHandshakeIfNeed should not be called concurrently")
+		return
 	}
 	// Always reset the seq of the dispatcher to 0 before sending a handshake event.
 	task.seq.Store(0)
-	wrapE := &wrapEvent{
-		serverID: node.ID(task.info.GetServerID()),
-		e: pevent.NewHandshakeEvent(
-			task.id,
-			task.resetTs.Load(),
-			task.seq.Add(1),
-			task.startTableInfo.Load()),
-		msgType: pevent.TypeHandshakeEvent,
-		postSendFunc: func() {
-			log.Info("checkAndSendHandshake", zap.String("changefeed", task.info.GetChangefeedID().String()), zap.String("dispatcher", task.id.String()), zap.Int("workerIndex", task.scanWorkerIndex), zap.Bool("isHandshaked", task.isHandshaked.Load()))
-			task.isHandshaked.Store(true)
-		},
-	}
-	c.getMessageCh(task.messageWorkerIndex) <- wrapE
+	remoteID := node.ID(task.info.GetServerID())
+	event := pevent.NewHandshakeEvent(
+		task.id,
+		task.resetTs.Load(),
+		task.seq.Add(1),
+		task.startTableInfo.Load())
+	wrapEvent := newWrapHandshakeEvent(remoteID, event)
+	c.getMessageCh(task.messageWorkerIndex) <- wrapEvent
 	metricEventServiceSendCommandCount.Inc()
-	return false
 }
 
 // hasSyncPointEventBeforeTs checks if there is any sync point events before the given ts.
@@ -498,7 +500,7 @@ func (c *eventBroker) doScan(ctx context.Context, task scanTask) {
 		return
 	}
 
-	needScan, dataRange := c.checkNeedScan(task, true)
+	needScan, dataRange := c.getScanTaskDataRange(task)
 	if !needScan {
 		return
 	}
@@ -515,8 +517,8 @@ func (c *eventBroker) doScan(ctx context.Context, task scanTask) {
 		return
 	}
 
-	// If the task is not running, we don't send the events to the dispatcher.
-	if !task.isRunning.Load() {
+	// Check whether the task is ready to receive data events again before sending events.
+	if !task.isReadyRecevingData.Load() {
 		return
 	}
 
@@ -589,19 +591,6 @@ func (c *eventBroker) runSendMessageWorker(ctx context.Context, workerIndex int)
 				if m.msgType == pevent.TypeResolvedEvent {
 					c.handleResolvedTs(ctx, resolvedTsCacheMap, m, workerIndex)
 					continue
-				}
-				// Check if the dispatcher is initialized, if so, ignore the handshake event.
-				if m.msgType == pevent.TypeHandshakeEvent {
-					// If the message is a handshake event, we need to reset the dispatcher.
-					d, ok := c.getDispatcher(m.getDispatcherID())
-					if !ok {
-						log.Warn("Get dispatcher failed", zap.Any("dispatcherID", m.getDispatcherID()))
-						continue
-					}
-					if d.isHandshaked.Load() {
-						log.Info("Ignore handshake event since the dispatcher already handshaked", zap.Any("dispatcherID", m.getDispatcherID()))
-						continue
-					}
 				}
 				tMsg := messaging.NewSingleTargetMessage(
 					m.serverID,
@@ -736,8 +725,7 @@ func (c *eventBroker) onNotify(d *dispatcherStat, resolvedTs uint64, latestCommi
 		d.lastReceivedResolvedTsTime.Store(time.Now())
 		metricEventStoreOutputResolved.Inc()
 		d.onLatestCommitTs(latestCommitTs)
-		needScan, _ := c.checkNeedScan(d, false)
-		if needScan {
+		if c.checkNeedScan(d) {
 			c.pushTask(d, true)
 		}
 	}
@@ -872,7 +860,7 @@ func (c *eventBroker) removeDispatcher(dispatcherInfo DispatcherInfo) {
 	}
 
 	stat.(*dispatcherStat).isRemoved.Store(true)
-	stat.(*dispatcherStat).isRunning.Store(false)
+	stat.(*dispatcherStat).isReadyRecevingData.Store(false)
 	c.eventStore.UnregisterDispatcher(id)
 	// todo: how to handle this error?
 	_ = c.schemaStore.UnregisterTable(dispatcherInfo.GetTableSpan().TableID)
@@ -898,7 +886,7 @@ func (c *eventBroker) pauseDispatcher(dispatcherInfo DispatcherInfo) {
 		zap.String("span", common.FormatTableSpan(stat.info.GetTableSpan())),
 		zap.Uint64("sentResolvedTs", stat.sentResolvedTs.Load()),
 		zap.Uint64("seq", stat.seq.Load()))
-	stat.isRunning.Store(false)
+	stat.isReadyRecevingData.Store(false)
 	stat.resetScanLimit()
 }
 
@@ -913,7 +901,7 @@ func (c *eventBroker) resumeDispatcher(dispatcherInfo DispatcherInfo) {
 		zap.String("span", common.FormatTableSpan(stat.info.GetTableSpan())),
 		zap.Uint64("sentResolvedTs", stat.sentResolvedTs.Load()),
 		zap.Uint64("seq", stat.seq.Load()))
-	stat.isRunning.Store(true)
+	stat.isReadyRecevingData.Store(true)
 }
 
 func (c *eventBroker) resetDispatcher(dispatcherInfo DispatcherInfo) {
@@ -927,7 +915,7 @@ func (c *eventBroker) resetDispatcher(dispatcherInfo DispatcherInfo) {
 
 	// Must set the isRunning to false before reset the dispatcher.
 	// Otherwise, the scan task goroutine will not return before reset the dispatcher.
-	stat.isRunning.Store(false)
+	stat.isReadyRecevingData.Store(false)
 
 	// Wait until the scan task goroutine return before reset the dispatcher.
 	for {
@@ -959,7 +947,7 @@ func (c *eventBroker) getOrSetChangefeedStatus(changefeedID common.ChangeFeedID)
 		stat = newChangefeedStatus(changefeedID)
 		log.Info("new changefeed status",
 			zap.Stringer("changefeedID", changefeedID),
-			zap.Bool("isRunning", stat.(*changefeedStatus).isRunning.Load()),
+			zap.Bool("isRunning", stat.(*changefeedStatus).isReadyRecevingData.Load()),
 		)
 		c.changefeedMap.Store(changefeedID, stat)
 	}

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -78,14 +78,14 @@ func TestCheckNeedScan(t *testing.T) {
 
 	// Case 1: Is scanning, and mustCheck is false, it should return false.
 	disp.isTaskScanning.Store(true)
-	needScan, _ := broker.checkNeedScan(disp, false)
+	needScan := broker.checkNeedScan(disp)
 	require.False(t, needScan)
 	disp.isTaskScanning.Store(false)
 	log.Info("Pass case 1")
 
 	// Case 2: ResetTs is 0, it should return false.
 	// And the broker will send a ready event.
-	needScan, _ = broker.checkNeedScan(disp, false)
+	needScan = broker.checkNeedScan(disp)
 	require.False(t, needScan)
 	e := <-broker.messageCh[0]
 	require.Equal(t, event.TypeReadyEvent, e.msgType)
@@ -96,15 +96,15 @@ func TestCheckNeedScan(t *testing.T) {
 	// And the task.scanning should be true.
 	// And the broker will send a handshake event.
 	disp.resetTs.Store(100)
-	needScan, _ = broker.checkNeedScan(disp, false)
+	needScan = broker.checkNeedScan(disp)
 	require.False(t, needScan)
 	e = <-broker.messageCh[0]
 	require.Equal(t, event.TypeHandshakeEvent, e.msgType)
 	log.Info("Pass case 3")
 
 	// Case 4: The task.isRunning is false, it should return false.
-	disp.isRunning.Store(false)
-	needScan, _ = broker.checkNeedScan(disp, false)
+	disp.isReadyRecevingData.Store(false)
+	needScan = broker.checkNeedScan(disp)
 	require.False(t, needScan)
 	log.Info("Pass case 4")
 }
@@ -198,13 +198,13 @@ func TestCURDDispatcher(t *testing.T) {
 	broker.pauseDispatcher(dispInfo)
 	disp, ok = broker.getDispatcher(dispInfo.GetID())
 	require.True(t, ok)
-	require.False(t, disp.isRunning.Load())
+	require.False(t, disp.isReadyRecevingData.Load())
 
 	// Case 4: Resume a dispatcher.
 	broker.resumeDispatcher(dispInfo)
 	disp, ok = broker.getDispatcher(dispInfo.GetID())
 	require.True(t, ok)
-	require.True(t, disp.isRunning.Load())
+	require.True(t, disp.isReadyRecevingData.Load())
 
 	// Case 5: Remove a dispatcher.
 	broker.removeDispatcher(dispInfo)

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -97,7 +97,7 @@ func TestCheckNeedScan(t *testing.T) {
 	// And the broker will send a handshake event.
 	disp.resetTs.Store(100)
 	needScan = broker.checkNeedScan(disp)
-	require.False(t, needScan)
+	require.True(t, needScan)
 	e = <-broker.messageCh[0]
 	require.Equal(t, event.TypeHandshakeEvent, e.msgType)
 	log.Info("Pass case 3")

--- a/pkg/eventservice/event_scanner.go
+++ b/pkg/eventservice/event_scanner.go
@@ -240,7 +240,7 @@ func (s *eventScanner) checkScanConditions(session *scanSession) (bool, error) {
 		return true, session.ctx.Err()
 	}
 
-	if !session.dispatcherStat.isRunning.Load() {
+	if !session.dispatcherStat.isReadyRecevingData.Load() {
 		return true, nil
 	}
 

--- a/pkg/eventservice/event_scanner_test.go
+++ b/pkg/eventservice/event_scanner_test.go
@@ -38,7 +38,7 @@ type mockMounter struct {
 
 func makeDispatcherReady(disp *dispatcherStat) {
 	disp.isHandshaked.Store(true)
-	disp.isRunning.Store(true)
+	disp.isReadyRecevingData.Store(true)
 	disp.resetTs.Store(disp.info.GetStartTs())
 }
 
@@ -74,8 +74,8 @@ func TestEventScanner(t *testing.T) {
 		maxBytes: 1000,
 		timeout:  10 * time.Second,
 	}
-	needScan, dataRange := broker.checkNeedScan(disp, true)
-	require.True(t, needScan)
+	ok, dataRange := broker.getScanTaskDataRange(disp)
+	require.True(t, ok)
 	events, isBroken, err := scanner.scan(context.Background(), disp, dataRange, sl)
 	require.NoError(t, err)
 	require.False(t, isBroken)
@@ -97,8 +97,8 @@ func TestEventScanner(t *testing.T) {
 	mockSchemaStore.AppendDDLEvent(tableID, ddlEvent)
 
 	disp.eventStoreResolvedTs.Store(resolvedTs)
-	needScan, dataRange = broker.checkNeedScan(disp, true)
-	require.True(t, needScan)
+	ok, dataRange = broker.getScanTaskDataRange(disp)
+	require.True(t, ok)
 
 	sl = scanLimit{
 		maxBytes: 1000,
@@ -124,8 +124,8 @@ func TestEventScanner(t *testing.T) {
 	err = mockEventStore.AppendEvents(dispatcherID, resolvedTs, kvEvents...)
 	require.NoError(t, err)
 	disp.eventStoreResolvedTs.Store(resolvedTs)
-	needScan, dataRange = broker.checkNeedScan(disp, true)
-	require.True(t, needScan)
+	ok, dataRange = broker.getScanTaskDataRange(disp)
+	require.True(t, ok)
 	sl = scanLimit{
 		maxBytes: 1000,
 		timeout:  10 * time.Second,
@@ -325,8 +325,8 @@ func TestEventScannerWithDDL(t *testing.T) {
 	}
 	mockSchemaStore.AppendDDLEvent(tableID, fakeDDL)
 	disp.eventStoreResolvedTs.Store(resolvedTs)
-	needScan, dataRange := broker.checkNeedScan(disp, true)
-	require.True(t, needScan)
+	ok, dataRange := broker.getScanTaskDataRange(disp)
+	require.True(t, ok)
 
 	eSize := len(kvEvents[0].Key) + len(kvEvents[0].Value) + len(kvEvents[0].OldValue)
 
@@ -423,8 +423,8 @@ func TestEventScannerWithDDL(t *testing.T) {
 	mockSchemaStore.AppendDDLEvent(tableID, fakeDDL3)
 	resolvedTs = resolvedTs + 3
 	disp.eventStoreResolvedTs.Store(resolvedTs)
-	needScan, dataRange = broker.checkNeedScan(disp, true)
-	require.True(t, needScan)
+	ok, dataRange = broker.getScanTaskDataRange(disp)
+	require.True(t, ok)
 
 	events, isBroken, err = scanner.scan(context.Background(), disp, dataRange, sl)
 	require.NoError(t, err)
@@ -1287,11 +1287,11 @@ func TestScanAndMergeEventsSingleUKUpdate(t *testing.T) {
 	// Create scan session
 	ctx := context.Background()
 	dispatcherStat := &dispatcherStat{
-		id:        dispatcherID,
-		isRunning: atomic.Bool{},
-		isRemoved: atomic.Bool{},
+		id:                  dispatcherID,
+		isReadyRecevingData: atomic.Bool{},
+		isRemoved:           atomic.Bool{},
 	}
-	dispatcherStat.isRunning.Store(true)
+	dispatcherStat.isReadyRecevingData.Store(true)
 
 	dataRange := common.DataRange{
 		Span: &heartbeatpb.TableSpan{

--- a/pkg/eventservice/metrics_collector.go
+++ b/pkg/eventservice/metrics_collector.go
@@ -117,7 +117,7 @@ func (mc *metricsCollector) collectDispatcherMetrics(snapshot *metricsSnapshot) 
 		snapshot.dispatcherCount++
 		dispatcher := value.(*dispatcherStat)
 
-		if dispatcher.isRunning.Load() {
+		if dispatcher.isReadyRecevingData.Load() {
 			snapshot.runningDispatcherCount++
 		} else {
 			snapshot.pausedDispatcherCount++
@@ -191,7 +191,7 @@ func (mc *metricsCollector) logSlowDispatchers(snapshot *metricsSnapshot) {
 		zap.Duration("updateDiff",
 			time.Since(snapshot.slowestDispatcher.lastReceivedResolvedTsTime.Load())-
 				time.Since(snapshot.slowestDispatcher.lastSentResolvedTsTime.Load())),
-		zap.Bool("isPaused", !snapshot.slowestDispatcher.isRunning.Load()),
+		zap.Bool("isPaused", !snapshot.slowestDispatcher.isReadyRecevingData.Load()),
 		zap.Bool("isHandshaked", snapshot.slowestDispatcher.isHandshaked.Load()),
 		zap.Bool("isTaskScanning", snapshot.slowestDispatcher.isTaskScanning.Load()),
 	)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #1328

### What is changed and how it works?
In the original implementation, `checkNeedScan` would return false if the handshake event hadn't been sent, meaning data events could only be transmitted after receiving the next resolved ts event. This behavior introduced an unavoidable latency of at least one `min-ts-interval` during operations like dispatcher scheduling, splitting, or merging.

However, we can optimize this workflow:
Data events can be safely transmitted immediately after sending the handshake event, provided we strictly maintain the event ordering guarantee that the handshake event precedes all subsequent data events.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
