### PR TITLE
DS: fix a data race that may cause PANIC

### DIFF
--- a/utils/dynstream/parallel_dynamic_stream.go
+++ b/utils/dynstream/parallel_dynamic_stream.go
@@ -185,7 +185,7 @@ func (s *parallelDynamicStream[A, P, T, D, H]) AddPath(path P, dest D, as ...Are
 
 	s.setMemControl(pi, as...)
 
-	if pi.stream.isClosed.Load() {
+	if pi.stream.closed.Load() {
 		return nil
 	}
 

--- a/utils/dynstream/parallel_dynamic_stream.go
+++ b/utils/dynstream/parallel_dynamic_stream.go
@@ -43,6 +43,7 @@ type parallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D
 
 	_statAddPathCount    atomic.Int64
 	_statRemovePathCount atomic.Int64
+	closed               atomic.Bool
 }
 
 func newParallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](hasher PathHasher[P], handler H, option Option) *parallelDynamicStream[A, P, T, D, H] {
@@ -85,16 +86,29 @@ func (s *parallelDynamicStream[A, P, T, D, H]) Start() {
 }
 
 func (s *parallelDynamicStream[A, P, T, D, H]) Close() {
-	// clean pathMap, to avoid sending into a closed channel after close()
+	// Use atomic operation to ensure Close() is called only once
+	if !s.closed.CompareAndSwap(false, true) {
+		return // Already closed
+	}
+
+	// Clear pathMap first to prevent new operations
 	s.pathMap.Lock()
-	defer s.pathMap.Unlock() // release lock after close all ds, to avoid data race with add path
 	clear(s.pathMap.m)
+	s.pathMap.Unlock()
+
+	// Then close all streams
 	for _, ds := range s.streams {
 		ds.close()
 	}
 }
 
 func (s *parallelDynamicStream[A, P, T, D, H]) Push(path P, e T) {
+	// Check if the stream is closed first to avoid accessing freed pathInfo
+	if s.closed.Load() {
+		s.handler.OnDrop(e)
+		return
+	}
+
 	s.pathMap.RLock()
 	pi, ok := s.pathMap.m[path]
 	if !ok {
@@ -102,8 +116,16 @@ func (s *parallelDynamicStream[A, P, T, D, H]) Push(path P, e T) {
 		s.pathMap.RUnlock()
 		return
 	}
-	s.pathMap.RUnlock()
 
+	// Double-check closed status while holding the read lock
+	// to prevent race condition with Close()
+	if s.closed.Load() {
+		s.handler.OnDrop(e)
+		s.pathMap.RUnlock()
+		return
+	}
+
+	// Keep the read lock until we finish using pathInfo to prevent it from being freed
 	ew := eventWrap[A, P, T, D, H]{
 		event:     e,
 		pathInfo:  pi,
@@ -113,18 +135,34 @@ func (s *parallelDynamicStream[A, P, T, D, H]) Push(path P, e T) {
 		timestamp: s.handler.GetTimestamp(e),
 		queueTime: time.Now(),
 	}
-	pi.stream.in() <- ew
+
+	// Only release the read lock after we've finished accessing pathInfo
+	pi.stream.addEvent(ew)
+	s.pathMap.RUnlock()
 }
 
 func (s *parallelDynamicStream[A, P, T, D, H]) Wake(path P) {
+	// Check if the stream is closed first
+	if s.closed.Load() {
+		return
+	}
+
 	s.pathMap.RLock()
 	pi, ok := s.pathMap.m[path]
 	if !ok {
 		s.pathMap.RUnlock()
 		return
 	}
+
+	// Double-check closed status while holding the read lock
+	if s.closed.Load() {
+		s.pathMap.RUnlock()
+		return
+	}
+
+	// Keep the read lock until we finish using pathInfo
+	pi.stream.addEvent(eventWrap[A, P, T, D, H]{wake: true, pathInfo: pi})
 	s.pathMap.RUnlock()
-	pi.stream.in() <- eventWrap[A, P, T, D, H]{wake: true, pathInfo: pi}
 }
 
 func (s *parallelDynamicStream[A, P, T, D, H]) Feedback() <-chan Feedback[A, P, D] {
@@ -133,7 +171,6 @@ func (s *parallelDynamicStream[A, P, T, D, H]) Feedback() <-chan Feedback[A, P, 
 
 func (s *parallelDynamicStream[A, P, T, D, H]) AddPath(path P, dest D, as ...AreaSettings) error {
 	s.pathMap.Lock()
-
 	_, ok := s.pathMap.m[path]
 	if ok {
 		s.pathMap.Unlock()
@@ -147,6 +184,10 @@ func (s *parallelDynamicStream[A, P, T, D, H]) AddPath(path P, dest D, as ...Are
 	s.pathMap.Unlock()
 
 	s.setMemControl(pi, as...)
+
+	if pi.stream.isClosed.Load() {
+		return nil
+	}
 
 	pi.stream.addPath(pi)
 
@@ -170,9 +211,7 @@ func (s *parallelDynamicStream[A, P, T, D, H]) RemovePath(path P) error {
 	}
 	delete(s.pathMap.m, path)
 	s.pathMap.Unlock()
-
-	pi.stream.in() <- eventWrap[A, P, T, D, H]{pathInfo: pi}
-
+	pi.stream.addEvent(eventWrap[A, P, T, D, H]{pathInfo: pi})
 	s._statRemovePathCount.Add(1)
 	return nil
 }

--- a/utils/dynstream/parallel_dynamic_stream_test.go
+++ b/utils/dynstream/parallel_dynamic_stream_test.go
@@ -14,12 +14,15 @@
 package dynstream
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 // Mock hasher
@@ -143,4 +146,231 @@ func TestFeedBack(t *testing.T) {
 
 	fb1.FeedbackType = ResumeArea
 	require.Equal(t, ResumeArea, fb1.FeedbackType)
+}
+
+// TestParallelDynamicStreamStress tests concurrent operations on multiple ParallelDynamicStream instances
+// to verify the system handles concurrent operations gracefully, including operations during shutdown.
+// This test is designed to detect data races and validate proper concurrent behavior.
+func TestParallelDynamicStreamStress(t *testing.T) {
+	const (
+		streamCount  = 100                    // Number of ParallelDynamicStream instances
+		workerCount  = 100                    // Number of concurrent goroutines
+		testDuration = 200 * time.Millisecond // How long to run the test
+	)
+
+	streams := make([]*parallelDynamicStream[int, string, *mockEvent, any, *mockHandler], streamCount)
+	handlers := make([]*mockHandler, streamCount)
+	done := make(chan struct{})
+
+	// Track panics to ensure they're handled properly
+	var panicCount atomic.Int64
+
+	// Create all streams
+	for i := 0; i < streamCount; i++ {
+		handlers[i] = &mockHandler{}
+		option := Option{StreamCount: 4}
+		streams[i] = newParallelDynamicStream(mockHasher, handlers[i], option)
+		streams[i].Start()
+	}
+
+	var wg sync.WaitGroup
+
+	// Launch workers to add paths and push events concurrently
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicCount.Add(1)
+					// Log but don't fail the test - we want to see if panics occur
+					t.Logf("Worker %d recovered from panic: %v", workerID, r)
+				}
+			}()
+
+			streamID := workerID % streamCount
+			stream := streams[streamID]
+			eventID := 0
+
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					// Continuously add paths, push events, remove paths
+					pathName := fmt.Sprintf("worker_%d_path_%d", workerID, eventID%10)
+					destName := fmt.Sprintf("dest_%d_%d", workerID, eventID%10)
+
+					// Add path (ignore errors - path may already exist)
+					stream.AddPath(pathName, destName)
+
+					// Push event
+					event := &mockEvent{
+						id:    eventID,
+						path:  pathName,
+						value: workerID*1000 + eventID,
+						sleep: 0, // No sleep to increase concurrency
+					}
+					stream.Push(pathName, event)
+
+					// Occasionally wake and remove paths
+					if eventID%5 == 0 {
+						stream.Wake(pathName)
+					}
+					if eventID%7 == 0 {
+						stream.RemovePath(pathName)
+					}
+
+					eventID++
+				}
+			}
+		}(i)
+	}
+
+	// Launch a goroutine to close streams during operation
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				panicCount.Add(1)
+				t.Logf("Close goroutine recovered from panic: %v", r)
+			}
+		}()
+
+		// Wait a bit for operations to start
+		time.Sleep(50 * time.Millisecond)
+
+		// Close streams during operation
+		for i := 0; i < streamCount; i++ {
+			select {
+			case <-done:
+				return
+			default:
+				// Close every 10th stream during operation
+				if i%10 == 0 {
+					streams[i].Close()
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}
+	}()
+
+	// Run for a specific duration
+	time.Sleep(testDuration)
+	close(done)
+
+	// Wait for all workers to complete
+	wg.Wait()
+
+	// Close remaining streams
+	for i, stream := range streams {
+		if i%10 != 0 { // Skip already closed streams
+			stream.Close()
+		}
+	}
+
+	// Report results
+	totalPanics := panicCount.Load()
+	t.Logf("Stress test completed: %d streams, %d workers, %d panics detected",
+		streamCount, workerCount, totalPanics)
+
+	// The test passes if it completes without crashing
+	// Panics are logged but not treated as failures since they may be expected
+	// during concurrent shutdown scenarios
+}
+
+// TestParallelDynamicStreamConcurrentClose tests the specific scenario that can cause
+// data races: concurrent Push/Wake operations while Close is being called.
+// This test is designed to detect race conditions and validate that the system
+// can handle concurrent shutdown scenarios gracefully.
+//
+// Expected behavior:
+// - Some panics may occur when pushing to closed channels (this is expected)
+// - Data races should be detected by the race detector if present
+// - The test should complete without crashing
+func TestParallelDynamicStreamConcurrentClose(t *testing.T) {
+	const (
+		iterations = 10 // Number of test iterations
+		pushers    = 50 // Number of goroutines pushing events
+		closers    = 5  // Number of goroutines closing streams
+	)
+
+	for iter := 0; iter < iterations; iter++ {
+		t.Run(fmt.Sprintf("iteration_%d", iter), func(t *testing.T) {
+			handler := &mockHandler{}
+			option := Option{StreamCount: 4}
+			stream := newParallelDynamicStream(mockHasher, handler, option)
+			stream.Start()
+
+			// Add some initial paths
+			for i := 0; i < 10; i++ {
+				pathName := fmt.Sprintf("path_%d", i)
+				stream.AddPath(pathName, fmt.Sprintf("dest_%d", i))
+			}
+
+			var wg sync.WaitGroup
+			done := make(chan struct{})
+			var panicCount atomic.Int64
+
+			// Launch pushers
+			for i := 0; i < pushers; i++ {
+				wg.Add(1)
+				go func(pusherID int) {
+					defer wg.Done()
+					defer func() {
+						if r := recover(); r != nil {
+							panicCount.Add(1)
+							// Expected during concurrent close
+						}
+					}()
+
+					eventID := 0
+					for {
+						select {
+						case <-done:
+							return
+						default:
+							pathName := fmt.Sprintf("path_%d", eventID%10)
+							event := &mockEvent{
+								id:    eventID,
+								path:  pathName,
+								value: pusherID*1000 + eventID,
+								sleep: 0,
+							}
+							stream.Push(pathName, event)
+							stream.Wake(pathName)
+							eventID++
+						}
+					}
+				}(i)
+			}
+
+			// Launch closers
+			for i := 0; i < closers; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer func() {
+						if r := recover(); r != nil {
+							panicCount.Add(1)
+						}
+					}()
+
+					// Wait a tiny bit then close
+					time.Sleep(time.Millisecond)
+					stream.Close()
+				}()
+			}
+
+			// Let it run for a short time
+			time.Sleep(10 * time.Millisecond)
+			close(done)
+			wg.Wait()
+
+			totalPanics := panicCount.Load()
+			t.Logf("Iteration %d: %d panics detected", iter, totalPanics)
+		})
+		log.Info("pass iteration", zap.Int("iter", iter))
+	}
 }

