### PR TITLE
Add a script to download integration test binaries for macOS to simplify the setup of integration test environments.

### DIFF
--- a/tests/scripts/download-integration-test-binaries-macos.sh
+++ b/tests/scripts/download-integration-test-binaries-macos.sh
@@ -11,7 +11,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+set -euo pipefail
 # ANSI color codes for styling the output
 RED='\033[0;31m'    # Sets text to red
 GREEN='\033[0;32m'  # Sets text to green

--- a/tests/scripts/download-integration-test-binaries-macos.sh
+++ b/tests/scripts/download-integration-test-binaries-macos.sh
@@ -111,7 +111,9 @@ if [ ! -x bin/etcdctl ]; then
 	echo -e "${YELLOW} downloading etcd...${NC}"
 	wget -O bin/etcd-v3.6.1-darwin-$arch.zip https://github.com/etcd-io/etcd/releases/download/v3.6.1/etcd-v3.6.1-darwin-$arch.zip
 	unzip -d bin/ bin/etcd-v3.6.1-darwin-$arch.zip
+	rm bin/etcd-v3.6.1-darwin-$arch.zip
 	mv bin/etcd-v3.6.1-darwin-$arch/etcdctl bin/
+	rm -rf bin/etcd-v3.6.1-darwin-$arch
 fi
 
 if [ ! -x bin/sync_diff_inspector ]; then

