### PR TITLE
filter: Fix sharing filter after update config

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -16,6 +16,7 @@ package filter
 import (
 	"sync"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/eventpb"
 	bf "github.com/pingcap/ticdc/pkg/binlog-filter"
@@ -364,114 +365,6 @@ func isFilterConfigEqual(cfg1, cfg2 *eventpb.FilterConfig) bool {
 		return false
 	}
 
-	// Compare top-level fields
-	if cfg1.CaseSensitive != cfg2.CaseSensitive {
-		return false
-	}
-	if cfg1.ForceReplicate != cfg2.ForceReplicate {
-		return false
-	}
-
-	// Compare FilterConfig
-	if cfg1.FilterConfig == nil && cfg2.FilterConfig == nil {
-		return true
-	}
-	if cfg1.FilterConfig == nil || cfg2.FilterConfig == nil {
-		return false
-	}
-
-	inner1 := cfg1.FilterConfig
-	inner2 := cfg2.FilterConfig
-
-	// Compare Rules
-	if len(inner1.Rules) != len(inner2.Rules) {
-		return false
-	}
-	for i, rule := range inner1.Rules {
-		if rule != inner2.Rules[i] {
-			return false
-		}
-	}
-
-	// Compare IgnoreTxnStartTs
-	if len(inner1.IgnoreTxnStartTs) != len(inner2.IgnoreTxnStartTs) {
-		return false
-	}
-	for i, ts := range inner1.IgnoreTxnStartTs {
-		if ts != inner2.IgnoreTxnStartTs[i] {
-			return false
-		}
-	}
-
-	// Compare EventFilters
-	if len(inner1.EventFilters) != len(inner2.EventFilters) {
-		return false
-	}
-	for i, rule1 := range inner1.EventFilters {
-		rule2 := inner2.EventFilters[i]
-		if !isEventFilterRuleEqual(rule1, rule2) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// isEventFilterRuleEqual compares two EventFilterRule for equality by content
-func isEventFilterRuleEqual(rule1, rule2 *eventpb.EventFilterRule) bool {
-	// Fast path: if pointers are equal, rules are definitely equal
-	if rule1 == rule2 {
-		return true
-	}
-
-	// Handle nil cases
-	if rule1 == nil || rule2 == nil {
-		return false
-	}
-
-	// Compare Matcher
-	if len(rule1.Matcher) != len(rule2.Matcher) {
-		return false
-	}
-	for i, matcher := range rule1.Matcher {
-		if matcher != rule2.Matcher[i] {
-			return false
-		}
-	}
-
-	// Compare IgnoreEvent
-	if len(rule1.IgnoreEvent) != len(rule2.IgnoreEvent) {
-		return false
-	}
-	for i, event := range rule1.IgnoreEvent {
-		if event != rule2.IgnoreEvent[i] {
-			return false
-		}
-	}
-
-	// Compare IgnoreSql
-	if len(rule1.IgnoreSql) != len(rule2.IgnoreSql) {
-		return false
-	}
-	for i, sql := range rule1.IgnoreSql {
-		if sql != rule2.IgnoreSql[i] {
-			return false
-		}
-	}
-
-	// Compare expression fields
-	if rule1.IgnoreInsertValueExpr != rule2.IgnoreInsertValueExpr {
-		return false
-	}
-	if rule1.IgnoreUpdateNewValueExpr != rule2.IgnoreUpdateNewValueExpr {
-		return false
-	}
-	if rule1.IgnoreUpdateOldValueExpr != rule2.IgnoreUpdateOldValueExpr {
-		return false
-	}
-	if rule1.IgnoreDeleteValueExpr != rule2.IgnoreDeleteValueExpr {
-		return false
-	}
-
-	return true
+	// Use protobuf's built-in Equal method for content comparison
+	return proto.Equal(cfg1, cfg2)
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -88,14 +88,15 @@ func TestSharedFilterStorage_SameConfigSharesFilter(t *testing.T) {
 
 	changeFeedID := createTestChangeFeedID("test-changefeed")
 	cfg := createTestFilterConfig()
+	timeZone := "UTC"
 
 	// First call - should create new filter
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter1)
 
 	// Second call with same config - should return same filter
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter2)
 
@@ -111,14 +112,15 @@ func TestSharedFilterStorage_SameConfigContentSharesFilter(t *testing.T) {
 	changeFeedID := createTestChangeFeedID("test-changefeed")
 	cfg1 := createTestFilterConfig()
 	cfg2 := createTestFilterConfig() // Create separate config object with same content
+	timeZone := "UTC"
 
 	// First call - should create new filter
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter1)
 
 	// Second call with different config object but same content - should return same filter
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter2)
 
@@ -135,14 +137,15 @@ func TestSharedFilterStorage_DifferentConfigCreatesNewFilter(t *testing.T) {
 	cfg1 := createTestFilterConfig()
 	cfg2 := createTestFilterConfig()
 	cfg2.CaseSensitive = true // Different configuration
+	timeZone := "UTC"
 
 	// First call with cfg1
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter1)
 
 	// Second call with cfg2 - should create new filter
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter2)
 
