### PR TITLE
logcoordinator: ignore down nodes

### DIFF
--- a/logservice/coordinator/coordinator_test.go
+++ b/logservice/coordinator/coordinator_test.go
@@ -25,6 +25,7 @@ import (
 func newLogCoordinatorForTest() *logCoordinator {
 	c := &logCoordinator{}
 	c.eventStoreStates.m = make(map[node.ID]*logservicepb.EventStoreState)
+	c.nodes.m = make(map[node.ID]*node.Info)
 	return c
 }
 
@@ -34,6 +35,9 @@ func TestGetCandidateNodes(t *testing.T) {
 	nodeID1 := node.ID("node-1")
 	nodeID2 := node.ID("node-2")
 	nodeID3 := node.ID("node-3")
+	coordinator.nodes.m[nodeID1] = &node.Info{ID: nodeID1}
+	coordinator.nodes.m[nodeID2] = &node.Info{ID: nodeID2}
+	coordinator.nodes.m[nodeID3] = &node.Info{ID: nodeID3}
 
 	// initialize table spans
 	tableID1 := int64(100)
@@ -181,5 +185,12 @@ func TestGetCandidateNodes(t *testing.T) {
 	{
 		nodes := coordinator.getCandidateNodes(nodeID3, &span1, uint64(100))
 		assert.Equal(t, []string{nodeID2.String(), nodeID1.String()}, nodes)
+	}
+
+	// remove node1 and check again
+	coordinator.nodes.m[nodeID1] = nil
+	{
+		nodes := coordinator.getCandidateNodes(nodeID3, &span1, uint64(100))
+		assert.Equal(t, []string{nodeID2.String()}, nodes)
 	}
 }

--- a/logservice/coordinator/coordinator_test.go
+++ b/logservice/coordinator/coordinator_test.go
@@ -188,7 +188,7 @@ func TestGetCandidateNodes(t *testing.T) {
 	}
 
 	// remove node1 and check again
-	coordinator.nodes.m[nodeID1] = nil
+	delete(coordinator.nodes.m, nodeID1)
 	{
 		nodes := coordinator.getCandidateNodes(nodeID3, &span1, uint64(100))
 		assert.Equal(t, []string{nodeID2.String()}, nodes)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1642

### What is changed and how it works?
**Node Filtering Logic**: The getCandidateNodes function now includes a check to ensure that only active and healthy nodes (those present and not nil in c.nodes.m) are considered when building the list of potential candidates for data retrieval.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
