### PR TITLE
logpuller: deregister the region before subscribe it when handle the prewrite not found error

### DIFF
--- a/logservice/logpuller/errors.go
+++ b/logservice/logpuller/errors.go
@@ -52,3 +52,7 @@ func (e *sendRequestToStoreErr) Error() string { return "send request to store e
 type requestCancelledErr struct{}
 
 func (e *requestCancelledErr) Error() string { return "region request is cancelled" }
+
+type prewriteNotFoundErr struct{}
+
+func (e *prewriteNotFoundErr) Error() string { return "prewrite not found" }

--- a/logservice/logpuller/region_event_handler.go
+++ b/logservice/logpuller/region_event_handler.go
@@ -91,6 +91,7 @@ func (h *regionEventHandler) Handle(span *subscribedSpan, events ...regionEvent)
 			if err != nil {
 				event.state.markStopped(err)
 				h.handleRegionError(event.state, event.worker)
+				continue
 			}
 		} else if event.resolvedTs != 0 {
 			resolvedTs := handleResolvedTs(span, event.state, event.resolvedTs)

--- a/logservice/logpuller/region_event_handler.go
+++ b/logservice/logpuller/region_event_handler.go
@@ -17,7 +17,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/cdcpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/common"
@@ -274,7 +273,7 @@ func handleEventEntries(span *subscribedSpan, state *regionFeedState, entries *c
 					// due to it is by design. By report error, trigger the region reconnection, so that
 					// the commit entry convert to the committed entry automatically.
 					// After the Next-Gen fix this issue, this workaround can be removed.
-					return errors.New("prewrite not found")
+					return &prewriteNotFoundErr{}
 				}
 				log.Fatal("prewrite not match",
 					zap.Int64("tableID", span.span.TableID),

--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -372,7 +372,7 @@ func (s *regionRequestWorker) processRegionSendTask(
 				},
 				FilterLoop: region.filterLoop,
 			}
-			if err := doSend(req); err != nil {
+			if err = doSend(req); err != nil {
 				return err
 			}
 			for _, state := range s.takeRegionStates(subID) {
@@ -383,7 +383,8 @@ func (s *regionRequestWorker) processRegionSendTask(
 				}
 				s.client.pushRegionEventToDS(subID, regionEvent)
 			}
-
+			log.Info("region is stopped",
+				zap.Uint64("regionID", region.verID.GetID()), zap.Uint64("subscriptionID", uint64(subID)))
 		} else if region.subscribedSpan.stopped.Load() {
 			// It can be skipped directly because there must be no pending states from
 			// the stopped subscribedTable, or the special singleRegionInfo for stopping

--- a/logservice/logpuller/region_state.go
+++ b/logservice/logpuller/region_state.go
@@ -46,6 +46,8 @@ type regionInfo struct {
 	// Whether to filter out the value write by cdc itself.
 	// It should be `true` in BDR mode
 	filterLoop bool
+
+	prewriteNotFound bool
 }
 
 func (s *regionInfo) isStopped() bool {

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -850,6 +850,7 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 		return nil
 	case *prewriteNotFoundErr:
 		s.scheduleRegionRequest(ctx, errInfo.regionInfo, TaskLowPrior)
+		return nil
 	default:
 		// TODO(qupeng): for some errors it's better to just deregister the region from TiKVs.
 		log.Warn("subscription client meets an internal error, fail the changefeed",

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -849,11 +849,12 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 		// the corresponding subscription has been unsubscribed, just ignore.
 		return nil
 	case *prewriteNotFoundErr:
-		log.Warn("prewrite not found",
+		errInfo.regionInfo.lockedRangeState = nil
+		s.regionTaskQueue.Push(NewRegionPriorityTask(TaskHighPrior, errInfo.regionInfo, s.pdClock.CurrentTS()))
+		log.Warn("prewrite not found, set locked range to nil",
 			zap.Uint64("regionID", errInfo.regionInfo.verID.GetID()),
 			zap.Uint64("subscriptionID", uint64(errInfo.regionInfo.subscribedSpan.subID)),
 			zap.Bool("isStopped", errInfo.regionInfo.isStopped()))
-		s.regionTaskQueue.Push(NewRegionPriorityTask(TaskHighPrior, errInfo.regionInfo, s.pdClock.CurrentTS()))
 		s.scheduleRegionRequest(ctx, errInfo.regionInfo, TaskLowPrior)
 		return nil
 	default:

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -849,6 +849,11 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 		// the corresponding subscription has been unsubscribed, just ignore.
 		return nil
 	case *prewriteNotFoundErr:
+		log.Warn("prewrite not found",
+			zap.Uint64("regionID", errInfo.regionInfo.verID.GetID()),
+			zap.Uint64("subscriptionID", uint64(errInfo.regionInfo.subscribedSpan.subID)),
+			zap.Bool("isStopped", errInfo.regionInfo.isStopped()))
+		s.regionTaskQueue.Push(NewRegionPriorityTask(TaskHighPrior, errInfo.regionInfo, s.pdClock.CurrentTS()))
 		s.scheduleRegionRequest(ctx, errInfo.regionInfo, TaskLowPrior)
 		return nil
 	default:

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -848,6 +848,8 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 	case *requestCancelledErr:
 		// the corresponding subscription has been unsubscribed, just ignore.
 		return nil
+	case *prewriteNotFoundErr:
+		s.scheduleRegionRequest(ctx, errInfo.regionInfo, TaskLowPrior)
 	default:
 		// TODO(qupeng): for some errors it's better to just deregister the region from TiKVs.
 		log.Warn("subscription client meets an internal error, fail the changefeed",

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -796,6 +796,10 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 			return nil
 		}
 		if innerErr.GetRegionNotFound() != nil {
+			log.Info("region not found",
+				zap.Uint64("regionID", errInfo.regionInfo.verID.GetID()),
+				zap.Uint64("subscriptionID", uint64(errInfo.regionInfo.subscribedSpan.subID)),
+				zap.Bool("isStopped", errInfo.regionInfo.isStopped()))
 			metricFeedRegionNotFoundCounter.Inc()
 			s.scheduleRangeRequest(ctx, errInfo.span, errInfo.subscribedSpan, errInfo.filterLoop, TaskHighPrior)
 			return nil
@@ -855,7 +859,7 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 			zap.Uint64("regionID", errInfo.regionInfo.verID.GetID()),
 			zap.Uint64("subscriptionID", uint64(errInfo.regionInfo.subscribedSpan.subID)),
 			zap.Bool("isStopped", errInfo.regionInfo.isStopped()))
-		s.scheduleRegionRequest(ctx, errInfo.regionInfo, TaskLowPrior)
+		//s.scheduleRegionRequest(ctx, errInfo.regionInfo, TaskLowPrior)
 		return nil
 	default:
 		// TODO(qupeng): for some errors it's better to just deregister the region from TiKVs.

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -853,9 +853,9 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 		// the corresponding subscription has been unsubscribed, just ignore.
 		return nil
 	case *prewriteNotFoundErr:
-		errInfo.regionInfo.lockedRangeState = nil
+		errInfo.regionInfo.prewriteNotFound = true
 		s.regionTaskQueue.Push(NewRegionPriorityTask(TaskHighPrior, errInfo.regionInfo, s.pdClock.CurrentTS()))
-		log.Warn("prewrite not found, set locked range to nil",
+		log.Warn("prewrite not found, deregister the region",
 			zap.Uint64("regionID", errInfo.regionInfo.verID.GetID()),
 			zap.Uint64("subscriptionID", uint64(errInfo.regionInfo.subscribedSpan.subID)),
 			zap.Bool("isStopped", errInfo.regionInfo.isStopped()))


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #2387

### What is changed and how it works?

* after #2388 merged, it return an error immediately, but it's not well handled by the region worker.
* When the match failed, the TiKV-CDC is still subscribing the region, deregister it first, and then register again, to avoid duplicate request error.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