@@ -159,13 +162,14 @@ func TestSharedFilterStorage_DifferentChangeFeedIDCreatesIndependentFilter(t *te
 	changeFeedID2 := createTestChangeFeedID("test-changefeed-2")
 	cfg1 := createTestFilterConfig()
 	cfg2 := createTestFilterConfigWithRules([]string{"test.*"}) // Create different config content
+	timeZone := "UTC"
 
 	// Call with different changeFeedID and different config objects with different content
-	filter1, err := storage.GetOrSetFilter(changeFeedID1, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID1, cfg1, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter1)
 
-	filter2, err := storage.GetOrSetFilter(changeFeedID2, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID2, cfg2, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter2)
 
@@ -182,11 +186,12 @@ func TestSharedFilterStorage_CaseSensitiveFieldDifference(t *testing.T) {
 	cfg1 := createTestFilterConfig()
 	cfg2 := createTestFilterConfig()
 	cfg2.CaseSensitive = true
+	timeZone := "UTC"
 
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 
 	assertFilterInstancesDifferent(t, filter1, filter2)
@@ -201,11 +206,12 @@ func TestSharedFilterStorage_ForceReplicateFieldDifference(t *testing.T) {
 	cfg1 := createTestFilterConfig()
 	cfg2 := createTestFilterConfig()
 	cfg2.ForceReplicate = true
+	timeZone := "UTC"
 
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 
 	assertFilterInstancesDifferent(t, filter1, filter2)
@@ -219,11 +225,12 @@ func TestSharedFilterStorage_RulesFieldDifference(t *testing.T) {
 	changeFeedID := createTestChangeFeedID("test-changefeed")
 	cfg1 := createTestFilterConfigWithRules([]string{"*.*"})
 	cfg2 := createTestFilterConfigWithRules([]string{"test.*"})
+	timeZone := "UTC"
 
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 
 	assertFilterInstancesDifferent(t, filter1, filter2)
@@ -238,11 +245,12 @@ func TestSharedFilterStorage_IgnoreTxnStartTsFieldDifference(t *testing.T) {
 	cfg1 := createTestFilterConfig()
 	cfg2 := createTestFilterConfig()
 	cfg2.FilterConfig.IgnoreTxnStartTs = []uint64{123456}
+	timeZone := "UTC"
 
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 
 	assertFilterInstancesDifferent(t, filter1, filter2)
@@ -256,11 +264,12 @@ func TestSharedFilterStorage_EventFiltersFieldDifference(t *testing.T) {
 	changeFeedID := createTestChangeFeedID("test-changefeed")
 	cfg1 := createTestFilterConfig()
 	cfg2 := createTestFilterConfigWithEventFilters([]*eventpb.EventFilterRule{createTestEventFilterRule()})
+	timeZone := "UTC"
 
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 
 	assertFilterInstancesDifferent(t, filter1, filter2)
@@ -272,6 +281,7 @@ func TestSharedFilterStorage_ComplexEventFiltersDifference(t *testing.T) {
 	}
 
 	changeFeedID := createTestChangeFeedID("test-changefeed")
+	timeZone := "UTC"
 
 	// Create first config with one event filter
 	eventFilter1 := createTestEventFilterRule()
@@ -283,10 +293,10 @@ func TestSharedFilterStorage_ComplexEventFiltersDifference(t *testing.T) {
 	eventFilter2.Matcher = []string{"test2.*"}
 	cfg2 := createTestFilterConfigWithEventFilters([]*eventpb.EventFilterRule{eventFilter2})
 
-	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1, timeZone)
 	require.NoError(t, err)
 
-	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2, timeZone)
 	require.NoError(t, err)
 
 	assertFilterInstancesDifferent(t, filter1, filter2)
@@ -307,8 +317,9 @@ func TestSharedFilterStorage_EmptyConfigTest(t *testing.T) {
 			EventFilters:     []*eventpb.EventFilterRule{},
 		},
 	}
+	timeZone := "UTC"
 
-	filter, err := storage.GetOrSetFilter(changeFeedID, cfg)
+	filter, err := storage.GetOrSetFilter(changeFeedID, cfg, timeZone)
 	require.NoError(t, err)
 	require.NotNil(t, filter)
 }
@@ -320,6 +331,7 @@ func TestSharedFilterStorage_ConcurrentAccessTest(t *testing.T) {
 
 	changeFeedID := createTestChangeFeedID("test-changefeed")
 	cfg := createTestFilterConfig()
+	timeZone := "UTC"
 
 	// Test concurrent access with same config
 	done := make(chan bool, 2)
@@ -327,12 +339,12 @@ func TestSharedFilterStorage_ConcurrentAccessTest(t *testing.T) {
 	var err1, err2 error
 
 	go func() {
-		filter1, err1 = storage.GetOrSetFilter(changeFeedID, cfg)
+		filter1, err1 = storage.GetOrSetFilter(changeFeedID, cfg, timeZone)
 		done <- true
 	}()
 
 	go func() {
-		filter2, err2 = storage.GetOrSetFilter(changeFeedID, cfg)
+		filter2, err2 = storage.GetOrSetFilter(changeFeedID, cfg, timeZone)
 		done <- true
 	}()
 
@@ -347,4 +359,39 @@ func TestSharedFilterStorage_ConcurrentAccessTest(t *testing.T) {
 
 	// Both should return the same filter instance due to sharing
 	assertFilterInstancesEqual(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_TimeZoneDifference(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	// Create config with expression filters to make timezone difference more apparent
+	cfg := createTestFilterConfigWithEventFilters([]*eventpb.EventFilterRule{
+		{
+			Matcher:                  []string{"test.*"},
+			IgnoreEvent:              []string{},
+			IgnoreSql:                []string{},
+			IgnoreInsertValueExpr:    "id > 1000",
+			IgnoreUpdateNewValueExpr: "",
+			IgnoreUpdateOldValueExpr: "",
+			IgnoreDeleteValueExpr:    "",
+		},
+	})
+	timeZone1 := "UTC"
+	timeZone2 := "Asia/Shanghai"
+
+	// First call with UTC timezone
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg, timeZone1)
+	require.NoError(t, err)
+	require.NotNil(t, filter1)
+
+	// Second call with different timezone - should create new filter
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg, timeZone2)
+	require.NoError(t, err)
+	require.NotNil(t, filter2)
+
+	// Verify different timezone creates different filter instances
+	assertFilterInstancesDifferent(t, filter1, filter2)
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -16,6 +16,8 @@ package filter
 import (
 	"testing"
 
+	"github.com/pingcap/ticdc/eventpb"
+	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/stretchr/testify/require"
 )
@@ -25,4 +27,324 @@ func TestFilterValue(t *testing.T) {
 	require.Nil(t, err)
 	ok := ft.ShouldIgnoreSchema(TiDBWorkloadSchema)
 	require.True(t, ok)
+}
+
+// Helper functions to create test configurations
+func createTestFilterConfig() *eventpb.FilterConfig {
+	return &eventpb.FilterConfig{
+		CaseSensitive:  false,
+		ForceReplicate: false,
+		FilterConfig: &eventpb.InnerFilterConfig{
+			Rules:            []string{"*.*"},
+			IgnoreTxnStartTs: []uint64{},
+			EventFilters:     []*eventpb.EventFilterRule{},
+		},
+	}
+}
+
+func createTestFilterConfigWithRules(rules []string) *eventpb.FilterConfig {
+	cfg := createTestFilterConfig()
+	cfg.FilterConfig.Rules = rules
+	return cfg
+}
+
+func createTestFilterConfigWithEventFilters(eventFilters []*eventpb.EventFilterRule) *eventpb.FilterConfig {
+	cfg := createTestFilterConfig()
+	cfg.FilterConfig.EventFilters = eventFilters
+	return cfg
+}
+
+func createTestEventFilterRule() *eventpb.EventFilterRule {
+	return &eventpb.EventFilterRule{
+		Matcher:                  []string{"test.*"},
+		IgnoreEvent:              []string{},
+		IgnoreSql:                []string{},
+		IgnoreInsertValueExpr:    "",
+		IgnoreUpdateNewValueExpr: "",
+		IgnoreUpdateOldValueExpr: "",
+		IgnoreDeleteValueExpr:    "",
+	}
+}
+
+func createTestChangeFeedID(name string) common.ChangeFeedID {
+	return common.NewChangeFeedIDWithName(name)
+}
+
+// Helper functions to verify filter instances
+func assertFilterInstancesEqual(t *testing.T, filter1, filter2 Filter) {
+	// Use pointer comparison to verify they are the same instance
+	require.Equal(t, filter1, filter2, "Filter instances should be the same")
+}
+
+func assertFilterInstancesDifferent(t *testing.T, filter1, filter2 Filter) {
+	// Use pointer comparison to verify they are different instances
+	require.NotEqual(t, filter1, filter2, "Filter instances should be different")
+}
+
+func TestSharedFilterStorage_SameConfigSharesFilter(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg := createTestFilterConfig()
+
+	// First call - should create new filter
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, filter1)
+
+	// Second call with same config - should return same filter
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, filter2)
+
+	// Verify both calls return the same filter instance
+	assertFilterInstancesEqual(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_SameConfigContentSharesFilter(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg1 := createTestFilterConfig()
+	cfg2 := createTestFilterConfig() // Create separate config object with same content
+
+	// First call - should create new filter
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+	require.NotNil(t, filter1)
+
+	// Second call with different config object but same content - should return same filter
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+	require.NotNil(t, filter2)
+
+	// Verify both calls return the same filter instance due to content equality
+	assertFilterInstancesEqual(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_DifferentConfigCreatesNewFilter(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg1 := createTestFilterConfig()
+	cfg2 := createTestFilterConfig()
+	cfg2.CaseSensitive = true // Different configuration
+
+	// First call with cfg1
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+	require.NotNil(t, filter1)
+
+	// Second call with cfg2 - should create new filter
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+	require.NotNil(t, filter2)
+
+	// Verify both calls return different filter instances
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_DifferentChangeFeedIDCreatesIndependentFilter(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID1 := createTestChangeFeedID("test-changefeed-1")
+	changeFeedID2 := createTestChangeFeedID("test-changefeed-2")
+	cfg1 := createTestFilterConfig()
+	cfg2 := createTestFilterConfigWithRules([]string{"test.*"}) // Create different config content
+
+	// Call with different changeFeedID and different config objects with different content
+	filter1, err := storage.GetOrSetFilter(changeFeedID1, cfg1)
+	require.NoError(t, err)
+	require.NotNil(t, filter1)
+
+	filter2, err := storage.GetOrSetFilter(changeFeedID2, cfg2)
+	require.NoError(t, err)
+	require.NotNil(t, filter2)
+
+	// Verify different changeFeedID with different config content creates different filter instances
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_CaseSensitiveFieldDifference(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg1 := createTestFilterConfig()
+	cfg2 := createTestFilterConfig()
+	cfg2.CaseSensitive = true
+
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_ForceReplicateFieldDifference(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg1 := createTestFilterConfig()
+	cfg2 := createTestFilterConfig()
+	cfg2.ForceReplicate = true
+
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_RulesFieldDifference(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg1 := createTestFilterConfigWithRules([]string{"*.*"})
+	cfg2 := createTestFilterConfigWithRules([]string{"test.*"})
+
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_IgnoreTxnStartTsFieldDifference(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg1 := createTestFilterConfig()
+	cfg2 := createTestFilterConfig()
+	cfg2.FilterConfig.IgnoreTxnStartTs = []uint64{123456}
+
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_EventFiltersFieldDifference(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg1 := createTestFilterConfig()
+	cfg2 := createTestFilterConfigWithEventFilters([]*eventpb.EventFilterRule{createTestEventFilterRule()})
+
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_ComplexEventFiltersDifference(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+
+	// Create first config with one event filter
+	eventFilter1 := createTestEventFilterRule()
+	eventFilter1.Matcher = []string{"test1.*"}
+	cfg1 := createTestFilterConfigWithEventFilters([]*eventpb.EventFilterRule{eventFilter1})
+
+	// Create second config with different event filter
+	eventFilter2 := createTestEventFilterRule()
+	eventFilter2.Matcher = []string{"test2.*"}
+	cfg2 := createTestFilterConfigWithEventFilters([]*eventpb.EventFilterRule{eventFilter2})
+
+	filter1, err := storage.GetOrSetFilter(changeFeedID, cfg1)
+	require.NoError(t, err)
+
+	filter2, err := storage.GetOrSetFilter(changeFeedID, cfg2)
+	require.NoError(t, err)
+
+	assertFilterInstancesDifferent(t, filter1, filter2)
+}
+
+func TestSharedFilterStorage_EmptyConfigTest(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg := &eventpb.FilterConfig{
+		CaseSensitive:  false,
+		ForceReplicate: false,
+		FilterConfig: &eventpb.InnerFilterConfig{
+			Rules:            []string{},
+			IgnoreTxnStartTs: []uint64{},
+			EventFilters:     []*eventpb.EventFilterRule{},
+		},
+	}
+
+	filter, err := storage.GetOrSetFilter(changeFeedID, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+}
+
+func TestSharedFilterStorage_ConcurrentAccessTest(t *testing.T) {
+	storage := &SharedFilterStorage{
+		m: make(map[common.ChangeFeedID]FilterWithConfig),
+	}
+
+	changeFeedID := createTestChangeFeedID("test-changefeed")
+	cfg := createTestFilterConfig()
+
+	// Test concurrent access with same config
+	done := make(chan bool, 2)
+	var filter1, filter2 Filter
+	var err1, err2 error
+
+	go func() {
+		filter1, err1 = storage.GetOrSetFilter(changeFeedID, cfg)
+		done <- true
+	}()
+
+	go func() {
+		filter2, err2 = storage.GetOrSetFilter(changeFeedID, cfg)
+		done <- true
+	}()
+
+	// Wait for both goroutines to complete
+	<-done
+	<-done
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	require.NotNil(t, filter1)
+	require.NotNil(t, filter2)
+
+	// Both should return the same filter instance due to sharing
+	assertFilterInstancesEqual(t, filter1, filter2)
 }

--- a/pkg/messaging/message.go
+++ b/pkg/messaging/message.go
@@ -209,7 +209,7 @@ func (r DispatcherRequest) GetFilter() filter.Filter {
 	changefeedID := r.GetChangefeedID()
 	filter, err := filter.
 		GetSharedFilterStorage().
-		GetOrSetFilter(changefeedID, r.DispatcherRequest.FilterConfig, r.DispatcherRequest.GetTimezone())
+		GetOrSetFilter(changefeedID, r.DispatcherRequest.FilterConfig, r.GetTimezone().String())
 	if err != nil {
 		log.Panic("create filter failed", zap.Error(err), zap.Any("filterConfig", r.DispatcherRequest.FilterConfig))
 	}

--- a/pkg/messaging/message.go
+++ b/pkg/messaging/message.go
@@ -209,7 +209,7 @@ func (r DispatcherRequest) GetFilter() filter.Filter {
 	changefeedID := r.GetChangefeedID()
 	filter, err := filter.
 		GetSharedFilterStorage().
-		GetOrSetFilter(changefeedID, r.DispatcherRequest.FilterConfig)
+		GetOrSetFilter(changefeedID, r.DispatcherRequest.FilterConfig, r.DispatcherRequest.GetTimezone())
 	if err != nil {
 		log.Panic("create filter failed", zap.Error(err), zap.Any("filterConfig", r.DispatcherRequest.FilterConfig))
 	}

--- a/pkg/messaging/message.go
+++ b/pkg/messaging/message.go
@@ -209,7 +209,7 @@ func (r DispatcherRequest) GetFilter() filter.Filter {
 	changefeedID := r.GetChangefeedID()
 	filter, err := filter.
 		GetSharedFilterStorage().
-		GetOrSetFilter(changefeedID, r.DispatcherRequest.FilterConfig, "", false)
+		GetOrSetFilter(changefeedID, r.DispatcherRequest.FilterConfig)
 	if err != nil {
 		log.Panic("create filter failed", zap.Error(err), zap.Any("filterConfig", r.DispatcherRequest.FilterConfig))
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/1677

### What is changed and how it works?

*   **New `FilterWithConfig` struct:** This struct encapsulates the `Filter` interface along with the `eventpb.FilterConfig` and `timeZone` string, providing a complete context for each stored filter.
*   **Enhanced `GetOrSetFilter` logic:** The method now performs a deep comparison of the incoming filter configuration and timezone against the stored ones. It leverages a new helper function, `isFilterConfigEqual`, which uses `proto.Equal` for robust comparison of protobuf messages.
*   **Conditional Filter Rebuilding:** A filter is now only rebuilt if its configuration or timezone has genuinely changed, preventing unnecessary re-initializations.
*   **Updated Call Site:** The `GetFilter()` method in `pkg/messaging/message.go` has been updated to correctly pass the timezone to the `GetOrSetFilter` function.
*   **Comprehensive Unit Tests:** Extensive new test cases have been added in `pkg/filter/filter_test.go` to validate the correct sharing and rebuilding behavior of filters under various configuration change scenarios, including concurrent access and differences in specific configuration fields.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
