### PR TITLE
kafkaSink: use unlimited chan to avoid block `handleEvents`

### DIFF
--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/sink/kafka"
 	"github.com/pingcap/ticdc/pkg/sink/util"
+	"github.com/pingcap/ticdc/utils/chann"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -57,8 +58,8 @@ type sink struct {
 	checkpointChan   chan uint64
 	tableSchemaStore *util.TableSchemaStore
 
-	eventChan chan *commonEvent.DMLEvent
-	rowChan   chan *commonEvent.MQRowEvent
+	eventChan *chann.UnlimitedChannel[*commonEvent.DMLEvent, any]
+	rowChan   *chann.UnlimitedChannel[*commonEvent.MQRowEvent, any]
 
 	// isNormal indicate whether the sink is in the normal state.
 	isNormal *atomic.Bool
@@ -111,8 +112,8 @@ func New(
 		statistics:    statistics,
 
 		checkpointChan: make(chan uint64, 16),
-		eventChan:      make(chan *commonEvent.DMLEvent, 32),
-		rowChan:        make(chan *commonEvent.MQRowEvent, 32),
+		eventChan:      chann.NewUnlimitedChannelDefault[*commonEvent.DMLEvent](),
+		rowChan:        chann.NewUnlimitedChannelDefault[*commonEvent.MQRowEvent](),
 
 		isNormal: atomic.NewBool(true),
 		ctx:      ctx,
@@ -144,7 +145,7 @@ func (s *sink) IsNormal() bool {
 }
 
 func (s *sink) AddDMLEvent(event *commonEvent.DMLEvent) {
-	s.eventChan <- event
+	s.eventChan.Push(event)
 }
 
 func (s *sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
@@ -166,6 +167,11 @@ func (s *sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 	return nil
 }
 
+func (s *sink) close() {
+	s.eventChan.Close()
+	s.rowChan.Close()
+}
+
 func (s *sink) sendDMLEvent(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -185,6 +191,9 @@ func (s *sink) sendDMLEvent(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
+		// UnlimitedChannel will block when there is no event, they cannot dirrectly find ctx.Done()
+		// Thus, we need to close the channel when the context is done
+		defer s.close()
 		return s.sendMessages(ctx)
 	})
 	return g.Wait()
@@ -195,7 +204,14 @@ func (s *sink) calculateKeyPartitions(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
-		case event := <-s.eventChan:
+		default:
+			event, ok := s.eventChan.Get()
+			if !ok {
+				log.Info("kafka sink event channel closed",
+					zap.String("namespace", s.changefeedID.Namespace()),
+					zap.String("changefeed", s.changefeedID.Name()))
+				return nil
+			}
 			schema := event.TableInfo.GetSchemaName()
 			table := event.TableInfo.GetTableName()
 			topic := s.comp.eventRouter.GetTopicForRowChange(schema, table)
@@ -249,7 +265,7 @@ func (s *sink) calculateKeyPartitions(ctx context.Context) error {
 						Checksum:        row.Checksum,
 					},
 				}
-				s.rowChan <- mqEvent
+				s.rowChan.Push(mqEvent)
 			}
 		}
 	}
@@ -260,7 +276,8 @@ func (s *sink) nonBatchEncodeRun(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
-		case event, ok := <-s.rowChan:
+		default:
+			event, ok := s.rowChan.Get()
 			if !ok {
 				log.Info("kafka sink event channel closed",
 					zap.String("namespace", s.changefeedID.Namespace()),
@@ -282,12 +299,10 @@ func (s *sink) batchEncodeRun(ctx context.Context) error {
 		metrics.WorkerBatchSize.DeleteLabelValues(s.changefeedID.Namespace(), s.changefeedID.Name())
 	}()
 
-	ticker := time.NewTicker(batchInterval)
-	defer ticker.Stop()
-	msgsBuf := make([]*commonEvent.MQRowEvent, batchSize)
+	msgsBuf := make([]*commonEvent.MQRowEvent, 0, batchSize)
 	for {
 		start := time.Now()
-		msgCount, err := s.batch(ctx, msgsBuf, ticker)
+		msgCount, err := s.batch(ctx, msgsBuf)
 		if err != nil {
 			log.Error("kafka sink batch dml events failed",
 				zap.String("namespace", s.changefeedID.Namespace()),
@@ -316,50 +331,19 @@ func (s *sink) batchEncodeRun(ctx context.Context) error {
 // batch collects a batch of messages from w.msgChan into buffer.
 // It returns the number of messages collected.
 // Note: It will block until at least one message is received.
-func (s *sink) batch(ctx context.Context, buffer []*commonEvent.MQRowEvent, ticker *time.Ticker) (int, error) {
-	msgCount := 0
-	maxBatchSize := len(buffer)
-	// We need to receive at least one message or be interrupted,
-	// otherwise it will lead to idling.
+func (s *sink) batch(ctx context.Context, buffer []*commonEvent.MQRowEvent) (int, error) {
 	select {
 	case <-ctx.Done():
-		return msgCount, ctx.Err()
-	case msg, ok := <-s.rowChan:
+		return 0, ctx.Err()
+	default:
+		msgs, ok := s.rowChan.GetMultipleNoGroup(buffer)
 		if !ok {
 			log.Info("kafka sink event channel closed",
 				zap.String("namespace", s.changefeedID.Namespace()),
 				zap.String("changefeed", s.changefeedID.Name()))
-			return msgCount, nil
+			return 0, nil
 		}
-
-		buffer[msgCount] = msg
-		msgCount++
-	}
-
-	// Reset the ticker to start a new batching.
-	// We need to stop batching when the interval is reached.
-	ticker.Reset(batchInterval)
-	for {
-		select {
-		case <-ctx.Done():
-			return msgCount, ctx.Err()
-		case msg, ok := <-s.rowChan:
-			if !ok {
-				log.Info("kafka sink event channel closed",
-					zap.String("namespace", s.changefeedID.Namespace()),
-					zap.String("changefeed", s.changefeedID.Name()))
-				return msgCount, nil
-			}
-
-			buffer[msgCount] = msg
-			msgCount++
-
-			if msgCount >= maxBatchSize {
-				return msgCount, nil
-			}
-		case <-ticker.C:
-			return msgCount, nil
-		}
+		return len(msgs), nil
 	}
 }
 

--- a/downstreamadapter/sink/kafka/sink_test.go
+++ b/downstreamadapter/sink/kafka/sink_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/sink/kafka"
+	"github.com/pingcap/ticdc/utils/chann"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
@@ -81,8 +82,8 @@ func newKafkaSinkForTest() (*sink, error) {
 		statistics:    statistics,
 
 		checkpointChan: make(chan uint64, 16),
-		eventChan:      make(chan *commonEvent.DMLEvent, 32),
-		rowChan:        make(chan *commonEvent.MQRowEvent, 32),
+		eventChan:      chann.NewUnlimitedChannelDefault[*commonEvent.DMLEvent](),
+		rowChan:        chann.NewUnlimitedChannelDefault[*commonEvent.MQRowEvent](),
 
 		isNormal: atomic.NewBool(true),
 		ctx:      ctx,


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/1595

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
