### PR TITLE
Improve changefeed keyspace management by refactoring etcd key extraction and registering all active keyspaces.

### DIFF
--- a/coordinator/changefeed/etcd_backend.go
+++ b/coordinator/changefeed/etcd_backend.go
@@ -48,8 +48,6 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 	allDataPrefix := etcd.BaseKey(b.etcdClient.GetClusterID())
 
 	resp, err := b.etcdClient.GetEtcdClient().Get(ctx, allDataPrefix, clientv3.WithPrefix())
-	// TODO tenfyzhong 2025-09-18 16:52:39 remove log
-	log.Info("get feeds from etcd", zap.String("allDataPrefix", allDataPrefix), zap.Any("resp", resp))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -71,7 +69,6 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 					zap.String("key", key), zap.Error(err))
 				continue
 			}
-			log.Info("load changefeed status", zap.String("key", key), zap.Any("status", status))
 			statusMap[common.NewChangeFeedDisplayName(cf, ks)] = status
 		} else {
 			detail := &config.ChangeFeedInfo{}
@@ -81,7 +78,6 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 					zap.String("key", key), zap.Error(err))
 				continue
 			}
-			log.Info("load changefeed info", zap.String("key", key), zap.Any("info", detail))
 			// we can not load the changefeed name from the value, it must an old version info
 			if detail.ChangefeedID.Name() == "" {
 				log.Warn("load a old version change feed Info, migrate it to new version",

--- a/coordinator/changefeed/etcd_backend.go
+++ b/coordinator/changefeed/etcd_backend.go
@@ -69,6 +69,7 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 					zap.String("key", key), zap.Error(err))
 				continue
 			}
+			log.Info("load changefeed status", zap.String("key", key), zap.Any("status", status))
 			statusMap[common.NewChangeFeedDisplayName(cf, ks)] = status
 		} else {
 			detail := &config.ChangeFeedInfo{}
@@ -78,6 +79,7 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 					zap.String("key", key), zap.Error(err))
 				continue
 			}
