### PR TITLE
eventstore: fix cannot find subStat panic

### DIFF
--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -823,11 +823,8 @@ func (e *eventStore) stopReceiveEventFromSubStat(dispatcherID common.DispatcherI
 	}
 	subStat.dispatchers.Lock()
 	defer subStat.dispatchers.Unlock()
-	for id, subscriber := range subStat.dispatchers.subscribers {
-		if id == dispatcherID {
-			subscriber.isStopped.Store(true)
-			break
-		}
+	if subscriber, ok := subStat.dispatchers.subscribers[dispatcherID]; ok {
+		subscriber.isStopped.Store(true)
 	}
 }
 

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -551,9 +551,9 @@ func (e *eventStore) RegisterDispatcher(
 		if subStat.resolvedTs.CompareAndSwap(currentResolvedTs, ts) {
 			subStat.dispatchers.Lock()
 			defer subStat.dispatchers.Unlock()
-			for _, subscriber := range subStat.dispatchers.subscribers {
+for _, subscriber := range subStat.dispatchers.subscribers {
 				if !subscriber.isStopped.Load() {
-					notifier(ts, subStat.maxEventCommitTs.Load())
+					subscriber.notifyFunc(ts, subStat.maxEventCommitTs.Load())
 				}
 			}
 			CounterResolved.Inc()

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -566,6 +566,8 @@ func (e *eventStore) RegisterDispatcher(
 	// Note: don't hold any lock when call Subscribe
 	e.subClient.Subscribe(subStat.subID, *dispatcherSpan, startTs, consumeKVEvents, advanceResolvedTs, resolvedTsAdvanceInterval, bdrMode)
 	log.Info("new subscription created",
+		zap.Stringer("dispatcherID", dispatcherID),
+		zap.Uint64("startTs", startTs),
 		zap.Uint64("subscriptionID", uint64(subStat.subID)),
 		zap.String("subSpan", common.FormatTableSpan(subStat.tableSpan)))
 	e.subscriptionChangeCh.In() <- SubscriptionChange{

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -57,6 +57,12 @@ var (
 
 type ResolvedTsNotifier func(watermark uint64, latestCommitTs uint64)
 
+// Subscriber represents the dispatcher which depends on the subscription.
+type Subscriber struct {
+	notifyFunc ResolvedTsNotifier
+	isStopped  atomic.Bool
+}
+
 type EventStore interface {
 	common.SubModule
 
@@ -98,13 +104,31 @@ type dispatcherStat struct {
 	tableSpan *heartbeatpb.TableSpan
 	// the max ts of events which is not needed by this dispatcher
 	checkpointTs uint64
-	// the subscription which this dispatcher is currently depends on
-	subStat *subscriptionStat
-	// the subscription which this dispatcher finally depends on.
-	// the difference between subStat and pendingSubStat is that
-	// subStat may have span larger than dispatcher span,
-	// while pendingSubStat must have span the same as dispatcher span.
-	pendingSubStat *subscriptionStat
+	// the difference between `subStat`, `pendingSubStat` and `removingSubStat`:
+	//   1) if there is no existing subscriptions which can be reused,
+	//      or there is a existing subscription with exact span match,
+	//      the dispatcher will just have a `subStat`.
+	//   2) if a dispatcher can only find an existing subscription which has a larger containing span,
+	//      it will reuse this existing subscription as `subStat`
+	//      and create a new subscription with exact span, and set it as `pendingSubStat`.
+	//   3) when `pendingStat` is ready, we try to switch `pendingStat` to `subStat`,
+	//      and set the old `subStat` as `removingSubStat`.
+	//      the reason why `removingSubStat` is need is that if we remove old `subStat` directly,
+	//      there is a gap between the time when old `subStat` is removed
+	//      and when the old `subStat` send a new resolved ts to the dispatcher.
+	//      the new resolved ts may trigger a new scan task,
+	// 		and if the new `subStat` doesn't advance to new resolved ts,
+	//      the scan task cannot work as expected which break our design.
+	//      so the correct way to remove the old `subStat` is
+	//      a) set old `subStat` as `removingSubStat`
+	//      b) stop receive resolve ts event from `removingSubStat`
+	//      c) during later scan requests, when the new `subStat` can cover the scan range,
+	// 		   remove the `removingSubStat`. if not, we can still use `removingSubStat` temporarily.
+	//         (note: at most one later scan requests
+	//          maybe triggered by the resolved ts event from old `subStat`)
+	pendingSubStat  *subscriptionStat
+	subStat         *subscriptionStat
+	removingSubStat *subscriptionStat
 }
 
 type subscriptionStat struct {
@@ -114,7 +138,7 @@ type subscriptionStat struct {
 	// dispatchers depend on this subscription
 	dispatchers struct {
 		sync.Mutex
-		notifiers map[common.DispatcherID]ResolvedTsNotifier
+		subscribers map[common.DispatcherID]*Subscriber
 	}
 	// the index of the db which stores the data of the subscription
 	// used to clean obselete data of the subscription
@@ -405,7 +429,10 @@ func (e *eventStore) RegisterDispatcher(
 					e.dispatcherMeta.dispatcherStats[dispatcherID] = stat
 					subStat.idleTime.Store(0)
 					subStat.dispatchers.Lock()
-					subStat.dispatchers.notifiers[dispatcherID] = notifier
+					subStat.dispatchers.subscribers[dispatcherID] = &Subscriber{
+						notifyFunc: notifier,
+						isStopped:  atomic.Bool{},
+					}
 					subStat.dispatchers.Unlock()
 					e.dispatcherMeta.Unlock()
 					log.Info("reuse existing subscription with exact span match",
@@ -435,7 +462,10 @@ func (e *eventStore) RegisterDispatcher(
 		e.dispatcherMeta.dispatcherStats[dispatcherID] = stat
 		bestMatch.idleTime.Store(0)
 		bestMatch.dispatchers.Lock()
-		bestMatch.dispatchers.notifiers[dispatcherID] = notifier
+		bestMatch.dispatchers.subscribers[dispatcherID] = &Subscriber{
+			notifyFunc: notifier,
+			isStopped:  atomic.Bool{},
+		}
 		bestMatch.dispatchers.Unlock()
 		e.dispatcherMeta.Unlock()
 		log.Info("reuse existing subscription with smallest containing span",
@@ -467,8 +497,11 @@ func (e *eventStore) RegisterDispatcher(
 		dbIndex:   chIndex,
 		eventCh:   e.chs[chIndex],
 	}
-	subStat.dispatchers.notifiers = make(map[common.DispatcherID]ResolvedTsNotifier)
-	subStat.dispatchers.notifiers[dispatcherID] = notifier
+	subStat.dispatchers.subscribers = make(map[common.DispatcherID]*Subscriber)
+	subStat.dispatchers.subscribers[dispatcherID] = &Subscriber{
+		notifyFunc: notifier,
+		isStopped:  atomic.Bool{},
+	}
 	subStat.checkpointTs.Store(startTs)
 	subStat.resolvedTs.Store(startTs)
 	subStat.maxEventCommitTs.Store(startTs)
@@ -518,8 +551,10 @@ func (e *eventStore) RegisterDispatcher(
 		if subStat.resolvedTs.CompareAndSwap(currentResolvedTs, ts) {
 			subStat.dispatchers.Lock()
 			defer subStat.dispatchers.Unlock()
-			for _, notifier := range subStat.dispatchers.notifiers {
-				notifier(ts, subStat.maxEventCommitTs.Load())
+			for _, subscriber := range subStat.dispatchers.subscribers {
+				if !subscriber.isStopped.Load() {
+					notifier(ts, subStat.maxEventCommitTs.Load())
+				}
 			}
 			CounterResolved.Inc()
 			metrics.EventStoreNotifyDispatcherDurationHist.Observe(float64(time.Since(start).Seconds()))
@@ -580,7 +615,7 @@ func (e *eventStore) UpdateDispatcherCheckpointTs(
 		}
 		// calculate the new checkpoint ts of the subscription
 		var newCheckpointTs uint64
-		for id := range subStat.dispatchers.notifiers {
+		for id := range subStat.dispatchers.subscribers {
 			dispatcherStat := e.dispatcherMeta.dispatcherStats[id]
 			if newCheckpointTs == 0 || dispatcherStat.checkpointTs < newCheckpointTs {
 				newCheckpointTs = dispatcherStat.checkpointTs
@@ -640,8 +675,16 @@ func (e *eventStore) GetIterator(dispatcherID common.DispatcherID, dataRange com
 		return nil
 	}
 
-	tryGetDB := func(subStat *subscriptionStat) *pebble.DB {
+	tryGetDB := func(subStat *subscriptionStat, force bool) *pebble.DB {
 		if subStat == nil {
+			if force {
+				log.Panic("subStat is nil, should not happen",
+					zap.Stringer("dispatcherID", dispatcherID),
+					zap.Int64("tableID", dataRange.Span.GetTableID()),
+					zap.Uint64("commitTsStart", dataRange.CommitTsStart),
+					zap.Uint64("commitTsEnd", dataRange.CommitTsEnd),
+					zap.Uint64("lastScannedTxnStartTs", dataRange.LastScannedTxnStartTs))
+			}
 			return nil
 		}
 		checkpointTs := subStat.checkpointTs.Load()
@@ -649,10 +692,23 @@ func (e *eventStore) GetIterator(dispatcherID common.DispatcherID, dataRange com
 			log.Panic("dataRange startTs is smaller than subscriptionStat checkpointTs, it should not happen",
 				zap.Stringer("dispatcherID", dispatcherID),
 				zap.Int64("tableID", dataRange.Span.GetTableID()),
-				zap.Uint64("startTs", dataRange.CommitTsStart),
-				zap.Uint64("checkpointTs", checkpointTs))
+				zap.Uint64("commitTsStart", dataRange.CommitTsStart),
+				zap.Uint64("commitTsEnd", dataRange.CommitTsEnd),
+				zap.Uint64("lastScannedTxnStartTs", dataRange.LastScannedTxnStartTs),
+				zap.Uint64("subStatCheckpointTs", checkpointTs),
+				zap.Uint64("subStatResolvedTs", subStat.resolvedTs.Load()))
 		}
 		if dataRange.CommitTsEnd > subStat.resolvedTs.Load() {
+			if force {
+				log.Panic("dataRange endTs is larger than subscriptionStat resolvedTs, it should not happen",
+					zap.Stringer("dispatcherID", dispatcherID),
+					zap.Int64("tableID", dataRange.Span.GetTableID()),
+					zap.Uint64("commitTsStart", dataRange.CommitTsStart),
+					zap.Uint64("commitTsEnd", dataRange.CommitTsEnd),
+					zap.Uint64("lastScannedTxnStartTs", dataRange.LastScannedTxnStartTs),
+					zap.Uint64("subStatCheckpointTs", checkpointTs),
+					zap.Uint64("subStatResolvedTs", subStat.resolvedTs.Load()))
+			}
 			return nil
 		}
 		return e.dbs[subStat.dbIndex]
@@ -660,25 +716,25 @@ func (e *eventStore) GetIterator(dispatcherID common.DispatcherID, dataRange com
 
 	// get from pendingSubStat first,
 	// because its span is more close to dispatcher span if it's not nil
-	var needUpgradeLock bool
-	db := tryGetDB(stat.pendingSubStat)
+	var pendingSubStatReady bool
+	var cleanRemovingSubStat bool
+	db := tryGetDB(stat.pendingSubStat, false)
 	subStat := stat.pendingSubStat
 	if db != nil {
-		needUpgradeLock = true
+		pendingSubStatReady = true
 	} else {
-		db = tryGetDB(stat.subStat)
+		db = tryGetDB(stat.subStat, stat.removingSubStat == nil)
 		subStat = stat.subStat
+		if db == nil {
+			db = tryGetDB(stat.removingSubStat, true)
+			subStat = stat.removingSubStat
+		} else if stat.removingSubStat != nil {
+			cleanRemovingSubStat = true
+		}
 	}
-	if db == nil {
-		e.dispatcherMeta.RUnlock()
-		log.Panic("fail to find db for dispatcher",
-			zap.Stringer("dispatcherID", dispatcherID),
-			zap.String("span", common.FormatTableSpan(stat.tableSpan)),
-			zap.Uint64("startTs", dataRange.CommitTsStart),
-			zap.Uint64("endTs", dataRange.CommitTsEnd))
-	}
-	if needUpgradeLock {
-		e.dispatcherMeta.RUnlock()
+	e.dispatcherMeta.RUnlock()
+
+	if pendingSubStatReady {
 		e.dispatcherMeta.Lock()
 		// check stat again because we release the lock for a short period
 		stat = e.dispatcherMeta.dispatcherStats[dispatcherID]
@@ -689,14 +745,19 @@ func (e *eventStore) GetIterator(dispatcherID common.DispatcherID, dataRange com
 		}
 		// GetIterator for the same dispatcher won't be called concurrently.
 		// So if the dispatcher is not unregistered during the unlock period,
-		// we can safely update the stat.subStat to stat.pendingSubStat.
-		e.detachFromSubStat(dispatcherID, stat.subStat)
+		// we can safely update stat.pendingSubStat as stat.subStat.
+		e.stopReceiveEventFromSubStat(dispatcherID, stat.subStat)
+		stat.removingSubStat = stat.subStat
 		stat.subStat = stat.pendingSubStat
 		stat.pendingSubStat = nil
 		subStat = stat.subStat
 		e.dispatcherMeta.Unlock()
-	} else {
-		e.dispatcherMeta.RUnlock()
+	}
+
+	if cleanRemovingSubStat {
+		e.dispatcherMeta.Lock()
+		e.detachFromSubStat(dispatcherID, stat.removingSubStat)
+		e.dispatcherMeta.Unlock()
 	}
 
 	// convert range before pass it to pebble: (startTs, endTs] is equal to [startTs + 1, endTs + 1)
@@ -742,13 +803,27 @@ func (e *eventStore) detachFromSubStat(dispatcherID common.DispatcherID, subStat
 	}
 	subStat.dispatchers.Lock()
 	defer subStat.dispatchers.Unlock()
-	delete(subStat.dispatchers.notifiers, dispatcherID)
-	if len(subStat.dispatchers.notifiers) == 0 {
+	delete(subStat.dispatchers.subscribers, dispatcherID)
+	if len(subStat.dispatchers.subscribers) == 0 {
 		subStat.idleTime.Store(time.Now().UnixMilli())
 		log.Info("subscription is idle, set idle time",
 			zap.Uint64("subscriptionID", uint64(subStat.subID)),
 			zap.Int("dbIndex", subStat.dbIndex),
 			zap.Int64("tableID", subStat.tableSpan.TableID))
+	}
+}
+
+func (e *eventStore) stopReceiveEventFromSubStat(dispatcherID common.DispatcherID, subStat *subscriptionStat) {
+	if subStat == nil {
+		return
+	}
+	subStat.dispatchers.Lock()
+	defer subStat.dispatchers.Unlock()
+	for id, subscriber := range subStat.dispatchers.subscribers {
+		if id == dispatcherID {
+			subscriber.isStopped.Store(true)
+			break
+		}
 	}
 }
 

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -725,11 +725,13 @@ func (e *eventStore) GetIterator(dispatcherID common.DispatcherID, dataRange com
 	} else {
 		db = tryGetDB(stat.subStat, stat.removingSubStat == nil)
 		subStat = stat.subStat
-		if db == nil {
+		if db != nil {
+			if stat.removingSubStat != nil {
+				cleanRemovingSubStat = true
+			}
+		} else if stat.removingSubStat != nil {
 			db = tryGetDB(stat.removingSubStat, true)
 			subStat = stat.removingSubStat
-		} else if stat.removingSubStat != nil {
-			cleanRemovingSubStat = true
 		}
 	}
 	e.dispatcherMeta.RUnlock()

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -177,10 +177,10 @@ func TestEventStoreOnlyReuseDispatcher(t *testing.T) {
 		// because there is only one subStat, we know its subID is 1
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		require.Equal(t, 1, len(subStat.dispatchers.notifiers))
+		require.Equal(t, 1, len(subStat.dispatchers.subscribers))
 		require.Equal(t, int64(0), subStat.idleTime.Load())
 		store.UnregisterDispatcher(dispatcherID3)
-		require.Equal(t, 0, len(subStat.dispatchers.notifiers))
+		require.Equal(t, 0, len(subStat.dispatchers.subscribers))
 		require.NotEqual(t, int64(0), subStat.idleTime.Load())
 	}
 }
@@ -237,7 +237,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		// subStat with subID 1 should have two dispatchers
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		require.Equal(t, 2, len(subStat.dispatchers.notifiers))
+		require.Equal(t, 2, len(subStat.dispatchers.subscribers))
 	}
 	// add a dispatcher(onlyReuse=false) with the same span
 	{
@@ -253,7 +253,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		// subStat with subID 1 should have three dispatchers
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		require.Equal(t, 3, len(subStat.dispatchers.notifiers))
+		require.Equal(t, 3, len(subStat.dispatchers.subscribers))
 	}
 	// test unregister dispatcherID3 can remove its dependency on two subscriptions
 	{
@@ -263,12 +263,12 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 2, len(subStat.dispatchers.notifiers))
+			require.Equal(t, 2, len(subStat.dispatchers.subscribers))
 		}
 		{
 			subStat := subStats[logpuller.SubscriptionID(3)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 0, len(subStat.dispatchers.notifiers))
+			require.Equal(t, 0, len(subStat.dispatchers.subscribers))
 		}
 	}
 }
@@ -352,12 +352,21 @@ func TestEventStoreUpdateCheckpointTs(t *testing.T) {
 	}
 }
 
-func TestEventStoreGetIterator(t *testing.T) {
+func TestEventStoreSwitchSubStat(t *testing.T) {
 	_, store := newEventStoreForTest(fmt.Sprintf("/tmp/%s", t.Name()))
 
 	dispatcherID1 := common.NewDispatcherID()
 	dispatcherID2 := common.NewDispatcherID()
 	tableID := int64(1)
+
+	updateSubStatResolvedTs := func(subID logpuller.SubscriptionID, ts uint64) {
+		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStat := subStats[subID]
+		require.NotNil(t, subStat)
+		subStat.resolvedTs.Store(ts)
+
+	}
+	// ============ prepare two subscriptions ============
 	// add a dispatcher to create an subscription
 	{
 		span := &heartbeatpb.TableSpan{
@@ -369,6 +378,7 @@ func TestEventStoreGetIterator(t *testing.T) {
 		require.True(t, ok)
 	}
 	// add a dispatcher(onlyReuse=false) with a containing span
+	// it will reuse the first subscription and create a new one
 	{
 		span := &heartbeatpb.TableSpan{
 			TableID:  tableID,
@@ -378,16 +388,15 @@ func TestEventStoreGetIterator(t *testing.T) {
 		ok := store.RegisterDispatcher(dispatcherID2, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
-	// update subStat 1 resolvedTs
+
+	// =========== check two subscriptions are created ============
 	{
 		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
-		{
-			subStat := subStats[logpuller.SubscriptionID(1)]
-			require.NotNil(t, subStat)
-			subStat.resolvedTs.Store(200)
-		}
+		require.Equal(t, 2, len(subStats))
 	}
-	// get iterator from subStat 1
+
+	// case 1: dispatcher 2 use data from subStat 1
+	updateSubStatResolvedTs(1, 200)
 	{
 		iter := store.GetIterator(dispatcherID2, common.DataRange{
 			Span: &heartbeatpb.TableSpan{
@@ -401,16 +410,9 @@ func TestEventStoreGetIterator(t *testing.T) {
 		iterImpl := iter.(*eventStoreIter)
 		require.True(t, iterImpl.needCheckSpan)
 	}
-	// update subStat 2 resolvedTs
-	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
-		{
-			subStat := subStats[logpuller.SubscriptionID(2)]
-			require.NotNil(t, subStat)
-			subStat.resolvedTs.Store(200)
-		}
-	}
-	// get iterator from subStat 2
+
+	// case 2: subStat 2 is ready, dispatcher 2 read data from subStat 2 and stop listen subStat 1
+	updateSubStatResolvedTs(2, 200)
 	{
 		iter := store.GetIterator(dispatcherID2, common.DataRange{
 			Span: &heartbeatpb.TableSpan{
@@ -424,13 +426,64 @@ func TestEventStoreGetIterator(t *testing.T) {
 		iterImpl := iter.(*eventStoreIter)
 		require.False(t, iterImpl.needCheckSpan)
 	}
-	// check dispatcher 2 is no longer depend on subStat 1
+	// check dispatcher 2 is no longer receive event from subStat 1
 	{
 		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 1, len(subStat.dispatchers.notifiers))
+			require.Equal(t, 2, len(subStat.dispatchers.subscribers))
+			require.Equal(t, true, subStat.dispatchers.subscribers[dispatcherID2].isStopped.Load())
+		}
+	}
+
+	// case 3: subStat 1 advance quicker than subStat 2, dispatcher 2 can still read data from subStat 1
+	updateSubStatResolvedTs(1, 220)
+	{
+		iter := store.GetIterator(dispatcherID2, common.DataRange{
+			Span: &heartbeatpb.TableSpan{
+				TableID:  tableID,
+				StartKey: []byte("b"),
+				EndKey:   []byte("h"),
+			},
+			CommitTsStart: 100,
+			CommitTsEnd:   220,
+		})
+		iterImpl := iter.(*eventStoreIter)
+		require.True(t, iterImpl.needCheckSpan)
+	}
+	{
+		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		{
+			subStat := subStats[logpuller.SubscriptionID(1)]
+			require.NotNil(t, subStat)
+			require.Equal(t, 2, len(subStat.dispatchers.subscribers))
+			require.Equal(t, true, subStat.dispatchers.subscribers[dispatcherID2].isStopped.Load())
+		}
+	}
+
+	// case 4: subStat 2 advance quicker or the same as subStat 1,
+	// dispatcher 2 read data from subStat 2 and totally remove itself from the subsriber list of subStat 1
+	updateSubStatResolvedTs(2, 220)
+	{
+		iter := store.GetIterator(dispatcherID2, common.DataRange{
+			Span: &heartbeatpb.TableSpan{
+				TableID:  tableID,
+				StartKey: []byte("b"),
+				EndKey:   []byte("h"),
+			},
+			CommitTsStart: 100,
+			CommitTsEnd:   220,
+		})
+		iterImpl := iter.(*eventStoreIter)
+		require.False(t, iterImpl.needCheckSpan)
+	}
+	{
+		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		{
+			subStat := subStats[logpuller.SubscriptionID(1)]
+			require.NotNil(t, subStat)
+			require.Equal(t, 1, len(subStat.dispatchers.subscribers))
 		}
 	}
 }

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -460,6 +460,12 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 			require.Equal(t, true, subStat.dispatchers.subscribers[dispatcherID2].isStopped.Load())
 		}
 	}
+	{
+		dispatcherStat := store.(*eventStore).dispatcherMeta.dispatcherStats[dispatcherID2]
+		require.NotNil(t, dispatcherStat)
+		require.Equal(t, logpuller.SubscriptionID(2), dispatcherStat.subStat.subID)
+		require.Equal(t, logpuller.SubscriptionID(1), dispatcherStat.removingSubStat.subID)
+	}
 
 	// case 4: subStat 2 advance quicker or the same as subStat 1,
 	// dispatcher 2 read data from subStat 2 and totally remove itself from the subsriber list of subStat 1
@@ -484,5 +490,11 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 			require.NotNil(t, subStat)
 			require.Equal(t, 1, len(subStat.dispatchers.subscribers))
 		}
+	}
+	{
+		dispatcherStat := store.(*eventStore).dispatcherMeta.dispatcherStats[dispatcherID2]
+		require.NotNil(t, dispatcherStat)
+		require.Equal(t, logpuller.SubscriptionID(2), dispatcherStat.subStat.subID)
+		require.Nil(t, dispatcherStat.removingSubStat)
 	}
 }

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -364,7 +364,6 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		subStat := subStats[subID]
 		require.NotNil(t, subStat)
 		subStat.resolvedTs.Store(ts)
-
 	}
 	// ============ prepare two subscriptions ============
 	// add a dispatcher to create an subscription


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2168

### What is changed and how it works?

Robust Subscription Management: Introduced a new Subscriber struct and a removingSubStat field within dispatcherStat to manage the lifecycle of subscriptions more robustly, especially during transitions.
Graceful Subscription Switching: Implemented a mechanism to gracefully switch a dispatcher's active subscription from a broader one to a more specific one, ensuring no data gaps and preventing panics by temporarily retaining the old subscription as removingSubStat.
Controlled Event Notification: Added an isStopped flag to the Subscriber struct and a stopReceiveEventFromSubStat function to prevent dispatchers from receiving resolved timestamp events from subscriptions that are being phased out.
Enhanced Error Handling: Refined the GetIterator logic with stricter checks and panic conditions in tryGetDB to immediately identify and prevent issues arising from unexpected nil subscriptions or out-of-range data requests.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
