### PR TITLE
event: dml size correctly calculated by using the chunk memory usage method instead of the raw entry size

### DIFF
--- a/cmd/kafka-consumer/event_group.go
+++ b/cmd/kafka-consumer/event_group.go
@@ -61,7 +61,6 @@ func (g *eventsGroup) Append(row *commonEvent.DMLEvent, force bool) {
 		lastDMLEvent.RowTypes = append(lastDMLEvent.RowTypes, row.RowTypes...)
 		lastDMLEvent.Length += row.Length
 		lastDMLEvent.PostTxnFlushed = append(lastDMLEvent.PostTxnFlushed, row.PostTxnFlushed...)
-		lastDMLEvent.ApproximateSize += row.ApproximateSize
 		return
 	}
 

--- a/cmd/pulsar-consumer/event_group.go
+++ b/cmd/pulsar-consumer/event_group.go
@@ -61,7 +61,6 @@ func (g *eventsGroup) Append(row *commonEvent.DMLEvent, force bool) {
 		lastDMLEvent.RowTypes = append(lastDMLEvent.RowTypes, row.RowTypes...)
 		lastDMLEvent.Length += row.Length
 		lastDMLEvent.PostTxnFlushed = append(lastDMLEvent.PostTxnFlushed, row.PostTxnFlushed...)
-		lastDMLEvent.ApproximateSize += row.ApproximateSize
 		return
 	}
 

--- a/downstreamadapter/sink/cloudstorage/dml_writers.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers.go
@@ -119,7 +119,7 @@ func (d *dmlWriters) AddDMLEvent(event *commonEvent.DMLEvent) {
 	_ = d.statistics.RecordBatchExecution(func() (int, int64, error) {
 		// emit a TxnCallbackableEvent encoupled with a sequence number starting from one.
 		d.msgCh.In() <- newEventFragment(seq, tbl, event)
-		return int(event.Len()), event.GetRowsSize(), nil
+		return int(event.Len()), event.GetSize(), nil
 	})
 }
 

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -139,7 +139,7 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 			}
 		}
 		// batchSize, batchWriteBytes, err
