### PR TITLE
eventboker: fix fail to scan events after truncate table

### DIFF
--- a/pkg/eventservice/event_scanner.go
+++ b/pkg/eventservice/event_scanner.go
@@ -203,7 +203,7 @@ func (s *eventScanner) scanAndMergeEvents(
 
 		rawEvent, isNewTxn := iter.Next()
 		if rawEvent == nil {
-			events, err := s.finalizeScan(session, merger, processor)
+			events, err := s.finalizeScan(session, merger, processor, session.dataRange.EndTs)
 			return events, false, err
 		}
 
@@ -224,7 +224,7 @@ func (s *eventScanner) scanAndMergeEvents(
 			// Some DMLs may have commitTs larger than the table's delete version.
 			// These DMLs can be safely skipped during scanning.
 			if tableDeleted {
-				events, err := s.finalizeScan(session, merger, processor)
+				events, err := s.finalizeScan(session, merger, processor, rawEvent.CRTs-1)
 				return events, false, err
 			}
 			continue
@@ -278,13 +278,7 @@ func (s *eventScanner) handleNewTransaction(
 					zap.Uint64("getTableInfoStartTs", rawEvent.CRTs-1))
 				return returnErr, false
 			}
-			// For table deleted case, we need to append remaining DDLs
-			if errors.Is(err, &schemastore.TableDeletedError{}) {
-				remainingEvents := merger.appendRemainingDDLs(session.dataRange.EndTs)
-				session.events = append(session.events, remainingEvents...)
-				return nil, true
-			}
-			return nil, false
+			return nil, errors.Is(err, &schemastore.TableDeletedError{})
 		}
 	}
 
@@ -311,6 +305,7 @@ func (s *eventScanner) finalizeScan(
 	session *session,
 	merger *eventMerger,
 	processor *dmlProcessor,
+	endTs uint64,
 ) ([]event.Event, error) {
 	if err := processor.clearCache(); err != nil {
 		return nil, err
@@ -320,7 +315,7 @@ func (s *eventScanner) finalizeScan(
 	session.events = append(session.events, events...)
 
 	// Append remaining DDLs
-	remainingEvents := merger.appendRemainingDDLs(session.dataRange.EndTs)
+	remainingEvents := merger.appendRemainingDDLs(endTs)
 	session.events = append(session.events, remainingEvents...)
 
 	return session.events, nil

--- a/pkg/eventservice/event_service_test.go
+++ b/pkg/eventservice/event_service_test.go
@@ -366,16 +366,21 @@ var _ schemastore.SchemaStore = &mockSchemaStore{}
 
 type mockSchemaStore struct {
 	DDLEvents map[common.TableID][]commonEvent.DDLEvent
-	TableInfo map[common.TableID][]*common.TableInfo
+	TableInfo map[common.TableID]*mockVersionTableInfo
 
 	resolvedTs     uint64
 	maxDDLCommitTs uint64
 }
 
+type mockVersionTableInfo struct {
+	tableInfos    []*common.TableInfo
+	deleteVersion uint64
+}
+
 func newMockSchemaStore() *mockSchemaStore {
 	return &mockSchemaStore{
 		DDLEvents:      make(map[common.TableID][]commonEvent.DDLEvent),
-		TableInfo:      make(map[common.TableID][]*common.TableInfo),
+		TableInfo:      make(map[common.TableID]*mockVersionTableInfo),
 		resolvedTs:     math.MaxUint64,
 		maxDDLCommitTs: math.MaxUint64,
 	}
@@ -393,22 +398,45 @@ func (m *mockSchemaStore) Close(ctx context.Context) error {
 	return nil
 }
 
+func (m *mockSchemaStore) DeleteTable(id common.TableID, ts common.Ts) {
+	if info, ok := m.TableInfo[id]; ok {
+		info.deleteVersion = uint64(ts)
+	} else {
+		m.TableInfo[id] = &mockVersionTableInfo{
+			tableInfos:    make([]*common.TableInfo, 0),
+			deleteVersion: uint64(ts),
+		}
+	}
+}
+
 func (m *mockSchemaStore) AppendDDLEvent(id common.TableID, ddls ...commonEvent.DDLEvent) {
 	for _, ddl := range ddls {
 		m.DDLEvents[id] = append(m.DDLEvents[id], ddl)
-		m.TableInfo[id] = append(m.TableInfo[id], ddl.TableInfo)
+		if _, ok := m.TableInfo[id]; !ok {
+			m.TableInfo[id] = &mockVersionTableInfo{
+				tableInfos:    make([]*common.TableInfo, 0),
+				deleteVersion: math.MaxUint64,
+			}
+		}
+		m.TableInfo[id].tableInfos = append(m.TableInfo[id].tableInfos, ddl.TableInfo)
 	}
 }
 
 func (m *mockSchemaStore) GetTableInfo(tableID common.TableID, ts common.Ts) (*common.TableInfo, error) {
-	infos := m.TableInfo[tableID]
-	idx := sort.Search(len(infos), func(i int) bool {
-		return infos[i].UpdateTS() > uint64(ts)
-	})
-	if idx == 0 {
-		return nil, nil
+	if info, ok := m.TableInfo[tableID]; ok {
+		if info.deleteVersion < uint64(ts) {
+			return nil, &schemastore.TableDeletedError{}
+		}
+		infos := m.TableInfo[tableID].tableInfos
+		idx := sort.Search(len(infos), func(i int) bool {
+			return infos[i].UpdateTS() > uint64(ts)
+		})
+		if idx == 0 {
+			return nil, nil
+		}
+		return infos[idx-1], nil
 	}
-	return infos[idx-1], nil
+	return nil, nil
 }
 
 func (m *mockSchemaStore) GetAllPhysicalTables(snapTs uint64, filter filter.Filter) ([]commonEvent.Table, error) {

--- a/pkg/eventservice/event_service_test.go
+++ b/pkg/eventservice/event_service_test.go
@@ -424,7 +424,7 @@ func (m *mockSchemaStore) AppendDDLEvent(id common.TableID, ddls ...commonEvent.
 
 func (m *mockSchemaStore) GetTableInfo(tableID common.TableID, ts common.Ts) (*common.TableInfo, error) {
 	if info, ok := m.TableInfo[tableID]; ok {
-		if info.deleteVersion < uint64(ts) {
+		if info.deleteVersion <= uint64(ts) {
 			return nil, &schemastore.TableDeletedError{}
 		}
 		infos := m.TableInfo[tableID].tableInfos


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
