### PR TITLE
cherry pick `cloudstorage: fix a bug causing context cancelled errors and stuck sink`

### DIFF
--- a/pkg/util/external_storage.go
+++ b/pkg/util/external_storage.go
@@ -207,13 +207,28 @@ func (s *extStorageWithTimeout) DeleteFile(ctx context.Context, name string) err
 func (s *extStorageWithTimeout) Open(
 	ctx context.Context, path string, _ *storage.ReaderOption,
 ) (storage.ExternalFileReader, error) {
+	// Unlike other methods, Open method cannot call cancel() in defer.
+	// This is because the reader's lifetime is bound to the context provided at Open().
+	// Subsequent Read() calls on reader will observe context cancellation.
+	// Instead, we wrap the reader in a struct and cancel it's context in Close().
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
-	defer cancel()
-	reader, err := s.ExternalStorage.Open(ctx, path, nil)
+	r, err := s.ExternalStorage.Open(ctx, path, nil)
 	if err != nil {
-		err = errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("Open")
+		cancel()
+		return nil, err
 	}
-	return reader, err
+	return &readerWithCancel{ExternalFileReader: r, cancel: cancel}, nil
+}
+
+type readerWithCancel struct {
+	storage.ExternalFileReader
+	cancel context.CancelFunc
+}
+
+// Close the reader and cancel the context.
+func (r *readerWithCancel) Close() error {
+	defer r.cancel()
+	return r.ExternalFileReader.Close()
 }
 
 // WalkDir traverse all the files in a dir.

--- a/pkg/util/external_storage_test.go
+++ b/pkg/util/external_storage_test.go
@@ -47,6 +47,15 @@ type mockExternalStorage struct {
 	httpClient              *http.Client
 }
 
+// Implement Open so tests can simulate readers that bind to the Open() context.
+func (m *mockExternalStorage) Open(ctx context.Context, path string, option *storage.ReaderOption) (storage.ExternalFileReader, error) {
+	return &ctxBoundReader{ctx: ctx}, nil
+}
+
+func (m *mockExternalStorage) URI() string { return "mock://" }
+
+func (m *mockExternalStorage) Close() {}
+
 // WriteFile simulates a write operation by making an HTTP request that respects context cancellation.
 func (m *mockExternalStorage) WriteFile(ctx context.Context, name string, data []byte) error {
 	if m.httpClient == nil {
@@ -124,4 +133,63 @@ func TestExtStorageWithTimeoutWriteFileSuccess(t *testing.T) {
 
 	// Assert success
 	require.NoError(t, err, "Expected no error for successful write within timeout")
+}
+
+// ctxBoundReader is a reader that checks the context passed to Open().
+// It simulates backends (e.g., Azure) that bind reader lifetime to the Open() context.
+type ctxBoundReader struct {
+	ctx context.Context
+}
+
+func (r *ctxBoundReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = 'x'
+	return 1, nil
+}
+
+func (r *ctxBoundReader) Seek(offset int64, whence int) (int64, error) {
+	return 0, nil
+}
+
+func (r *ctxBoundReader) Close() error { return nil }
+
+func (r *ctxBoundReader) GetFileSize() (int64, error) { return 1, nil }
+
+func TestExtStorageOpenDoesNotCancelReaderContext(t *testing.T) {
+	timedStore := &extStorageWithTimeout{
+		ExternalStorage: &mockExternalStorage{},
+		timeout:         100 * time.Millisecond,
+	}
+
+	rd, err := timedStore.Open(context.Background(), "file", nil)
+	require.NoError(t, err)
+	defer rd.Close()
+
+	// If Open() had used a derived context with immediate cancel, this would fail with context canceled.
+	_, err = rd.Read(make([]byte, 1))
+	require.NoError(t, err)
+}
+
+func TestExtStorageOpenReaderRespectsCallerCancel(t *testing.T) {
+	timedStore := &extStorageWithTimeout{
+		ExternalStorage: &mockExternalStorage{},
+		timeout:         10 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rd, err := timedStore.Open(ctx, "file", nil)
+	require.NoError(t, err)
+	defer rd.Close()
+
+	// This should cause the reader to fail with context canceled.
+	cancel()
+	_, err = rd.Read(make([]byte, 1))
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

cherry pick https://github.com/pingcap/tiflow/pull/12276 from tilflow

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