-		return int(event.Len()), event.GetRowsSize(), nil
+		return int(event.Len()), event.GetSize(), nil
 	})
 }
 

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -231,11 +231,7 @@ func (b *BatchDMLEvent) GetStartTs() common.Ts {
 }
 
 func (b *BatchDMLEvent) GetSize() int64 {
-	var size int64
-	for _, e := range b.DMLEvents {
-		size += e.Rows.MemoryUsage()
-	}
-	return size
+	return b.Rows.MemoryUsage()
 }
 
 func (b *BatchDMLEvent) IsPaused() bool {

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -232,8 +232,8 @@ func (b *BatchDMLEvent) GetStartTs() common.Ts {
 
 func (b *BatchDMLEvent) GetSize() int64 {
 	var size int64
-	for _, dml := range b.DMLEvents {
-		size += dml.GetSize()
+	for _, e := range b.DMLEvents {
+		size += e.Rows.MemoryUsage()
 	}
 	return size
 }

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -265,8 +265,6 @@ type DMLEvent struct {
 	// Note: it is the logic length of the transaction, not the number of physical rows in the Rows chunk.
 	// For an update event, it has two physical rows in the Rows chunk.
 	Length int32 `json:"length"`
-	// ApproximateSize is the approximate size of all rows in the transaction.
-	ApproximateSize int64 `json:"approximate_size"`
 	// RowTypes is the types of every row in the transaction.
 	RowTypes []RowType `json:"row_types"`
 	// Rows shares BatchDMLEvent rows
@@ -301,8 +299,8 @@ type DMLEvent struct {
 }
 
 func (t *DMLEvent) String() string {
-	return fmt.Sprintf("DMLEvent{Version: %d, DispatcherID: %s, Seq: %d, PhysicalTableID: %d, StartTs: %d, CommitTs: %d, Table: %v, Checksum: %v, Length: %d, ApproximateSize: %d}",
-		t.Version, t.DispatcherID.String(), t.Seq, t.PhysicalTableID, t.StartTs, t.CommitTs, t.TableInfo.TableName, t.Checksum, t.Length, t.ApproximateSize)
+	return fmt.Sprintf("DMLEvent{Version: %d, DispatcherID: %s, Seq: %d, PhysicalTableID: %d, StartTs: %d, CommitTs: %d, Table: %v, Checksum: %v, Length: %d, Size: %d}",
+		t.Version, t.DispatcherID.String(), t.Seq, t.PhysicalTableID, t.StartTs, t.CommitTs, t.TableInfo.TableName, t.Checksum, t.Length, t.GetSize())
 }
 
 // NewDMLEvent creates a new DMLEvent with the given parameters
@@ -349,7 +347,6 @@ func (t *DMLEvent) AppendRow(raw *common.RawKVEntry,
 		t.RowTypes = append(t.RowTypes, rowType)
 	}
 	t.Length += 1
-	t.ApproximateSize += int64(len(raw.Key) + len(raw.Value) + len(raw.OldValue))
 	if checksum != nil {
 		t.Checksum = append(t.Checksum, checksum)
 	}
@@ -474,14 +471,7 @@ func (t *DMLEvent) Unmarshal(data []byte) error {
 
 // GetSize returns the size of the event in bytes, including all fields.
 func (t *DMLEvent) GetSize() int64 {
-	// Notice: events send from local channel will not have the size field.
-	// return t.eventSize
-	return t.GetRowsSize()
-}
-
-// GetRowsSize returns the approximate size of the rows in the transaction.
-func (t *DMLEvent) GetRowsSize() int64 {
-	return t.ApproximateSize
+	return t.Rows.MemoryUsage()
 }
 
 func (t *DMLEvent) IsPaused() bool {
@@ -502,7 +492,7 @@ func (t *DMLEvent) encodeV0() ([]byte, error) {
 		return nil, nil
 	}
 	// Calculate the total size needed for the encoded data
-	size := 1 + t.DispatcherID.GetSize() + 5*8 + 4*3 + t.State.GetSize() + len(t.RowTypes)
+	size := 1 + t.DispatcherID.GetSize() + 4*8 + 4*3 + t.State.GetSize() + len(t.RowTypes)
 
 	// Allocate a buffer with the calculated size
 	buf := make([]byte, size)
@@ -536,9 +526,6 @@ func (t *DMLEvent) encodeV0() ([]byte, error) {
 	// Length
 	binary.LittleEndian.PutUint32(buf[offset:], uint32(t.Length))
 	offset += 4
-	// ApproximateSize
-	binary.LittleEndian.PutUint64(buf[offset:], uint64(t.ApproximateSize))
-	offset += 8
 	// PreviousTotalOffset
 	binary.LittleEndian.PutUint32(buf[offset:], uint32(t.PreviousTotalOffset))
 	offset += 4
@@ -587,8 +574,6 @@ func (t *DMLEvent) decodeV0(data []byte) error {
 	offset += t.State.GetSize()
 	t.Length = int32(binary.LittleEndian.Uint32(data[offset:]))
 	offset += 4
-	t.ApproximateSize = int64(binary.LittleEndian.Uint64(data[offset:]))
-	offset += 8
 	t.PreviousTotalOffset = int(binary.LittleEndian.Uint32(data[offset:]))
 	offset += 4
 	length := int32(binary.LittleEndian.Uint32(data[offset:]))

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -549,7 +549,7 @@ func (t *DMLEvent) decode(data []byte) error {
 }
 
 func (t *DMLEvent) decodeV0(data []byte) error {
-	if len(data) < 1+16+8*5+4*3 {
+	if len(data) < 1+16+8*4+4*3 {
 		return errors.ErrDecodeFailed.FastGenByArgs("data length is less than the minimum value")
 	}
 	if t.Version != DMLEventVersion {

--- a/pkg/common/kv_entry.go
+++ b/pkg/common/kv_entry.go
@@ -101,9 +101,8 @@ func (v *RawKVEntry) String() string {
 		v.OpType, string(v.Key), string(v.Value), string(v.OldValue), v.StartTs, v.CRTs, v.RegionID)
 }
 
-// ApproximateDataSize calculate the approximate size of protobuf binary
-// representation of this event.
-func (v *RawKVEntry) ApproximateDataSize() int64 {
+// GetSize return the size of the RawKVEntry in bytes
+func (v *RawKVEntry) GetSize() int64 {
 	return int64(len(v.Key)+len(v.Value)+len(v.OldValue)) + 40 // 4*uint32 + 3*uint64
 }
 

--- a/pkg/eventservice/event_scanner.go
+++ b/pkg/eventservice/event_scanner.go
@@ -207,7 +207,7 @@ func (s *eventScanner) scanAndMergeEvents(
 			return events, false, err
 		}
 
-		session.addBytes(rawEvent.ApproximateDataSize())
+		session.addBytes(rawEvent.GetSize())
 		session.scannedEntryCount++
 
 		if isNewTxn && checker.checkLimits(session.scannedBytes) {

--- a/pkg/eventservice/event_scanner.go
+++ b/pkg/eventservice/event_scanner.go
@@ -392,6 +392,12 @@ func (s *session) isContextDone() bool {
 func (s *session) recordMetrics() {
 	metrics.EventServiceScanDuration.Observe(time.Since(s.startTime).Seconds())
 	metrics.EventServiceScannedCount.Observe(float64(s.scannedEntryCount))
+	metrics.EventServiceScannedTxnCount.Observe(float64(s.dmlCount))
+	var size int64
+	for _, item := range s.events {
+		size += item.GetSize()
+	}
+	metrics.EventServiceScannedDMLSize.Observe(float64(size))
 }
 
 // limitChecker manages scan limits and interruption logic

--- a/pkg/eventservice/event_scanner.go
+++ b/pkg/eventservice/event_scanner.go
@@ -392,12 +392,6 @@ func (s *session) isContextDone() bool {
 func (s *session) recordMetrics() {
 	metrics.EventServiceScanDuration.Observe(time.Since(s.startTime).Seconds())
 	metrics.EventServiceScannedCount.Observe(float64(s.scannedEntryCount))
-	metrics.EventServiceScannedTxnCount.Observe(float64(s.dmlCount))
-	var size int64
-	for _, item := range s.events {
-		size += item.GetSize()
-	}
-	metrics.EventServiceScannedDMLSize.Observe(float64(size))
 }
 
 // limitChecker manages scan limits and interruption logic

--- a/pkg/eventservice/event_scanner_test.go
+++ b/pkg/eventservice/event_scanner_test.go
@@ -330,7 +330,7 @@ func TestEventScannerWithDDL(t *testing.T) {
 	ok, dataRange := broker.getScanTaskDataRange(disp)
 	require.True(t, ok)
 
-	eSize := kvEvents[0].ApproximateDataSize()
+	eSize := kvEvents[0].GetSize()
 
 	// case 1: Scanning interrupted at dml1
 	// Tests interruption at first DML due to size limit

--- a/pkg/metrics/event_service.go
+++ b/pkg/metrics/event_service.go
@@ -61,7 +61,7 @@ var (
 			Subsystem: "event_service",
 			Name:      "scan_duration",
 			Help:      "The duration of scanning a data range from eventStore",
-			Buckets:   prometheus.ExponentialBuckets(0.00004, 2.0, 28), // 40us to 1.5h
+			Buckets:   prometheus.ExponentialBuckets(0.00128, 2.0, 14), // 1.28ms to 10s
 		})
 	EventServiceScannedCount = prometheus.NewHistogram(
 		prometheus.HistogramOpts{

--- a/pkg/metrics/event_service.go
+++ b/pkg/metrics/event_service.go
@@ -115,21 +115,6 @@ var (
 			Name:      "skip_resolved_ts_count",
 			Help:      "The number of skipped resolved ts",
 		})
-	EventServiceScannedDMLSize = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: "ticdc",
-		Subsystem: "event_service",
-		Name:      "scanned_dml_size",
-		Help:      "The size of scanned DML events from eventStore",
-		Buckets:   prometheus.ExponentialBuckets(1024, 2.0, 16), // 1KB to 64MB
-	})
-
-	EventServiceScannedTxnCount = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: "ticdc",
-		Subsystem: "event_service",
-		Name:      "scanned_txn_count",
-		Help:      "The number of transactions scanned from eventStore",
-		Buckets:   prometheus.ExponentialBuckets(1, 2.0, 8), // 1 ~ 256
-	})
 )
 
 // InitEventServiceMetrics registers all metrics in this file.
@@ -147,6 +132,4 @@ func InitEventServiceMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(EventServicePendingScanTaskCount)
 	registry.MustRegister(EventServiceDispatcherUpdateResolvedTsDiff)
 	registry.MustRegister(EventServiceSkipResolvedTsCount)
-	registry.MustRegister(EventServiceScannedDMLSize)
-	registry.MustRegister(EventServiceScannedTxnCount)
 }

--- a/pkg/metrics/event_service.go
+++ b/pkg/metrics/event_service.go
@@ -115,6 +115,21 @@ var (
 			Name:      "skip_resolved_ts_count",
 			Help:      "The number of skipped resolved ts",
 		})
+	EventServiceScannedDMLSize = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "ticdc",
+		Subsystem: "event_service",
+		Name:      "scanned_dml_size",
+		Help:      "The size of scanned DML events from eventStore",
+		Buckets:   prometheus.ExponentialBuckets(1024, 2.0, 16), // 1KB to 64MB
+	})
+
+	EventServiceScannedTxnCount = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "ticdc",
+		Subsystem: "event_service",
+		Name:      "scanned_txn_count",
+		Help:      "The number of transactions scanned from eventStore",
+		Buckets:   prometheus.ExponentialBuckets(1, 2.0, 8), // 1 ~ 256
+	})
 )
 
 // InitEventServiceMetrics registers all metrics in this file.
@@ -132,4 +147,6 @@ func InitEventServiceMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(EventServicePendingScanTaskCount)
 	registry.MustRegister(EventServiceDispatcherUpdateResolvedTsDiff)
 	registry.MustRegister(EventServiceSkipResolvedTsCount)
+	registry.MustRegister(EventServiceScannedDMLSize)
+	registry.MustRegister(EventServiceScannedTxnCount)
 }

--- a/pkg/sink/codec/canal/canal_json_txn_decoder.go
+++ b/pkg/sink/codec/canal/canal_json_txn_decoder.go
@@ -109,7 +109,6 @@ func (d *txnDecoder) canalJSONMessage2RowChange() *commonEvent.DMLEvent {
 	result := new(commonEvent.DMLEvent)
 	result.Length++                    // todo: set this field correctly
 	result.StartTs = msg.getCommitTs() // todo: how to set this correctly?
-	result.ApproximateSize = 0
 	result.TableInfo = tableInfo
 	chk := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
 	result.CommitTs = msg.getCommitTs()

--- a/pkg/sink/mysql/mysql_writer_dml.go
+++ b/pkg/sink/mysql/mysql_writer_dml.go
@@ -58,7 +58,7 @@ func (w *Writer) prepareDMLs(events []*commonEvent.DMLEvent) *preparedDMLs {
 		if len(dmls.startTs) == 0 || dmls.startTs[len(dmls.startTs)-1] != event.StartTs {
 			dmls.startTs = append(dmls.startTs, event.StartTs)
 		}
-		dmls.approximateSize += event.GetRowsSize()
+		dmls.approximateSize += event.GetSize()
 		tableID := event.GetTableID()
 		if _, ok := eventsGroup[tableID]; !ok {
 			eventsGroup[tableID] = make([]*commonEvent.DMLEvent, 0)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1591

### What is changed and how it works?

* RawEntry size also + 40 bytes, for other length fields.
* DMLEvent and BatchDMLEvent size is calculated by using the chunk provided memory usage method. Compare to previous implementation based on the raw entry size, it's more accurate, enlarged around 50% according to the test.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