--- a/tests/scripts/download-integration-test-binaries-macos.sh
+++ b/tests/scripts/download-integration-test-binaries-macos.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Copyright 2025 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ANSI color codes for styling the output
+RED='\033[0;31m'    # Sets text to red
+GREEN='\033[0;32m'  # Sets text to green
+YELLOW='\033[0;33m' # Sets text to yellow
+BLUE='\033[0;34m'   # Sets text to blue
+NC='\033[0m'        # Resets the text color to default, no color
+
+ver=
+disable_tidb=0
+
+show_help() {
+	echo -e "${GREEN}Usage: $0 [OPTIONS]${NC}"
+	echo -e "Downloads integration test binaries for macOS"
+	echo -e "\n${BLUE}Options:${NC}"
+	echo -e "  -v, --version VERSION  Set TiDB component version (default: latest)"
+	echo -e "  --disable-tidb         Skip downloading TiDB components"
+	echo -e "  -h, --help             Show this help message"
+	echo -e "\n${YELLOW}Downloads:${NC}"
+	echo -e "  - minio, jq, confluent"
+	echo -e "  - go-ycsb, etcdctl, sync_diff_inspector"
+	echo -e "  - TiDB components (unless --disable-tidb is set):"
+	echo -e "    tidb, tikv, cdc, pd, tiflash, ctl"
+}
+
+get_latest_tidb_version() {
+	local latest_version="v8.5.2" # fallback version
+	# Try to get latest version from GitHub API
+	if command -v curl &>/dev/null; then
+		latest_version=$(curl -s https://api.github.com/repos/pingcap/tidb/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+	elif command -v wget &>/dev/null; then
+		latest_version=$(wget -qO- https://api.github.com/repos/pingcap/tidb/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+	fi
+	# If version extraction failed, use fallback
+	if [[ ! "$latest_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+		latest_version="v8.5.2"
+	fi
+	echo "$latest_version"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-v | --version)
+		ver="$2"
+		shift 2
+		;;
+	--disable-tidb)
+		disable_tidb=1
+		shift
+		;;
+	-h | --help)
+		show_help
+		exit 0
+		;;
+	*) ;;
+	esac
+
+done
+
+if [ -z "$ver" ]; then
+	ver=$(get_latest_tidb_version)
+fi
+
+mkdir -p bin
+
+arch=$(uname -m)
+
+if [ ! -x bin/minio ]; then
+	# Download minio
+	echo -e "${YELLOW} downloading minio...${NC}"
+	wget -O bin/minio https://dl.min.io/server/minio/release/darwin-$arch/minio
+	chmod +x bin/minio
+fi
+
+if [ ! -x bin/jq ]; then
+	# Download jq using curl
+	echo -e "${YELLOW} downloading jq...${NC}"
+	wget -O bin/jq https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-macos-$arch
+	chmod +x bin/jq
+fi
+
+if [ ! -d bin/bin ]; then
+	echo -e "${YELLOW} downloading confluent...${NC}"
+	wget -O bin/confluent-7.5.2.tar.gz https://packages.confluent.io/archive/7.5/confluent-7.5.2.tar.gz
+	tar -C bin/ -xzf bin/confluent-7.5.2.tar.gz
+	mv bin/confluent-7.5.2/bin/ bin/
+	rm -rf confluent-7.5.2
+fi
+
+if [ ! -x bin/go-ycsb ]; then
+	echo -e "${YELLOW} downloading go-ycsb...${NC}"
+	wget -O bin/go-ycsb-darwin-$arch.tar.gz https://github.com/pingcap/go-ycsb/releases/latest/download/go-ycsb-darwin-$arch.tar.gz
+	tar -C bin/ -xzf bin/go-ycsb-darwin-$arch.tar.gz
+fi
+
+if [ ! -x bin/etcdctl ]; then
+	echo -e "${YELLOW} downloading etcd...${NC}"
+	wget -O bin/etcd-v3.6.1-darwin-$arch.zip https://github.com/etcd-io/etcd/releases/download/v3.6.1/etcd-v3.6.1-darwin-$arch.zip
+	unzip -d bin/ bin/etcd-v3.6.1-darwin-$arch.zip
+	mv bin/etcd-v3.6.1-darwin-$arch/etcdctl bin/
+fi
+
+if [ ! -x bin/sync_diff_inspector ]; then
+	echo -e "${YELLOW} downloading sync-diff-inspector...${NC}"
+	wget -O bin/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz
+	tar -C bin/ -xzf bin/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz
+fi
+
+if [[ "$disable_tidb" == "1" ]]; then
+	echo -e "${RED}You should copy the tidb binaries to the bin/ directory on your own.${NC}"
+	exit 0
+fi
+
+wget -O bin/tidb-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tidb-$ver-darwin-$arch.tar.gz
+tar -C bin/ -xvf bin/tidb-$ver-darwin-$arch.tar.gz
+
+wget -O bin/tikv-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tikv-$ver-darwin-$arch.tar.gz
+tar -C bin/ -xvf bin/tikv-$ver-darwin-$arch.tar.gz
+
+wget -O bin/cdc-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/cdc-$ver-darwin-$arch.tar.gz
+tar -C bin/ -xvf bin/cdc-$ver-darwin-$arch.tar.gz
+cp bin/cdc bin/cdc.test
+
+wget -O bin/pd-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/pd-$ver-darwin-$arch.tar.gz
+tar -C bin/ -xvf bin/pd-$ver-darwin-$arch.tar.gz
+
+wget -O bin/tiflash-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tiflash-$ver-darwin-$arch.tar.gz
+tar -C bin/ -xvf bin/tiflash-$ver-darwin-$arch.tar.gz
+mv bin/tiflash bin/tiflash-$ver-darwin-$arch
+mv bin/tiflash-$ver-darwin-$arch/tiflash bin/
+
+wget -O bin/ctl-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/ctl-$ver-darwin-$arch.tar.gz
+tar -C bin/ -xvf bin/ctl-$ver-darwin-$arch.tar.gz

--- a/tests/scripts/download-integration-test-binaries-macos.sh
+++ b/tests/scripts/download-integration-test-binaries-macos.sh
@@ -146,8 +146,8 @@ tar -C bin/ -xvf bin/pd-$ver-darwin-$arch.tar.gz
 
 wget -O bin/tiflash-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tiflash-$ver-darwin-$arch.tar.gz
 tar -C bin/ -xvf bin/tiflash-$ver-darwin-$arch.tar.gz
-mv bin/tiflash bin/tiflash-$ver-darwin-$arch
-mv bin/tiflash-$ver-darwin-$arch/tiflash bin/
+mv bin/tiflash/tiflash bin/
+rm -rf bin/tiflash
 
 wget -O bin/ctl-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/ctl-$ver-darwin-$arch.tar.gz
 tar -C bin/ -xvf bin/ctl-$ver-darwin-$arch.tar.gz

--- a/tests/scripts/download-integration-test-binaries-macos.sh
+++ b/tests/scripts/download-integration-test-binaries-macos.sh
@@ -80,20 +80,20 @@ arch=$(uname -m)
 
 if [ ! -x bin/minio ]; then
 	# Download minio
-	echo -e "${YELLOW} downloading minio...${NC}"
-	wget -O bin/minio https://dl.min.io/server/minio/release/darwin-$arch/minio
+	echo -e "${YELLOW}downloading minio...${NC}"
+	wget -O bin/minio "https://dl.min.io/server/minio/release/darwin-$arch/minio"
 	chmod +x bin/minio
 fi
 
 if [ ! -x bin/jq ]; then
 	# Download jq using curl
-	echo -e "${YELLOW} downloading jq...${NC}"
-	wget -O bin/jq https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-macos-$arch
+	echo -e "${YELLOW}downloading jq...${NC}"
+	wget -O bin/jq "https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-macos-$arch"
 	chmod +x bin/jq
 fi
 
 if [ ! -x bin/bin/kafka-server-start ]; then
-	echo -e "${YELLOW} downloading confluent...${NC}"
+	echo -e "${YELLOW}downloading confluent...${NC}"
 	wget -O bin/confluent-7.5.2.tar.gz https://packages.confluent.io/archive/7.5/confluent-7.5.2.tar.gz
 	tar -C bin/ -xzf bin/confluent-7.5.2.tar.gz
 	rm bin/confluent-7.5.2.tar.gz
@@ -102,24 +102,26 @@ if [ ! -x bin/bin/kafka-server-start ]; then
 fi
 
 if [ ! -x bin/go-ycsb ]; then
-	echo -e "${YELLOW} downloading go-ycsb...${NC}"
-	wget -O bin/go-ycsb-darwin-$arch.tar.gz https://github.com/pingcap/go-ycsb/releases/latest/download/go-ycsb-darwin-$arch.tar.gz
-	tar -C bin/ -xzf bin/go-ycsb-darwin-$arch.tar.gz
+	echo -e "${YELLOW}downloading go-ycsb...${NC}"
+	wget -O "bin/go-ycsb-darwin-$arch.tar.gz" "https://github.com/pingcap/go-ycsb/releases/latest/download/go-ycsb-darwin-$arch.tar.gz"
+	tar -C bin/ -xzf "bin/go-ycsb-darwin-$arch.tar.gz"
+	rm -rf "bin/go-ycsb-darwin-$arch.tar.gz"
 fi
 
 if [ ! -x bin/etcdctl ]; then
-	echo -e "${YELLOW} downloading etcd...${NC}"
-	wget -O bin/etcd-v3.6.1-darwin-$arch.zip https://github.com/etcd-io/etcd/releases/download/v3.6.1/etcd-v3.6.1-darwin-$arch.zip
-	unzip -d bin/ bin/etcd-v3.6.1-darwin-$arch.zip
-	rm bin/etcd-v3.6.1-darwin-$arch.zip
-	mv bin/etcd-v3.6.1-darwin-$arch/etcdctl bin/
-	rm -rf bin/etcd-v3.6.1-darwin-$arch
+	echo -e "${YELLOW}downloading etcd...${NC}"
+	wget -O "bin/etcd-v3.6.1-darwin-$arch.zip" "https://github.com/etcd-io/etcd/releases/download/v3.6.1/etcd-v3.6.1-darwin-$arch.zip"
+	unzip -d bin/ "bin/etcd-v3.6.1-darwin-$arch.zip"
+	rm "bin/etcd-v3.6.1-darwin-$arch.zip"
+	mv "bin/etcd-v3.6.1-darwin-$arch/etcdctl" bin/
+	rm -rf "bin/etcd-v3.6.1-darwin-$arch"
 fi
 
 if [ ! -x bin/sync_diff_inspector ]; then
-	echo -e "${YELLOW} downloading sync-diff-inspector...${NC}"
-	wget -O bin/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz
-	tar -C bin/ -xzf bin/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz
+	echo -e "${YELLOW}downloading sync-diff-inspector...${NC}"
+	wget -O "bin/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz" "https://tiup-mirrors.pingcap.com/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz"
+	tar -C bin/ -xzf "bin/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz"
+	rm -rf "bin/sync-diff-inspector-v9.0.0-beta.1-darwin-$arch.tar.gz"
 fi
 
 if [[ "$disable_tidb" == "1" ]]; then
@@ -128,26 +130,39 @@ if [[ "$disable_tidb" == "1" ]]; then
 fi
 
 if [ ! -x bin/tidb-server ]; then
-    echo -e "${YELLOW} downloading tidb...${NC}"
-    wget -O bin/tidb-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tidb-$ver-darwin-$arch.tar.gz
-    tar -C bin/ -xvf bin/tidb-$ver-darwin-$arch.tar.gz
-    rm bin/tidb-$ver-darwin-$arch.tar.gz
+	echo -e "${YELLOW}downloading tidb...${NC}"
+	wget -O "bin/tidb-$ver-darwin-$arch.tar.gz" "https://tiup-mirrors.pingcap.com/tidb-$ver-darwin-$arch.tar.gz"
+	tar -C bin/ -xvf "bin/tidb-$ver-darwin-$arch.tar.gz"
+	rm "bin/tidb-$ver-darwin-$arch.tar.gz"
 fi
 
-wget -O bin/tikv-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tikv-$ver-darwin-$arch.tar.gz
-tar -C bin/ -xvf bin/tikv-$ver-darwin-$arch.tar.gz
+if [ ! -x bin/tikv-server ]; then
+	echo -e "${YELLOW}downloading tikv...${NC}"
+	wget -O "bin/tikv-$ver-darwin-$arch.tar.gz" "https://tiup-mirrors.pingcap.com/tikv-$ver-darwin-$arch.tar.gz"
+	tar -C bin/ -xvf "bin/tikv-$ver-darwin-$arch.tar.gz"
+	rm "bin/tikv-$ver-darwin-$arch.tar.gz"
+fi
 
-wget -O bin/cdc-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/cdc-$ver-darwin-$arch.tar.gz
-tar -C bin/ -xvf bin/cdc-$ver-darwin-$arch.tar.gz
-cp bin/cdc bin/cdc.test
+if [ ! -x bin/pd-server ]; then
+	echo -e "${YELLOW}downloading pd...${NC}"
+	wget -O "bin/pd-$ver-darwin-$arch.tar.gz" "https://tiup-mirrors.pingcap.com/pd-$ver-darwin-$arch.tar.gz"
+	tar -C bin/ -xvf "bin/pd-$ver-darwin-$arch.tar.gz"
+	rm "bin/pd-$ver-darwin-$arch.tar.gz"
+fi
 
-wget -O bin/pd-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/pd-$ver-darwin-$arch.tar.gz
-tar -C bin/ -xvf bin/pd-$ver-darwin-$arch.tar.gz
+if [ ! -x bin/tiflash ]; then
+	echo -e "${YELLOW}downloading tiflash...${NC}"
+	wget -O "bin/tiflash-$ver-darwin-$arch.tar.gz" "https://tiup-mirrors.pingcap.com/tiflash-$ver-darwin-$arch.tar.gz"
+	tar -C bin/ -xvf "bin/tiflash-$ver-darwin-$arch.tar.gz"
+	mv bin/tiflash "bin/tiflash-bin"
+	mv bin/tiflash-bin/* bin/
+	rm -rf "bin/tiflash-$ver-darwin-$arch.tar.gz"
+	rm -rf bin/tiflash-bin
+fi
 
-wget -O bin/tiflash-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tiflash-$ver-darwin-$arch.tar.gz
-tar -C bin/ -xvf bin/tiflash-$ver-darwin-$arch.tar.gz
-mv bin/tiflash/tiflash bin/
-rm -rf bin/tiflash
-
-wget -O bin/ctl-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/ctl-$ver-darwin-$arch.tar.gz
-tar -C bin/ -xvf bin/ctl-$ver-darwin-$arch.tar.gz
+if [ ! -x bin/pd-ctl ]; then
+	echo -e "${YELLOW}downloading ctl...${NC}"
+	wget -O "bin/ctl-$ver-darwin-$arch.tar.gz" "https://tiup-mirrors.pingcap.com/ctl-$ver-darwin-$arch.tar.gz"
+	tar -C bin/ -xvf "bin/ctl-$ver-darwin-$arch.tar.gz"
+	rm -rf "bin/ctl-$ver-darwin-$arch.tar.gz"
+fi

--- a/tests/scripts/download-integration-test-binaries-macos.sh
+++ b/tests/scripts/download-integration-test-binaries-macos.sh
@@ -92,12 +92,13 @@ if [ ! -x bin/jq ]; then
 	chmod +x bin/jq
 fi
 
-if [ ! -d bin/bin ]; then
+if [ ! -x bin/bin/kafka-server-start ]; then
 	echo -e "${YELLOW} downloading confluent...${NC}"
 	wget -O bin/confluent-7.5.2.tar.gz https://packages.confluent.io/archive/7.5/confluent-7.5.2.tar.gz
 	tar -C bin/ -xzf bin/confluent-7.5.2.tar.gz
+	rm bin/confluent-7.5.2.tar.gz
 	mv bin/confluent-7.5.2/bin/ bin/
-	rm -rf confluent-7.5.2
+	rm -rf bin/confluent-7.5.2
 fi
 
 if [ ! -x bin/go-ycsb ]; then

--- a/tests/scripts/download-integration-test-binaries-macos.sh
+++ b/tests/scripts/download-integration-test-binaries-macos.sh
@@ -127,8 +127,12 @@ if [[ "$disable_tidb" == "1" ]]; then
 	exit 0
 fi
 
-wget -O bin/tidb-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tidb-$ver-darwin-$arch.tar.gz
-tar -C bin/ -xvf bin/tidb-$ver-darwin-$arch.tar.gz
+if [ ! -x bin/tidb-server ]; then
+    echo -e "${YELLOW} downloading tidb...${NC}"
+    wget -O bin/tidb-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tidb-$ver-darwin-$arch.tar.gz
+    tar -C bin/ -xvf bin/tidb-$ver-darwin-$arch.tar.gz
+    rm bin/tidb-$ver-darwin-$arch.tar.gz
+fi
 
 wget -O bin/tikv-$ver-darwin-$arch.tar.gz https://tiup-mirrors.pingcap.com/tikv-$ver-darwin-$arch.tar.gz
 tar -C bin/ -xvf bin/tikv-$ver-darwin-$arch.tar.gz


### PR DESCRIPTION
### What problem does this PR solve?

Running integration tests on macOS currently requires manually downloading and setting up various binaries (TiDB components, Kafka, MinIO, etc.). This PR addresses this by providing an automated script to download all necessary integration test binaries for macOS users, simplifying the setup process and ensuring consistency across developer environments.

Issue Number: close #2231

### What is changed and how it works?

A new shell script `tests/scripts/download-integration-test-binaries-macos.sh` has been added. This script automates the download and setup of all external binaries required to run TiCDC integration tests on macOS.

* The script downloads essential tools: `minio`, `jq`, `confluent`, `go-ycsb`, `etcdctl`, and `sync_diff_inspector`.
* It downloads TiDB components: `tidb`, `tikv`, `cdc`, `pd`, `tiflash`, and `ctl` from `tiup-mirrors.pingcap.com`.
* The script automatically detects the system architecture (`darwin-$arch`).
* It includes options:
  * `-v, --version <VERSION>`: To specify the desired TiDB component version (defaults to the latest stable release).
  * `--disable-tidb`: To skip downloading TiDB components, allowing users to provide their own.
* The downloaded binaries are extracted and placed into a `bin/` directory relative to the script's location.
* The script uses `wget` for downloading and `tar`/`unzip` for extracting archives.
* It includes basic checks to avoid re-downloading existing binaries and provides colored output for better readability.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

* Manual test (add detailed scripts or steps below)
    1. Run the script: `./tests/scripts/download-integration-test-binaries-macos.sh`
    2. Verify that a `bin/` directory is created (if not already present).
    3. Check that all specified binaries (minio, jq, confluent, go-ycsb, etcdctl, sync_diff_inspector, tidb, tikv, cdc, pd, tiflash, ctl) are downloaded and extracted into the `bin/` directory.
    4. Test with `--disable-tidb`: `./tests/scripts/download-integration-test-binaries-macos.sh --disable-tidb` and confirm TiDB components are not downloaded.
    5. Test with `-v <version>`: `./tests/scripts/download-integration-test-binaries-macos.sh -v v8.5.0` and confirm the specified version of TiDB components are downloaded.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No, this is a new utility script for development/testing setup and does not affect runtime performance or break compatibility of the main TiCDC product.

##### Do you need to update user documentation, design documentation or monitoring documentation?

It might be beneficial to mention this script in the `CONTRIBUTING.md` or a developer guide for macOS users to simplify their setup for running integration tests.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
