### PR TITLE
eventcollector: avoid drop local messages

### DIFF
--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -175,6 +175,7 @@ func (d *dispatcherStat) doReset(serverID node.ID, resetTs uint64) {
 	log.Info("Send reset dispatcher request to event service to reset the dispatcher",
 		zap.Stringer("dispatcher", d.getDispatcherID()),
 		zap.Stringer("eventServiceID", serverID),
+		zap.Uint64("epoch", epoch),
 		zap.Uint64("resetTs", resetTs))
 }
 

--- a/downstreamadapter/eventcollector/event_collector.go
+++ b/downstreamadapter/eventcollector/event_collector.go
@@ -343,7 +343,7 @@ func (c *EventCollector) sendDispatcherRequests(ctx context.Context) error {
 				}
 				log.Info("failed to send dispatcher request message, try again later",
 					zap.String("message", req.Message.String()),
-					zap.Duration("sleepInterval(s)", sleepInterval),
+					zap.Duration("sleepInterval", sleepInterval),
 					zap.Error(err))
 				if !req.decrAndCheckRetry() {
 					log.Warn("dispatcher request retry limit exceeded, dropping request",

--- a/downstreamadapter/eventcollector/event_collector.go
+++ b/downstreamadapter/eventcollector/event_collector.go
@@ -66,6 +66,9 @@ func newDispatcherMessage(msg *messaging.TargetMessage, droppable bool) Dispatch
 }
 
 func (d *DispatcherMessage) decrAndCheckRetry() bool {
+	if !d.Droppable {
+		return true
+	}
 	d.RetryQuota--
 	return d.RetryQuota > 0
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1605 

### What is changed and how it works?
- Enhanced Message Retry Logic: I've refactored the message retry mechanism within the event collector to distinguish between local and remote messages. Local messages will now retry indefinitely, ensuring critical internal communications are not dropped, while remote messages will adhere to a defined retry quota.
- Dynamic Retry Backoff: I've introduced dynamic sleep intervals for message retries. Specifically, if a message send fails due to congestion, the system will now wait for a longer period (1 second) before retrying, helping to alleviate pressure on the system.
- Improved Dispatcher Registration Logging: I've added a new logging mechanism to warn when a dispatcher is registered with a startTs that is significantly behind the current PD time, which can help in diagnosing potential timing issues.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
