### PR TITLE
metrics: Added checkpointTs lag reported by the coordinator

### DIFF
--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -173,7 +173,7 @@ func NewController(
 }
 
 func (c *Controller) collectMetrics(ctx context.Context) error {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -173,7 +173,7 @@ func NewController(
 }
 
 func (c *Controller) collectMetrics(ctx context.Context) error {
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {

--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -143,6 +143,264 @@
       "id": 19999,
       "panels": [
         {
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The status of each changefeed.\n\n0: Normal\n\n1 and 6: Warning\n\n2: Failed\n\n3: Stopped\n\n4: Finished\n\n-1: Unknown",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "stepAfter",
+                "barAlignment": 0,
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "spanNulls": true,
+                "showPoints": "always",
+                "pointSize": 4,
+                "axisPlacement": "auto",
+                "axisLabel": "",
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "hideFrom": {
+                  "tooltip": false,
+                  "graph": false,
+                  "legend": false
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": -1
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  },
+                  {
+                    "color": "#E24D42",
+                    "value": 2
+                  },
+                  {
+                    "color": "#EF843C",
+                    "value": 3
+                  },
+                  {
+                    "color": "#6ED0E0",
+                    "value": 4
+                  }
+                ]
+              },
+              "mappings": [
+                {
+                  "from": "",
+                  "id": 1,
+                  "text": "Normal",
+                  "to": "",
+                  "type": 1,
+                  "value": "0"
+                },
+                {
+                  "from": "",
+                  "id": 2,
+                  "text": "Pending",
+                  "to": "",
+                  "type": 1,
+                  "value": "1"
+                },
+                {
+                  "from": "",
+                  "id": 3,
+                  "text": "Failed",
+                  "to": "",
+                  "type": 1,
+                  "value": "2"
+                },
+                {
+                  "from": "",
+                  "id": 4,
+                  "text": "Stopped",
+                  "to": "",
+                  "type": 1,
+                  "value": "3"
+                },
+                {
+                  "from": "",
+                  "id": 5,
+                  "text": "Finished",
+                  "to": "",
+                  "type": 1,
+                  "value": "4"
+                },
+                {
+                  "from": "",
+                  "id": 6,
+                  "text": "Other",
+                  "to": "",
+                  "type": 1,
+                  "value": "5"
+                },
+                {
+                  "from": "6",
+                  "id": 7,
+                  "text": "-",
+                  "to": "1000",
+                  "type": 2
+                }
+              ],
+              "decimals": 0,
+              "max": 5,
+              "min": 0,
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 22301,
+          "links": [],
+          "options": {
+            "tooltipOptions": {
+              "mode": "single"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "graph": {}
+          },
+          "pluginVersion": "7.5.17",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "max(ticdc_owner_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",namespace=~\"$namespace\", changefeed=~\"$changefeed\"}) by (namespace,changefeed)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{namespace}}-{{changefeed}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The status of changefeeds",
+          "type": "timeseries",
+          "timeFrom": null,
+          "timeShift": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The lag between changefeed coordinator checkpoint ts and the tso of upstream TiDB.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 22302,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "max(ticdc_owner_coordinator_checkpoint_ts_lag{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", namespace=~\"$namespace\",  changefeed=~\"$changefeed\"}) by (namespace, changefeed)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{namespace}}-{{changefeed}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Global Checkpoint Lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -159,7 +417,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 7
           },
           "hiddenSeries": false,
           "id": 18999,
@@ -256,7 +514,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 7
           },
           "hiddenSeries": false,
           "id": 20198,
@@ -350,7 +608,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 20003,
@@ -446,7 +704,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 20000,
@@ -550,7 +808,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 13
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 10049,
@@ -649,7 +907,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 13
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 719,
@@ -806,7 +1064,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Checkpoint Lag",
+          "title": "Maintainer Checkpoint Lag",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -369,7 +369,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Global Checkpoint Lag",
+          "title": "Changefeed Checkpoint Lag",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/pkg/config/changefeed.go
+++ b/pkg/config/changefeed.go
@@ -64,7 +64,7 @@ func (s FeedState) ToInt() int {
 	switch s {
 	case StateNormal:
 		return 0
-	case StatePending:
+	case StateWarning:
 		return 1
 	case StateFailed:
 		return 2
@@ -74,7 +74,7 @@ func (s FeedState) ToInt() int {
 		return 4
 	case StateRemoved:
 		return 5
-	case StateWarning:
+	case StatePending:
 		return 6
 	case StateUnInitialized:
 		return 7

--- a/pkg/metrics/changefeed.go
+++ b/pkg/metrics/changefeed.go
@@ -97,6 +97,14 @@ var (
 			Help:      "The status of changefeeds",
 		}, []string{"namespace", "changefeed"})
 
+	ChangefeedCoordinatorCheckpointTsLagGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "owner",
+			Name:      "coordinator_checkpoint_ts_lag",
+			Help:      "coordinator checkpoint ts lag in changefeeds in seconds",
+		}, []string{"namespace", "changefeed"})
+
 	ChangefeedTickDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "ticdc",
@@ -119,4 +127,5 @@ func initChangefeedMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(HandleMaintainerRequsetCounter)
 	registry.MustRegister(ChangefeedStatusGauge)
 	registry.MustRegister(ChangefeedTickDuration)
+	registry.MustRegister(ChangefeedCoordinatorCheckpointTsLagGauge)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/2289

### What is changed and how it works?

To ensure clear monitoring information when a changefeed experiences an abnormal state, we've added two new metrics to the summary: changefeed status and changefeed checkpoint lag. Changefeed checkpoint lag metrics are regularly updated by the coordinator and are therefore unaffected by maintainer status. Even if a changefeed anomaly prevents maintainer creation, the changefeed checkpoint lag metrics will still display normally.

<img width="2908" height="1394" alt="image" src="https://github.com/user-attachments/assets/2345e794-e5dd-49dd-935d-4eb9ffa6277d" />

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
