### PR TITLE
eventborker: update wrong received resolved ts metrics

### DIFF
--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -55,7 +55,7 @@ type SchemaStore interface {
 	// TODO: add a parameter limit
 	FetchTableDDLEvents(keyspaceID uint32, dispatcherID common.DispatcherID, tableID int64, tableFilter filter.Filter, start, end uint64) ([]commonEvent.DDLEvent, error)
 
-	FetchTableTriggerDDLEvents(keyspaceID uint32, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error)
+	FetchTableTriggerDDLEvents(keyspaceID uint32, dispatcherID common.DispatcherID, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error)
 
 	// RegisterKeyspace register a keyspace to fetch table ddl
 	RegisterKeyspace(ctx context.Context, keyspaceName string) error
@@ -377,7 +377,7 @@ func (s *schemaStore) FetchTableDDLEvents(keyspaceID uint32, dispatcherID common
 }
 
 // FetchTableTriggerDDLEvents returns the next ddl events which finishedTs are within the range (start, end]
-func (s *schemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error) {
+func (s *schemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, dispatcherID common.DispatcherID, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error) {
 	if limit == 0 {
 		log.Panic("limit cannot be 0")
 	}
@@ -405,6 +405,7 @@ func (s *schemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, tableFilter 
 		end = events[len(events)-1].FinishedTs
 	}
 	log.Debug("FetchTableTriggerDDLEvents end",
+		zap.Stringer("dispatcherID", dispatcherID),
 		zap.Uint64("start", start),
 		zap.Int("limit", limit),
 		zap.Uint64("end", end),

--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -401,6 +401,8 @@ func (s *schemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, dispatcherID
 		return events, events[limit-1].FinishedTs, nil
 	}
 	end := currentResolvedTs
+	// after we get currentResolvedTs, there may be new ddl events with FinishedTs > currentResolvedTs
+	// so we need to extend the end to include these new ddl events
 	if len(events) > 0 && events[len(events)-1].FinishedTs > currentResolvedTs {
 		end = events[len(events)-1].FinishedTs
 	}

--- a/pkg/eventservice/dispatcher_stat_test.go
+++ b/pkg/eventservice/dispatcher_stat_test.go
@@ -54,7 +54,7 @@ func TestNewDispatcherStat(t *testing.T) {
 	require.True(t, stat.enableSyncPoint)
 	require.Equal(t, info.nextSyncPoint, stat.nextSyncPoint.Load())
 	require.Equal(t, syncPointInterval, stat.syncPointInterval)
-	require.Equal(t, startTs, stat.eventStoreResolvedTs.Load())
+	require.Equal(t, startTs, stat.receivedResolvedTs.Load())
 	require.Equal(t, startTs, stat.checkpointTs.Load())
 	require.Equal(t, startTs, stat.sentResolvedTs.Load())
 	require.True(t, stat.isReadyReceivingData.Load())
@@ -70,7 +70,7 @@ func TestDispatcherStatResolvedTs(t *testing.T) {
 	// Test normal update
 	updated := stat.onResolvedTs(150)
 	require.True(t, updated)
-	require.Equal(t, uint64(150), stat.eventStoreResolvedTs.Load())
+	require.Equal(t, uint64(150), stat.receivedResolvedTs.Load())
 
 	// Test same ts update
 	updated = stat.onResolvedTs(150)
@@ -126,20 +126,20 @@ func TestDispatcherStatUpdateWatermark(t *testing.T) {
 
 	// Case 1: no new events, only watermark change
 	stat.onResolvedTs(200)
-	require.Equal(t, uint64(200), stat.eventStoreResolvedTs.Load())
+	require.Equal(t, uint64(200), stat.receivedResolvedTs.Load())
 
 	// Case 2: new events, and watermark increase
 	stat.onLatestCommitTs(300)
 	stat.onResolvedTs(400)
 	require.Equal(t, uint64(300), stat.eventStoreCommitTs.Load())
-	require.Equal(t, uint64(400), stat.eventStoreResolvedTs.Load())
+	require.Equal(t, uint64(400), stat.receivedResolvedTs.Load())
 
 	// Case 3: new events, and watermark decrease
 	// watermark should not decrease
 	stat.onLatestCommitTs(500)
 	stat.onResolvedTs(300)
 	require.Equal(t, uint64(500), stat.eventStoreCommitTs.Load())
-	require.Equal(t, uint64(400), stat.eventStoreResolvedTs.Load())
+	require.Equal(t, uint64(400), stat.receivedResolvedTs.Load())
 }
 
 func TestResolvedTsCache(t *testing.T) {

--- a/pkg/eventservice/event_scanner_test.go
+++ b/pkg/eventservice/event_scanner_test.go
@@ -78,7 +78,7 @@ func TestEventScanner(t *testing.T) {
 	// [Resolved(ts=102)]
 	scanner := newEventScanner(broker.eventStore, broker.schemaStore, &mockMounter{}, 0)
 
-	disp.eventStoreResolvedTs.Store(102)
+	disp.receivedResolvedTs.Store(102)
 	sl := scanLimit{
 		maxDMLBytes: 1000,
 		timeout:     10 * time.Second,
@@ -98,7 +98,7 @@ func TestEventScanner(t *testing.T) {
 	broker.schemaStore.(*mockSchemaStore).AppendDDLEvent(tableID, ddlEvent)
 
 	resolvedTs := kvEvents[len(kvEvents)-1].CRTs + 1
-	disp.eventStoreResolvedTs.Store(resolvedTs)
+	disp.receivedResolvedTs.Store(resolvedTs)
 	ok, dataRange = broker.getScanTaskDataRange(disp)
 	require.True(t, ok)
 
@@ -129,7 +129,7 @@ func TestEventScanner(t *testing.T) {
 	err = broker.eventStore.(*mockEventStore).AppendEvents(dispatcherID, resolvedTs, kvEvents...)
 	require.NoError(t, err)
 
-	disp.eventStoreResolvedTs.Store(resolvedTs)
+	disp.receivedResolvedTs.Store(resolvedTs)
 	require.True(t, ok)
 	dataRange.CommitTsStart = ddlEvent.GetCommitTs()
 
@@ -170,7 +170,7 @@ func TestEventScanner(t *testing.T) {
 	//   DDL(ts=x) -> DML(ts=x+1) -> DML(ts=x+2) -> DML(ts=x+3) -> DML(ts=x+4) -> Resolved(ts=x+5)
 	// Expected result:
 	// [DDL(x), BatchDML_1[DML(x+1)], BatchDML_2[DML(x+2), DML(x+3), DML(x+4)], Resolved(x+5)]
-	disp.eventStoreResolvedTs.Store(resolvedTs)
+	disp.receivedResolvedTs.Store(resolvedTs)
 	ok, dataRange = broker.getScanTaskDataRange(disp)
 	require.True(t, ok)
 
@@ -411,7 +411,7 @@ func TestEventScannerWithDeleteTable(t *testing.T) {
 	dml1 := kvEvents[1]
 	dml2 := kvEvents[2]
 	mockSchemaStore.DeleteTable(tableID, dml2.CRTs)
-	disp.eventStoreResolvedTs.Store(resolvedTs)
+	disp.receivedResolvedTs.Store(resolvedTs)
 	ok, dataRange := broker.getScanTaskDataRange(disp)
 	require.True(t, ok)
 
@@ -503,7 +503,7 @@ func TestEventScannerWithDDL(t *testing.T) {
 	}
 	mockSchemaStore.AppendDDLEvent(tableID, fakeDDL)
 
-	disp.eventStoreResolvedTs.Store(resolvedTs)
+	disp.receivedResolvedTs.Store(resolvedTs)
 	ok, dataRange := broker.getScanTaskDataRange(disp)
 	require.True(t, ok)
 
@@ -662,7 +662,7 @@ func TestEventScannerWithDDL(t *testing.T) {
 		mockSchemaStore.AppendDDLEvent(tableID, fakeDDL3)
 
 		resolvedTs = resolvedTs + 3
-		disp.eventStoreResolvedTs.Store(resolvedTs)
+		disp.receivedResolvedTs.Store(resolvedTs)
 
 		ok, dataRange = broker.getScanTaskDataRange(disp)
 		require.True(t, ok)

--- a/pkg/eventservice/metrics_collector.go
+++ b/pkg/eventservice/metrics_collector.go
@@ -178,7 +178,7 @@ func (mc *metricsCollector) collectDispatcherMetrics(snapshot *metricsSnapshot) 
 		metrics.EventServiceDispatcherUpdateResolvedTsDiff.Observe(updateDiff.Seconds())
 
 		// Track min resolved timestamps
-		resolvedTs := dispatcher.eventStoreResolvedTs.Load()
+		resolvedTs := dispatcher.receivedResolvedTs.Load()
 		if resolvedTs < snapshot.receivedMinResolvedTs {
 			snapshot.receivedMinResolvedTs = resolvedTs
 		}
@@ -247,7 +247,7 @@ func (mc *metricsCollector) logSlowDispatchers(snapshot *metricsSnapshot) {
 	log.Warn("slowest dispatcher",
 		zap.Stringer("dispatcherID", snapshot.slowestDispatcher.id),
 		zap.Uint64("sentResolvedTs", snapshot.slowestDispatcher.sentResolvedTs.Load()),
-		zap.Uint64("receivedResolvedTs", snapshot.slowestDispatcher.eventStoreResolvedTs.Load()),
+		zap.Uint64("receivedResolvedTs", snapshot.slowestDispatcher.receivedResolvedTs.Load()),
 		zap.Duration("lag", lag),
 		zap.Duration("updateDiff",
 			time.Since(snapshot.slowestDispatcher.lastSentResolvedTsTime.Load())-

--- a/pkg/eventservice/test_helper.go
+++ b/pkg/eventservice/test_helper.go
@@ -141,7 +141,7 @@ func (m *mockSchemaStore) FetchTableDDLEvents(keyspaceID uint32, dispatcherID co
 	return events[l:r], nil
 }
 
-func (m *mockSchemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error) {
+func (m *mockSchemaStore) FetchTableTriggerDDLEvents(keyspaceID uint32, dispatcherID common.DispatcherID, tableFilter filter.Filter, start uint64, limit int) ([]commonEvent.DDLEvent, uint64, error) {
 	return nil, 0, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #2139

### What is changed and how it works?

* **Metric Renaming and Clarification**: The `eventStoreResolvedTs` field in `dispatcherStat` has been renamed to `receivedResolvedTs` to more accurately reflect that it tracks resolved timestamps received from both the event store and the schema store.
* **Schema Store Integration**: The `FetchTableTriggerDDLEvents` function in the `SchemaStore` interface and its implementation now accept a `dispatcherID` parameter, allowing for more specific tracking and logging related to individual dispatchers.
* **Correct Resolved Timestamp Updates**: The `receivedResolvedTs` metric is now correctly updated with the `endTs` returned after fetching DDL events from the schema store, ensuring the metric reflects the latest processed timestamp from all relevant sources.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
