### PR TITLE
cmd: patch tidb config set tikvclient max batch size to 0

### DIFF
--- a/cmd/cdc/server/server.go
+++ b/cmd/cdc/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/pingcap/ticdc/pkg/version"
 	"github.com/pingcap/ticdc/server"
+	ticonfig "github.com/pingcap/tidb/pkg/config"
 	tiflowServer "github.com/pingcap/tiflow/pkg/cmd/server"
 	tiflowConfig "github.com/pingcap/tiflow/pkg/config"
 	"github.com/spf13/cobra"
@@ -328,7 +329,13 @@ func NewCmdServer() *cobra.Command {
 			return runTiFlowServer(o, cmd)
 		},
 	}
-
+	patchTiDBConfig()
 	o.addFlags(command)
 	return command
+}
+
+func patchTiDBConfig() {
+	ticonfig.UpdateGlobal(func(conf *ticonfig.Config) {
+		conf.TiKVClient.MaxBatchSize = 0
+	})
 }

--- a/cmd/cdc/server/server.go
+++ b/cmd/cdc/server/server.go
@@ -336,6 +336,7 @@ func NewCmdServer() *cobra.Command {
 
 func patchTiDBConfig() {
 	ticonfig.UpdateGlobal(func(conf *ticonfig.Config) {
+		// Disable kv client batch send loop introduced by tidb library, it's not used by the TiCDC server.
 		conf.TiKVClient.MaxBatchSize = 0
 	})
 }

--- a/logservice/logpuller/region_event_handler.go
+++ b/logservice/logpuller/region_event_handler.go
@@ -128,7 +128,7 @@ func (h *regionEventHandler) GetArea(path SubscriptionID, dest *subscribedSpan) 
 }
 
 func (h *regionEventHandler) GetTimestamp(event regionEvent) dynstream.Timestamp {
-	if event.entries != nil {
+	if event.entries != nil && event.entries.Entries != nil && len(event.entries.Entries.GetEntries()) > 0 {
 		entries := event.entries.Entries.GetEntries()
 		switch entries[0].Type {
 		case cdcpb.Event_INITIALIZED:


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1621 

### What is changed and how it works?

When start the server, set the `TiKV.MaxBatchSize` to 0, since it's not used by the ticdc server, also may not support by other upstream components.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
