### PR TITLE
Add `config2model` tool to convert TOML configuration files to JSON.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,11 +117,11 @@ UT_PACKAGES_DISPATCHER := ./pkg/sink/cloudstorage/... ./pkg/sink/mysql/... ./pkg
 UT_PACKAGES_MAINTAINER := ./maintainer/...
 UT_PACKAGES_COORDINATOR := ./coordinator/...
 UT_PACKAGES_LOGSERVICE := ./logservice/...
-UT_PACKAGES_OTHERS := ./pkg/eventservice/... ./pkg/version/... ./utils/dynstream/... ./pkg/common/event/... 
+UT_PACKAGES_OTHERS := ./pkg/eventservice/... ./pkg/version/... ./utils/dynstream/... ./pkg/common/event/...
 
 include tools/Makefile
 
-generate-protobuf: 
+generate-protobuf:
 	@echo "generate-protobuf"
 	./scripts/generate-protobuf.sh
 
@@ -146,6 +146,9 @@ oauth2_server:
 
 filter_helper:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc_filter_helper ./cmd/filter-helper/main.go
+
+config2model:
+	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc_config2model ./cmd/config2model/main.go
 
 fmt: tools/bin/gofumports tools/bin/shfmt tools/bin/gci
 	@echo "run gci (format imports)"

--- a/cmd/config2model/.gitignore
+++ b/cmd/config2model/.gitignore
@@ -1,0 +1,1 @@
+config2model

--- a/cmd/config2model/main.go
+++ b/cmd/config2model/main.go
@@ -1,0 +1,74 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+	v2 "github.com/pingcap/ticdc/api/v2"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cfgPath string
+)
+
+const (
+	ExitCodeNoFilePath = 255 - iota
+	ExitCodeDecodeTomlFailed
+	ExitCodeMarshalJson
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "config2model -c [path]",
+		Short: "A tool to convert config from toml to json",
+		Run:   runConvert,
+	}
+	rootCmd.Flags().StringVarP(&cfgPath, "config", "c", "", "changefeed config file path")
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func runConvert(cmd *cobra.Command, args []string) {
+	if cfgPath == "" {
+		fmt.Fprintln(os.Stderr, "please specify the config file path")
+		os.Exit(ExitCodeNoFilePath)
+		return
+	}
+
+	cfg := &config.ReplicaConfig{}
+	_, err := toml.DecodeFile(cfgPath, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "decode config file error: %v\n", err)
+		os.Exit(ExitCodeDecodeTomlFailed)
+		return
+	}
+
+	model := v2.ToAPIReplicaConfig(cfg)
+
+	data, err := json.Marshal(model)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal config error: %v\n", err)
+		os.Exit(ExitCodeMarshalJson)
+		return
+	}
+	fmt.Printf("%s\n", data)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
This PR introduces a new utility to convert TiCDC changefeed configurations from their TOML file format to a JSON representation that matches the TiCDC API v2 model. This tool simplifies the process of inspecting or programmatically handling changefeed configurations, ensuring consistency with the API's expected data structures. It's particularly useful for debugging or integration with other tools that consume JSON.

Issue Number: close #1472

### What is changed and how it works?

*   **Added `config2model` command-line utility:** A new Go application has been introduced under `cmd/config2model`. This utility allows users to specify a path to a changefeed configuration file (in TOML format).
*   **TOML to API v2 JSON conversion:** The utility reads the provided TOML configuration file, decodes it into an internal `config.ReplicaConfig` struct, and then converts this into the `api/v2` representation using `v2.ToAPIReplicaConfig()`.
*   **JSON output:** The converted API v2 configuration model is then marshaled into JSON format and printed to standard output, making it easily consumable by other tools or scripts.
*   **Makefile integration:** A new `config2model` target has been added to the `Makefile`, allowing the new utility to be built as `bin/cdc_config2model`.
*   **Gitignore update:** Added `config2model` to `cmd/config2model/.gitignore` to prevent committing the compiled executable.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No, this PR introduces a new standalone utility and does not change any existing TiCDC core logic or API behavior. It will not cause performance regression or break compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?
Yes, if this tool is intended for general user consumption, it should be documented in the TiCDC user documentation as a useful utility for configuration inspection.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
