### PR TITLE
maintainer: fix data race

### DIFF
--- a/maintainer/barrier_event_test.go
+++ b/maintainer/barrier_event_test.go
@@ -48,7 +48,7 @@ func TestScheduleEvent(t *testing.T) {
 		IsBlocked:         true,
 		BlockTs:           10,
 		NeedDroppedTables: &heartbeatpb.InfluencedTables{InfluenceType: heartbeatpb.InfluenceType_Normal, TableIDs: []int64{1}},
-		NeedAddedTables:   []*heartbeatpb.Table{{2, 1, true}, {3, 1, true}},
+		NeedAddedTables:   []*heartbeatpb.Table{{TableID: 2, SchemaID: 1, Splitable: true}, {TableID: 3, SchemaID: 1, Splitable: true}},
 	}, true)
 	event.scheduleBlockEvent()
 	// drop table will be executed first
@@ -61,7 +61,7 @@ func TestScheduleEvent(t *testing.T) {
 			InfluenceType: heartbeatpb.InfluenceType_DB,
 			SchemaID:      1,
 		},
-		NeedAddedTables: []*heartbeatpb.Table{{4, 1, true}},
+		NeedAddedTables: []*heartbeatpb.Table{{TableID: 4, SchemaID: 1, Splitable: true}},
 	}, false)
 	event.scheduleBlockEvent()
 	// drop table will be executed first, then add the new table
@@ -74,7 +74,7 @@ func TestScheduleEvent(t *testing.T) {
 			InfluenceType: heartbeatpb.InfluenceType_Normal,
 			TableIDs:      []int64{4},
 		},
-		NeedAddedTables: []*heartbeatpb.Table{{5, 1, true}},
+		NeedAddedTables: []*heartbeatpb.Table{{TableID: 5, SchemaID: 1, Splitable: true}},
 	}, false)
 	event.scheduleBlockEvent()
 	// drop table will be executed first, then add the new table

--- a/maintainer/maintainer_controller_bootstrap.go
+++ b/maintainer/maintainer_controller_bootstrap.go
@@ -306,7 +306,7 @@ func (c *Controller) createSpanReplication(spanInfo *heartbeatpb.BootstrapTableS
 		c.changefeedID,
 		common.NewDispatcherIDFromPB(spanInfo.ID),
 		spanInfo.SchemaID,
-		spanInfo.Span,
+		spanInfo.Span.Copy(),
 		status,
 		node,
 	)

--- a/maintainer/maintainer_controller_bootstrap.go
+++ b/maintainer/maintainer_controller_bootstrap.go
@@ -306,7 +306,7 @@ func (c *Controller) createSpanReplication(spanInfo *heartbeatpb.BootstrapTableS
 		c.changefeedID,
 		common.NewDispatcherIDFromPB(spanInfo.ID),
 		spanInfo.SchemaID,
-		spanInfo.Span.Copy(),
+		spanInfo.Span,
 		status,
 		node,
 	)

--- a/maintainer/replica/default_span_split_checker.go
+++ b/maintainer/replica/default_span_split_checker.go
@@ -111,9 +111,7 @@ func (s *defaultSpanSplitChecker) AddReplica(replica *SpanReplication) {
 
 func (s *defaultSpanSplitChecker) RemoveReplica(replica *SpanReplication) {
 	delete(s.allTasks, replica.ID)
-	if _, ok := s.splitReadyTasks[replica.ID]; ok {
-		delete(s.splitReadyTasks, replica.ID)
-	}
+	delete(s.splitReadyTasks, replica.ID)
 }
 
 func (s *defaultSpanSplitChecker) UpdateStatus(replica *SpanReplication) {
@@ -154,9 +152,7 @@ func (s *defaultSpanSplitChecker) UpdateStatus(replica *SpanReplication) {
 			s.splitReadyTasks[status.ID] = status
 		}
 	} else {
-		if _, ok := s.splitReadyTasks[status.ID]; ok {
-			delete(s.splitReadyTasks, status.ID)
-		}
+		delete(s.splitReadyTasks, status.ID)
 	}
 }
 

--- a/maintainer/span/span_controller.go
+++ b/maintainer/span/span_controller.go
@@ -168,7 +168,6 @@ func (c *Controller) AddNewTable(table commonEvent.Table, startTs uint64) {
 // AddWorkingSpans adds working spans
 func (c *Controller) AddWorkingSpans(tableMap utils.Map[*heartbeatpb.TableSpan, *replica.SpanReplication]) {
 	tableMap.Ascend(func(span *heartbeatpb.TableSpan, stm *replica.SpanReplication) bool {
-		stm.Span.KeyspaceID = c.GetkeyspaceID()
 		c.AddReplicatingSpan(stm)
 		return true
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2196 

### What is changed and how it works?

* **Data Race Prevention (Span Replication)**: Introduced defensive copying of `Span` objects during the creation of span replications to prevent concurrent modification issues and ensure thread safety.
* **Data Race Prevention (KeyspaceID Assignment)**: Removed a potentially racy assignment of `KeyspaceID` to shared `Span` objects within the `AddWorkingSpans` function, eliminating a source of concurrency bugs.
* **Code Simplification**: Streamlined map deletion logic in `default_span_split_checker.go` by removing redundant `if _, ok` checks, as Go's `delete` operation is safe for non-existent keys.
* **Test Refinement**: Updated test cases in `barrier_event_test.go` to use named fields for `heartbeatpb.Table` initialization, improving code readability and maintainability.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
