### PR TITLE
logpuller: fix a data race in priority queue

### DIFF
--- a/logservice/logpuller/priority_queue.go
+++ b/logservice/logpuller/priority_queue.go
@@ -123,5 +123,4 @@ func (pq *PriorityQueue) Close() {
 	for pq.Len() > 0 {
 		pq.TryPop()
 	}
-	close(pq.signal)
 }

--- a/logservice/logpuller/priority_queue_test.go
+++ b/logservice/logpuller/priority_queue_test.go
@@ -247,6 +247,7 @@ func TestPriorityQueue_ConcurrentOperations(t *testing.T) {
 	var mu sync.Mutex
 	consumedTasks := make([]PriorityTask, 0, totalTasks)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Start consumers
 	for i := 0; i < numConsumers; i++ {
@@ -372,11 +373,42 @@ func TestPriorityQueue_Close(t *testing.T) {
 	pq.Push(task3)
 	require.Equal(t, 3, pq.Len())
 
-	// Test that close doesn't panic
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			pq.Push(newMockPriorityTask(i, "task"))
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		defer cancel()
+
+		for i := 0; i < 1000; i++ {
+			// Test that close doesn't panic
+			require.NotPanics(t, func() {
+				pq.Close()
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			// Make sure it won't block when the queue is closed
+			pq.Pop(ctx)
+		}
+	}()
+
+	wg.Wait()
 	require.NotPanics(t, func() {
 		pq.Close()
 	})
-
 	// Test that the tasks are popped
 	require.Equal(t, 0, pq.Len())
 }

--- a/logservice/logpuller/priority_queue_test.go
+++ b/logservice/logpuller/priority_queue_test.go
@@ -434,7 +434,9 @@ func TestPriorityQueue_EmptyQueueOperations(t *testing.T) {
 
 func TestPriorityQueue_RealPriorityTaskIntegration(t *testing.T) {
 	pq := NewPriorityQueue()
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	currentTs := oracle.GoTimeToTS(time.Now())
 
 	// Create real priority tasks with different types
@@ -484,6 +486,7 @@ func TestPriorityQueue_RealPriorityTaskIntegration(t *testing.T) {
 	require.Equal(t, 0, pq.Len())
 
 	pq.Close()
+	cancel()
 	task, err := pq.Pop(ctx)
 	require.Nil(t, task)
 	require.Error(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2120 

### What is changed and how it works?

Don't close the `p.signal` channel when closing the queue. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
