### PR TITLE
fix(DMLEvent): prevent DMLEvent inconsistency on zero-row decodes and refactor helpers

### DIFF
--- a/pkg/common/kv_entry.go
+++ b/pkg/common/kv_entry.go
@@ -63,9 +63,17 @@ func (v *RawKVEntry) IsResolved() bool {
 	return v.OpType == OpTypeResolved
 }
 
+func (v *RawKVEntry) IsDelete() bool {
+	return v.OpType == OpTypeDelete
+}
+
 // IsUpdate checks if the event is an update event.
 func (v *RawKVEntry) IsUpdate() bool {
 	return v.OpType == OpTypePut && len(v.OldValue) > 0 && len(v.Value) > 0
+}
+
+func (v *RawKVEntry) IsInsert() bool {
+	return !v.IsDelete() && !v.IsUpdate() && !v.IsResolved()
 }
 
 func (v *RawKVEntry) SplitUpdate() (deleteRow, insertRow *RawKVEntry, err error) {

--- a/pkg/eventservice/event_scanner_test.go
+++ b/pkg/eventservice/event_scanner_test.go
@@ -43,7 +43,11 @@ func makeDispatcherReady(disp *dispatcherStat) {
 }
 
 func (m *mockMounter) DecodeToChunk(rawKV *common.RawKVEntry, tableInfo *common.TableInfo, chk *chunk.Chunk) (int, *integrity.Checksum, error) {
-	return 0, nil, nil
+	if rawKV.IsUpdate() {
+		return 2, nil, nil
+	} else {
+		return 1, nil, nil
+	}
 }
 
 func TestEventScanner(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1617

### What is changed and how it works?

This PR addresses a bug that causes `DMLEvent` to enter an inconsistent state. It also introduces several code quality improvements for better readability and maintenance.

#### What this PR does and why it's needed

The core issue is that `DMLEvent.AppendRow` would increment its `Length` counter even if the underlying call to `DecodeToChunk` returned zero rows. This is an abnormal but possible scenario that leads to a corrupted event object, risking panics downstream.

This PR makes the system more robust by handling this exceptional case correctly. It also refactors related code for better clarity.

#### Detailed Changes

* **Robust Handling in `DMLEvent.AppendRow`**
    * The logic for appending row data and incrementing event counters (`Length`, `ApproximateSize`) is now enclosed within an `if count > 0` block. This is the primary fix that ensures the event's state is only updated when new rows are actually present.
    * An `else` block has been added to handle the abnormal `count == 0` case. It logs a warning to make such occurrences visible for debugging, noting that this is primarily expected in test environments.

* **Code Quality Refactoring in `RawKVEntry`**
    * New helper methods, `IsDelete()` and `IsInsert()`, have been added to `RawKVEntry`. These methods encapsulate the logic for identifying an entry's operation type, improving readability and centralizing the logic.
    * The `if raw.OpType == common.OpTypeDelete` check in `DMLEvent.AppendRow` has been updated to use the cleaner `raw.IsDelete()` method.

* **Correction of Test Mock**
    * In `pkg/eventservice/event_scanner_test.go`, the `mockMounter`'s implementation of `DecodeToChunk` has been updated.
    * Previously, it always returned a count of `0`, which constantly triggered the now-handled abnormal case.
    * It now returns realistic row counts (2 for an update, 1 for other DML types) to properly test the normal execution path and prevent unnecessary warnings during tests.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
