### PR TITLE
mysql: group events by tableInfo updateTs 

### DIFF
--- a/logservice/schemastore/ddl_job_fetcher.go
+++ b/logservice/schemastore/ddl_job_fetcher.go
@@ -279,16 +279,17 @@ func getAllDDLSpan(keyspaceID uint32) ([]heartbeatpb.TableSpan, error) {
 		EndKey:     common.ToComparableKey(end),
 		KeyspaceID: keyspaceID,
 	})
-	start, end, err = common.GetKeyspaceTableRange(keyspaceID, JobHistoryID)
-	if err != nil {
-		return nil, err
-	}
-	spans = append(spans, heartbeatpb.TableSpan{
-		TableID:    JobHistoryID,
-		StartKey:   common.ToComparableKey(start),
-		EndKey:     common.ToComparableKey(end),
-		KeyspaceID: keyspaceID,
-	})
+
+	// start, end, err = common.GetKeyspaceTableRange(keyspaceID, JobHistoryID)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// spans = append(spans, heartbeatpb.TableSpan{
+	// 	TableID:    JobHistoryID,
+	// 	StartKey:   common.ToComparableKey(start),
+	// 	EndKey:     common.ToComparableKey(end),
+	// 	KeyspaceID: keyspaceID,
+	// })
 	return spans, nil
 }
 

--- a/logservice/schemastore/ddl_job_fetcher.go
+++ b/logservice/schemastore/ddl_job_fetcher.go
@@ -280,16 +280,16 @@ func getAllDDLSpan(keyspaceID uint32) ([]heartbeatpb.TableSpan, error) {
 		KeyspaceID: keyspaceID,
 	})
 
-	// start, end, err = common.GetKeyspaceTableRange(keyspaceID, JobHistoryID)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// spans = append(spans, heartbeatpb.TableSpan{
-	// 	TableID:    JobHistoryID,
-	// 	StartKey:   common.ToComparableKey(start),
-	// 	EndKey:     common.ToComparableKey(end),
-	// 	KeyspaceID: keyspaceID,
-	// })
+	start, end, err = common.GetKeyspaceTableRange(keyspaceID, JobHistoryID)
+	if err != nil {
+		return nil, err
+	}
+	spans = append(spans, heartbeatpb.TableSpan{
+		TableID:    JobHistoryID,
+		StartKey:   common.ToComparableKey(start),
+		EndKey:     common.ToComparableKey(end),
+		KeyspaceID: keyspaceID,
+	})
 	return spans, nil
 }
 

--- a/logservice/schemastore/persist_storage.go
+++ b/logservice/schemastore/persist_storage.go
@@ -714,6 +714,7 @@ func (p *persistentStorage) handleDDLJob(job *model.Job) error {
 		log.Error("unknown ddl type, ignore it", zap.Any("ddlType", job.Type), zap.String("query", job.Query))
 		return nil
 	}
