### PR TITLE
Register keyspace when it was not found in the schema cache

### DIFF
--- a/cmd/cdc/cli/cli_changefeed_create.go
+++ b/cmd/cdc/cli/cli_changefeed_create.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/ticdc/cmd/cdc/factory"
 	"github.com/pingcap/ticdc/cmd/util"
 	apiv2client "github.com/pingcap/ticdc/pkg/api/v2"
-	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/filter"
 	putil "github.com/pingcap/ticdc/pkg/util"
@@ -122,7 +121,7 @@ func newCreateChangefeedOptions(commonChangefeedOptions *changefeedCommonOptions
 // flags related to template printing to it.
 func (o *createChangefeedOptions) addFlags(cmd *cobra.Command) {
 	o.commonChangefeedOptions.addFlags(cmd)
-	cmd.PersistentFlags().StringVarP(&o.keyspace, "keyspace", "k", common.DefaultKeyspace, "Replication task (changefeed) Keyspace")
+	cmd.PersistentFlags().StringVarP(&o.keyspace, "keyspace", "k", "", "Replication task (changefeed) Keyspace")
 	cmd.PersistentFlags().StringVarP(&o.changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
 	cmd.PersistentFlags().BoolVarP(&o.disableGCSafePointCheck, "disable-gc-check", "", false, "Disable GC safe point check")
 	cmd.PersistentFlags().Uint64Var(&o.startTs, "start-ts", 0, "Start ts of changefeed")

--- a/cmd/cdc/cli/cli_changefeed_pause.go
+++ b/cmd/cdc/cli/cli_changefeed_pause.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pingcap/ticdc/cmd/cdc/factory"
 	"github.com/pingcap/ticdc/cmd/util"
 	apiv2client "github.com/pingcap/ticdc/pkg/api/v2"
-	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +38,7 @@ func newPauseChangefeedOptions() *pauseChangefeedOptions {
 // addFlags receives a *cobra.Command reference and binds
 // flags related to template printing to it.
 func (o *pauseChangefeedOptions) addFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(&o.keyspace, "keyspace", "k", common.DefaultKeyspace, "Replication task (changefeed) Keyspace")
+	cmd.PersistentFlags().StringVarP(&o.keyspace, "keyspace", "k", "", "Replication task (changefeed) Keyspace")
 	cmd.PersistentFlags().StringVarP(&o.changefeedID, "changefeed-id", "c", "", "Replication task (changefeed) ID")
 	_ = cmd.MarkPersistentFlagRequired("changefeed-id")
 }

--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -261,7 +261,7 @@ func (s *schemaStore) getKeyspaceSchemaStore(keyspaceID uint32) (*keyspaceSchema
 		return nil, errors.Trace(err)
 	}
 
-	if err := s.RegisterKeyspace(context.Background(), keyspaceMeta.Name); err != nil {
+	if err := s.RegisterKeyspace(ctx, keyspaceMeta.Name); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -254,9 +254,8 @@ func (s *schemaStore) getKeyspaceSchemaStore(keyspaceID uint32) (*keyspaceSchema
 
 	ctx := context.Background()
 
-	// if the schemastore does not contain the keyspace, it means the current
-	// cdc node is a follower node. It should register the keyspace when it try
-	// to get keyspace schema_store
+	// If the schemastore does not contain the keyspace, it means it is not a maintainer node.
+	// It should register the keyspace when it try to get keyspace schema_store.
 	keyspaceManager := appcontext.GetService[keyspace.KeyspaceManager](appcontext.KeyspaceManager)
 	keyspaceMeta, err := keyspaceManager.GetKeyspaceByID(ctx, keyspaceID)
 	if err != nil {

--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -246,11 +246,10 @@ func (s *schemaStore) Name() string {
 func (s *schemaStore) getKeyspaceSchemaStore(keyspaceID uint32) (*keyspaceSchemaStore, error) {
 	s.keyspaceLocker.RLock()
 	store, ok := s.keyspaceSchemaStoreMap[keyspaceID]
+	s.keyspaceLocker.RUnlock()
 	if ok {
-		s.keyspaceLocker.RUnlock()
 		return store, nil
 	}
-	s.keyspaceLocker.RUnlock()
 
 	ctx := context.Background()
 
@@ -262,18 +261,16 @@ func (s *schemaStore) getKeyspaceSchemaStore(keyspaceID uint32) (*keyspaceSchema
 		return nil, errors.Trace(err)
 	}
 
-	err = s.RegisterKeyspace(context.Background(), keyspaceMeta.Name)
-	if err != nil {
+	if err := s.RegisterKeyspace(context.Background(), keyspaceMeta.Name); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	s.keyspaceLocker.RLock()
 	store, ok = s.keyspaceSchemaStoreMap[keyspaceID]
+	s.keyspaceLocker.RUnlock()
 	if ok {
-		s.keyspaceLocker.RUnlock()
 		return store, nil
 	}
-	s.keyspaceLocker.RUnlock()
 
 	return nil, errors.ErrKeyspaceNotFound
 }

--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -247,10 +247,11 @@ func (s *schemaStore) getKeyspaceSchemaStore(keyspaceID uint32) (*keyspaceSchema
 	s.keyspaceLocker.RLock()
 	defer s.keyspaceLocker.RUnlock()
 	store, ok := s.keyspaceSchemaStoreMap[keyspaceID]
-	if !ok {
-		return nil, errors.ErrInvalidKeyspace
+	if ok {
+		return store, nil
 	}
-	return store, nil
+
+	return nil, errors.ErrInvalidKeyspace
 }
 
 func (s *schemaStore) initialize(ctx context.Context) {

--- a/logservice/txnutil/lock_resolver.go
+++ b/logservice/txnutil/lock_resolver.go
@@ -71,14 +71,14 @@ func (r *resolver) Resolve(ctx context.Context, keyspaceID uint32, regionID uint
 	})
 
 	keyspaceManager := appcontext.GetService[keyspace.KeyspaceManager](appcontext.KeyspaceManager)
-	keyspaceMeta := keyspaceManager.GetKeyspaceByID(keyspaceID)
-	if keyspaceMeta == nil {
-		return cerror.ErrInvalidKeyspace
+	keyspaceMeta, err := keyspaceManager.GetKeyspaceByID(ctx, keyspaceID)
+	if err != nil {
+		return cerror.Trace(err)
 	}
 
 	storage, err := keyspaceManager.GetStorage(keyspaceMeta.Name)
 	if err != nil {
-		return err
+		return cerror.Trace(err)
 	}
 	kvStorage := storage.(tikv.Storage)
 

--- a/maintainer/testutil/test_util.go
+++ b/maintainer/testutil/test_util.go
@@ -157,3 +157,7 @@ func (m *MockPDAPIClient) Healthy(ctx context.Context, endpoint string) error {
 func (m *MockPDAPIClient) LoadKeyspace(ctx context.Context, keyspace string) (*keyspacepb.KeyspaceMeta, error) {
 	return nil, nil
 }
+
+func (m *MockPDAPIClient) GetKeyspaceMetaByID(ctx context.Context, keyspaceID uint32) (*keyspacepb.KeyspaceMeta, error) {
+	return nil, nil
+}

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -361,8 +361,12 @@ var (
 		errors.RFCCodeText("CDC:ErrInvalidKeyspace"),
 	)
 	ErrKeyspaceNotFound = errors.Normalize(
-		`keyspace not found`,
+		"keyspace not found",
 		errors.RFCCodeText("CDC:ErrKeyspaceNotFound"),
+	)
+	ErrKeyspaceIDInvalid = errors.Normalize(
+		"keyspace id is invalid",
+		errors.RFCCodeText("CDC:ErrKeyspaceIDInvalid"),
 	)
 	ErrInvalidEtcdKey = errors.Normalize(
 		"invalid key: %s",

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -360,6 +360,10 @@ var (
 		`bad keyspace, please match the pattern "^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$", the length should no more than %d, eg, "simple-keyspace-test"`,
 		errors.RFCCodeText("CDC:ErrInvalidKeyspace"),
 	)
+	ErrKeyspaceNotFound = errors.Normalize(
+		`keyspace not found`,
+		errors.RFCCodeText("CDC:ErrKeyspaceNotFound"),
+	)
 	ErrInvalidEtcdKey = errors.Normalize(
 		"invalid key: %s",
 		errors.RFCCodeText("CDC:ErrInvalidEtcdKey"),

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -925,6 +925,7 @@ func (c *eventBroker) addDispatcher(info DispatcherInfo) error {
 	err := c.schemaStore.RegisterTable(span.KeyspaceID, span.GetTableID(), info.GetStartTs())
 	if err != nil {
 		log.Error("register table to schemaStore failed",
+			zap.Uint32("keyspaceID", span.KeyspaceID),
 			zap.Stringer("dispatcherID", id), zap.Int64("tableID", span.GetTableID()),
 			zap.Uint64("startTs", info.GetStartTs()), zap.String("span", common.FormatTableSpan(span)),
 			zap.Error(err),

--- a/pkg/pdutil/api_client.go
+++ b/pkg/pdutil/api_client.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/retry"
 	"github.com/pingcap/ticdc/pkg/security"
 	pd "github.com/tikv/pd/client"
+	pdhttp "github.com/tikv/pd/client/http"
 	"go.uber.org/zap"
 )
 
@@ -104,13 +105,15 @@ type PDAPIClient interface {
 	Healthy(ctx context.Context, endpoint string) error
 	ScanRegions(ctx context.Context, span heartbeatpb.TableSpan) ([]RegionInfo, error)
 	LoadKeyspace(ctx context.Context, name string) (*keyspacepb.KeyspaceMeta, error)
+	GetKeyspaceMetaByID(ctx context.Context, keyspaceID uint32) (*keyspacepb.KeyspaceMeta, error)
 	Close()
 }
 
 // pdAPIClient is the api client of Placement Driver, include grpc client and http client.
 type pdAPIClient struct {
-	grpcClient pd.Client
-	httpClient *httputil.Client
+	grpcClient   pd.Client
+	httpClient   *httputil.Client
+	pdHttpClient pdhttp.Client
 }
 
 // NewPDAPIClient create a new pdAPIClient.
@@ -119,9 +122,24 @@ func NewPDAPIClient(pdClient pd.Client, conf *security.Credential) (PDAPIClient,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	discovery := pdClient.GetServiceDiscovery()
+	pdhttpOpts := make([]pdhttp.ClientOption, 0)
+
+	tlsConf, err := conf.ToTLSConfigWithVerify()
+	if err != nil {
+		return nil, err
+	}
+
+	if tlsConf != nil {
+		opt := pdhttp.WithTLSConfig(tlsConf)
+		pdhttpOpts = append(pdhttpOpts, opt)
+	}
+
 	return &pdAPIClient{
-		grpcClient: pdClient,
-		httpClient: dialClient,
+		grpcClient:   pdClient,
+		httpClient:   dialClient,
+		pdHttpClient: pdhttp.NewClientWithServiceDiscovery("cdc", discovery, pdhttpOpts...),
 	}, nil
 }
 
@@ -281,6 +299,14 @@ func (pc *pdAPIClient) LoadKeyspace(ctx context.Context, name string) (*keyspace
 		return &keyspacepb.KeyspaceMeta{}, nil
 	}
 	return pc.grpcClient.LoadKeyspace(ctx, name)
+}
+
+func (pc *pdAPIClient) GetKeyspaceMetaByID(ctx context.Context, keyspaceID uint32) (*keyspacepb.KeyspaceMeta, error) {
+	if kerneltype.IsClassic() {
+		return &keyspacepb.KeyspaceMeta{}, nil
+	}
+
+	return pc.pdHttpClient.GetKeyspaceMetaByID(ctx, keyspaceID)
 }
 
 // ServiceSafePoint contains gc service safe point

--- a/pkg/pdutil/api_client.go
+++ b/pkg/pdutil/api_client.go
@@ -125,7 +125,7 @@ func NewPDAPIClient(pdClient pd.Client, conf *security.Credential) (PDAPIClient,
 
 	pdHttpClient, err := newPdHttpClient(pdClient, conf)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	return &pdAPIClient{
@@ -141,7 +141,7 @@ func newPdHttpClient(pdClient pd.Client, conf *security.Credential) (pdhttp.Clie
 
 	tlsConf, err := conf.ToTLSConfigWithVerify()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	if tlsConf != nil {

--- a/pkg/pdutil/api_client.go
+++ b/pkg/pdutil/api_client.go
@@ -125,7 +125,7 @@ func NewPDAPIClient(pdClient pd.Client, conf *security.Credential) (PDAPIClient,
 
 	pdHttpClient, err := newPdHttpClient(pdClient, conf)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	return &pdAPIClient{


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses the issue where components like the schema store and lock resolver might fail to retrieve keyspace metadata if the local cache does not contain it, especially on non-maintainer nodes or during initial setup. Previously, this could lead to `ErrInvalidKeyspace` or other failures when a keyspace was not locally registered, hindering operation in multi-keyspace environments.

Issue Number: close #2292, close #2213, close #2295

### What is changed and how it works?

This PR introduces several changes to enhance keyspace metadata retrieval and management, enabling dynamic fetching from PD when needed:

* **Dynamic Keyspace Retrieval and Registration in SchemaStore**:
  * The `getKeyspaceSchemaStore` function in `logservice/schemastore/schema_store.go` is modified to dynamically fetch and register a keyspace if it's not found in the local map.
  * It now uses the `KeyspaceManager` to get keyspace metadata by ID. If successful, it then attempts to register the keyspace.
  * A new error `errors.ErrKeyspaceNotFound` is introduced and returned if the keyspace cannot be found or registered after the dynamic fetch attempt.
* **Updated KeyspaceManager Interface and Implementation**:
  * The `GetKeyspaceByID` method in `pkg/keyspace/keyspace_manager.go` now accepts a `context.Context` and returns an error, changing its signature from `(keyspaceID uint32) *keyspacepb.KeyspaceMeta` to `(ctx context.Context, keyspaceID uint32) (*keyspacepb.KeyspaceMeta, error)`.
  * This method now includes logic to fetch keyspace metadata from PD via the `PDAPIClient` if it's not found in the local cache, using a retry mechanism for robustness.
  * The fetched metadata is then cached locally for subsequent requests, ensuring efficiency after the initial fetch.
* **Enhanced PDAPIClient for Keyspace Metadata Retrieval**:
  * A new `GetKeyspaceMetaByID` method is added to the `pkg/pdutil/api_client.go` interface and implementation.
  * This method leverages a new `pdhttp.Client` (from `github.com/tikv/pd/client/http`) to fetch keyspace metadata by ID directly from PD's HTTP API.
  * The `pdAPIClient` constructor is updated to initialize this new HTTP client, including proper TLS configuration.
* **Error Handling Improvements**:
  * Error handling in `logservice/txnutil/lock_resolver.go` is updated to correctly trace errors returned by the modified `KeyspaceManager.GetKeyspaceByID` method, replacing direct `cerror.ErrInvalidKeyspace` with `cerror.Trace(err)`.
  * A new error `pkg/errors.ErrKeyspaceNotFound` is defined to specifically indicate when a keyspace cannot be located.
* **CLI Default Keyspace Change**:
  * The default value for the `--keyspace` (`-k`) flag in `cdc cli changefeed create` and `cdc cli changefeed pause` commands has been changed from `common.DefaultKeyspace` to an empty string. This makes the keyspace parameter optional for users, aligning with a more dynamic keyspace management approach.
* **Mock Client Update**:
  * `maintainer/testutil/test_util.go` is updated to include a mock implementation for the new `GetKeyspaceMetaByID` method in `MockPDAPIClient`.
* **Minor Logging Enhancement**:
  * Added `keyspaceID` to a log message in `pkg/eventservice/event_broker.go` for better debugging context.

### Check List

#### Tests

* Unit test
* Integration test

#### Questions

##### Will it cause performance regression or break compatibility?

There might be a minor performance impact when `GetKeyspaceByID` is called for a keyspace not present in the local cache, as it will involve a network call to PD and a retry mechanism. However, this is expected to be an infrequent fallback, and keyspace metadata is typically small and cached after the first fetch, so the overall impact should be minimal. The retry mechanism adds robustness but also potential latency during initial fetch failures.
Compatibility: The interface changes to `KeyspaceManager` and `PDAPIClient` might affect components that directly implement these interfaces. Consumers of these interfaces typically use the provided implementations, minimizing direct impact on most parts of the codebase.

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes, user and design documentation related to keyspace management and how components interact with PD for keyspace metadata should be updated to reflect the dynamic fetching capabilities and the change in CLI default keyspace behavior.

### Release note

```release-note
Improved keyspace management by enabling components like the schema store and lock resolver to dynamically fetch and register keyspace metadata from PD when needed, enhancing robustness in multi-keyspace environments. The default keyspace flag in `cdc cli` commands is now optional.
```