--- a/utils/dynstream/stream_bench_test.go
+++ b/utils/dynstream/stream_bench_test.go
@@ -14,9 +14,12 @@
 package dynstream
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/pingcap/ticdc/utils/deque"
 )
 
 type inc struct {
@@ -127,5 +130,356 @@ func BenchmarkSLoop1000x100(b *testing.B) {
 func BenchmarkSLoop100000x100(b *testing.B) {
 	for k := 0; k < b.N; k++ {
 		runLoop(100000, 100)
+	}
+}
+
+// addEventDirectSend simulates direct channel send without select
+func addEventDirectSend[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](
+	ch chan eventWrap[A, P, T, D, H],
+	event eventWrap[A, P, T, D, H],
+) bool {
+	ch <- event
+	return true
+}
+
+// go test -bench=BenchmarkChannel -benchmem ./utils/dynstream/
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/pingcap/ticdc/utils/dynstream
+// cpu: Apple M4 Max
+// BenchmarkChannelDirectSend-14                                   38532294                30.59 ns/op            0 B/op          0 allocs/op
+// BenchmarkChannelDirectSendHighContention-14                      7781707               162.4 ns/op             0 B/op          0 allocs/op
+// BenchmarkChannelOptimizedWithContext-14                         39117944                35.40 ns/op            0 B/op          0 allocs/op
+// BenchmarkChannelOptimizedWithContextHighContention-14            5897019               205.1 ns/op             0 B/op          0 allocs/op
+// PASS
+// ok      github.com/pingcap/ticdc/utils/dynstream        6.454s
+func BenchmarkChannelDirectSend(b *testing.B) {
+	ch := make(chan eventWrap[int, string, *inc, D, *incHandler], 1000)
+	event := eventWrap[int, string, *inc, D, *incHandler]{
+		event: &inc{times: 1, n: &atomic.Int64{}, done: &sync.WaitGroup{}},
+	}
+
+	// Consumer goroutine
+	go func() {
+		for range ch {
+			// consume events
+		}
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addEventDirectSend(ch, event)
+	}
+}
+
+func BenchmarkChannelDirectSendHighContention(b *testing.B) {
+	ch := make(chan eventWrap[int, string, *inc, D, *incHandler], 10) // Small buffer to create contention
+	event := eventWrap[int, string, *inc, D, *incHandler]{
+		event: &inc{times: 1, n: &atomic.Int64{}, done: &sync.WaitGroup{}},
+	}
+
+	// Slow consumer to create backpressure
+	go func() {
+		for range ch {
+			// Simulate slow processing
+		}
+	}()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			addEventDirectSend(ch, event)
+		}
+	})
+}
+
+// addEventOptimized implements the fast path optimization with atomic check first
+func addEventWithContextAndCloseCheck[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](
+	closed *atomic.Bool,
+	ctx context.Context,
+	ch chan eventWrap[A, P, T, D, H],
+	event eventWrap[A, P, T, D, H],
+) bool {
+	if closed.Load() {
+		return false
+	}
+
+	// Fast path: try direct send without blocking
+	select {
+	case ch <- event:
+		return true
+	default:
+		// Slow path: check for closure while waiting
+		select {
+		case <-ctx.Done():
+			return false
+		case ch <- event:
+			return true
+		}
+	}
+}
+
+func BenchmarkChannelOptimizedWithContext(b *testing.B) {
+	ctx := context.Background()
+	ch := make(chan eventWrap[int, string, *inc, D, *incHandler], 1000)
+	closed := &atomic.Bool{}
+	event := eventWrap[int, string, *inc, D, *incHandler]{
+		event: &inc{times: 1, n: &atomic.Int64{}, done: &sync.WaitGroup{}},
+	}
+
+	// Consumer goroutine
+	go func() {
+		for range ch {
+			// consume events
+		}
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addEventWithContextAndCloseCheck(closed, ctx, ch, event)
+	}
+}
+
+// High contention benchmarks for optimized versions
+func BenchmarkChannelOptimizedWithContextHighContention(b *testing.B) {
+	ctx := context.Background()
+	ch := make(chan eventWrap[int, string, *inc, D, *incHandler], 10) // Small buffer to create contention
+	closed := &atomic.Bool{}
+	event := eventWrap[int, string, *inc, D, *incHandler]{
+		event: &inc{times: 1, n: &atomic.Int64{}, done: &sync.WaitGroup{}},
+	}
+
+	// Slow consumer to create backpressure
+	go func() {
+		for range ch {
+			// Simulate slow processing
+		}
+	}()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			addEventWithContextAndCloseCheck(closed, ctx, ch, event)
+		}
+	})
+}
+
+// receiverOnlyEventCh simulates receiver that only listens to event channel (no ctx.Done())
+func receiverOnlyEventCh[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](
+	inChan <-chan eventWrap[A, P, T, D, H],
+	outChan chan<- eventWrap[A, P, T, D, H],
+	closed *atomic.Bool,
+	bufferCount *atomic.Int64,
+	wg *sync.WaitGroup,
+) {
+	buffer := deque.NewDeque[eventWrap[A, P, T, D, H]](BlockLenInPendingQueue)
+	defer func() {
+		// Move all remaining events out of the buffer.
+		for {
+			_, ok := buffer.FrontRef()
+			if !ok {
+				break
+			} else {
+				buffer.PopFront()
+				bufferCount.Add(-1)
+			}
+		}
+		close(outChan)
+		wg.Done()
+	}()
+
+	for {
+		event, ok := buffer.FrontRef()
+		if closed.Load() {
+			return
+		}
+		if !ok {
+			// Only listen to inChan, no ctx.Done()
+			e, ok := <-inChan
+			if !ok {
+				return
+			}
+			buffer.PushBack(e)
+			bufferCount.Add(1)
+		} else {
+			if closed.Load() {
+				return
+			}
+
+			select {
+			case e, ok := <-inChan:
+				if !ok {
+					return
+				}
+				buffer.PushBack(e)
+				bufferCount.Add(1)
+			case outChan <- *event:
+				buffer.PopFront()
+				bufferCount.Add(-1)
+			}
+		}
+	}
+}
+
+// receiverWithContextCheck simulates receiver that listens to both event channel and ctx.Done()
+func receiverWithContextCheck[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](
+	ctx context.Context,
+	inChan <-chan eventWrap[A, P, T, D, H],
+	outChan chan<- eventWrap[A, P, T, D, H],
+	closed *atomic.Bool,
+	bufferCount *atomic.Int64,
+	wg *sync.WaitGroup,
+) {
+	buffer := deque.NewDeque[eventWrap[A, P, T, D, H]](BlockLenInPendingQueue)
+	defer func() {
+		// Move all remaining events out of the buffer.
+		for {
+			_, ok := buffer.FrontRef()
+			if !ok {
+				break
+			} else {
+				buffer.PopFront()
+				bufferCount.Add(-1)
+			}
+		}
+		close(outChan)
+		wg.Done()
+	}()
+
+	for {
+		event, ok := buffer.FrontRef()
+		if closed.Load() {
+			return
+		}
+		if !ok {
+			select {
+			case <-ctx.Done():
+				return
+			case e, ok := <-inChan:
+				if !ok {
+					return
+				}
+				buffer.PushBack(e)
+				bufferCount.Add(1)
+			}
+		} else {
+			if closed.Load() {
+				return
+			}
+
+			select {
+			case e, ok := <-inChan:
+				if !ok {
+					return
+				}
+				buffer.PushBack(e)
+				bufferCount.Add(1)
+			case outChan <- *event:
+				buffer.PopFront()
+				bufferCount.Add(-1)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// runReceiverBenchmark runs a benchmark for receiver performance
+func runReceiverBenchmark(eventCount int, withContext bool) {
+	inChan := make(chan eventWrap[int, string, *inc, D, *incHandler], 1000)
+	outChan := make(chan eventWrap[int, string, *inc, D, *incHandler], 1000)
+	closed := &atomic.Bool{}
+	bufferCount := &atomic.Int64{}
+	wg := &sync.WaitGroup{}
+
+	ctx := context.Background()
+
+	// Start receiver
+	wg.Add(1)
+	if withContext {
+		go receiverWithContextCheck(ctx, inChan, outChan, closed, bufferCount, wg)
+	} else {
+		go receiverOnlyEventCh(inChan, outChan, closed, bufferCount, wg)
+	}
+
+	// Start consumer
+	consumeDone := &sync.WaitGroup{}
+	consumeDone.Add(1)
+	go func() {
+		defer consumeDone.Done()
+		count := 0
+		for range outChan {
+			count++
+			if count >= eventCount {
+				break
+			}
+		}
+	}()
+
+	// Send events
+	pi := newPathInfo[int, string, *inc, D, *incHandler](0, "p1", D{})
+	for i := 0; i < eventCount; i++ {
+		event := eventWrap[int, string, *inc, D, *incHandler]{
+			event:    &inc{times: 1, n: &atomic.Int64{}, done: &sync.WaitGroup{}},
+			pathInfo: pi,
+		}
+		inChan <- event
+	}
+
+	// Wait for consumption to complete
+	consumeDone.Wait()
+
+	// Clean up
+	closed.Store(true)
+	close(inChan)
+	wg.Wait()
+}
+
+// go test -bench="BenchmarkReceiver.*1000" -benchmem ./utils/dynstream/
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/pingcap/ticdc/utils/dynstream
+// cpu: Apple M4 Max
+// BenchmarkReceiverOnlyEventCh1000-14                 4467            260194 ns/op          373209 B/op       3079 allocs/op
+// BenchmarkReceiverWithContext1000-14                 4453            257699 ns/op          373228 B/op       3079 allocs/op
+// BenchmarkReceiverOnlyEventCh10000-14                 469           2573837 ns/op         1933906 B/op      30641 allocs/op
+// BenchmarkReceiverWithContext10000-14                 452           2621993 ns/op         1933926 B/op      30641 allocs/op
+// BenchmarkReceiverOnlyEventCh100000-14                 48          25852419 ns/op        17547378 B/op     306267 allocs/op
+// BenchmarkReceiverWithContext100000-14                 46          26000457 ns/op        17547428 B/op     306267 allocs/op
+// PASS
+// ok      github.com/pingcap/ticdc/utils/dynstream        9.749s
+func BenchmarkReceiverOnlyEventCh1000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runReceiverBenchmark(1000, false)
+	}
+}
+
+func BenchmarkReceiverWithContext1000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runReceiverBenchmark(1000, true)
+	}
+}
+
+func BenchmarkReceiverOnlyEventCh10000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runReceiverBenchmark(10000, false)
+	}
+}
+
+func BenchmarkReceiverWithContext10000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runReceiverBenchmark(10000, true)
+	}
+}
+
+func BenchmarkReceiverOnlyEventCh100000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runReceiverBenchmark(100000, false)
+	}
+}
+
+func BenchmarkReceiverWithContext100000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runReceiverBenchmark(100000, true)
 	}
 }