+			log.Info("load changefeed info", zap.String("key", key), zap.Any("info", detail))
 			// we can not load the changefeed name from the value, it must an old version info
 			if detail.ChangefeedID.Name() == "" {
 				log.Warn("load a old version change feed Info, migrate it to new version",

--- a/coordinator/changefeed/etcd_backend.go
+++ b/coordinator/changefeed/etcd_backend.go
@@ -366,16 +366,21 @@ func (b *EtcdBackend) UpdateChangefeedCheckpointTs(ctx context.Context, cps map[
 // "6a6c6dd290bc8732" from /tidb/cdc/cluster/keyspace/changefeed/info/6a6c6dd290bc8732
 // or from /tidb/cdc/cluster/keyspace/changefeed/status/6a6c6dd290bc8732
 func extractKeySuffix(key string) (ks string, cf string, isStatus bool, isChangefeed bool) {
-	const keyspaceIndex = 3
-	const changefeedItemIndex = 4
-	const statusIndex = 5
-	const changefeedIDIndex = 6
+	const keyspaceIndex = 4
+	const changefeedItemIndex = 5
+	const statusIndex = 6
+	const changefeedIDIndex = 7
 
 	subs := strings.Split(key, "/")
 	if len(subs) <= changefeedItemIndex || subs[changefeedItemIndex] != "changefeed" {
 		isChangefeed = false
 		return ks, cf, isStatus, isChangefeed
 	}
+	if len(subs) <= changefeedIDIndex {
+		isChangefeed = false
+		return ks, cf, isStatus, isChangefeed
+	}
+
 	ks = subs[keyspaceIndex]
 	cf = subs[changefeedIDIndex]
 	isStatus = subs[statusIndex] == "status"

--- a/coordinator/changefeed/etcd_backend.go
+++ b/coordinator/changefeed/etcd_backend.go
@@ -48,6 +48,8 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 	allDataPrefix := etcd.BaseKey(b.etcdClient.GetClusterID())
 
 	resp, err := b.etcdClient.GetEtcdClient().Get(ctx, allDataPrefix, clientv3.WithPrefix())
+	// TODO tenfyzhong 2025-09-18 16:52:39 remove log
+	log.Info("get feeds from etcd", zap.String("allDataPrefix", allDataPrefix), zap.Any("resp", resp))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/coordinator/changefeed/etcd_backend.go
+++ b/coordinator/changefeed/etcd_backend.go
@@ -45,9 +45,9 @@ func NewEtcdBackend(etcdClient etcd.CDCEtcdClient) *EtcdBackend {
 }
 
 func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeFeedID]*ChangefeedMetaWrapper, error) {
-	changefeedPrefix := etcd.KeyspacePrefix(b.etcdClient.GetClusterID(), common.DefaultKeyspace) + "/changefeed"
+	allDataPrefix := etcd.BaseKey(b.etcdClient.GetClusterID())
 
-	resp, err := b.etcdClient.GetEtcdClient().Get(ctx, changefeedPrefix, clientv3.WithPrefix())
+	resp, err := b.etcdClient.GetEtcdClient().Get(ctx, allDataPrefix, clientv3.WithPrefix())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -56,7 +56,11 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 	cfMap := make(map[common.ChangeFeedID]*ChangefeedMetaWrapper)
 	for _, kv := range resp.Kvs {
 		key := string(kv.Key)
-		ns, cf, isStatus := extractKeySuffix(key)
+		ks, cf, isStatus, isChangefeed := extractKeySuffix(key)
+		if !isChangefeed {
+			continue
+		}
+
 		if isStatus {
 			status := &config.ChangeFeedStatus{}
 			err = status.Unmarshal(kv.Value)
@@ -65,7 +69,7 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 					zap.String("key", key), zap.Error(err))
 				continue
 			}
-			statusMap[common.NewChangeFeedDisplayName(cf, ns)] = status
+			statusMap[common.NewChangeFeedDisplayName(cf, ks)] = status
 		} else {
 			detail := &config.ChangeFeedInfo{}
 			err = detail.Unmarshal(kv.Value)
@@ -80,7 +84,7 @@ func (b *EtcdBackend) GetAllChangefeeds(ctx context.Context) (map[common.ChangeF
 					zap.String("key", key))
 				detail.ChangefeedID = common.NewChangeFeedIDWithDisplayName(common.ChangeFeedDisplayName{
 					Name:     cf,
-					Keyspace: ns,
+					Keyspace: ks,
 				})
 				if data, err := detail.Marshal(); err != nil {
 					log.Warn("failed to marshal change feed Info, ignore",
@@ -357,9 +361,22 @@ func (b *EtcdBackend) UpdateChangefeedCheckpointTs(ctx context.Context, cps map[
 // extractKeySuffix extracts the suffix of an etcd key, such as extracting
 // "6a6c6dd290bc8732" from /tidb/cdc/cluster/keyspace/changefeed/info/6a6c6dd290bc8732
 // or from /tidb/cdc/cluster/keyspace/changefeed/status/6a6c6dd290bc8732
-func extractKeySuffix(key string) (string, string, bool) {
+func extractKeySuffix(key string) (ks string, cf string, isStatus bool, isChangefeed bool) {
+	const keyspaceIndex = 3
+	const changefeedItemIndex = 4
+	const statusIndex = 5
+	const changefeedIDIndex = 6
+
 	subs := strings.Split(key, "/")
-	return subs[len(subs)-4], subs[len(subs)-1], subs[len(subs)-2] == "status"
+	if len(subs) <= changefeedItemIndex || subs[changefeedItemIndex] != "changefeed" {
+		isChangefeed = false
+		return ks, cf, isStatus, isChangefeed
+	}
+	ks = subs[keyspaceIndex]
+	cf = subs[changefeedIDIndex]
+	isStatus = subs[statusIndex] == "status"
+	isChangefeed = true
+	return ks, cf, isStatus, isChangefeed
 }
 
 func logEtcdOps(ops []clientv3.Op, committed bool) {

--- a/coordinator/changefeed/etcd_backend_test.go
+++ b/coordinator/changefeed/etcd_backend_test.go
@@ -354,18 +354,10 @@ func TestExtractKeySuffix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotKs, gotCf, gotIsStatus, gotIsChangefeed := extractKeySuffix(tt.args.key)
-			if gotKs != tt.wantKs {
-				t.Errorf("extractKeySuffix() gotKs = %v, want %v", gotKs, tt.wantKs)
-			}
-			if gotCf != tt.wantCf {
-				t.Errorf("extractKeySuffix() gotCf = %v, want %v", gotCf, tt.wantCf)
-			}
-			if gotIsStatus != tt.wantIsStatus {
-				t.Errorf("extractKeySuffix() gotIsStatus = %v, want %v", gotIsStatus, tt.wantIsStatus)
-			}
-			if gotIsChangefeed != tt.wantIsChangefeed {
-				t.Errorf("extractKeySuffix() gotIsChangefeed = %v, want %v", gotIsChangefeed, tt.wantIsChangefeed)
-			}
+			require.Equal(t, tt.wantKs, gotKs)
+			require.Equal(t, tt.wantCf, gotCf)
+			require.Equal(t, tt.wantIsStatus, gotIsStatus)
+			require.Equal(t, tt.wantIsChangefeed, gotIsChangefeed)
 		})
 	}
 }

--- a/coordinator/changefeed/etcd_backend_test.go
+++ b/coordinator/changefeed/etcd_backend_test.go
@@ -268,3 +268,104 @@ func (f *FuncMarcher) Matches(x interface{}) bool {
 func (f *FuncMarcher) String() string {
 	return "func"
 }
+
+func TestExtractKeySuffix(t *testing.T) {
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantKs           string
+		wantCf           string
+		wantIsStatus     bool
+		wantIsChangefeed bool
+	}{
+		{
+			name: "an empty key",
+			args: args{
+				key: "",
+			},
+			wantIsChangefeed: false,
+		},
+		{
+			name: "an invalid key",
+			args: args{
+				key: "foobar",
+			},
+			wantIsChangefeed: false,
+		},
+		{
+			name: "an slash key",
+			args: args{
+				key: "/",
+			},
+			wantIsChangefeed: false,
+		},
+		{
+			name: "3 parts",
+			args: args{
+				key: "/tidb/cdc/default",
+			},
+			wantIsChangefeed: false,
+		},
+		{
+			name: "not a changefeed",
+			args: args{
+				key: "/tidb/cdc/default/keyspace1/foobar/info/hello",
+			},
+			wantIsChangefeed: false,
+		},
+		{
+			name: "a changefeed info",
+			args: args{
+				key: "/tidb/cdc/default/keyspace1/changefeed/info/hello",
+			},
+			wantKs:           "keyspace1",
+			wantCf:           "hello",
+			wantIsStatus:     false,
+			wantIsChangefeed: true,
+		},
+		{
+			name: "a changefeed status",
+			args: args{
+				key: "/tidb/cdc/default/keyspace1/changefeed/status/hello",
+			},
+			wantKs:           "keyspace1",
+			wantCf:           "hello",
+			wantIsStatus:     true,
+			wantIsChangefeed: true,
+		},
+		{
+			name: "an invalid changefeed status",
+			args: args{
+				key: "/tidb/cdc/default/keyspace1/changefeed/status",
+			},
+			wantIsChangefeed: false,
+		},
+		{
+			name: "capture info",
+			args: args{
+				key: "/tidb/cdc/default/__cdc_meta__/capture/786afb7b-c780-48df-8fb6-567d4647c007",
+			},
+			wantIsChangefeed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotKs, gotCf, gotIsStatus, gotIsChangefeed := extractKeySuffix(tt.args.key)
+			if gotKs != tt.wantKs {
+				t.Errorf("extractKeySuffix() gotKs = %v, want %v", gotKs, tt.wantKs)
+			}
+			if gotCf != tt.wantCf {
+				t.Errorf("extractKeySuffix() gotCf = %v, want %v", gotCf, tt.wantCf)
+			}
+			if gotIsStatus != tt.wantIsStatus {
+				t.Errorf("extractKeySuffix() gotIsStatus = %v, want %v", gotIsStatus, tt.wantIsStatus)
+			}
+			if gotIsChangefeed != tt.wantIsChangefeed {
+				t.Errorf("extractKeySuffix() gotIsChangefeed = %v, want %v", gotIsChangefeed, tt.wantIsChangefeed)
+			}
+		})
+	}
+}

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -458,6 +458,7 @@ func (c *Controller) FinishBootstrap(runningChangefeeds map[common.ChangeFeedID]
 		if err != nil {
 			log.Error("RegisterKeyspace failed", zap.String("keyspace", id.Keyspace()), zap.Error(err))
 		}
+		registeredKeyspace[id.Keyspace()] = struct{}{}
 	}
 
 	log.Info("load all changefeeds", zap.Int("size", len(allChangefeeds)))

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/ticdc/coordinator/operator"
 	coscheduler "github.com/pingcap/ticdc/coordinator/scheduler"
 	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/pingcap/ticdc/logservice/schemastore"
 	"github.com/pingcap/ticdc/pkg/bootstrap"
 	"github.com/pingcap/ticdc/pkg/common"
 	appcontext "github.com/pingcap/ticdc/pkg/common/context"
@@ -443,6 +444,22 @@ func (c *Controller) FinishBootstrap(runningChangefeeds map[common.ChangeFeedID]
 	if err != nil {
 		log.Panic("load all changefeeds failed", zap.Error(err))
 	}
+
+	// Register keyspace
+	schemaStore := appcontext.GetService[schemastore.SchemaStore](appcontext.SchemaStore)
+	registeredKeyspace := make(map[string]struct{})
+	ctx := context.Background()
+	for id := range allChangefeeds {
+		if _, ok := registeredKeyspace[id.Keyspace()]; ok {
+			continue
+		}
+
+		err := schemaStore.RegisterKeyspace(ctx, id.Keyspace())
+		if err != nil {
+			log.Error("RegisterKeyspace failed", zap.String("keyspace", id.Keyspace()), zap.Error(err))
+		}
+	}
+
 	log.Info("load all changefeeds", zap.Int("size", len(allChangefeeds)))
 	// Compare all changefeeds and running changefeeds, and add them to changefeedDB
 	for cfID, cfMeta := range allChangefeeds {

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -35,6 +35,7 @@ import (
 	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/etcd"
+	"github.com/pingcap/ticdc/pkg/eventservice"
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/pkg/messaging/proto"
 	"github.com/pingcap/ticdc/pkg/node"
@@ -242,6 +243,9 @@ func TestCoordinatorScheduling(t *testing.T) {
 		info.ID, config.NewDefaultMessageCenterConfig(info.AdvertiseAddr), nil)
 	mc.Run(ctx)
 	defer mc.Close()
+
+	mockSchemaStore := eventservice.NewMockSchemaStore()
+	appcontext.SetService(appcontext.SchemaStore, mockSchemaStore)
 
 	appcontext.SetService(appcontext.MessageCenter, mc)
 	m := NewMaintainerManager(mc)

--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -256,7 +256,13 @@ func (s *schemaStore) getKeyspaceSchemaStore(keyspaceID uint32) (*keyspaceSchema
 func (s *schemaStore) initialize(ctx context.Context) {
 	// we should fetch ddl at startup for classic mode
 	if kerneltype.IsClassic() {
-		s.RegisterKeyspace(ctx, common.DefaultKeyspace)
+		err := s.RegisterKeyspace(ctx, common.DefaultKeyspace)
+		if err != nil {
+			// initialize is called when the server starts
+			// if the keyspace register failed, we can panic the server to let
+			// it register again
+			log.Panic("RegisterKeyspace failed", zap.Error(err))
+		}
 	}
 }
 

--- a/pkg/common/event/mounter.go
+++ b/pkg/common/event/mounter.go
@@ -170,7 +170,6 @@ func RemoveKeyspacePrefix(key []byte) []byte {
 	}
 
 	if key[0] != apiV2TxnModePrefix {
-		log.Warn("the first byte of key is not 'x', it may not be in api v2 txn mode", zap.Any("byte", key[0]))
 		return key
 	}
 	return key[keyspacePrefixLen:]

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/tidb/pkg/util/naming"
 	"go.uber.org/zap"
 )
 
@@ -287,18 +288,9 @@ func ValidateChangefeedID(changefeedID string) error {
 	return nil
 }
 
-const keyspaceMaxLen = 128
-
-var keyspaceRe = regexp.MustCompile(`^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$`)
-
-// ValidateKeyspace returns true if the keyspace matches
-// the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$",
-// length no more than "changeFeedIDMaxLen", eg, "simple-changefeed-task".
+// ValidateKeyspace use the naming rules of TiDB to check the validation of the keyspace
 func ValidateKeyspace(keyspace string) error {
-	if !keyspaceRe.MatchString(keyspace) || len(keyspace) > keyspaceMaxLen {
-		return errors.ErrInvalidKeyspace.GenWithStackByArgs(keyspaceRe)
-	}
-	return nil
+	return errors.Trace(naming.CheckKeyspaceName(keyspace))
 }
 
 func NewChangefeedID4Test(keyspace, name string) ChangeFeedID {

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -36,7 +36,7 @@ func newEventBrokerForTest() (*eventBroker, *mockEventStore, *mockSchemaStore) {
 	mockPDClock := pdutil.NewClock4Test()
 	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
 	es := newMockEventStore(100)
-	ss := newMockSchemaStore()
+	ss := NewMockSchemaStore()
 	mc := newMockMessageCenter()
 	return newEventBroker(context.Background(), 1, es, ss, mc, time.UTC, &integrity.Config{
 		IntegrityCheckLevel:   integrity.CheckLevelNone,

--- a/pkg/eventservice/event_scanner_test.go
+++ b/pkg/eventservice/event_scanner_test.go
@@ -710,7 +710,7 @@ func TestDMLProcessor(t *testing.T) {
 
 	// Create a mock mounter and schema getter
 	mockMounter := &mockMounter{}
-	mockSchemaGetter := newMockSchemaStore()
+	mockSchemaGetter := NewMockSchemaStore()
 	mockSchemaGetter.AppendDDLEvent(tableID, ddlEvent)
 
 	// Test case 0: create a new DML processor
@@ -933,7 +933,7 @@ func TestDMLProcessorAppendRow(t *testing.T) {
 
 	// Create a mock mounter and schema getter
 	mockMounter := &mockMounter{}
-	mockSchemaGetter := newMockSchemaStore()
+	mockSchemaGetter := NewMockSchemaStore()
 	mockSchemaGetter.AppendDDLEvent(tableID, ddlEvent)
 
 	// Test case 1: appendRow before txn started, illegal usage.
@@ -1264,7 +1264,7 @@ func TestEventMerger(t *testing.T) {
 			}...)
 
 		tableID := ddlEvent.TableID
-		mockSchemaGetter := newMockSchemaStore()
+		mockSchemaGetter := NewMockSchemaStore()
 		mockSchemaGetter.AppendDDLEvent(tableID, ddlEvent)
 
 		processor := newDMLProcessor(&mockMounter{}, mockSchemaGetter, nil, false)
@@ -1297,7 +1297,7 @@ func TestEventMerger(t *testing.T) {
 		merger := newEventMerger([]event.Event{&ddlEvent})
 
 		tableID := ddlEvent.TableID
-		mockSchemaGetter := newMockSchemaStore()
+		mockSchemaGetter := NewMockSchemaStore()
 		mockSchemaGetter.AppendDDLEvent(tableID, ddlEvent)
 		processor := newDMLProcessor(&mockMounter{}, mockSchemaGetter, nil, false)
 
@@ -1325,7 +1325,7 @@ func TestEventMerger(t *testing.T) {
 		helper := event.NewEventTestHelper(t)
 		defer helper.Close()
 
-		mockSchemaGetter := newMockSchemaStore()
+		mockSchemaGetter := NewMockSchemaStore()
 
 		ddlEvent1, kvEvents1 := genEvents(helper,
 			`create table test.t1(id int primary key, c char(50))`,
@@ -1460,7 +1460,7 @@ func TestScanAndMergeEventsSingleUKUpdate(t *testing.T) {
 		"update test.t_uk set a = 20 where id = 1")
 
 	// Create mock components
-	mockSchemaGetter := newMockSchemaStore()
+	mockSchemaGetter := NewMockSchemaStore()
 	mockSchemaGetter.AppendDDLEvent(tableID, *ddlEvent)
 
 	// Create a mock iterator that returns only the single update event

--- a/pkg/eventservice/event_service_test.go
+++ b/pkg/eventservice/event_service_test.go
@@ -16,8 +16,6 @@ package eventservice
 import (
 	"context"
 	"fmt"
-	"math"
-	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -36,7 +34,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/pdutil"
-	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -45,7 +42,7 @@ func startEventService(
 	ctx context.Context, t *testing.T,
 	mc messaging.MessageCenter, mockStore eventstore.EventStore,
 ) *eventService {
-	mockSchemaStore := newMockSchemaStore()
+	mockSchemaStore := NewMockSchemaStore()
 	mockPDClock := pdutil.NewClock4Test()
 	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
 	appcontext.SetService(appcontext.MessageCenter, mc)
@@ -373,134 +370,6 @@ func (m *mockEventIterator) Close() (int64, error) {
 }
 
 var _ schemastore.SchemaStore = &mockSchemaStore{}
-
-type mockSchemaStore struct {
-	DDLEvents map[common.TableID][]commonEvent.DDLEvent
-	TableInfo map[common.TableID]*mockVersionTableInfo
-
-	resolvedTs     uint64
-	maxDDLCommitTs uint64
-}
-
-type mockVersionTableInfo struct {
-	tableInfos    []*common.TableInfo
-	deleteVersion uint64
-}
-
-func newMockSchemaStore() *mockSchemaStore {
-	return &mockSchemaStore{
-		DDLEvents:      make(map[common.TableID][]commonEvent.DDLEvent),
-		TableInfo:      make(map[common.TableID]*mockVersionTableInfo),
-		resolvedTs:     math.MaxUint64,
-		maxDDLCommitTs: math.MaxUint64,
-	}
-}
-
-func (m *mockSchemaStore) Name() string {
-	return "mockSchemaStore"
-}
-
-func (m *mockSchemaStore) Run(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockSchemaStore) Close(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockSchemaStore) DeleteTable(id common.TableID, ts common.Ts) {
-	if info, ok := m.TableInfo[id]; ok {
-		info.deleteVersion = uint64(ts)
-	} else {
-		m.TableInfo[id] = &mockVersionTableInfo{
-			tableInfos:    make([]*common.TableInfo, 0),
-			deleteVersion: uint64(ts),
-		}
-	}
-}
-
-func (m *mockSchemaStore) AppendDDLEvent(id common.TableID, ddls ...commonEvent.DDLEvent) {
-	for _, ddl := range ddls {
-		m.DDLEvents[id] = append(m.DDLEvents[id], ddl)
-		if _, ok := m.TableInfo[id]; !ok {
-			m.TableInfo[id] = &mockVersionTableInfo{
-				tableInfos:    make([]*common.TableInfo, 0),
-				deleteVersion: math.MaxUint64,
-			}
-		}
-		m.TableInfo[id].tableInfos = append(m.TableInfo[id].tableInfos, ddl.TableInfo)
-	}
-}
-
-func (m *mockSchemaStore) GetTableInfo(keyspaceID uint32, tableID common.TableID, ts common.Ts) (*common.TableInfo, error) {
-	if info, ok := m.TableInfo[tableID]; ok {
-		if info.deleteVersion <= uint64(ts) {
-			return nil, &schemastore.TableDeletedError{}
-		}
-		infos := m.TableInfo[tableID].tableInfos
-		idx := sort.Search(len(infos), func(i int) bool {
-			return infos[i].GetUpdateTS() > uint64(ts)
-		})
-		if idx == 0 {
-			return nil, nil
-		}
-		return infos[idx-1], nil
-	}
-	return nil, nil
-}
-
-func (m *mockSchemaStore) GetAllPhysicalTables(keyspaceID uint32, snapTs uint64, filter filter.Filter) ([]commonEvent.Table, error) {
-	return nil, nil
-}
-
-func (m *mockSchemaStore) GetTableDDLEventState(keyspaceID uint32, tableID int64) (schemastore.DDLEventState, error) {
-	return schemastore.DDLEventState{
-		ResolvedTs:       m.resolvedTs,
-		MaxEventCommitTs: m.maxDDLCommitTs,
-	}, nil
-}
-
-func (m *mockSchemaStore) RegisterTable(
-	keyspaceID uint32,
-	tableID int64,
-	startTS common.Ts,
-) error {
-	return nil
-}
-
-func (m *mockSchemaStore) UnregisterTable(_ uint32, _ int64) error {
-	return nil
-}
-
-// GetNextDDLEvents returns the next ddl event which finishedTs is within the range (start, end]
-func (m *mockSchemaStore) FetchTableDDLEvents(keyspaceID uint32, dispatcherID common.DispatcherID, tableID int64, tableFilter filter.Filter, start, end uint64) ([]commonEvent.DDLEvent, error) {
-	events := m.DDLEvents[tableID]
-	if len(events) == 0 {
-		return nil, nil
-	}
-	l := sort.Search(len(events), func(i int) bool {
-		return events[i].FinishedTs > start
-	})
-	if l == len(events) {
-		return nil, nil
-	}
-	r := sort.Search(len(events), func(i int) bool {
-		return events[i].FinishedTs > end
-	})
-	return events[l:r], nil
-}
-
-func (m *mockSchemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error) {
-	return nil, 0, nil
-}
-
-func (m *mockSchemaStore) RegisterKeyspace(ctx context.Context, keyspaceName string) error {
-	return nil
-}
-
-func (m *mockSchemaStore) GetKVStorage(keyspaceID uint32) (kv.Storage, error) {
-	return nil, nil
-}
 
 type mockSpanStats struct {
 	mu                 sync.RWMutex

--- a/pkg/eventservice/test_helper.go
+++ b/pkg/eventservice/test_helper.go
@@ -1,0 +1,154 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventservice
+
+import (
+	"context"
+	"math"
+	"sort"
+
+	"github.com/pingcap/ticdc/logservice/schemastore"
+	"github.com/pingcap/ticdc/pkg/common"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/filter"
+	"github.com/pingcap/tidb/pkg/kv"
+)
+
+type mockVersionTableInfo struct {
+	tableInfos    []*common.TableInfo
+	deleteVersion uint64
+}
+
+type mockSchemaStore struct {
+	DDLEvents map[common.TableID][]commonEvent.DDLEvent
+	TableInfo map[common.TableID]*mockVersionTableInfo
+
+	resolvedTs     uint64
+	maxDDLCommitTs uint64
+}
+
+func NewMockSchemaStore() *mockSchemaStore {
+	return &mockSchemaStore{
+		DDLEvents:      make(map[common.TableID][]commonEvent.DDLEvent),
+		TableInfo:      make(map[common.TableID]*mockVersionTableInfo),
+		resolvedTs:     math.MaxUint64,
+		maxDDLCommitTs: math.MaxUint64,
+	}
+}
+
+func (m *mockSchemaStore) Name() string {
+	return "mockSchemaStore"
+}
+
+func (m *mockSchemaStore) Run(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockSchemaStore) Close(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockSchemaStore) DeleteTable(id common.TableID, ts common.Ts) {
+	if info, ok := m.TableInfo[id]; ok {
+		info.deleteVersion = uint64(ts)
+	} else {
+		m.TableInfo[id] = &mockVersionTableInfo{
+			tableInfos:    make([]*common.TableInfo, 0),
+			deleteVersion: uint64(ts),
+		}
+	}
+}
+
+func (m *mockSchemaStore) AppendDDLEvent(id common.TableID, ddls ...commonEvent.DDLEvent) {
+	for _, ddl := range ddls {
+		m.DDLEvents[id] = append(m.DDLEvents[id], ddl)
+		if _, ok := m.TableInfo[id]; !ok {
+			m.TableInfo[id] = &mockVersionTableInfo{
+				tableInfos:    make([]*common.TableInfo, 0),
+				deleteVersion: math.MaxUint64,
+			}
+		}
+		m.TableInfo[id].tableInfos = append(m.TableInfo[id].tableInfos, ddl.TableInfo)
+	}
+}
+
+func (m *mockSchemaStore) GetTableInfo(keyspaceID uint32, tableID common.TableID, ts common.Ts) (*common.TableInfo, error) {
+	if info, ok := m.TableInfo[tableID]; ok {
+		if info.deleteVersion <= uint64(ts) {
+			return nil, &schemastore.TableDeletedError{}
+		}
+		infos := m.TableInfo[tableID].tableInfos
+		idx := sort.Search(len(infos), func(i int) bool {
+			return infos[i].GetUpdateTS() > uint64(ts)
+		})
+		if idx == 0 {
+			return nil, nil
+		}
+		return infos[idx-1], nil
+	}
+	return nil, nil
+}
+
+func (m *mockSchemaStore) GetAllPhysicalTables(keyspaceID uint32, snapTs uint64, filter filter.Filter) ([]commonEvent.Table, error) {
+	return nil, nil
+}
+
+func (m *mockSchemaStore) GetTableDDLEventState(keyspaceID uint32, tableID int64) (schemastore.DDLEventState, error) {
+	return schemastore.DDLEventState{
+		ResolvedTs:       m.resolvedTs,
+		MaxEventCommitTs: m.maxDDLCommitTs,
+	}, nil
+}
+
+func (m *mockSchemaStore) RegisterTable(
+	keyspaceID uint32,
+	tableID int64,
+	startTS common.Ts,
+) error {
+	return nil
+}
+
+func (m *mockSchemaStore) UnregisterTable(_ uint32, _ int64) error {
+	return nil
+}
+
+// GetNextDDLEvents returns the next ddl event which finishedTs is within the range (start, end]
+func (m *mockSchemaStore) FetchTableDDLEvents(keyspaceID uint32, dispatcherID common.DispatcherID, tableID int64, tableFilter filter.Filter, start, end uint64) ([]commonEvent.DDLEvent, error) {
+	events := m.DDLEvents[tableID]
+	if len(events) == 0 {
+		return nil, nil
+	}
+	l := sort.Search(len(events), func(i int) bool {
+		return events[i].FinishedTs > start
+	})
+	if l == len(events) {
+		return nil, nil
+	}
+	r := sort.Search(len(events), func(i int) bool {
+		return events[i].FinishedTs > end
+	})
+	return events[l:r], nil
+}
+
+func (m *mockSchemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error) {
+	return nil, 0, nil
+}
+
+func (m *mockSchemaStore) RegisterKeyspace(ctx context.Context, keyspaceName string) error {
+	return nil
+}
+
+func (m *mockSchemaStore) GetKVStorage(keyspaceID uint32) (kv.Storage, error) {
+	return nil, nil
+}


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses several issues related to the robustness and correctness of changefeed and keyspace management within TiCDC.
Previously, the extraction of changefeed and keyspace information from etcd keys was fragile, relying on fixed array indices which could break if the key path structure changed. This could lead to incorrect parsing of changefeed metadata.
Additionally, keyspaces associated with existing changefeeds were not automatically registered in the schema store during TiCDC bootstrap, potentially causing issues with schema management for these keyspaces.
Finally, keyspace validation was inconsistent, using a custom regex rather than a standard TiDB utility.

Issue Number: close #2186 #2191 #2194

### What is changed and how it works?

This PR significantly improves the reliability of etcd key parsing for changefeeds, ensures proper keyspace registration, and standardizes keyspace validation.

* **Robust Etcd Key Parsing:**
  * The `extractKeySuffix` function in `coordinator/changefeed/etcd_backend.go` has been refactored to use explicit checks and named indices instead of fragile array indexing. It now accurately identifies changefeed info/status keys and extracts the correct keyspace and changefeed ID, also returning a boolean `isChangefeed` to indicate if the key is indeed a changefeed key.
  * `GetAllChangefeeds` now fetches all data under the cluster ID and uses the improved `extractKeySuffix` to filter and process only relevant changefeed keys, making it more resilient to other data existing in etcd.
  * Comprehensive unit tests have been added for `extractKeySuffix` to cover various valid and invalid key formats.

* **Automatic Keyspace Registration:**
  * During the `FinishBootstrap` phase of the `Controller`, TiCDC now iterates through all loaded changefeeds and registers their respective keyspaces in the schema store if they are not already registered. This ensures that the schema store is aware of all active keyspaces from the start.

* **Standardized Keyspace Validation:**
  * The `ValidateKeyspace` function in `pkg/common/types.go` now uses `naming.CheckKeyspaceName` from TiDB, aligning keyspace validation with TiDB's naming rules for consistency and robustness.

* **Improved Startup Error Handling:**
  * In `logservice/schemastore/schema_store.go`, the `initialize` function now explicitly checks for errors when registering the `common.DefaultKeyspace` and panics if registration fails, preventing silent failures during critical startup operations in classic mode.

* **Removed Noisy Log Warning:**
  * A potentially noisy `log.Warn` message in `pkg/common/event/mounter.go` that was triggered when a key didn't start with 'x' has been removed, as it was not critical for the intended functionality.

### Check List

#### Tests

* Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No, this PR should not cause performance regression. The changes to etcd key parsing are internal and aim to improve correctness and robustness. Compatibility should be improved due to more reliable handling of etcd keys.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No, these are internal implementation details and do not require updates to user, design, or monitoring documentation.

### Release note

```release-note
None
```
