### PR TITLE
feat(filter, ddl): add `start_ts` filtering and differentiate discard/ignore for DDLs

### DIFF
--- a/cmd/filter-helper/main.go
+++ b/cmd/filter-helper/main.go
@@ -73,7 +73,12 @@ func runFilter(cmd *cobra.Command, args []string) {
 		fmt.Printf("Table: %s, Not matched filter rule\n", table)
 	case "ddl":
 		ddlType := timodel.ActionCreateTable
-		ignored, err := ft.ShouldIgnoreDDL(tableAndSchema[0], tableAndSchema[1], ddl, ddlType, nil, 0)
+		discard := ft.ShouldDiscardDDL(tableAndSchema[0], tableAndSchema[1], ddlType, nil, 0)
+		if discard {
+			fmt.Printf("DDL: %s, should be discard by event filter rule\n", ddl)
+			return
+		}
+		ignored, err := ft.ShouldIgnoreDDL(tableAndSchema[0], tableAndSchema[1], ddl, ddlType)
 		if err != nil {
 			fmt.Printf("filter ddl error: %s, error: %v\n", ddl, err)
 			return

--- a/cmd/filter-helper/main.go
+++ b/cmd/filter-helper/main.go
@@ -73,7 +73,7 @@ func runFilter(cmd *cobra.Command, args []string) {
 		fmt.Printf("Table: %s, Not matched filter rule\n", table)
 	case "ddl":
 		ddlType := timodel.ActionCreateTable
-		ignored, err := ft.ShouldIgnoreDDL(tableAndSchema[0], tableAndSchema[1], ddl, ddlType, nil)
+		ignored, err := ft.ShouldIgnoreDDL(tableAndSchema[0], tableAndSchema[1], ddl, ddlType, nil, 0)
 		if err != nil {
 			fmt.Printf("filter ddl error: %s, error: %v\n", ddl, err)
 			return

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -530,6 +530,7 @@ func buildPersistedDDLEventCommon(args buildPersistedDDLEventFuncArgs) Persisted
 		DBInfo:            job.BinlogInfo.DBInfo,
 		TableInfo:         job.BinlogInfo.TableInfo,
 		FinishedTs:        job.BinlogInfo.FinishedTS,
+		StartTs:           job.StartTS,
 		BDRRole:           job.BDRRole,
 		CDCWriteSource:    job.CDCWriteSource,
 	}
@@ -1527,13 +1528,20 @@ func buildDDLEventCommon(rawEvent *PersistedDDLEvent, tableFilter filter.Filter,
 		if tableFilter != nil && rawEvent.SchemaName != "" && rawEvent.TableName != "" {
 			var err error
 			notSync, err = tableFilter.ShouldIgnoreDDL(
-				rawEvent.SchemaName, rawEvent.TableName, rawEvent.Query, model.ActionType(rawEvent.Type), rawEvent.TableInfo)
+				rawEvent.SchemaName, rawEvent.TableName, rawEvent.Query, model.ActionType(rawEvent.Type), rawEvent.TableInfo, rawEvent.StartTs)
 			if err != nil {
 				return commonEvent.DDLEvent{}, false, err
 			}
 			// if the ddl involve another table name, only set filtered to true when all of them should be filtered
 			if rawEvent.ExtraSchemaName != "" && rawEvent.ExtraTableName != "" {
-				notSyncByExtraTable, err := tableFilter.ShouldIgnoreDDL(rawEvent.ExtraSchemaName, rawEvent.ExtraTableName, rawEvent.Query, model.ActionType(rawEvent.Type), rawEvent.TableInfo)
+				notSyncByExtraTable, err := tableFilter.ShouldIgnoreDDL(
+					rawEvent.ExtraSchemaName,
+					rawEvent.ExtraTableName,
+					rawEvent.Query,
+					model.ActionType(rawEvent.Type),
+					rawEvent.TableInfo,
+					rawEvent.StartTs,
+				)
 				if err != nil {
 					return commonEvent.DDLEvent{}, false, err
 				}

--- a/logservice/schemastore/types.go
+++ b/logservice/schemastore/types.go
@@ -68,6 +68,7 @@ type PersistedDDLEvent struct {
 	Query         string `msg:"query"`
 	SchemaVersion int64  `msg:"schema_version"`
 	FinishedTs    uint64 `msg:"finished_ts"`
+	StartTs       uint64 `msg:"start_ts"`
 
 	DBInfo *model.DBInfo `msg:"-"`
 	// it is from upstream job.TableInfo

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -394,7 +394,7 @@ func (t *DMLEvent) AppendRow(raw *common.RawKVEntry,
 	}
 
 	if filter != nil {
-		skip, err := filter.ShouldIgnoreDML(rowType, preRow, row, t.TableInfo)
+		skip, err := filter.ShouldIgnoreDML(rowType, preRow, row, t.TableInfo, raw.StartTs)
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1796

### What is changed and how it works?

This PR refactors the event filter to introduce a clear distinction between "discarding" and "ignoring" DDL events, making the filtering logic more precise and easier to reason about. It also adds support for filtering both DML and DDL events based on their transaction `startTs`.

#### Key Changes:

1.  **Introduced `ShouldDiscardDDL` for Early Filtering**

    A new filter method, `ShouldDiscardDDL`, has been added. This function is responsible for dropping DDL events that should not be processed at all. A DDL is discarded if:
    * It is an unsupported DDL type.
    * Its `startTs` is in the `ignore-txn-start-ts` list.
    * It acts on a system schema (`mysql`, etc.).
    * The table does not match the configured table filter rules (e.g., `test.t1` is included but `otherdb.t1` is not).

2.  **Clarified the Role of `ShouldIgnoreDDL`**

    The existing `ShouldIgnoreDDL` function is now responsible only for checking against event-specific filter rules (e.g., `ignore-event = ["drop table"]`) and SQL expression matchers.
    * An **ignored** DDL is not sent downstream but is still processed internally to update the schema state. This ensures that subsequent DML events for a newly created (but ignored) table are handled correctly.
    * A **discarded** DDL is dropped entirely and has no impact on the internal state.

    The following example from the comments illustrates the difference:
    * `CREATE TABLE test.worker`: If an event filter ignores `create table`, this DDL is **ignored**. The table's schema is tracked, but the DDL is not sent downstream.
    * `CREATE TABLE other.worker`: If `other.*` is not in the table filter rules, this DDL is **discarded**. The changefeed does not track the table at all.

3.  **Added `startTs` Filtering for DML and DDL**

    To support transaction-level filtering, the `startTs` is now passed through the event processing pipeline.
    * The `PersistedDDLEvent` struct now includes the `StartTs` field.
    * The `ShouldIgnoreDML` and the new `ShouldDiscardDDL` methods now accept `startTs` as a parameter, allowing events from specific transactions to be filtered out uniformly.

4.  **Updated Function Signatures and Tests**

    * The signatures for `ShouldIgnoreDML` and `ShouldIgnoreDDL` have been updated to reflect the new parameters and responsibilities.
    * New unit tests, including `TestShouldDiscardDDL` and `TestShouldIgnoreStartTs`, have been added to verify the correctness of the new logic. Existing tests have been updated accordingly.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