--- a/utils/dynstream/stream_bench_test.go
+++ b/utils/dynstream/stream_bench_test.go
@@ -64,7 +64,7 @@ func runStream(eventCount int, times int) {
 
 	done.Add(eventCount)
 	for i := 0; i < eventCount; i++ {
-		stream.in() <- eventWrap[int, string, *inc, D, *incHandler]{event: &inc{times: times, n: total, done: done}, pathInfo: pi}
+		stream.addEvent(eventWrap[int, string, *inc, D, *incHandler]{event: &inc{times: times, n: total, done: done}, pathInfo: pi})
 	}
 
 	done.Wait()

--- a/utils/dynstream/stream_test.go
+++ b/utils/dynstream/stream_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,6 +51,7 @@ func newMockEvent(id int, path string, sleep time.Duration, work mockWork, start
 }
 
 type mockHandler struct {
+	mu            sync.Mutex
 	droppedEvents []*mockEvent
 }
 
@@ -75,6 +77,8 @@ func (h *mockHandler) Handle(dest any, events ...*mockEvent) (await bool) {
 		event.done.Done()
 	}
 
+	log.Info("fizz handle event")
+
 	return false
 }
 
@@ -84,11 +88,15 @@ func (h *mockHandler) GetTimestamp(event *mockEvent) Timestamp { return 0 }
 func (h *mockHandler) GetType(event *mockEvent) EventType      { return DefaultEventType }
 func (h *mockHandler) IsPaused(event *mockEvent) bool          { return false }
 func (h *mockHandler) OnDrop(event *mockEvent) interface{} {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.droppedEvents = append(h.droppedEvents, event)
 	return nil
 }
 
 func (h *mockHandler) drainDroppedEvents() []*mockEvent {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	events := h.droppedEvents
 	h.droppedEvents = nil
 	return events
@@ -138,7 +146,7 @@ func TestStreamBasic(t *testing.T) {
 	}
 
 	// Send event to stream
-	stream.in() <- newEvent(1)
+	stream.addEvent(newEvent(1))
 
 	notify.Wait()
 	// Verify event was processed
@@ -146,8 +154,8 @@ func TestStreamBasic(t *testing.T) {
 	require.Equal(t, 0, stream.getPendingSize())
 
 	// Test multiple events
-	stream.in() <- newEvent(2)
-	stream.in() <- newEvent(3)
+	stream.addEvent(newEvent(2))
+	stream.addEvent(newEvent(3))
 
 	notify.Wait()
 	// Verify all events were processed
@@ -177,7 +185,7 @@ func TestStreamBasicWithBuffer(t *testing.T) {
 	}
 
 	// Send event to stream
-	stream.in() <- newEvent(1)
+	stream.addEvent(newEvent(1))
 
 	notify.Wait()
 	// Verify event was processed
@@ -185,8 +193,8 @@ func TestStreamBasicWithBuffer(t *testing.T) {
 	require.Equal(t, 0, stream.getPendingSize())
 
 	// Test multiple events
-	stream.in() <- newEvent(2)
-	stream.in() <- newEvent(3)
+	stream.addEvent(newEvent(2))
+	stream.addEvent(newEvent(3))
 
 	notify.Wait()
 	// Verify all events were processed

--- a/utils/dynstream/stream_test.go
+++ b/utils/dynstream/stream_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,9 +75,6 @@ func (h *mockHandler) Handle(dest any, events ...*mockEvent) (await bool) {
 	if event.done != nil {
 		event.done.Done()
 	}
-
-	log.Info("fizz handle event")
-
 	return false
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2217 

### What is changed and how it works?


```
go test -bench=BenchmarkChannel -benchmem ./utils/dynstream/

goos: darwin
goarch: arm64
pkg: github.com/pingcap/ticdc/utils/dynstream
cpu: Apple M4 Max
# Original implementation
BenchmarkChannelDirectSend-14                                   38532294                30.59 ns/op            0 B/op          0 allocs/op
BenchmarkChannelDirectSendHighContention-14                      7781707               162.4 ns/op             0 B/op          0 allocs/op

# Current implementatuion
BenchmarkChannelOptimizedWithContext-14                         39117944                35.40 ns/op            0 B/op          0 allocs/op
BenchmarkChannelOptimizedWithContextHighContention-14            5897019               205.1 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/ticdc/utils/dynstream        6.454s
```

The benchmark validates the expected behavior. Using select with ctx.Done() introduces a measurable overhead compared to a direct channel send.

Under low contention, this adds `~5 ns (~16%)` per operation. This performance gap widens significantly under high contention, where the overhead increases to `~43 ns (~26%)` as the runtime scheduler handles more complex waiting conditions.

While the performance cost is real, it is paid in nanoseconds. This is a classic trade-off: accepting a small performance hit for the critical benefit of preventing goroutine leaks and enabling robust, graceful shutdowns. 

Base on the benchmark result , we can conduct a CPU overhead analysis.

Scenario | Throughput (events/sec) | Overhead (ms/sec) | Equivalent Single CPU Core Usage
-- | -- | -- | --
Lowest Throughput & Low Contention | 120,000 | 0.58 | 0.58 / 1000 = 0.058%
Lowest Throughput & High Contention | 120,000 | 5.12 | 5.12 / 1000 = 0.512%
Highest Throughput & Low Contention | 250,000 | 1.20 | 1.20 / 1000 = 0.120%
Highest Throughput & High Contention | 250,000 | 10.68 | 10.68 / 1000 = 1.07%
  |   |   |  

Even in the absolute worst-case scenario (highest throughput combined with high channel contention), the CPU overhead is now just ~1.07% of a single core.
The data clearly shows that the CPU cost for ensuring graceful shutdown is very small and predictable. Paying a maximum of 1.07% of a single core's time is a good trade-off for the critical benefit of preventing PANIC. The current implementation is well-justified.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
