### PR TITLE
fix(ddl): use correct table info for exchange partition ddl

### DIFF
--- a/logservice/schemastore/persist_storage.go
+++ b/logservice/schemastore/persist_storage.go
@@ -725,6 +725,7 @@ func (p *persistentStorage) handleDDLJob(job *model.Job) error {
 
 	// TODO: do we have a better way to do this?
 	if ddlEvent.Type == byte(model.ActionExchangeTablePartition) {
+		// ExtraTableInfo is the normal table info before exchange
 		ddlEvent.ExtraTableInfo, _ = p.forceGetTableInfo(ddlEvent.TableID, ddlEvent.FinishedTs)
 	}
 

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -2164,7 +2164,8 @@ func buildDDLEventForExchangeTablePartition(rawEvent *PersistedDDLEvent, tableFi
 			rawEvent.TableName,
 			rawEvent.Query,
 			model.ActionExchangeTablePartition,
-			rawEvent.TableInfo,
+			// rawEvent.ExtraTableInfo is the normal table info before exchange.
+			rawEvent.ExtraTableInfo.ToTiDBTableInfo(),
 			rawEvent.StartTs,
 		)
 		if err != nil {
@@ -2176,6 +2177,11 @@ func buildDDLEventForExchangeTablePartition(rawEvent *PersistedDDLEvent, tableFi
 			rawEvent.ExtraTableName,
 			rawEvent.Query,
 			model.ActionExchangeTablePartition,
+			// rawEvent.TableInfo is the partition table info after exchange,
+			// typically, we should use the table info before exchange to do filtering,
+			// but we don't have the table info before exchange here,
+			// so we use the partition table info after exchange instead,
+			// because the difference between this two table info is just one partition table id changed.
 			rawEvent.TableInfo,
 			rawEvent.StartTs,
 		)

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -655,10 +655,12 @@ func buildPersistedDDLEventForNormalPartitionDDL(args buildPersistedDDLEventFunc
 // the TableInfo belongs to the previous table(pt)
 func buildPersistedDDLEventForExchangePartition(args buildPersistedDDLEventFuncArgs) PersistedDDLEvent {
 	event := buildPersistedDDLEventCommon(args)
+	// these are the info of the normal table before exchange
 	event.TableName = getTableName(args.tableMap, event.TableID)
 	event.SchemaID = getSchemaID(args.tableMap, event.TableID)
 	event.SchemaName = getSchemaName(args.databaseMap, event.SchemaID)
 
+	// these are the info of the partition table after exchange
 	event.ExtraTableID = event.TableInfo.ID
 	event.ExtraTableName = getTableName(args.tableMap, event.ExtraTableID)
 	event.ExtraSchemaID = getSchemaID(args.tableMap, event.ExtraTableID)
@@ -2155,6 +2157,7 @@ func buildDDLEventForExchangeTablePartition(rawEvent *PersistedDDLEvent, tableFi
 	ddlEvent.ExtraSchemaName = rawEvent.ExtraSchemaName
 	ddlEvent.ExtraTableName = rawEvent.ExtraTableName
 	// TODO: rawEvent.TableInfo is not correct for ignoreNormalTable
+	// ignoreNormalTable and ignorePartitionTable are the table info before exchange
 	ignoreNormalTable, ignorePartitionTable := false, false
 	notSyncPartitionTable := false
 	if tableFilter != nil {

--- a/logservice/schemastore/persist_storage_test.go
+++ b/logservice/schemastore/persist_storage_test.go
@@ -67,7 +67,7 @@ func TestApplyDDLJobs(t *testing.T) {
 	}{
 		// test drop schema can clear table info and partition info
 		{
-			"drop schema",
+			"drop_schema",
 			nil,
 			func() []*model.Job {
 				return []*model.Job{
@@ -93,7 +93,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test create table/drop table/truncate table
 		{
-			"create/drop/truncate table",
+			"create_drop_truncate_table",
 			nil,
 			func() []*model.Job {
 				return []*model.Job{
@@ -282,7 +282,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test create table/drop table for partition table
 		{
-			"drop partition table",
+			"drop_partition_table",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -378,7 +378,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test partition table related ddl
 		{
-			"partition table",
+			"partition_table",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -661,7 +661,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test exchange partition
 		{
-			"exchange table partition",
+			"exchange_table_partition",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -811,7 +811,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test rename table
 		{
-			"rename table",
+			"rename_table",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -983,7 +983,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test rename partition table
 		{
-			"rename partition table",
+			"rename_partition_table",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -1131,7 +1131,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test rename tables
 		{
-			"rename tables",
+			"rename_tables",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -1320,7 +1320,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test rename tables to swap names
 		{
-			"rename tables to swap names",
+			"rename_tables_to_swap_names",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -1510,7 +1510,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		// },
 		// test create tables
 		{
-			"create tables",
+			"create_tables",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -1692,7 +1692,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test create tables for partition table
 		{
-			"create partition tables",
+			"create_partition_tables",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -1888,7 +1888,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		},
 		// test alter/remove partitioning
 		{
-			"alter remove partitioning",
+			"alter_remove_partitioning",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{
@@ -2031,7 +2031,7 @@ func TestApplyDDLJobs(t *testing.T) {
 		// test multi schema change
 		// test add/drop column
 		{
-			"trivial ddls",
+			"trivial_ddls",
 			[]mockDBInfo{
 				{
 					dbInfo: &model.DBInfo{

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -363,7 +363,7 @@ func (ti *TableInfo) IsEligible(forceReplicate bool) bool {
 	return ti.HasPKOrNotNullUK
 }
 
-func originalHasPKOrNotNullUK(tableInfo *model.TableInfo) bool {
+func OriginalHasPKOrNotNullUK(tableInfo *model.TableInfo) bool {
 	// If the table has primary key, it is eligible.
 	// the PKIsHandle can not handle all primary key cases, for example:
 	// CREATE TABLE t (a int, b int, primary key(a, b));
@@ -517,7 +517,8 @@ func (ti *TableInfo) ToTiDBTableInfo() *model.TableInfo {
 		Comment:  ti.Comment,
 		View:     ti.View,
 		Sequence: ti.Sequence,
-		Columns:  ti.columnSchema.Cols(), // Get public state columns, that's enough.
+		Columns:  ti.columnSchema.Columns,
+		Indices:  ti.columnSchema.Indices,
 	}
 }
 
@@ -530,7 +531,7 @@ func newTableInfo(schema string, table string, tableID int64, isPartition bool, 
 			IsPartition: isPartition,
 		},
 		columnSchema:     columnSchema,
-		HasPKOrNotNullUK: originalHasPKOrNotNullUK(tableInfo),
+		HasPKOrNotNullUK: OriginalHasPKOrNotNullUK(tableInfo),
 		View:             tableInfo.View,
 		Sequence:         tableInfo.Sequence,
 		Charset:          tableInfo.Charset,

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -510,15 +510,16 @@ func (ti *TableInfo) IsHandleKey(colID int64) bool {
 
 func (ti *TableInfo) ToTiDBTableInfo() *model.TableInfo {
 	return &model.TableInfo{
-		ID:       ti.TableName.TableID,
-		Name:     ast.NewCIStr(ti.TableName.Table),
-		Charset:  ti.Charset,
-		Collate:  ti.Collate,
-		Comment:  ti.Comment,
-		View:     ti.View,
-		Sequence: ti.Sequence,
-		Columns:  ti.columnSchema.Columns,
-		Indices:  ti.columnSchema.Indices,
+		ID:         ti.TableName.TableID,
+		Name:       ast.NewCIStr(ti.TableName.Table),
+		Charset:    ti.Charset,
+		Collate:    ti.Collate,
+		Comment:    ti.Comment,
+		View:       ti.View,
+		Sequence:   ti.Sequence,
+		Columns:    ti.columnSchema.Columns,
+		Indices:    ti.columnSchema.Indices,
+		PKIsHandle: ti.columnSchema.PKIsHandle,
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2284

### What is changed and how it works?

This fix ensures that the DDL event for the non-partitioned table correctly contains its schema as it existed immediately *before* the exchange operation, which is the behavior backend component expect.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
