### PR TITLE
cli: fix typo in the help message for the --user flag

### DIFF
--- a/cmd/cdc/factory/factory.go
+++ b/cmd/cdc/factory/factory.go
@@ -198,7 +198,7 @@ func (c *ClientFlags) AddFlags(cmd *cobra.Command) {
 		"log level (etc: debug|info|warn|error)")
 
 	cmd.PersistentFlags().StringVar(&c.User, "user", "", "User name for authentication. "+
-		"You can sqpecify it via environment variable TICDC_USER")
+		"You can specify it via environment variable TICDC_USER")
 	cmd.PersistentFlags().StringVar(&c.Password, "password", "", "Password for authentication. "+
 		"You can specify it via environment variable TICDC_PASSWORD")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1631

### What is changed and how it works?

Fixed a typo in the help message displayed when running the `/cdc cli help` command.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

Nothing.

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes (CLI's help), but just only fixing a typo.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
