### PR TITLE
eventCollector: allow resolvedTs and dml event in the same batch

### DIFF
--- a/downstreamadapter/dispatcher/dispatcher.go
+++ b/downstreamadapter/dispatcher/dispatcher.go
@@ -248,6 +248,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 	block = false
 	dmlWakeOnce := &sync.Once{}
 	dmlEvents := make([]*commonEvent.DMLEvent, 0, len(dispatcherEvents))
+	latestResolvedTs := uint64(0)
 	// Dispatcher is ready, handle the events
 	for _, dispatcherEvent := range dispatcherEvents {
 		log.Debug("dispatcher receive all event",
@@ -279,7 +280,7 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 
 		switch event.GetType() {
 		case commonEvent.TypeResolvedEvent:
-			atomic.StoreUint64(&d.resolvedTs, event.(commonEvent.ResolvedEvent).ResolvedTs)
+			latestResolvedTs = event.(commonEvent.ResolvedEvent).ResolvedTs
 		case commonEvent.TypeDMLEvent:
 			dml := event.(*commonEvent.DMLEvent)
 			if dml.Len() == 0 {
@@ -353,8 +354,17 @@ func (d *Dispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallba
 				zap.Uint64("commitTs", event.GetCommitTs()))
 		}
 	}
+	// resolvedTs and dml events can be in the same batch,
+	// We need to update the resolvedTs after all the dml events are added to sink.
+	//
+	// If resolvedTs updated first, and then dml events are added to sink,
+	// the checkpointTs may be incorrect set as the new resolvedTs,
+	// due to the tableProgress is empty before dml events add into sink.
 	if len(dmlEvents) > 0 {
 		d.AddDMLEventsToSink(dmlEvents)
+	}
+	if latestResolvedTs > 0 {
+		atomic.StoreUint64(&d.resolvedTs, latestResolvedTs)
 	}
 	return block
 }

--- a/downstreamadapter/eventcollector/helper.go
+++ b/downstreamadapter/eventcollector/helper.go
@@ -24,7 +24,7 @@ import (
 
 func NewEventDynamicStream(collector *EventCollector) dynstream.DynamicStream[common.GID, common.DispatcherID, dispatcher.DispatcherEvent, *dispatcherStat, *EventsHandler] {
 	option := dynstream.NewOption()
-	option.BatchCount = 4196
+	option.BatchCount = 67136
 	option.UseBuffer = false
 	// Enable memory control for dispatcher events dynamic stream.
 	option.EnableMemoryControl = true

--- a/downstreamadapter/eventcollector/helper.go
+++ b/downstreamadapter/eventcollector/helper.go
@@ -108,8 +108,10 @@ func (h *EventsHandler) Handle(stat *dispatcherStat, events ...dispatcher.Dispat
 }
 
 const (
-	DataGroupResolvedTs = iota + 1
-	DataGroupDML
+	// We ensure the resolvedTs and dml events can be in the same batch
+	// To avoid the dml batch to be too small with frequent resolvedTs events.
+	// If the dml event batch is too small, the sink may not be able to batch enough, leading to the performance degradation.
+	DataGroupResolvedTsOrDML = iota + 1
 	DataGroupDDL
 	DataGroupSyncPoint
 	DataGroupHandshake
@@ -122,9 +124,9 @@ const (
 func (h *EventsHandler) GetType(event dispatcher.DispatcherEvent) dynstream.EventType {
 	switch event.GetType() {
 	case commonEvent.TypeResolvedEvent:
-		return dynstream.EventType{DataGroup: DataGroupResolvedTs, Property: dynstream.PeriodicSignal, Droppable: true}
+		return dynstream.EventType{DataGroup: DataGroupResolvedTsOrDML, Property: dynstream.PeriodicSignal, Droppable: true}
 	case commonEvent.TypeDMLEvent:
-		return dynstream.EventType{DataGroup: DataGroupDML, Property: dynstream.BatchableData, Droppable: true}
+		return dynstream.EventType{DataGroup: DataGroupResolvedTsOrDML, Property: dynstream.BatchableData, Droppable: true}
 	case commonEvent.TypeDDLEvent:
 		return dynstream.EventType{DataGroup: DataGroupDDL, Property: dynstream.NonBatchable, Droppable: true}
 	case commonEvent.TypeSyncPointEvent:


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
* **Event Batching Optimization**: Resolved timestamp (resolvedTs) events and Data Manipulation Language (DML) events are now grouped into a single data group (`DataGroupResolvedTsOrDML`). This change aims to prevent DML batches from becoming too small due to frequent resolvedTs events, thereby improving the overall performance of the sink by allowing for more efficient batching.
* **Correct Resolved Timestamp Update Order**: The update of the `resolvedTs` in the `Dispatcher` is now deferred. Instead of updating it immediately upon receiving a `TypeResolvedEvent`, the timestamp is temporarily stored and then applied *after* all DML events in the current batch have been added to the sink. This critical reordering prevents potential issues where the `checkpointTs` could be incorrectly advanced if `resolvedTs` was updated prematurely, especially when `tableProgress` might be empty before DML events are processed.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
