### PR TITLE
fix(test): sort actual results in TestApplyDDLJobs for stable comparison

### DIFF
--- a/logservice/schemastore/persist_storage_test.go
+++ b/logservice/schemastore/persist_storage_test.go
@@ -2023,6 +2023,10 @@ func TestApplyDDLJobs(t *testing.T) {
 							// TableID should be unique, so it is enough
 							return expectedDDLEvent.UpdatedSchemas[i].TableID < expectedDDLEvent.UpdatedSchemas[j].TableID
 						})
+						sort.Slice(actualDDLEvent.UpdatedSchemas, func(i, j int) bool {
+							// TableID should be unique, so it is enough
+							return actualDDLEvent.UpdatedSchemas[i].TableID < actualDDLEvent.UpdatedSchemas[j].TableID
+						})
 						if !reflect.DeepEqual(expectedDDLEvent.UpdatedSchemas, actualDDLEvent.UpdatedSchemas) {
 							return false
 						}
@@ -2048,6 +2052,10 @@ func TestApplyDDLJobs(t *testing.T) {
 						sort.Slice(expectedDDLEvent.NeedAddedTables, func(i, j int) bool {
 							// TableID should be unique, so it is enough
 							return expectedDDLEvent.NeedAddedTables[i].TableID < expectedDDLEvent.NeedAddedTables[j].TableID
+						})
+						sort.Slice(actualDDLEvent.NeedAddedTables, func(i, j int) bool {
+							// TableID should be unique, so it is enough
+							return actualDDLEvent.NeedAddedTables[i].TableID < actualDDLEvent.NeedAddedTables[j].TableID
 						})
 						if !reflect.DeepEqual(expectedDDLEvent.NeedAddedTables, actualDDLEvent.NeedAddedTables) {
 							return false
@@ -2076,6 +2084,24 @@ func TestApplyDDLJobs(t *testing.T) {
 									return false
 								} else {
 									return expectedDDLEvent.TableNameChange.DropName[i].SchemaName < expectedDDLEvent.TableNameChange.DropName[j].SchemaName
+								}
+							})
+							sort.Slice(actualDDLEvent.TableNameChange.AddName, func(i, j int) bool {
+								if actualDDLEvent.TableNameChange.AddName[i].TableName < actualDDLEvent.TableNameChange.AddName[j].TableName {
+									return true
+								} else if actualDDLEvent.TableNameChange.AddName[i].TableName > actualDDLEvent.TableNameChange.AddName[j].TableName {
+									return false
+								} else {
+									return actualDDLEvent.TableNameChange.AddName[i].SchemaName < actualDDLEvent.TableNameChange.AddName[j].SchemaName
+								}
+							})
+							sort.Slice(actualDDLEvent.TableNameChange.DropName, func(i, j int) bool {
+								if actualDDLEvent.TableNameChange.DropName[i].TableName < actualDDLEvent.TableNameChange.DropName[j].TableName {
+									return true
+								} else if actualDDLEvent.TableNameChange.DropName[i].TableName > actualDDLEvent.TableNameChange.DropName[j].TableName {
+									return false
+								} else {
+									return actualDDLEvent.TableNameChange.DropName[i].SchemaName < actualDDLEvent.TableNameChange.DropName[j].SchemaName
 								}
 							})
 							if !reflect.DeepEqual(expectedDDLEvent.TableNameChange, actualDDLEvent.TableNameChange) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1899

### What is changed and how it works?

This PR fixes a flaky unit test, `TestApplyDDLJobs`, which was failing due to an incorrect comparison between expected and actual results.

The test sorts several slices within the `expected` struct but did not sort the corresponding slices in the `actual` struct returned by the function. Since the order of elements in these slices is not guaranteed, the `reflect.DeepEqual` comparison would fail whenever the actual order did not match the expected sorted order, making the test unreliable.

This change introduces sorting for the `actual` result slices to mirror the sorting applied to the `expected` result slices, ensuring the test is deterministic and only checks for content equality.

**Detailed changes:**

- Sorts `actualDDLEvent.UpdatedSchemas` by `TableID`.
- Sorts `actualDDLEvent.NeedAddedTables` by `TableID`.
- Sorts `actualDDLEvent.TableNameChange.AddName` and `actualDDLEvent.TableNameChange.DropName` first by `TableName` and then by `SchemaName`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