+
 	ddlEvent := handler.buildPersistedDDLEventFunc(buildPersistedDDLEventFuncArgs{
 		job:          job,
 		databaseMap:  p.databaseMap,

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -1764,6 +1764,7 @@ func buildDDLEventForNormalDDLOnSingleTable(rawEvent *PersistedDDLEvent, tableFi
 	if err != nil {
 		return commonEvent.DDLEvent{}, false, err
 	}
+	// means it is filtered
 	if !ok {
 		return ddlEvent, false, err
 	}

--- a/pkg/common/event/mounter.go
+++ b/pkg/common/event/mounter.go
@@ -217,7 +217,9 @@ func ParseDDLJob(rawKV *common.RawKVEntry, ddlTableInfo *DDLTableInfo) (*model.J
 		datum = row[ddlTableInfo.JobMetaColumnIDinHistoryTable]
 		v = datum.GetBytes()
 
-		return parseJob(v, rawKV.StartTs, rawKV.CRTs, true)
+		job, err := parseJob(v, rawKV.StartTs, rawKV.CRTs, true)
+		log.Info("fizz ddl from ddlHistoryTable, ignore it", zap.Any("job", job))
+		return nil, nil
 	}
 
 	return nil, fmt.Errorf("invalid tableID %v in rawKV.Key", tableID)

--- a/pkg/common/event/mounter.go
+++ b/pkg/common/event/mounter.go
@@ -213,7 +213,7 @@ func ParseDDLJob(rawKV *common.RawKVEntry, ddlTableInfo *DDLTableInfo) (*model.J
 		}
 
 		if job != nil && job.Type == model.ActionCreateTable {
-			log.Info("ddl from ddlTable", zap.Any("job", job), zap.Any("commitTs", rawKV.CRTs), zap.Any("startTs", rawKV.StartTs))
+			log.Info("fizz ddl from ddlTable", zap.Any("job", job), zap.Any("commitTs", rawKV.CRTs), zap.Any("startTs", rawKV.StartTs), zap.Any("query", job.Query))
 		}
 		return job, nil
 
@@ -228,8 +228,9 @@ func ParseDDLJob(rawKV *common.RawKVEntry, ddlTableInfo *DDLTableInfo) (*model.J
 
 		job, err := parseJob(v, rawKV.StartTs, rawKV.CRTs, true)
 		if job != nil && job.Type == model.ActionCreateTable {
-			log.Info("fizz ddl from ddlHistoryTable, ignore it", zap.Any("job", job), zap.Any("commitTs", rawKV.CRTs), zap.Any("startTs", rawKV.StartTs))
+			log.Info("fizz ddl from ddlHistoryTable, ignore it", zap.Any("job", job), zap.Any("commitTs", rawKV.CRTs), zap.Any("startTs", rawKV.StartTs), zap.Any("query", job.Query))
 		}
+
 		return nil, nil
 	}
 

--- a/pkg/sink/mysql/mysql_writer_dml.go
+++ b/pkg/sink/mysql/mysql_writer_dml.go
@@ -18,6 +18,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -41,6 +42,67 @@ type eventGroupKey struct {
 	tableUpdateTS uint64
 }
 
+// EventGroupResult holds the result of grouping events
+type EventGroupResult struct {
+	TotalSize   int64
+	EventGroups []EventGroupWithKey
+}
+
+// EventGroupWithKey contains events and their group key
+type EventGroupWithKey struct {
+	Key    eventGroupKey
+	Events []*commonEvent.DMLEvent
+}
+
+// groupEventsByTable groups events by table ID and table update timestamp.
+// It returns total size of all events and grouped events sorted by table update timestamp (ascending order).
+func groupEventsByTable(events []*commonEvent.DMLEvent) *EventGroupResult {
+	if len(events) == 0 {
+		return &EventGroupResult{
+			TotalSize:   0,
+			EventGroups: []EventGroupWithKey{},
+		}
+	}
+
+	eventsGroup := make(map[eventGroupKey][]*commonEvent.DMLEvent)
+	var totalSize int64
+
+	// Group events and collect metrics
+	for _, event := range events {
+		// Calculate total size
+		totalSize += event.GetSize()
+
+		groupKey := eventGroupKey{
+			tableID:       event.GetTableID(),
+			tableUpdateTS: event.TableInfo.GetUpdateTS(),
+		}
+
+		if _, ok := eventsGroup[groupKey]; !ok {
+			eventsGroup[groupKey] = make([]*commonEvent.DMLEvent, 0)
+		}
+		eventsGroup[groupKey] = append(eventsGroup[groupKey], event)
+	}
+
+	// Convert map to slice and sort by table update timestamp
+	eventGroups := make([]EventGroupWithKey, 0, len(eventsGroup))
+	for key, events := range eventsGroup {
+		eventGroups = append(eventGroups, EventGroupWithKey{
+			Key:    key,
+			Events: events,
+		})
+	}
+
+	// Sort event groups by table update timestamp (ascending)
+	sort.Slice(eventGroups, func(i, j int) bool {
+		return eventGroups[i].Key.tableUpdateTS < eventGroups[j].Key.tableUpdateTS
+	})
+
+	return &EventGroupResult{
+		TotalSize:   totalSize,
+		EventGroups: eventGroups,
+	}
+}
+
 // for multiple events, we try to batch the events of the same table into limited update / insert / delete query,
 // to enhance the performance of the sink.
 // While we only support to batch the events with pks, and all the events inSafeMode or all not in inSafeMode.
@@ -54,33 +116,26 @@ type eventGroupKey struct {
 func (w *Writer) prepareDMLs(events []*commonEvent.DMLEvent) (*preparedDMLs, error) {
 	dmls := dmlsPool.Get().(*preparedDMLs)
 	dmls.reset()
-	// Step 1: group the events by table ID
-	eventsGroup := make(map[eventGroupKey][]*commonEvent.DMLEvent) // tableID --> events
+
+	// Step 1: group the events by table ID using the extracted function
+	groupResult := groupEventsByTable(events)
+
+	// Calculate metrics from the grouped result
 	for _, event := range events {
-		// calculate for metrics
 		dmls.rowCount += int(event.Len())
 		if len(dmls.tsPairs) == 0 || dmls.tsPairs[len(dmls.tsPairs)-1].startTs != event.StartTs {
 			dmls.tsPairs = append(dmls.tsPairs, tsPair{startTs: event.StartTs, commitTs: event.CommitTs})
 		}
-		dmls.approximateSize += event.GetSize()
-
-		groupKey := eventGroupKey{
-			tableID:       event.GetTableID(),
-			tableUpdateTS: event.TableInfo.GetUpdateTS(),
-		}
-
-		if _, ok := eventsGroup[groupKey]; !ok {
-			eventsGroup[groupKey] = make([]*commonEvent.DMLEvent, 0)
-		}
-		eventsGroup[groupKey] = append(eventsGroup[groupKey], event)
 	}
+	dmls.approximateSize = groupResult.TotalSize
 
 	// Step 2: prepare the dmls for each group
 	var (
 		queryList []string
 		argsList  [][]interface{}
 	)
-	for _, eventsInGroup := range eventsGroup {
+	for _, eventGroup := range groupResult.EventGroups {
+		eventsInGroup := eventGroup.Events
 		tableInfo := eventsInGroup[0].TableInfo
 		// We check if the table versions and update ts here to avoid data loss due to unknown bug.
 		firstTableVersion := eventsInGroup[0].TableInfoVersion

--- a/pkg/sink/mysql/mysql_writer_dml_test.go
+++ b/pkg/sink/mysql/mysql_writer_dml_test.go
@@ -623,20 +623,13 @@ func TestGenerateBatchSQLWithDifferentTableVersion(t *testing.T) {
 	// This should potentially cause a panic due to different table versions
 	events := []*commonEvent.DMLEvent{dmlInsertEvent1, dmlInsertEvent2, dmlInsertEvent3, dmlInsertEvent4}
 
-	// This should return an error instead of panic since we add table version check
+	// This should panic since events have different table schema
+	require.Panics(t, func() {
+		writer.generateBatchSQL(events)
+	})
+
+	// This should not return an error instead of panic since we grouped the events by table version
 	dmls, err := writer.prepareDMLs(events)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "events in the same group have different table versions")
-	require.Nil(t, dmls)
-
-	events1 := []*commonEvent.DMLEvent{dmlInsertEvent1, dmlInsertEvent2}
-	events2 := []*commonEvent.DMLEvent{dmlInsertEvent3, dmlInsertEvent4}
-	// This call is ok since we have grouped the events by table version
-	dmls, err = writer.prepareDMLs(events1)
-	require.NoError(t, err)
-	require.NotNil(t, dmls)
-
-	dmls, err = writer.prepareDMLs(events2)
 	require.NoError(t, err)
 	require.NotNil(t, dmls)
 }

--- a/pkg/sink/mysql/mysql_writer_dml_test.go
+++ b/pkg/sink/mysql/mysql_writer_dml_test.go
@@ -710,3 +710,167 @@ func TestAllRowInSameSafeMode(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupEventsByTable(t *testing.T) {
+	t.Run("empty events", func(t *testing.T) {
+		result := groupEventsByTable([]*commonEvent.DMLEvent{})
+		require.Equal(t, int64(0), result.TotalSize)
+		require.Empty(t, result.EventGroups)
+	})
+
+	t.Run("single event", func(t *testing.T) {
+		helper := commonEvent.NewEventTestHelper(t)
+		defer helper.Close()
+
+		helper.Tk().MustExec("use test")
+		createTableSQL := "create table t (id int primary key, name varchar(32));"
+		job := helper.DDL2Job(createTableSQL)
+		require.NotNil(t, job)
+
+		// Create a real event using the helper
+		event := helper.DML2Event("test", "t", "insert into t values (1, 'test')")
+		events := []*commonEvent.DMLEvent{event}
+
+		result := groupEventsByTable(events)
+
+		require.Len(t, result.EventGroups, 1)
+
+		// Verify the group key
+		expectedKey := eventGroupKey{
+			tableID:       event.GetTableID(),
+			tableUpdateTS: event.TableInfo.GetUpdateTS(),
+		}
+		require.Equal(t, expectedKey, result.EventGroups[0].Key)
+		require.Len(t, result.EventGroups[0].Events, 1)
+		require.Equal(t, event, result.EventGroups[0].Events[0])
+	})
+
+	t.Run("multiple events same table different update timestamps", func(t *testing.T) {
+		helper := commonEvent.NewEventTestHelper(t)
+		defer helper.Close()
+
+		helper.Tk().MustExec("use test")
+
+		// Create first table version
+		createTableSQL1 := "create table t1 (id int primary key, name varchar(32));"
+		job1 := helper.DDL2Job(createTableSQL1)
+		require.NotNil(t, job1)
+
+		// Create second table version (different table)
+		createTableSQL2 := "create table t2 (id int primary key, name varchar(32), age int);"
+		job2 := helper.DDL2Job(createTableSQL2)
+		require.NotNil(t, job2)
+
+		// Create events with different table update timestamps
+		event1 := helper.DML2Event("test", "t1", "insert into t1 values (1, 'test1')")
+		event2 := helper.DML2Event("test", "t2", "insert into t2 values (2, 'test2', 20)")
+
+		events := []*commonEvent.DMLEvent{event1, event2}
+		result := groupEventsByTable(events)
+
+		// Check start timestamps are collected and sorted
+
+		// Check that we have 2 groups (different tables/update timestamps)
+		require.Len(t, result.EventGroups, 2)
+
+		// Check that groups are sorted by update timestamp (ascending)
+		updateTS1 := result.EventGroups[0].Key.tableUpdateTS
+		updateTS2 := result.EventGroups[1].Key.tableUpdateTS
+		require.True(t, updateTS1 < updateTS2, "Groups should be sorted by update timestamp")
+	})
+
+	t.Run("multiple events same table same update timestamp", func(t *testing.T) {
+		helper := commonEvent.NewEventTestHelper(t)
+		defer helper.Close()
+
+		helper.Tk().MustExec("use test")
+		createTableSQL := "create table t (id int primary key, name varchar(32));"
+		job := helper.DDL2Job(createTableSQL)
+		require.NotNil(t, job)
+
+		// Create events with same table and same update timestamp
+		event1 := helper.DML2Event("test", "t", "insert into t values (1, 'test1')")
+		helper.ExecuteDeleteDml("test", "t", "delete from t where id = 1")
+		event2 := helper.DML2Event("test", "t", "insert into t values (2, 'test2')")
+		helper.ExecuteDeleteDml("test", "t", "delete from t where id = 2")
+		event3 := helper.DML2Event("test", "t", "insert into t values (3, 'test3')")
+
+		events := []*commonEvent.DMLEvent{event1, event2, event3}
+		result := groupEventsByTable(events)
+
+		// Check that we have 1 group (same table ID and update timestamp)
+		require.Len(t, result.EventGroups, 1)
+
+		// Check the group contains all events
+		require.Len(t, result.EventGroups[0].Events, 3)
+		require.Contains(t, result.EventGroups[0].Events, event1)
+		require.Contains(t, result.EventGroups[0].Events, event2)
+		require.Contains(t, result.EventGroups[0].Events, event3)
+	})
+
+	t.Run("events with different table versions should be grouped separately", func(t *testing.T) {
+		helper := commonEvent.NewEventTestHelper(t)
+		defer helper.Close()
+
+		helper.Tk().MustExec("use test")
+
+		// Create table with 3 columns
+		createTableSQL := "create table t (id int primary key, name varchar(32), age int);"
+		job1 := helper.DDL2Job(createTableSQL)
+		require.NotNil(t, job1)
+
+		// Create events with original table structure
+		event1 := helper.DML2Event("test", "t", "insert into t values (1, 'test1', 20)")
+		helper.ExecuteDeleteDml("test", "t", "delete from t where id = 1")
+		event2 := helper.DML2Event("test", "t", "insert into t values (2, 'test2', 25)")
+		helper.ExecuteDeleteDml("test", "t", "delete from t where id = 2")
+
+		// Drop column to create new table version
+		dropColumnSQL := "alter table t drop column age;"
+		job2 := helper.DDL2Job(dropColumnSQL)
+		require.NotNil(t, job2)
+
+		// Create events with new table structure
+		event3 := helper.DML2Event("test", "t", "insert into t values (3, 'test3')")
+		helper.ExecuteDeleteDml("test", "t", "delete from t where id = 3")
+		event4 := helper.DML2Event("test", "t", "insert into t values (4, 'test4')")
+
+		events := []*commonEvent.DMLEvent{event1, event2, event3, event4}
+		result := groupEventsByTable(events)
+
+		// Should have 2 groups for different table versions
+		require.Len(t, result.EventGroups, 2)
+
+		// Groups should be sorted by update timestamp
+		updateTS1 := result.EventGroups[0].Key.tableUpdateTS
+		updateTS2 := result.EventGroups[1].Key.tableUpdateTS
+		require.True(t, updateTS1 < updateTS2, "Groups should be sorted by update timestamp")
+
+		// First group should contain events 1 and 2 (old table version)
+		require.Len(t, result.EventGroups[0].Events, 2)
+		// Second group should contain events 3 and 4 (new table version)
+		require.Len(t, result.EventGroups[1].Events, 2)
+	})
+
+	t.Run("total size calculation", func(t *testing.T) {
+		helper := commonEvent.NewEventTestHelper(t)
+		defer helper.Close()
+
+		helper.Tk().MustExec("use test")
+		createTableSQL := "create table t (id int primary key, name varchar(32));"
+		job := helper.DDL2Job(createTableSQL)
+		require.NotNil(t, job)
+
+		// Create events
+		event1 := helper.DML2Event("test", "t", "insert into t values (1, 'test1')")
+		helper.ExecuteDeleteDml("test", "t", "delete from t where id = 1")
+		event2 := helper.DML2Event("test", "t", "insert into t values (2, 'test2')")
+
+		events := []*commonEvent.DMLEvent{event1, event2}
+		result := groupEventsByTable(events)
+
+		// Total size should be sum of all event sizes
+		expectedSize := event1.GetSize() + event2.GetSize()
+		require.Equal(t, expectedSize, result.TotalSize)
+	})
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2288 

### What is changed and how it works?

 

#### Root Cause Analysis  
1. **Incomplete DDL Filtering in SchemaStore**  
   In the `schemaStore.handleDDLJob()` method, certain DDLs are filtered out via `filter.ShouldDiscardDDL()`. These filtered DDLs are not delivered to the `eventBroker`, but the `tableInfo` is still updated—leading to changes in `tableInfo.updateTs`.  

2. **Batch Splitting by `eventBroker` Based on `updateTs`**  
   When scanning events, the `eventBroker` splits `batchDML` into different batches according to DDLs and `tableInfo.updateTs`. Even if no actual DDL events are delivered, the change in `updateTs` still results in multiple `batchDML`s with different `updateTs` values.  

3. **Regrouping by Dispatcher**  
   After receiving `batchDML`, the `dispatcher` splits it into multiple `dmlEvent`s. Without intermediate DDLs, these events may be regrouped into the same group and sent to the MySQL Sink.  

4. **Consistency Check Failure in MySQL Sink**  
   In the `prepareDMLs()` method of MySQL Sink, a check is performed to verify whether `tableInfo.updateTs` values are consistent among events in the same group. If inconsistencies exist, an error is triggered.  


#### Solution  
In the `prepareDMLs()` method of MySQL Sink, group events by `tableID` and `tableInfo.updateTs`, then sort the eventGroup with same `tableID` by `tableInfo.UpdateTs` to ensure that all events within the same group share the same table schema version.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
