### PR TITLE
fix(filter): ensure event filter respects case-sensitive setting

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -84,7 +84,7 @@ func NewFilter(cfg *config.FilterConfig, tz string, caseSensitive bool, forceRep
 	if err != nil {
 		return nil, err
 	}
-	sqlEventFilter, err := newSQLEventFilter(cfg)
+	sqlEventFilter, err := newSQLEventFilter(cfg, caseSensitive)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/filter/sql_event_filter_test.go
+++ b/pkg/filter/sql_event_filter_test.go
@@ -250,6 +250,7 @@ func TestSQLEventFilterDDL(t *testing.T) {
 		})
 	}
 }
+
 func TestSQLEventFilterCaseSensitivity(t *testing.T) {
 	t.Parallel()
 	cfg := &config.FilterConfig{


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1809

### What is changed and how it works?

This PR fixes a bug where the event filter feature was ignoring the global `case-sensitive` configuration and always performing case-sensitive table matching.

**Changes:**

1.  **Propagate `caseSensitive` Flag:** The `caseSensitive` boolean is now passed through the filter creation chain: `NewFilter` -\> `newSQLEventFilter` -\> `newSQLEventFilterRule`. This ensures the SQL event filter is aware of the global case sensitivity setting.

2.  **Conditional Case-Insensitive Matching:** In `newSQLEventFilterRule`, the `tfilter` is now conditionally wrapped with `tfilter.CaseInsensitive(tf)` only when `caseSensitive` is `false`. When `true`, the default case-sensitive `tfilter` is used, achieving the desired behavior.

3.  **Refactor and Add Testing:**

      * Removed a hardcoded `caseSensitive = false` constant in `sql_event_filter.go`.
      * Added new, comprehensive unit tests (`TestShouldIgnoreDMLCaseSensitivity`, `TestShouldIgnoreDDLCaseSensitivity`, `TestSQLEventFilterCaseSensitivity`) to verify the correct filtering behavior for both DML and DDL events in both case-sensitive and case-insensitive modes.
      * Updated existing tests to run against both `caseSensitive = true` and `caseSensitive = false` to prevent regressions.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
