### PR TITLE
tests: Add integration test to validate changefeed state persistence across CDC server restarts, including paused and active states.

### DIFF
--- a/tests/integration_tests/restart_changefeed/conf/diff_config.toml
+++ b/tests/integration_tests/restart_changefeed/conf/diff_config.toml
@@ -1,0 +1,29 @@
+# diff Configuration.
+
+check-thread-count = 4
+
+export-fix-sql = true
+
+check-struct-only = false
+
+[task]
+    output-dir = "/tmp/tidb_cdc_test/restart_changefeed/sync_diff/output"
+
+    source-instances = ["tidb0"]
+
+    target-instance = "tidb1"
+
+    target-check-tables = ["restart_changefeed.finish_mark_1"]
+
+[data-sources]
+[data-sources.tidb0]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+
+[data-sources.tidb1]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/integration_tests/restart_changefeed/run.sh
+++ b/tests/integration_tests/restart_changefeed/run.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Copyright 2025 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+export PS4='+$(basename ${BASH_SOURCE}):${LINENO}:'
+set -x
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+function kill_cdc_and_restart() {
+	pd_addr=$1
+	work_dir=$2
+	cdc_binary=$3
+	MAX_RETRIES=10
+	status=$(curl -s http://127.0.0.1:8300/status)
+	cdc_pid=$(echo "$status" | grep -v "Command to ticdc" | jq '.pid')
+
+	kill_cdc_pid $cdc_pid
+	run_cdc_server --workdir $work_dir --binary $cdc_binary --pd $pd_addr
+}
+
+function run_restart_and_check() {
+	if [ "$SINK_TYPE" != "mysql" ]; then
+		return
+	fi
+	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+	start_tidb_cluster --workdir $WORK_DIR
+
+	cd $WORK_DIR
+
+	start_ts=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
+
+	run_sql "CREATE DATABASE restart_changefeed;"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+
+	TOPIC_NAME="ticdc-restart-changefeed-$RANDOM"
+	case $SINK_TYPE in
+	*) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1" ;;
+	esac
+	run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c "changefeed-restart"
+
+	run_sql "CREATE TABLE restart_changefeed.finish_mark_1 (a int primary key);"
+	check_table_exists "restart_changefeed.finish_mark_1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+
+	run_sql "INSERT INTO restart_changefeed.finish_mark_1 VALUES (1);"
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+
+	pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+	kill_cdc_and_restart $pd_addr $WORK_DIR $CDC_BINARY
+
+	changefeed_data=$(run_cdc_cli changefeed query -c changefeed-restart -s 2>/dev/null)
+	if [ -z "$changefeed_data" ]; then
+		exit 1
+	fi
+	state=$(echo "$changefeed_data" | jq -r ".state")
+	if [ $state != "normal" ]; then
+		exit 1
+	fi
+
+	cleanup_process $CDC_BINARY
+	stop_tidb_cluster
+}
+
+function run_pause_restart_resume() {
+	if [ "$SINK_TYPE" != "mysql" ]; then
+		return
+	fi
+	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+	start_tidb_cluster --workdir $WORK_DIR
+
+	cd $WORK_DIR
+
+	start_ts=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
+
+	run_sql "CREATE DATABASE restart_changefeed;"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+
+	TOPIC_NAME="ticdc-restart-changefeed-$RANDOM"
+	case $SINK_TYPE in
+	*) SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1" ;;
+	esac
+	run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c "changefeed-restart"
+
+	run_sql "CREATE TABLE restart_changefeed.finish_mark_1 (a int primary key);"
+	check_table_exists "restart_changefeed.finish_mark_1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 300
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+
+	run_sql "INSERT INTO restart_changefeed.finish_mark_1 VALUES (1);"
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+
+	run_cdc_cli changefeed pause -c changefeed-restart
+
+	pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+	kill_cdc_and_restart $pd_addr $WORK_DIR $CDC_BINARY
+
+	changefeed_data=$(run_cdc_cli changefeed query -c changefeed-restart -s 2>/dev/null)
+	if [ -z "$changefeed_data" ]; then
+		exit 1
+	fi
+	state=$(echo "$changefeed_data" | jq -r ".state")
+	if [ $state != "stopped" ]; then
+		exit 1
+	fi
+
+	run_cdc_cli changefeed resume -c changefeed-restart
+	changefeed_data=$(run_cdc_cli changefeed query -c changefeed-restart -s 2>/dev/null)
+	if [ -z "$changefeed_data" ]; then
+		exit 1
+	fi
+	state=$(echo "$changefeed_data" | jq -r ".state")
+	if [ $state != "normal" ]; then
+		exit 1
+	fi
+
+	cleanup_process $CDC_BINARY
+	stop_tidb_cluster
+}
+
+trap stop_tidb_cluster EXIT
+run_restart_and_check $*
+run_pause_restart_resume $*
+
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/restart_changefeed/run.sh
+++ b/tests/integration_tests/restart_changefeed/run.sh
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 set -eu
-export PS4='+$(basename ${BASH_SOURCE}):${LINENO}:'
-set -x
 
 CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source $CUR/../_utils/test_prepare


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses the need for robust integration tests to verify TiCDC's behavior during server restarts. Specifically, it ensures that changefeeds maintain their correct state (normal or stopped) and resume data synchronization successfully after a TiCDC server process is killed and restarted. This helps to confirm the fault tolerance and stability of the changefeed mechanism.

Issue Number: close #2315

### What is changed and how it works?

This PR introduces a new integration test suite `restart_changefeed` to validate TiCDC's resilience to server restarts.

The changes include:

* **Added `tests/integration_tests/restart_changefeed/conf/diff_config.toml`**: A new configuration file for `sync_diff` to specify the tables and instances for data consistency checks within the new test.
* **Added `tests/integration_tests/restart_changefeed/run.sh`**: The main test script that orchestrates the restart scenarios.
  * **`run_restart_and_check` function**:
    * Initializes a TiDB cluster and a TiCDC server.
    * Creates a changefeed and a test table.
    * Inserts data and verifies synchronization using `sync_diff`.
    * Kills the running TiCDC server process and immediately restarts it.
    * Queries the changefeed state to ensure it remains "normal" after the restart.
  * **`run_pause_restart_resume` function**:
    * Similar setup to `run_restart_and_check`.
    * Pauses the changefeed after initial data sync.
    * Kills and restarts the TiCDC server.
    * Verifies that the changefeed state remains "stopped" after the restart.
    * Resumes the changefeed and then verifies its state becomes "normal".
    * Ensures data consistency throughout the process using `sync_diff`.
* The tests are designed to run specifically for the `mysql` sink type.

### Check List

#### Tests

* Integration test

#### Questions

##### Will it cause performance regression or break compatibility?

No, this PR only adds new integration tests and does not introduce any changes to the core TiCDC logic or user-facing features.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No, this is an internal test addition.

### Release note

```release-note
None
```
