### PR TITLE
change data size from int64 to uint64

### DIFF
--- a/downstreamadapter/dispatcher/helper.go
+++ b/downstreamadapter/dispatcher/helper.go
@@ -354,8 +354,8 @@ func (h *DispatcherStatusHandler) Handle(dispatcher *Dispatcher, events ...Dispa
 	return false
 }
 
-func (h *DispatcherStatusHandler) GetSize(event T) uint64                     { return 0 }
-func (h *DispatcherStatusHandler) IsPaused(event DispatcherStatusWithID) bool { return false }
+func (h *DispatcherStatusHandler) GetSize(event DispatcherStatusWithID) uint64 { return 0 }
+func (h *DispatcherStatusHandler) IsPaused(event DispatcherStatusWithID) bool  { return false }
 func (h *DispatcherStatusHandler) GetArea(path common.DispatcherID, dest *Dispatcher) common.GID {
 	return dest.GetChangefeedID().ID()
 }

--- a/downstreamadapter/dispatcher/helper.go
+++ b/downstreamadapter/dispatcher/helper.go
@@ -354,7 +354,7 @@ func (h *DispatcherStatusHandler) Handle(dispatcher *Dispatcher, events ...Dispa
 	return false
 }
 
-func (h *DispatcherStatusHandler) GetSize(event DispatcherStatusWithID) int   { return 0 }
+func (h *DispatcherStatusHandler) GetSize(event T) uint64                     { return 0 }
 func (h *DispatcherStatusHandler) IsPaused(event DispatcherStatusWithID) bool { return false }
 func (h *DispatcherStatusHandler) GetArea(path common.DispatcherID, dest *Dispatcher) common.GID {
 	return dest.GetChangefeedID().ID()

--- a/downstreamadapter/dispatcher/helper.go
+++ b/downstreamadapter/dispatcher/helper.go
@@ -301,7 +301,7 @@ type DispatcherEvent struct {
 	commonEvent.Event
 }
 
-func (d DispatcherEvent) GetSize() int64 {
+func (d DispatcherEvent) GetSize() uint64 {
 	return d.From.GetSize() + d.Event.GetSize()
 }
 

--- a/downstreamadapter/dispatcher/table_progress.go
+++ b/downstreamadapter/dispatcher/table_progress.go
@@ -38,7 +38,7 @@ type TableProgress struct {
 
 	// cumulate dml event size for a period of time,
 	// it will be cleared after once query
-	cumulateEventSize int64
+	cumulateEventSize uint64
 	// it used to calculate the sum-dml-event-size/s for each dispatcher
 	lastQueryTime time.Time
 }

--- a/downstreamadapter/dispatchermanager/helper.go
+++ b/downstreamadapter/dispatchermanager/helper.go
@@ -226,7 +226,10 @@ func (h *SchedulerDispatcherRequestHandler) Handle(eventDispatcherManager *Event
 	return false
 }
 
-func (h *SchedulerDispatcherRequestHandler) GetSize(event SchedulerDispatcherRequest) int { return 0 }
+func (h *SchedulerDispatcherRequestHandler) GetSize(event SchedulerDispatcherRequest) uint64 {
+	return 0
+}
+
 func (h *SchedulerDispatcherRequestHandler) IsPaused(event SchedulerDispatcherRequest) bool {
 	return false
 }
@@ -322,8 +325,8 @@ func (h *HeartBeatResponseHandler) Handle(eventDispatcherManager *EventDispatche
 	return false
 }
 
-func (h *HeartBeatResponseHandler) GetSize(event HeartBeatResponse) int   { return 0 }
-func (h *HeartBeatResponseHandler) IsPaused(event HeartBeatResponse) bool { return false }
+func (h *HeartBeatResponseHandler) GetSize(event HeartBeatResponse) uint64 { return 0 }
+func (h *HeartBeatResponseHandler) IsPaused(event HeartBeatResponse) bool  { return false }
 func (h *HeartBeatResponseHandler) GetArea(path common.GID, dest *EventDispatcherManager) int {
 	return 0
 }
@@ -375,8 +378,8 @@ func (h *CheckpointTsMessageHandler) Handle(eventDispatcherManager *EventDispatc
 	return false
 }
 
-func (h *CheckpointTsMessageHandler) GetSize(event CheckpointTsMessage) int   { return 0 }
-func (h *CheckpointTsMessageHandler) IsPaused(event CheckpointTsMessage) bool { return false }
+func (h *CheckpointTsMessageHandler) GetSize(event CheckpointTsMessage) uint64 { return 0 }
+func (h *CheckpointTsMessageHandler) IsPaused(event CheckpointTsMessage) bool  { return false }
 func (h *CheckpointTsMessageHandler) GetArea(path common.GID, dest *EventDispatcherManager) int {
 	return 0
 }
@@ -429,8 +432,8 @@ func (h *MergeDispatcherRequestHandler) Handle(eventDispatcherManager *EventDisp
 	return false
 }
 
-func (h *MergeDispatcherRequestHandler) GetSize(event MergeDispatcherRequest) int   { return 0 }
-func (h *MergeDispatcherRequestHandler) IsPaused(event MergeDispatcherRequest) bool { return false }
+func (h *MergeDispatcherRequestHandler) GetSize(event MergeDispatcherRequest) uint64 { return 0 }
+func (h *MergeDispatcherRequestHandler) IsPaused(event MergeDispatcherRequest) bool  { return false }
 func (h *MergeDispatcherRequestHandler) GetArea(path common.GID, dest *EventDispatcherManager) int {
 	return 0
 }

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -116,7 +116,7 @@ type mockEvent struct {
 	dispatcherID common.DispatcherID
 	commitTs     common.Ts
 	startTs      common.Ts
-	size         int64
+	size         uint64
 	isPaused     bool
 	len          int32
 	epoch        uint64
@@ -146,7 +146,7 @@ func (m *mockEvent) GetStartTs() common.Ts {
 	return m.startTs
 }
 
-func (m *mockEvent) GetSize() int64 {
+func (m *mockEvent) GetSize() uint64 {
 	return m.size
 }
 

--- a/downstreamadapter/eventcollector/helper.go
+++ b/downstreamadapter/eventcollector/helper.go
@@ -148,7 +148,7 @@ func (h *EventsHandler) GetType(event dispatcher.DispatcherEvent) dynstream.Even
 	return dynstream.DefaultEventType
 }
 
-func (h *EventsHandler) GetSize(event dispatcher.DispatcherEvent) int { return int(event.GetSize()) }
+func (h *EventsHandler) GetSize(event T) uint64 { return int(event.GetSize()) }
 
 func (h *EventsHandler) IsPaused(event dispatcher.DispatcherEvent) bool { return event.IsPaused() }
 

--- a/downstreamadapter/eventcollector/helper.go
+++ b/downstreamadapter/eventcollector/helper.go
@@ -148,7 +148,7 @@ func (h *EventsHandler) GetType(event dispatcher.DispatcherEvent) dynstream.Even
 	return dynstream.DefaultEventType
 }
 
-func (h *EventsHandler) GetSize(event T) uint64 { return int(event.GetSize()) }
+func (h *EventsHandler) GetSize(event dispatcher.DispatcherEvent) uint64 { return event.GetSize() }
 
 func (h *EventsHandler) IsPaused(event dispatcher.DispatcherEvent) bool { return event.IsPaused() }
 

--- a/downstreamadapter/sink/cloudstorage/dml_writers.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers.go
@@ -116,7 +116,7 @@ func (d *dmlWriters) AddDMLEvent(event *commonEvent.DMLEvent) {
 		TableInfoVersion: event.TableInfo.UpdateTS(),
 	}
 	seq := atomic.AddUint64(&d.lastSeqNum, 1)
-	_ = d.statistics.RecordBatchExecution(func() (int, int64, error) {
+	_ = d.statistics.RecordBatchExecution(func() (int, uint64, error) {
 		// emit a TxnCallbackableEvent encoupled with a sequence number starting from one.
 		d.msgCh.In() <- newEventFragment(seq, tbl, event)
 		return int(event.Len()), event.GetRowsSize(), nil

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -397,7 +397,7 @@ func (s *sink) sendMessages(ctx context.Context) error {
 			}
 			for _, message := range future.Messages {
 				start := time.Now()
-				if err = s.statistics.RecordBatchExecution(func() (int, int64, error) {
+				if err = s.statistics.RecordBatchExecution(func() (int, uint64, error) {
 					message.SetPartitionKey(future.Key.PartitionKey)
 					log.Debug("send message to kafka", zap.String("messageKey", string(message.Key)), zap.String("messageValue", string(message.Value)))
 					if err = s.dmlProducer.AsyncSend(
@@ -407,7 +407,7 @@ func (s *sink) sendMessages(ctx context.Context) error {
 						message); err != nil {
 						return 0, 0, err
 					}
-					return message.GetRowsCount(), int64(message.Length()), nil
+					return message.GetRowsCount(), uint64(message.Length()), nil
 				}); err != nil {
 					return err
 				}

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -35,7 +35,7 @@ func MysqlSinkForTest() (*Sink, sqlmock.Sqlmock) {
 	cfg := mysql.New()
 	cfg.WorkerCount = 1
 	cfg.DMLMaxRetry = 1
-	cfg.MaxAllowedPacket = int64(vardef.DefMaxAllowedPacket)
+	cfg.MaxAllowedPacket = vardef.DefMaxAllowedPacket
 	cfg.CachePrepStmts = false
 
 	sink := newMySQLSink(ctx, changefeedID, cfg, db)

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -501,12 +501,12 @@ func (s *sink) sendMessages(ctx context.Context) error {
 			}
 			for _, message := range future.Messages {
 				start := time.Now()
-				if err = s.statistics.RecordBatchExecution(func() (int, int64, error) {
+				if err = s.statistics.RecordBatchExecution(func() (int, uint64, error) {
 					message.SetPartitionKey(future.Key.PartitionKey)
 					if err = s.dmlProducer.asyncSendMessage(ctx, future.Key.Topic, message); err != nil {
 						return 0, 0, err
 					}
-					return message.GetRowsCount(), int64(message.Length()), nil
+					return message.GetRowsCount(), uint64(message.Length()), nil
 				}); err != nil {
 					return errors.Trace(err)
 				}

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -122,7 +122,7 @@ func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 }
 
 func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
-	_ = s.statistics.RecordBatchExecution(func() (int, int64, error) {
+	_ = s.statistics.RecordBatchExecution(func() (int, uint64, error) {
 		event.Rewind()
 		for {
 			row, ok := event.GetNextRow()

--- a/logservice/logpuller/region_event_handler.go
+++ b/logservice/logpuller/region_event_handler.go
@@ -45,7 +45,7 @@ type regionEvent struct {
 	resolvedTs uint64
 }
 
-func (event *regionEvent) getSize() int {
+func (event *regionEvent) getSize() uint64 {
 	if event == nil {
 		return 0
 	}
@@ -60,7 +60,7 @@ func (event *regionEvent) getSize() int {
 			size += len(row.OldValue)
 		}
 	}
-	return size
+	return uint64(size)
 }
 
 type regionEventHandler struct {
@@ -119,7 +119,7 @@ func (h *regionEventHandler) Handle(span *subscribedSpan, events ...regionEvent)
 	return false
 }
 
-func (h *regionEventHandler) GetSize(event regionEvent) int {
+func (h *regionEventHandler) GetSize(event regionEvent) uint64 {
 	return event.getSize()
 }
 

--- a/pkg/common/event/ddl_event.go
+++ b/pkg/common/event/ddl_event.go
@@ -93,7 +93,7 @@ type DDLEvent struct {
 	// Call when event flush is completed
 	PostTxnFlushed []func() `json:"-"`
 	// eventSize is the size of the event in bytes. It is set when it's unmarshaled.
-	eventSize int64 `json:"-"`
+	eventSize uint64 `json:"-"`
 
 	// for simple protocol
 	IsBootstrap bool `msg:"-"`
@@ -301,7 +301,7 @@ func (t DDLEvent) Marshal() ([]byte, error) {
 
 func (t *DDLEvent) Unmarshal(data []byte) error {
 	// restData | dispatcherIDData | dispatcherIDDataSize | tableInfoData | tableInfoDataSize | multipleTableInfos | multipletableInfosDataSize
-	t.eventSize = int64(len(data))
+	t.eventSize = uint64(len(data))
 	end := len(data)
 	multipletableInfosDataSize := binary.BigEndian.Uint64(data[end-8 : end])
 	for i := 0; i < int(multipletableInfosDataSize); i++ {
@@ -346,7 +346,7 @@ func (t *DDLEvent) Unmarshal(data []byte) error {
 	return nil
 }
 
-func (t *DDLEvent) GetSize() int64 {
+func (t *DDLEvent) GetSize() uint64 {
 	return t.eventSize
 }
 

--- a/pkg/common/event/dispatcher_heartbeat.go
+++ b/pkg/common/event/dispatcher_heartbeat.go
@@ -41,7 +41,7 @@ func NewDispatcherProgress(dispatcherID common.DispatcherID, checkpointTs uint64
 	}
 }
 
-func (dp DispatcherProgress) GetSize() int {
+func (dp DispatcherProgress) GetSize() uint64 {
 	return dp.DispatcherID.GetSize() + 8 + 1 // version
 }
 
@@ -71,7 +71,7 @@ func (dp *DispatcherProgress) decodeV0(data []byte) error {
 	if err != nil {
 		return err
 	}
-	dp.DispatcherID.Unmarshal(buf.Next(dp.DispatcherID.GetSize()))
+	dp.DispatcherID.Unmarshal(buf.Next(int(dp.DispatcherID.GetSize())))
 	dp.CheckpointTs = binary.BigEndian.Uint64(buf.Next(8))
 	return nil
 }
@@ -98,8 +98,9 @@ func (d *DispatcherHeartbeat) Append(dp DispatcherProgress) {
 	d.DispatcherProgresses = append(d.DispatcherProgresses, dp)
 }
 
-func (d *DispatcherHeartbeat) GetSize() int {
-	size := 1 // version
+func (d *DispatcherHeartbeat) GetSize() uint64 {
+	var size uint64
+	size += 1 // version
 	size += 8 // clusterID
 	size += 4 // dispatcher count
 	for _, dp := range d.DispatcherProgresses {
@@ -143,8 +144,8 @@ func (d *DispatcherHeartbeat) decodeV0(data []byte) error {
 	d.DispatcherProgresses = make([]DispatcherProgress, 0, d.DispatcherCount)
 	for range d.DispatcherCount {
 		var dp DispatcherProgress
-		dpData := buf.Next(dp.GetSize())
-		if err := dp.Unmarshal(dpData); err != nil {
+		dpData := buf.Next(int(dp.GetSize()))
+		if err = dp.Unmarshal(dpData); err != nil {
 			return err
 		}
 		d.DispatcherProgresses = append(d.DispatcherProgresses, dp)
@@ -173,7 +174,7 @@ func NewDispatcherState(dispatcherID common.DispatcherID, state DSState) Dispatc
 	}
 }
 
-func (d *DispatcherState) GetSize() int {
+func (d *DispatcherState) GetSize() uint64 {
 	return d.DispatcherID.GetSize() + 2 // version + state
 }
 
@@ -192,7 +193,7 @@ func (d *DispatcherState) decodeV0(data []byte) error {
 	if err != nil {
 		return err
 	}
-	d.DispatcherID.Unmarshal(buf.Next(d.DispatcherID.GetSize()))
+	d.DispatcherID.Unmarshal(buf.Next(int(d.DispatcherID.GetSize())))
 	state, err := buf.ReadByte()
 	if err != nil {
 		return err
@@ -232,8 +233,9 @@ func (d *DispatcherHeartbeatResponse) Append(ds DispatcherState) {
 	d.DispatcherStates = append(d.DispatcherStates, ds)
 }
 
-func (d *DispatcherHeartbeatResponse) GetSize() int {
-	size := 1 // version
+func (d *DispatcherHeartbeatResponse) GetSize() uint64 {
+	var size uint64
+	size += 1 // version
 	size += 8 // clusterID
 	size += 4 // dispatcher count
 	for _, ds := range d.DispatcherStates {
@@ -262,7 +264,7 @@ func (d *DispatcherHeartbeatResponse) decodeV0(data []byte) error {
 	d.DispatcherStates = make([]DispatcherState, 0, d.DispatcherCount)
 	for range d.DispatcherCount {
 		var ds DispatcherState
-		dsData := buf.Next(ds.GetSize())
+		dsData := buf.Next(int(ds.GetSize()))
 		if err = ds.Unmarshal(dsData); err != nil {
 			return err
 		}

--- a/pkg/common/event/dispatcher_heartbeat_test.go
+++ b/pkg/common/event/dispatcher_heartbeat_test.go
@@ -35,7 +35,7 @@ func TestDispatcherProgress(t *testing.T) {
 	// Test Marshal and Unmarshal
 	data, err := progress.Marshal()
 	require.NoError(t, err)
-	require.Len(t, data, progress.GetSize())
+	require.Len(t, data, int(progress.GetSize()))
 
 	var unmarshalledProgress DispatcherProgress
 	err = unmarshalledProgress.Unmarshal(data)
@@ -94,7 +94,7 @@ func TestDispatcherHeartbeat(t *testing.T) {
 	heartbeat.DispatcherCount = uint32(len(heartbeat.DispatcherProgresses))
 	data, err := heartbeat.Marshal()
 	require.NoError(t, err)
-	require.Len(t, data, heartbeat.GetSize())
+	require.Len(t, data, int(heartbeat.GetSize()))
 
 	var unmarshalledResponse DispatcherHeartbeat
 	err = unmarshalledResponse.Unmarshal(data)
@@ -172,7 +172,7 @@ func TestDispatcherState(t *testing.T) {
 	// Test Marshal and Unmarshal
 	data, err := ds.Marshal()
 	require.NoError(t, err)
-	require.Len(t, data, ds.GetSize())
+	require.Len(t, data, int(ds.GetSize()))
 
 	var unmarshaledState DispatcherState
 	err = unmarshaledState.Unmarshal(data)
@@ -215,7 +215,7 @@ func TestDispatcherHeartbeatResponse(t *testing.T) {
 	response.DispatcherCount = uint32(len(response.DispatcherStates))
 	data, err := response.Marshal()
 	require.NoError(t, err)
-	require.Len(t, data, response.GetSize())
+	require.Len(t, data, int(response.GetSize()))
 
 	var unmarshalledResponse DispatcherHeartbeatResponse
 	err = unmarshalledResponse.Unmarshal(data)

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -500,7 +500,7 @@ func (t *DMLEvent) encodeV0() ([]byte, error) {
 		return nil, nil
 	}
 	// Calculate the total size needed for the encoded data
-	size := 1 + t.DispatcherID.GetSize() + 5*8 + 4*3 + t.State.GetSize() + uint64(int(t.Length))
+	size := 1 + t.DispatcherID.GetSize() + 5*8 + 4*3 + t.State.GetSize() + uint64(t.Length)
 
 	// Allocate a buffer with the calculated size
 	buf := make([]byte, size)

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -230,10 +230,10 @@ func (b *BatchDMLEvent) GetStartTs() common.Ts {
 	return b.DMLEvents[0].GetStartTs()
 }
 
-func (b *BatchDMLEvent) GetSize() int64 {
-	var size int64
-	for _, dml := range b.DMLEvents {
-		size += dml.GetSize()
+func (b *BatchDMLEvent) GetSize() uint64 {
+	var size uint64
+	for _, item := range b.DMLEvents {
+		size += item.GetSize()
 	}
 	return size
 }
@@ -268,7 +268,7 @@ type DMLEvent struct {
 	// Length is the number of rows in the transaction.
 	Length int32 `json:"length"`
 	// ApproximateSize is the approximate size of all rows in the transaction.
-	ApproximateSize int64 `json:"approximate_size"`
+	ApproximateSize uint64 `json:"approximate_size"`
 	// RowTypes is the types of every row in the transaction.
 	RowTypes []RowType `json:"row_types"`
 	// Rows shares BatchDMLEvent rows
@@ -347,7 +347,7 @@ func (t *DMLEvent) AppendRow(raw *common.RawKVEntry,
 		t.RowTypes = append(t.RowTypes, rowType)
 	}
 	t.Length += 1
-	t.ApproximateSize += int64(len(raw.Key) + len(raw.Value) + len(raw.OldValue))
+	t.ApproximateSize += uint64(len(raw.Key) + len(raw.Value) + len(raw.OldValue))
 	if checksum != nil {
 		t.Checksum = append(t.Checksum, checksum)
 	}
@@ -471,14 +471,14 @@ func (t *DMLEvent) Unmarshal(data []byte) error {
 }
 
 // GetSize returns the size of the event in bytes, including all fields.
-func (t *DMLEvent) GetSize() int64 {
+func (t *DMLEvent) GetSize() uint64 {
 	// Notice: events send from local channel will not have the size field.
 	// return t.eventSize
 	return t.GetRowsSize()
 }
 
 // GetRowsSize returns the approximate size of the rows in the transaction.
-func (t *DMLEvent) GetRowsSize() int64 {
+func (t *DMLEvent) GetRowsSize() uint64 {
 	return t.ApproximateSize
 }
 
@@ -500,7 +500,7 @@ func (t *DMLEvent) encodeV0() ([]byte, error) {
 		return nil, nil
 	}
 	// Calculate the total size needed for the encoded data
-	size := 1 + t.DispatcherID.GetSize() + 5*8 + 4*3 + t.State.GetSize() + int(t.Length)
+	size := 1 + t.DispatcherID.GetSize() + 5*8 + 4*3 + t.State.GetSize() + uint64(int(t.Length))
 
 	// Allocate a buffer with the calculated size
 	buf := make([]byte, size)
@@ -530,12 +530,12 @@ func (t *DMLEvent) encodeV0() ([]byte, error) {
 	offset += 8
 	// State
 	copy(buf[offset:], t.State.encode())
-	offset += t.State.GetSize()
+	offset += int(t.State.GetSize())
 	// Length
 	binary.LittleEndian.PutUint32(buf[offset:], uint32(t.Length))
 	offset += 4
 	// ApproximateSize
-	binary.LittleEndian.PutUint64(buf[offset:], uint64(t.ApproximateSize))
+	binary.LittleEndian.PutUint64(buf[offset:], t.ApproximateSize)
 	offset += 8
 	// PreviousTotalOffset
 	binary.LittleEndian.PutUint32(buf[offset:], uint32(t.PreviousTotalOffset))
@@ -569,7 +569,7 @@ func (t *DMLEvent) decodeV0(data []byte) error {
 	}
 	offset := 1
 	t.DispatcherID.Unmarshal(data[offset:])
-	offset += t.DispatcherID.GetSize()
+	offset += int(t.DispatcherID.GetSize())
 	t.PhysicalTableID = int64(binary.LittleEndian.Uint64(data[offset:]))
 	offset += 8
 	t.StartTs = binary.LittleEndian.Uint64(data[offset:])
@@ -579,10 +579,10 @@ func (t *DMLEvent) decodeV0(data []byte) error {
 	t.Seq = binary.LittleEndian.Uint64(data[offset:])
 	offset += 8
 	t.State.decode(data[offset:])
-	offset += t.State.GetSize()
+	offset += int(t.State.GetSize())
 	t.Length = int32(binary.LittleEndian.Uint32(data[offset:]))
 	offset += 4
-	t.ApproximateSize = int64(binary.LittleEndian.Uint64(data[offset:]))
+	t.ApproximateSize = binary.LittleEndian.Uint64(data[offset:])
 	offset += 8
 	t.PreviousTotalOffset = int(binary.LittleEndian.Uint32(data[offset:]))
 	offset += 4

--- a/pkg/common/event/drop_event.go
+++ b/pkg/common/event/drop_event.go
@@ -81,8 +81,8 @@ func (e *DropEvent) GetStartTs() common.Ts {
 }
 
 // GetSize returns the approximate size of the event in bytes
-func (e *DropEvent) GetSize() int64 {
-	return int64(1 + e.DispatcherID.GetSize() + 8 + 8) // version + dispatcherID + seq + commitTs
+func (e *DropEvent) GetSize() uint64 {
+	return 1 + e.DispatcherID.GetSize() + 8 + 8 // version + dispatcherID + seq + commitTs
 }
 
 // IsPaused returns false as drop events are not pausable

--- a/pkg/common/event/drop_event.go
+++ b/pkg/common/event/drop_event.go
@@ -135,14 +135,14 @@ func (e *DropEvent) encodeV0() ([]byte, error) {
 
 	// DispatcherID
 	copy(data[offset:], e.DispatcherID.Marshal())
-	offset += e.DispatcherID.GetSize()
+	offset += int(e.DispatcherID.GetSize())
 
 	// DroppedSeq
 	binary.LittleEndian.PutUint64(data[offset:], e.DroppedSeq)
 	offset += 8
 
 	// DroppedCommitTs
-	binary.LittleEndian.PutUint64(data[offset:], uint64(e.DroppedCommitTs))
+	binary.LittleEndian.PutUint64(data[offset:], e.DroppedCommitTs)
 	offset += 8
 
 	return data, nil
@@ -156,7 +156,7 @@ func (e *DropEvent) decodeV0(data []byte) error {
 	offset += 1
 
 	// DispatcherID
-	dispatcherIDSize := e.DispatcherID.GetSize()
+	dispatcherIDSize := int(e.DispatcherID.GetSize())
 	err := e.DispatcherID.Unmarshal(data[offset : offset+dispatcherIDSize])
 	if err != nil {
 		return err
@@ -168,7 +168,7 @@ func (e *DropEvent) decodeV0(data []byte) error {
 	offset += 8
 
 	// DroppedCommitTs
-	e.DroppedCommitTs = common.Ts(binary.LittleEndian.Uint64(data[offset:]))
+	e.DroppedCommitTs = binary.LittleEndian.Uint64(data[offset:])
 	offset += 8
 
 	return nil

--- a/pkg/common/event/handshake_event.go
+++ b/pkg/common/event/handshake_event.go
@@ -132,7 +132,7 @@ func (e HandshakeEvent) encodeV0() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	data := make([]byte, e.GetSize()+int64(len(tableInfoData)))
+	data := make([]byte, e.GetSize()+uint64(len(tableInfoData)))
 	offset := 0
 	data[offset] = e.Version
 	offset += 1
@@ -143,9 +143,9 @@ func (e HandshakeEvent) encodeV0() ([]byte, error) {
 	binary.BigEndian.PutUint64(data[offset:], e.Epoch)
 	offset += 8
 	copy(data[offset:], e.State.encode())
-	offset += e.State.GetSize()
+	offset += int(e.State.GetSize())
 	copy(data[offset:], e.DispatcherID.Marshal())
-	offset += e.DispatcherID.GetSize()
+	offset += int(e.DispatcherID.GetSize())
 	copy(data[offset:], tableInfoData)
 	return data, nil
 }
@@ -161,14 +161,14 @@ func (e *HandshakeEvent) decodeV0(data []byte) error {
 	e.Epoch = binary.BigEndian.Uint64(data[offset:])
 	offset += 8
 	e.State.decode(data[offset:])
-	offset += e.State.GetSize()
+	offset += int(e.State.GetSize())
 	dispatcherIDData := data[offset:]
 	var err error
 	err = e.DispatcherID.Unmarshal(dispatcherIDData)
 	if err != nil {
 		return err
 	}
-	offset += e.DispatcherID.GetSize()
+	offset += int(e.DispatcherID.GetSize())
 	e.TableInfo, err = common.UnmarshalJSONToTableInfo(data[offset:])
 	if err != nil {
 		return err

--- a/pkg/common/event/handshake_event.go
+++ b/pkg/common/event/handshake_event.go
@@ -91,9 +91,9 @@ func (e *HandshakeEvent) GetStartTs() common.Ts {
 }
 
 // GetSize returns the approximate size of the event in bytes
-func (e *HandshakeEvent) GetSize() int64 {
+func (e *HandshakeEvent) GetSize() uint64 {
 	// All fields size except tableInfo
-	return int64(1 + 8 + 8 + 8 + e.State.GetSize() + e.DispatcherID.GetSize())
+	return 1 + 8 + 8 + 8 + e.State.GetSize() + e.DispatcherID.GetSize()
 }
 
 func (e *HandshakeEvent) IsPaused() bool {

--- a/pkg/common/event/interface.go
+++ b/pkg/common/event/interface.go
@@ -28,7 +28,7 @@ type Event interface {
 	GetStartTs() common.Ts
 	// GetSize returns the approximate size of the event in bytes.
 	// It's used for memory control and monitoring.
-	GetSize() int64
+	GetSize() uint64
 	IsPaused() bool
 	// GetLen returns the number of rows in the event.
 	Len() int32
@@ -213,7 +213,7 @@ func (s *EventSenderState) decode(data []byte) {
 	*s = EventSenderState(data[0])
 }
 
-func (s EventSenderState) GetSize() int {
+func (s EventSenderState) GetSize() uint64 {
 	return 1
 }
 

--- a/pkg/common/event/not_reusable_event.go
+++ b/pkg/common/event/not_reusable_event.go
@@ -77,8 +77,8 @@ func (e *NotReusableEvent) GetStartTs() common.Ts {
 }
 
 // GetSize returns the approximate size of the event in bytes
-func (e *NotReusableEvent) GetSize() int64 {
-	return int64(1 + e.DispatcherID.GetSize())
+func (e *NotReusableEvent) GetSize() uint64 {
+	return 1 + e.DispatcherID.GetSize()
 }
 
 func (e *NotReusableEvent) IsPaused() bool {

--- a/pkg/common/event/not_reusable_event.go
+++ b/pkg/common/event/not_reusable_event.go
@@ -115,7 +115,7 @@ func (e *NotReusableEvent) decode(data []byte) error {
 
 func (e NotReusableEvent) encodeV0() ([]byte, error) {
 	data := make([]byte, e.GetSize())
-	offset := 0
+	var offset uint64
 	data[offset] = e.Version
 	offset += 1
 	copy(data[offset:], e.DispatcherID.Marshal())

--- a/pkg/common/event/not_reusable_event_test.go
+++ b/pkg/common/event/not_reusable_event_test.go
@@ -44,7 +44,7 @@ func TestNotReusableEvent(t *testing.T) {
 	require.Equal(t, event, reverseEvent)
 
 	// 4. Test Other methods
-	require.Equal(t, event.GetSize(), int64(len(data)))
+	require.Equal(t, event.GetSize(), uint64(len(data)))
 	require.Equal(t, event.GetDispatcherID(), dispatcherID)
 	require.Equal(t, event.GetCommitTs(), common.Ts(0))
 	require.Equal(t, event.GetStartTs(), common.Ts(0))

--- a/pkg/common/event/ready_event.go
+++ b/pkg/common/event/ready_event.go
@@ -77,8 +77,8 @@ func (e *ReadyEvent) GetStartTs() common.Ts {
 }
 
 // GetSize returns the approximate size of the event in bytes
-func (e *ReadyEvent) GetSize() int64 {
-	return int64(1 + e.DispatcherID.GetSize())
+func (e *ReadyEvent) GetSize() uint64 {
+	return 1 + e.DispatcherID.GetSize()
 }
 
 func (e *ReadyEvent) IsPaused() bool {

--- a/pkg/common/event/ready_event.go
+++ b/pkg/common/event/ready_event.go
@@ -115,7 +115,7 @@ func (e *ReadyEvent) decode(data []byte) error {
 
 func (e ReadyEvent) encodeV0() ([]byte, error) {
 	data := make([]byte, e.GetSize())
-	offset := 0
+	var offset uint64
 	data[offset] = e.Version
 	offset += 1
 	copy(data[offset:], e.DispatcherID.Marshal())

--- a/pkg/common/event/resolved_ts_event.go
+++ b/pkg/common/event/resolved_ts_event.go
@@ -95,7 +95,7 @@ func (b *BatchResolvedEvent) Unmarshal(data []byte) error {
 }
 
 // No one will use this method, just for implementing Event interface.
-func (b *BatchResolvedEvent) GetSize() int64 {
+func (b *BatchResolvedEvent) GetSize() uint64 {
 	return 0
 }
 
@@ -193,10 +193,10 @@ func (e ResolvedEvent) encodeV0() ([]byte, error) {
 	offset := 0
 	data[offset] = e.Version
 	offset += 1
-	binary.BigEndian.PutUint64(data[offset:], uint64(e.ResolvedTs))
+	binary.BigEndian.PutUint64(data[offset:], e.ResolvedTs)
 	offset += 8
 	copy(data[offset:], e.State.encode())
-	offset += e.State.GetSize()
+	offset += int(e.State.GetSize())
 	copy(data[offset:], e.DispatcherID.Marshal())
 	return data, nil
 }
@@ -209,7 +209,7 @@ func (e *ResolvedEvent) decodeV0(data []byte) error {
 	e.ResolvedTs = common.Ts(binary.BigEndian.Uint64(data[offset:]))
 	offset += 8
 	e.State.decode(data[offset:])
-	offset += e.State.GetSize()
+	offset += int(e.State.GetSize())
 	return e.DispatcherID.Unmarshal(data[offset:])
 }
 
@@ -218,8 +218,8 @@ func (e ResolvedEvent) String() string {
 }
 
 // Update GetSize method to reflect the new structure
-func (e ResolvedEvent) GetSize() int64 {
-	return int64(1 + 8 + e.State.GetSize() + e.DispatcherID.GetSize()) // Version(1) + ResolvedTs(8) + State(1) + DispatcherID(16)
+func (e ResolvedEvent) GetSize() uint64 {
+	return 1 + 8 + e.State.GetSize() + e.DispatcherID.GetSize() // Version(1) + ResolvedTs(8) + State(1) + DispatcherID(16)
 }
 
 func (e ResolvedEvent) IsPaused() bool {

--- a/pkg/common/event/sync_point_event.go
+++ b/pkg/common/event/sync_point_event.go
@@ -57,8 +57,8 @@ func (e *SyncPointEvent) GetStartTs() common.Ts {
 	return e.CommitTsList[0]
 }
 
-func (e *SyncPointEvent) GetSize() int64 {
-	return int64(e.State.GetSize() + e.DispatcherID.GetSize() + 8*len(e.CommitTsList))
+func (e *SyncPointEvent) GetSize() uint64 {
+	return e.State.GetSize() + e.DispatcherID.GetSize() + 8*uint64(len(e.CommitTsList))
 }
 
 func (e *SyncPointEvent) IsPaused() bool {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -67,7 +67,7 @@ func (d DispatcherID) String() string {
 	return GID(d).String()
 }
 
-func (d *DispatcherID) GetSize() int {
+func (d *DispatcherID) GetSize() uint64 {
 	return 16
 }
 

--- a/pkg/metrics/statistics.go
+++ b/pkg/metrics/statistics.go
@@ -61,7 +61,7 @@ type Statistics struct {
 }
 
 // RecordBatchExecution stats batch executors which return (batchRowCount, batchWriteBytes, error).
-func (b *Statistics) RecordBatchExecution(executor func() (int, int64, error)) error {
+func (b *Statistics) RecordBatchExecution(executor func() (int, uint64, error)) error {
 	batchSize, batchWriteBytes, err := executor()
 	if err != nil {
 		b.metricExecErrCnt.Inc()

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -31,8 +31,8 @@ func (s ID) String() string {
 	return string(s)
 }
 
-func (s ID) GetSize() int64 {
-	return int64(len(s))
+func (s ID) GetSize() uint64 {
+	return uint64(len(s))
 }
 
 func NewID() ID {

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -123,7 +123,7 @@ type Config struct {
 
 	// implement stmtCache to improve performance, especially when the downstream is TiDB
 	stmtCache        *lru.Cache
-	MaxAllowedPacket int64
+	MaxAllowedPacket uint64
 
 	HasVectorType bool // HasVectorType is true if the column is vector type
 
@@ -310,7 +310,7 @@ func NewMysqlConfigAndDB(
 		log.Warn("failed to query max_allowed_packet, use default value",
 			zap.String("changefeed", changefeedID.String()),
 			zap.Error(err))
-		cfg.MaxAllowedPacket = int64(vardef.DefMaxAllowedPacket)
+		cfg.MaxAllowedPacket = vardef.DefMaxAllowedPacket
 	}
 	return cfg, db, nil
 }

--- a/pkg/sink/mysql/helper.go
+++ b/pkg/sink/mysql/helper.go
@@ -456,13 +456,13 @@ func queryMaxPreparedStmtCount(ctx context.Context, db *sql.DB) (int, error) {
 }
 
 // queryMaxAllowedPacket gets the value of max_allowed_packet
-func queryMaxAllowedPacket(ctx context.Context, db *sql.DB) (int64, error) {
+func queryMaxAllowedPacket(ctx context.Context, db *sql.DB) (uint64, error) {
 	row := db.QueryRowContext(ctx, "select @@global.max_allowed_packet;")
 	var maxAllowedPacket sql.NullInt64
 	if err := row.Scan(&maxAllowedPacket); err != nil {
 		return 0, cerror.WrapError(cerror.ErrMySQLQueryError, err)
 	}
-	return maxAllowedPacket.Int64, nil
+	return uint64(maxAllowedPacket.Int64), nil
 }
 
 func getDDLCreateTime(ctx context.Context, db *sql.DB) string {

--- a/pkg/sink/mysql/mysql_writer.go
+++ b/pkg/sink/mysql/mysql_writer.go
@@ -56,7 +56,7 @@ type Writer struct {
 	stmtCache *lru.Cache
 	// Indicate if the CachePrepStmts should be enabled or not
 	cachePrepStmts   bool
-	maxAllowedPacket int64
+	maxAllowedPacket uint64
 
 	statistics *metrics.Statistics
 	needFormat bool
@@ -186,7 +186,7 @@ func (w *Writer) Flush(events []*commonEvent.DMLEvent) error {
 		err = w.execDMLWithMaxRetries(dmls)
 	} else {
 		w.tryDryRunBlock()
-		err = w.statistics.RecordBatchExecution(func() (int, int64, error) {
+		err = w.statistics.RecordBatchExecution(func() (int, uint64, error) {
 			return dmls.rowCount, dmls.approximateSize, nil
 		})
 	}

--- a/pkg/sink/mysql/mysql_writer_dml.go
+++ b/pkg/sink/mysql/mysql_writer_dml.go
@@ -504,7 +504,7 @@ func (w *Writer) execDMLWithMaxRetries(dmls *preparedDMLs) error {
 	writeTimeout, _ := time.ParseDuration(w.cfg.WriteTimeout)
 	writeTimeout += networkDriftDuration
 
-	tryExec := func() (int, int64, error) {
+	tryExec := func() (int, uint64, error) {
 		if fallbackToSeqWay {
 			// use sequence way to execute the dmls
 			tx, err := w.db.BeginTx(w.ctx, nil)

--- a/pkg/sink/mysql/mysql_writer_test.go
+++ b/pkg/sink/mysql/mysql_writer_test.go
@@ -38,7 +38,7 @@ func newTestMysqlWriter(t *testing.T) (*Writer, *sql.DB, sqlmock.Sqlmock) {
 
 	ctx := context.Background()
 	cfg := &Config{
-		MaxAllowedPacket:   int64(vardef.DefMaxAllowedPacket),
+		MaxAllowedPacket:   vardef.DefMaxAllowedPacket,
 		SyncPointRetention: 100 * time.Second,
 		MaxTxnRow:          256,
 		BatchDMLEnable:     true,
@@ -56,7 +56,7 @@ func newTestMysqlWriterForTiDB(t *testing.T) (*Writer, *sql.DB, sqlmock.Sqlmock)
 
 	ctx := context.Background()
 	cfg := &Config{
-		MaxAllowedPacket:   int64(vardef.DefMaxAllowedPacket),
+		MaxAllowedPacket:   vardef.DefMaxAllowedPacket,
 		SyncPointRetention: 100 * time.Second,
 		IsTiDB:             true,
 		EnableDDLTs:        defaultEnableDDLTs,

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -28,7 +28,7 @@ type preparedDMLs struct {
 	sqls            []string
 	values          [][]interface{}
 	rowCount        int
-	approximateSize int64
+	approximateSize uint64
 	startTs         []uint64
 }
 

--- a/utils/dynstream/dynamic_stream_bench_test.go
+++ b/utils/dynstream/dynamic_stream_bench_test.go
@@ -45,7 +45,7 @@ func (h *intEventHandler) Handle(dest D, events ...intEvent) (await bool) {
 	return false
 }
 
-func (h *intEventHandler) GetSize(event intEvent) int            { return 0 }
+func (h *intEventHandler) GetSize(event intEvent) uint64         { return 0 }
 func (h *intEventHandler) GetArea(path int, dest D) int          { return 0 }
 func (h *intEventHandler) GetTimestamp(event intEvent) Timestamp { return 0 }
 func (h *intEventHandler) GetType(event intEvent) EventType      { return DefaultEventType }

--- a/utils/dynstream/interfaces.go
+++ b/utils/dynstream/interfaces.go
@@ -105,7 +105,7 @@ type Handler[A Area, P Path, T Event, D Dest] interface {
 	// Return 0 by default implementation, if the size is not used.
 	//
 	// Used by the memory control.
-	GetSize(event T) int
+	GetSize(event T) uint64
 
 	// IsPaused Returns the pause status from the upstream status.
 	// DynamicStream sends feedbacks if the pause status of upstream is not equals to the local status.

--- a/utils/dynstream/memory_control.go
+++ b/utils/dynstream/memory_control.go
@@ -256,12 +256,6 @@ func (as *areaMemStat[A, P, T, D, H]) updateAreaPauseState(path *pathInfo[A, P, 
 
 func (as *areaMemStat[A, P, T, D, H]) decPendingSize(path *pathInfo[A, P, T, D, H], size uint64) {
 	as.totalPendingSize.Add(-size)
-	if as.totalPendingSize.Load() < 0 {
-		log.Warn("Total pending size is less than 0, reset it to 0",
-			zap.Uint64("totalPendingSize", as.totalPendingSize.Load()),
-			zap.String("component", as.settings.Load().component))
-		as.totalPendingSize.Store(0)
-	}
 	as.updatePathPauseState(path)
 	as.updateAreaPauseState(path)
 }

--- a/utils/dynstream/memory_control.go
+++ b/utils/dynstream/memory_control.go
@@ -44,7 +44,7 @@ type areaMemStat[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]] struct 
 	feedbackChan chan<- Feedback[A, P, D]
 
 	pathCount            atomic.Int64
-	totalPendingSize     atomic.Int64
+	totalPendingSize     atomic.Uint64
 	paused               atomic.Bool
 	lastSendFeedbackTime atomic.Value
 	algorithm            MemoryControlAlgorithm
@@ -131,8 +131,8 @@ func (as *areaMemStat[A, P, T, D, H]) appendEvent(
 	// Add the event to the pending queue.
 	path.pendingQueue.PushBack(event)
 	// Update the pending size.
-	path.updatePendingSize(int64(event.eventSize))
-	as.totalPendingSize.Add(int64(event.eventSize))
+	path.updatePendingSize(event.eventSize)
+	as.totalPendingSize.Add(event.eventSize)
 	return true
 }
 
@@ -254,10 +254,12 @@ func (as *areaMemStat[A, P, T, D, H]) updateAreaPauseState(path *pathInfo[A, P, 
 	}
 }
 
-func (as *areaMemStat[A, P, T, D, H]) decPendingSize(path *pathInfo[A, P, T, D, H], size int64) {
-	as.totalPendingSize.Add(int64(-size))
+func (as *areaMemStat[A, P, T, D, H]) decPendingSize(path *pathInfo[A, P, T, D, H], size uint64) {
+	as.totalPendingSize.Add(-size)
 	if as.totalPendingSize.Load() < 0 {
-		log.Warn("Total pending size is less than 0, reset it to 0", zap.Int64("totalPendingSize", as.totalPendingSize.Load()), zap.String("component", as.settings.Load().component))
+		log.Warn("Total pending size is less than 0, reset it to 0",
+			zap.Uint64("totalPendingSize", as.totalPendingSize.Load()),
+			zap.String("component", as.settings.Load().component))
 		as.totalPendingSize.Store(0)
 	}
 	as.updatePathPauseState(path)
@@ -308,7 +310,7 @@ func (m *memControl[A, P, T, D, H]) addPathToArea(path *pathInfo[A, P, T, D, H],
 // This method is called after the path is removed.
 func (m *memControl[A, P, T, D, H]) removePathFromArea(path *pathInfo[A, P, T, D, H]) {
 	area := path.areaMemStat
-	area.decPendingSize(path, int64(path.pendingSize.Load()))
+	area.decPendingSize(path, path.pendingSize.Load())
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -328,7 +330,7 @@ func (m *memControl[A, P, T, D, H]) getMetrics() MemoryMetric[A] {
 		areaMetric := AreaMemoryMetric[A]{
 			area:       area.area,
 			usedMemory: area.totalPendingSize.Load(),
-			maxMemory:  int64(area.settings.Load().maxPendingSize),
+			maxMemory:  area.settings.Load().maxPendingSize,
 		}
 		metrics.AreaMemoryMetrics = append(metrics.AreaMemoryMetrics, areaMetric)
 	}
@@ -341,19 +343,19 @@ type MemoryMetric[A Area] struct {
 
 type AreaMemoryMetric[A Area] struct {
 	area       A
-	usedMemory int64
-	maxMemory  int64
+	usedMemory uint64
+	maxMemory  uint64
 }
 
 func (a *AreaMemoryMetric[A]) MemoryUsageRatio() float64 {
 	return float64(a.usedMemory) / float64(a.maxMemory)
 }
 
-func (a *AreaMemoryMetric[A]) MemoryUsage() int64 {
+func (a *AreaMemoryMetric[A]) MemoryUsage() uint64 {
 	return a.usedMemory
 }
 
-func (a *AreaMemoryMetric[A]) MaxMemory() int64 {
+func (a *AreaMemoryMetric[A]) MaxMemory() uint64 {
 	return a.maxMemory
 }
 

--- a/utils/dynstream/memory_control_algorithm.go
+++ b/utils/dynstream/memory_control_algorithm.go
@@ -18,11 +18,11 @@ package dynstream
 type MemoryControlAlgorithm interface {
 	// ShouldPausePath determines if a path should be paused based on its memory usage.
 	// Returns pause, resume flags and the memory usage ratio.
-	ShouldPausePath(paused bool, pathPendingSize int64, areaPendingSize int64, maxPendingSize uint64, pathCount int64) (pause bool, resume bool, memoryUsageRatio float64)
+	ShouldPausePath(paused bool, pathPendingSize, areaPendingSize, maxPendingSize uint64, pathCount int64) (pause bool, resume bool, memoryUsageRatio float64)
 
 	// ShouldPauseArea determines if an area should be paused based on its memory usage.
 	// Returns pause, resume flags and the memory usage ratio.
-	ShouldPauseArea(paused bool, pendingSize int64, maxPendingSize uint64) (pause bool, resume bool, memoryUsageRatio float64)
+	ShouldPauseArea(paused bool, pendingSize uint64, maxPendingSize uint64) (pause bool, resume bool, memoryUsageRatio float64)
 }
 
 // NewMemoryControlAlgorithm creates a new MemoryControlAlgorithm based on the algorithm type.
@@ -40,7 +40,7 @@ func NewMemoryControlAlgorithm(algorithm int) MemoryControlAlgorithm {
 type PullerMemoryControl struct{}
 
 // ShouldPausePath implements MemoryControlAlgorithm.ShouldPausePath for puller components.
-func (p *PullerMemoryControl) ShouldPausePath(paused bool, pathPendingSize int64, areaPendingSize int64, maxPendingSize uint64, pathCount int64) (bool, bool, float64) {
+func (p *PullerMemoryControl) ShouldPausePath(paused bool, pathPendingSize, _, maxPendingSize uint64, _ int64) (bool, bool, float64) {
 	memoryUsageRatio := float64(pathPendingSize) / float64(maxPendingSize)
 
 	switch {
@@ -58,7 +58,7 @@ func (p *PullerMemoryControl) ShouldPausePath(paused bool, pathPendingSize int64
 }
 
 // ShouldPauseArea implements MemoryControlAlgorithm.ShouldPauseArea for puller components.
-func (p *PullerMemoryControl) ShouldPauseArea(paused bool, pendingSize int64, maxPendingSize uint64) (bool, bool, float64) {
+func (p *PullerMemoryControl) ShouldPauseArea(paused bool, pendingSize uint64, maxPendingSize uint64) (bool, bool, float64) {
 	memoryUsageRatio := float64(pendingSize) / float64(maxPendingSize)
 
 	switch {
@@ -80,7 +80,7 @@ func (p *PullerMemoryControl) ShouldPauseArea(paused bool, pendingSize int64, ma
 type EventCollectorMemoryControl struct{}
 
 // ShouldPausePath implements MemoryControlAlgorithm.ShouldPausePath for event collector components.
-func (e *EventCollectorMemoryControl) ShouldPausePath(paused bool, pathPendingSize int64, areaPendingSize int64, maxPendingSize uint64, pathCount int64) (bool, bool, float64) {
+func (e *EventCollectorMemoryControl) ShouldPausePath(paused bool, pathPendingSize, areaPendingSize, maxPendingSize uint64, pathCount int64) (bool, bool, float64) {
 	if pathCount == 0 {
 		pathCount = 1
 	}
@@ -157,7 +157,7 @@ func (e *EventCollectorMemoryControl) calculateThresholds(pathCount int64, areaM
 }
 
 // ShouldPauseArea implements MemoryControlAlgorithm.ShouldPauseArea for event collector components.
-func (e *EventCollectorMemoryControl) ShouldPauseArea(paused bool, pendingSize int64, maxPendingSize uint64) (bool, bool, float64) {
+func (e *EventCollectorMemoryControl) ShouldPauseArea(_ bool, pendingSize uint64, maxPendingSize uint64) (bool, bool, float64) {
 	memoryUsageRatio := float64(pendingSize) / float64(maxPendingSize)
 	return false, false, memoryUsageRatio
 }

--- a/utils/dynstream/memory_control_algorithm_test.go
+++ b/utils/dynstream/memory_control_algorithm_test.go
@@ -23,8 +23,8 @@ func TestPullerMemoryControl_ShouldPausePath(t *testing.T) {
 	tests := []struct {
 		name            string
 		paused          bool
-		pathPendingSize int64
-		areaPendingSize int64
+		pathPendingSize uint64
+		areaPendingSize uint64
 		maxPendingSize  uint64
 		pathCount       int64
 		wantPause       bool
@@ -100,7 +100,7 @@ func TestPullerMemoryControl_ShouldPauseArea(t *testing.T) {
 	tests := []struct {
 		name           string
 		paused         bool
-		pendingSize    int64
+		pendingSize    uint64
 		maxPendingSize uint64
 		wantPause      bool
 		wantResume     bool
@@ -165,8 +165,8 @@ func TestEventCollectorMemoryControl_ShouldPausePath(t *testing.T) {
 	tests := []struct {
 		name            string
 		paused          bool
-		pathPendingSize int64
-		areaPendingSize int64
+		pathPendingSize uint64
+		areaPendingSize uint64
 		maxPendingSize  uint64
 		pathCount       int64
 		wantPause       bool
@@ -264,7 +264,7 @@ func TestEventCollectorMemoryControl_ShouldPauseArea(t *testing.T) {
 	tests := []struct {
 		name           string
 		paused         bool
-		pendingSize    int64
+		pendingSize    uint64
 		maxPendingSize uint64
 		wantPause      bool
 		wantResume     bool

--- a/utils/dynstream/memory_control_test.go
+++ b/utils/dynstream/memory_control_test.go
@@ -83,7 +83,7 @@ func TestAreaMemStatAppendEvent(t *testing.T) {
 	}
 	ok := path1.areaMemStat.appendEvent(path1, normalEvent1, handler)
 	require.True(t, ok)
-	require.Equal(t, int64(1), path1.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, uint64(1), path1.areaMemStat.totalPendingSize.Load())
 	require.False(t, path1.paused.Load())
 	require.False(t, path1.areaMemStat.paused.Load())
 
@@ -97,7 +97,7 @@ func TestAreaMemStatAppendEvent(t *testing.T) {
 	}
 	ok = path1.areaMemStat.appendEvent(path1, periodicEvent, handler)
 	require.True(t, ok)
-	require.Equal(t, int64(2), path1.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, uint64(2), path1.areaMemStat.totalPendingSize.Load())
 	require.Equal(t, 2, path1.pendingQueue.Length())
 	back, _ := path1.pendingQueue.BackRef()
 	require.Equal(t, periodicEvent.timestamp, back.timestamp)
@@ -111,7 +111,7 @@ func TestAreaMemStatAppendEvent(t *testing.T) {
 	ok = path1.areaMemStat.appendEvent(path1, periodicEvent2, handler)
 	require.False(t, ok)
 	// Size should remain the same as the signal was replaced
-	require.Equal(t, int64(2), path1.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, uint64(2), path1.areaMemStat.totalPendingSize.Load())
 	// The pending queue should only have 2 events
 	require.Equal(t, 2, path1.pendingQueue.Length())
 	// The last event timestamp should be the latest
@@ -129,7 +129,7 @@ func TestAreaMemStatAppendEvent(t *testing.T) {
 	}
 	ok = path1.areaMemStat.appendEvent(path1, normalEvent2, handler)
 	require.True(t, ok)
-	require.Equal(t, int64(22), path1.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, uint64(22), path1.areaMemStat.totalPendingSize.Load())
 	require.Equal(t, 3, path1.pendingQueue.Length())
 	back, _ = path1.pendingQueue.BackRef()
 	require.Equal(t, normalEvent2.timestamp, back.timestamp)
@@ -163,7 +163,7 @@ func TestAreaMemStatAppendEvent(t *testing.T) {
 	}
 	ok = path1.areaMemStat.appendEvent(path1, normalEvent3, handler)
 	require.True(t, ok)
-	require.Equal(t, int64(42), path1.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, uint64(42), path1.areaMemStat.totalPendingSize.Load())
 	require.Equal(t, 4, path1.pendingQueue.Length())
 	back, _ = path1.pendingQueue.BackRef()
 	require.Equal(t, normalEvent3.timestamp, back.timestamp)
@@ -215,13 +215,13 @@ func TestGetMetrics(t *testing.T) {
 	}, nil)
 	metrics = mc.getMetrics()
 	require.Equal(t, 1, len(metrics.AreaMemoryMetrics))
-	require.Equal(t, int64(0), metrics.AreaMemoryMetrics[0].usedMemory)
-	require.Equal(t, int64(100), metrics.AreaMemoryMetrics[0].maxMemory)
+	require.Equal(t, uint64(0), metrics.AreaMemoryMetrics[0].usedMemory)
+	require.Equal(t, uint64(100), metrics.AreaMemoryMetrics[0].maxMemory)
 
 	path.areaMemStat.totalPendingSize.Store(100)
 	metrics = mc.getMetrics()
-	require.Equal(t, int64(100), metrics.AreaMemoryMetrics[0].usedMemory)
-	require.Equal(t, int64(100), metrics.AreaMemoryMetrics[0].maxMemory)
+	require.Equal(t, uint64(100), metrics.AreaMemoryMetrics[0].usedMemory)
+	require.Equal(t, uint64(100), metrics.AreaMemoryMetrics[0].maxMemory)
 }
 
 func TestUpdateAreaPauseState(t *testing.T) {

--- a/utils/dynstream/memory_control_test.go
+++ b/utils/dynstream/memory_control_test.go
@@ -235,22 +235,22 @@ func TestUpdateAreaPauseState(t *testing.T) {
 	mc.addPathToArea(path, settings, feedbackChan)
 	areaMemStat := path.areaMemStat
 
-	areaMemStat.totalPendingSize.Store(int64(10))
+	areaMemStat.totalPendingSize.Store(uint64(10))
 	areaMemStat.updateAreaPauseState(path)
 	require.False(t, areaMemStat.paused.Load())
 
-	areaMemStat.totalPendingSize.Store(int64(60))
+	areaMemStat.totalPendingSize.Store(uint64(60))
 	areaMemStat.updateAreaPauseState(path)
 	require.False(t, areaMemStat.paused.Load())
 
-	areaMemStat.totalPendingSize.Store(int64(80))
+	areaMemStat.totalPendingSize.Store(uint64(80))
 	areaMemStat.updateAreaPauseState(path)
 	require.True(t, areaMemStat.paused.Load())
 	fb := <-feedbackChan
 	require.Equal(t, PauseArea, fb.FeedbackType)
 	require.Equal(t, path.area, fb.Area)
 
-	areaMemStat.totalPendingSize.Store(int64(30))
+	areaMemStat.totalPendingSize.Store(uint64(30))
 	areaMemStat.updateAreaPauseState(path)
 	require.False(t, areaMemStat.paused.Load())
 	fb = <-feedbackChan
@@ -279,18 +279,18 @@ func TestUpdatePathPauseState(t *testing.T) {
 	mc.addPathToArea(path, settings, feedbackChan)
 	areaMemStat := path.areaMemStat
 
-	path.pendingSize.Store(int64(10))
+	path.pendingSize.Store(uint64(10))
 	areaMemStat.updatePathPauseState(path)
 	require.False(t, path.paused.Load())
 
-	path.pendingSize.Store(int64(60))
+	path.pendingSize.Store(uint64(60))
 	areaMemStat.updatePathPauseState(path)
 	require.True(t, path.paused.Load())
 	fb := <-feedbackChan
 	require.Equal(t, PausePath, fb.FeedbackType)
 	require.Equal(t, path.area, fb.Area)
 
-	path.pendingSize.Store(int64(9))
+	path.pendingSize.Store(uint64(9))
 	areaMemStat.updatePathPauseState(path)
 	require.True(t, path.paused.Load())
 

--- a/utils/dynstream/parallel_dynamic_stream.go
+++ b/utils/dynstream/parallel_dynamic_stream.go
@@ -36,7 +36,7 @@ type parallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D
 		m map[P]*pathInfo[A, P, T, D, H]
 	}
 
-	eventExtraSize int
+	eventExtraSize uint64
 	memControl     *memControl[A, P, T, D, H] // TODO: implement memory control
 
 	feedbackChan chan Feedback[A, P, D]
@@ -48,15 +48,15 @@ type parallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D
 func newParallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](hasher PathHasher[P], handler H, option Option) *parallelDynamicStream[A, P, T, D, H] {
 	option.fix()
 	var (
-		eventExtraSize int
+		eventExtraSize uint64
 		zero           T
 	)
 	if reflect.TypeOf(zero).Kind() == reflect.Pointer {
-		eventExtraSize = int(unsafe.Sizeof(eventWrap[A, P, T, D, H]{}))
+		eventExtraSize = uint64(unsafe.Sizeof(eventWrap[A, P, T, D, H]{}))
 	} else {
 		a := unsafe.Sizeof(eventWrap[A, P, T, D, H]{})
 		b := unsafe.Sizeof(zero)
-		eventExtraSize = int(a - b)
+		eventExtraSize = uint64(a - b)
 	}
 
 	s := &parallelDynamicStream[A, P, T, D, H]{

--- a/utils/dynstream/stream.go
+++ b/utils/dynstream/stream.go
@@ -349,10 +349,6 @@ func (pi *pathInfo[A, P, T, D, H]) popEvent() (eventWrap[A, P, T, D, H], bool) {
 
 func (pi *pathInfo[A, P, T, D, H]) updatePendingSize(delta uint64) {
 	pi.pendingSize.Add(delta)
-	if pi.pendingSize.Load() < 0 {
-		log.Warn("pendingSize is negative", zap.Uint64("pendingSize", pi.pendingSize.Load()))
-		pi.pendingSize.Store(0)
-	}
 }
 
 // eventWrap contains the event and the path info.

--- a/utils/dynstream/stream.go
+++ b/utils/dynstream/stream.go
@@ -287,8 +287,8 @@ type pathInfo[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]] struct {
 	// Fields used by the memory control.
 	areaMemStat *areaMemStat[A, P, T, D, H]
 
-	pendingSize          atomic.Int64 // The total size(bytes) of pending events in the pendingQueue of the path.
-	paused               atomic.Bool  // The path is paused to send events.
+	pendingSize          atomic.Uint64 // The total size(bytes) of pending events in the pendingQueue of the path.
+	paused               atomic.Bool   // The path is paused to send events.
 	lastSendFeedbackTime atomic.Value
 }
 
@@ -317,7 +317,7 @@ func (pi *pathInfo[A, P, T, D, H]) appendEvent(event eventWrap[A, P, T, D, H], h
 
 	if event.eventType.Property != PeriodicSignal {
 		pi.pendingQueue.PushBack(event)
-		pi.updatePendingSize(int64(event.eventSize))
+		pi.updatePendingSize(event.eventSize)
 		return true
 	}
 
@@ -329,7 +329,7 @@ func (pi *pathInfo[A, P, T, D, H]) appendEvent(event eventWrap[A, P, T, D, H], h
 		return false
 	} else {
 		pi.pendingQueue.PushBack(event)
-		pi.updatePendingSize(int64(event.eventSize))
+		pi.updatePendingSize(event.eventSize)
 		return true
 	}
 }
@@ -339,18 +339,18 @@ func (pi *pathInfo[A, P, T, D, H]) popEvent() (eventWrap[A, P, T, D, H], bool) {
 	if !ok {
 		return eventWrap[A, P, T, D, H]{}, false
 	}
-	pi.updatePendingSize(int64(-e.eventSize))
+	pi.updatePendingSize(-e.eventSize)
 
 	if pi.areaMemStat != nil {
-		pi.areaMemStat.decPendingSize(pi, int64(e.eventSize))
+		pi.areaMemStat.decPendingSize(pi, e.eventSize)
 	}
 	return e, true
 }
 
-func (pi *pathInfo[A, P, T, D, H]) updatePendingSize(delta int64) {
+func (pi *pathInfo[A, P, T, D, H]) updatePendingSize(delta uint64) {
 	pi.pendingSize.Add(delta)
 	if pi.pendingSize.Load() < 0 {
-		log.Warn("pendingSize is negative", zap.Int64("pendingSize", pi.pendingSize.Load()))
+		log.Warn("pendingSize is negative", zap.Uint64("pendingSize", pi.pendingSize.Load()))
 		pi.pendingSize.Store(0)
 	}
 }
@@ -365,7 +365,7 @@ type eventWrap[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]] struct {
 	pathInfo *pathInfo[A, P, T, D, H]
 
 	paused    bool
-	eventSize int
+	eventSize uint64
 	eventType EventType
 
 	timestamp Timestamp

--- a/utils/dynstream/stream_bench_test.go
+++ b/utils/dynstream/stream_bench_test.go
@@ -45,7 +45,7 @@ func (h *incHandler) Handle(dest D, events ...*inc) (await bool) {
 	return false
 }
 
-func (h *incHandler) GetSize(event *inc) int            { return 0 }
+func (h *incHandler) GetSize(event *inc) uint64         { return 0 }
 func (h *incHandler) GetArea(path string, dest D) int   { return 0 }
 func (h *incHandler) GetTimestamp(event *inc) Timestamp { return 0 }
 func (h *incHandler) GetType(event *inc) EventType      { return DefaultEventType }

--- a/utils/dynstream/stream_test.go
+++ b/utils/dynstream/stream_test.go
@@ -199,7 +199,7 @@ func TestPathInfo(t *testing.T) {
 	pi := newPathInfo[int, string, *mockEvent, any, *mockHandler](1, "test/path", nil)
 	require.Equal(t, 1, pi.area)
 	require.Equal(t, "test/path", pi.path)
-	require.Equal(t, int64(0), pi.pendingSize.Load())
+	require.Equal(t, uint64(0), pi.pendingSize.Load())
 	require.Equal(t, false, pi.paused.Load())
 	require.Equal(t, time.Unix(0, 0), pi.lastSendFeedbackTime.Load())
 }

--- a/utils/dynstream/stream_test.go
+++ b/utils/dynstream/stream_test.go
@@ -78,7 +78,7 @@ func (h *mockHandler) Handle(dest any, events ...*mockEvent) (await bool) {
 	return false
 }
 
-func (h *mockHandler) GetSize(event *mockEvent) int            { return 0 }
+func (h *mockHandler) GetSize(event *mockEvent) uint64         { return 0 }
 func (h *mockHandler) GetArea(path string, dest any) int       { return 0 }
 func (h *mockHandler) GetTimestamp(event *mockEvent) Timestamp { return 0 }
 func (h *mockHandler) GetType(event *mockEvent) EventType      { return DefaultEventType }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1525 

### What is changed and how it works?

This pull request implements a significant type system refinement across the event handling and data dispatching components. The primary objective is to migrate all data size-related fields and GetSize() method return types from int64 to uint64. This change enhances the system's ability to accurately represent and process potentially very large, inherently non-negative data sizes, thereby improving overall robustness and preventing potential data integrity issues.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
