### PR TITLE
coordinator: cut down the long error message info to avoid error `ResourceExhausted` occurs when interacting with etcd

### DIFF
--- a/pkg/config/changefeed.go
+++ b/pkg/config/changefeed.go
@@ -357,6 +357,10 @@ func (info *ChangeFeedInfo) GetTargetTs() uint64 {
 
 // Marshal returns the json marshal format of a ChangeFeedInfo
 func (info *ChangeFeedInfo) Marshal() (string, error) {
+	if info.Error != nil && len(info.Error.Message) > 100 {
+		// we cut down error message to 100 characters to avoid the whole message too long to send to etcd
+		info.Error.Message = info.Error.Message[:100] + "..."
+	}
 	data, err := json.Marshal(info)
 	return string(data), cerror.WrapError(cerror.ErrMarshalFailed, err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/1541

### What is changed and how it works?

**Error Message Truncation**: Implemented logic within the ChangeFeedInfo.Marshal() method to truncate long error messages. If an error message exceeds 100 characters, it will be cut down to 100 characters, with '...' appended, before being marshaled into JSON.
**Etcd Resource Management**: This change directly addresses the ResourceExhausted error that can occur when attempting to store excessively long error messages in etcd, ensuring more stable and reliable interaction with the etcd key-value store.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
