### PR TITLE
log: degrade the log level to avoid too many useless log

### DIFF
--- a/downstreamadapter/dispatcher/basic_dispatcher.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher.go
@@ -470,7 +470,7 @@ func (d *BasicDispatcher) handleEvents(dispatcherEvents []DispatcherEvent, wakeC
 // 1. If the action is a write, we need to add the ddl event to the sink for writing to downstream.
 // 2. If the action is a pass, we just need to pass the event
 func (d *BasicDispatcher) HandleDispatcherStatus(dispatcherStatus *heartbeatpb.DispatcherStatus) {
-	log.Info("dispatcher handle dispatcher status",
+	log.Debug("dispatcher handle dispatcher status",
 		zap.Any("dispatcherStatus", dispatcherStatus),
 		zap.Stringer("dispatcher", d.id),
 		zap.Any("action", dispatcherStatus.GetAction()),

--- a/tests/integration_tests/_utils/check_logs
+++ b/tests/integration_tests/_utils/check_logs
@@ -36,3 +36,21 @@ else
 	echo "no DATA RACE found"
 	exit 0
 fi
+
+grep -q -i 'panic' $WORK_DIR/stdout*.log
+
+if [ $? -eq 0 ]; then
+	# check each log file to see if it contains panic
+	for log in $logs; do
+		echo "check $log"
+		grep -q -i 'panic' $log
+		if [ $? -eq 1 ]; then
+			continue
+		fi
+	done
+	echo "found panic, but it is not a TiCDC issue, please check the logs"
+	exit 0
+else
+	echo "no panic found"
+	exit 0
+fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

* **Log Level Adjustment**: I've observed that the log level for the `HandleDispatcherStatus` function in `downstreamadapter/dispatcher/basic_dispatcher.go` has been degraded from `log.Info` to `log.Debug`. This change aims to reduce the verbosity of the logs.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
