### PR TITLE
Operator: Remove incorrect originNodeStopped flag setting in MoveDispatcherOperator

### DIFF
--- a/maintainer/operator/operator_controller.go
+++ b/maintainer/operator/operator_controller.go
@@ -252,7 +252,7 @@ func (oc *Controller) pollQueueingOperator() (
 		log.Info("operator finished",
 			zap.String("role", oc.role),
 			zap.String("changefeed", oc.changefeedID.Name()),
-			zap.String("operator", opID.String()),
+			zap.String("operatorID", opID.String()),
 			zap.String("operator", op.String()))
 		return nil, true
 	}

--- a/maintainer/operator/operator_move.go
+++ b/maintainer/operator/operator_move.go
@@ -140,7 +140,6 @@ func (m *MoveDispatcherOperator) OnNodeRemove(n node.ID) {
 		m.dest = m.origin
 		m.spanController.BindSpanToNode(m.dest, m.origin, m.replicaSet)
 		m.bind = true
-		m.originNodeStopped.Store(true)
 	}
 	if n == m.origin {
 		log.Info("origin node is stopped",

--- a/maintainer/operator/operator_move_test.go
+++ b/maintainer/operator/operator_move_test.go
@@ -1,0 +1,254 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/pingcap/ticdc/maintainer/replica"
+	"github.com/pingcap/ticdc/maintainer/span"
+	"github.com/pingcap/ticdc/maintainer/testutil"
+	"github.com/pingcap/ticdc/pkg/common"
+	appcontext "github.com/pingcap/ticdc/pkg/common/context"
+	"github.com/pingcap/ticdc/pkg/messaging"
+	"github.com/pingcap/ticdc/pkg/node"
+	"github.com/pingcap/ticdc/server/watcher"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestEnvironment(t *testing.T) (*span.Controller, common.ChangeFeedID, *replica.SpanReplication, node.ID, node.ID) {
+	nodeManager := watcher.NewNodeManager(nil, nil)
+	appcontext.SetService(watcher.NodeManagerName, nodeManager)
+
+	changefeedID := common.NewChangeFeedIDWithName("test-changefeed", common.DefaultKeyspace)
+	dispatcherID := common.NewDispatcherID()
+
+	tableSpan := testutil.GetTableSpanByID(100)
+	status := &heartbeatpb.TableSpanStatus{
+		ID:              dispatcherID.ToPB(),
+		ComponentStatus: heartbeatpb.ComponentState_Working,
+		CheckpointTs:    1000,
+	}
+
+	nodeA := node.ID("node-a")
+	nodeB := node.ID("node-b")
+
+	ddlDispatcherID := common.NewDispatcherID()
+	ddlSpan := replica.NewWorkingSpanReplication(
+		changefeedID,
+		ddlDispatcherID,
+		common.DDLSpanSchemaID,
+		common.KeyspaceDDLSpan(common.DefaultKeyspaceID),
+		&heartbeatpb.TableSpanStatus{
+			ID:              ddlDispatcherID.ToPB(),
+			ComponentStatus: heartbeatpb.ComponentState_Working,
+			CheckpointTs:    1,
+		},
+		nodeA,
+	)
+
+	spanController := span.NewController(changefeedID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+
+	replicaSet := replica.NewWorkingSpanReplication(
+		changefeedID,
+		dispatcherID,
+		1,
+		tableSpan,
+		status,
+		nodeA,
+	)
+
+	return spanController, changefeedID, replicaSet, nodeA, nodeB
+}
+
+// TestMoveOperator_DestNodeRemovedBeforeOriginStopped tests the scenario where:
+// 1. Dispatcher 'a' is on node A, maintainer is also on node A
+// 2. A move operation is initiated to move 'a' from node A to node B
+// 3. Before node A reports non-working status, node B is removed
+// 4. Verify that dispatcher 'a' can be recreated on node A
+func TestMoveOperator_DestNodeRemovedBeforeOriginStopped(t *testing.T) {
+	spanController, _, replicaSet, nodeA, nodeB := setupTestEnvironment(t)
+
+	op := NewMoveDispatcherOperator(spanController, replicaSet, nodeA, nodeB)
+	require.NotNil(t, op)
+
+	op.Start()
+	require.False(t, op.IsFinished())
+
+	require.False(t, op.originNodeStopped.Load())
+
+	op.OnNodeRemove(nodeB)
+
+	require.False(t, op.originNodeStopped.Load())
+
+	require.True(t, op.bind)
+	require.Equal(t, nodeA, op.dest)
+	require.Equal(t, nodeA, op.origin)
+
+	msg := op.Schedule()
+	require.NotNil(t, msg)
+	require.Equal(t, messaging.TypeScheduleDispatcherRequest, msg.Type)
+	scheduleMsg, ok := msg.Message[0].(*heartbeatpb.ScheduleDispatcherRequest)
+	require.True(t, ok)
+	require.Equal(t, heartbeatpb.ScheduleAction_Remove, scheduleMsg.ScheduleAction)
+	require.Equal(t, replicaSet.ID.ToPB(), scheduleMsg.Config.DispatcherID)
+
+	nonWorkingStatus := &heartbeatpb.TableSpanStatus{
+		ID:              replicaSet.ID.ToPB(),
+		ComponentStatus: heartbeatpb.ComponentState_Stopped,
+		CheckpointTs:    1500,
+	}
+	op.Check(nodeA, nonWorkingStatus)
+	require.True(t, op.originNodeStopped.Load())
+
+	msg = op.Schedule()
+	require.NotNil(t, msg)
+	require.Equal(t, messaging.TypeScheduleDispatcherRequest, msg.Type)
+	scheduleMsg, ok = msg.Message[0].(*heartbeatpb.ScheduleDispatcherRequest)
+	require.True(t, ok)
+	require.Equal(t, heartbeatpb.ScheduleAction_Create, scheduleMsg.ScheduleAction)
+	require.Equal(t, nodeA.String(), msg.To.String())
+	require.Equal(t, replicaSet.ID.ToPB(), scheduleMsg.Config.DispatcherID)
+
+	workingStatus := &heartbeatpb.TableSpanStatus{
+		ID:              replicaSet.ID.ToPB(),
+		ComponentStatus: heartbeatpb.ComponentState_Working,
+		CheckpointTs:    2000,
+	}
+	op.Check(nodeA, workingStatus)
+	require.True(t, op.IsFinished())
+}
+
+// TestMoveOperator_DestNodeRemovedAfterOriginStopped tests the scenario where:
+// 1. Dispatcher 'a' is on node A, maintainer is also on node A
+// 2. A move operation is initiated to move 'a' from node A to node B
+// 3. Node A reports non-working status first
+// 4. Then node B is removed
+// 5. Verify that the span is marked as absent for rescheduling
+func TestMoveOperator_DestNodeRemovedAfterOriginStopped(t *testing.T) {
+	spanController, _, replicaSet, nodeA, nodeB := setupTestEnvironment(t)
+
+	op := NewMoveDispatcherOperator(spanController, replicaSet, nodeA, nodeB)
+	require.NotNil(t, op)
+
+	op.Start()
+	require.False(t, op.IsFinished())
+
+	nonWorkingStatus := &heartbeatpb.TableSpanStatus{
+		ID:              replicaSet.ID.ToPB(),
+		ComponentStatus: heartbeatpb.ComponentState_Stopped,
+		CheckpointTs:    1500,
+	}
+	op.Check(nodeA, nonWorkingStatus)
+	require.True(t, op.originNodeStopped.Load())
+
+	op.OnNodeRemove(nodeB)
+
+	require.True(t, op.noPostFinishNeed)
+	require.True(t, op.IsFinished())
+
+	require.Equal(t, 1, spanController.GetAbsentSize())
+}
+
+// TestMoveOperator_OriginNodeRemovedBeforeOriginStopped tests the scenario where:
+// 1. Dispatcher 'a' is on node A
+// 2. A move operation is initiated to move 'a' from node A to node B
+// 3. Before node A reports non-working status, node A is removed
+// 4. Verify that the operator waits for node B to report working status before finishing
+func TestMoveOperator_OriginNodeRemovedBeforeOriginStopped(t *testing.T) {
+	spanController, _, replicaSet, nodeA, nodeB := setupTestEnvironment(t)
+
+	op := NewMoveDispatcherOperator(spanController, replicaSet, nodeA, nodeB)
+	require.NotNil(t, op)
+
+	op.Start()
+	require.False(t, op.IsFinished())
+
+	require.False(t, op.originNodeStopped.Load())
+
+	op.OnNodeRemove(nodeA)
+
+	require.True(t, op.originNodeStopped.Load())
+	require.Equal(t, nodeA, op.origin)
+	require.Equal(t, nodeB, op.dest)
+
+	msg := op.Schedule()
+	require.NotNil(t, msg)
+	require.Equal(t, messaging.TypeScheduleDispatcherRequest, msg.Type)
+	scheduleMsg, ok := msg.Message[0].(*heartbeatpb.ScheduleDispatcherRequest)
+	require.True(t, ok)
+	require.Equal(t, heartbeatpb.ScheduleAction_Create, scheduleMsg.ScheduleAction)
+	require.Equal(t, nodeB.String(), msg.To.String())
+	require.Equal(t, replicaSet.ID.ToPB(), scheduleMsg.Config.DispatcherID)
+
+	require.False(t, op.IsFinished())
+
+	workingStatus := &heartbeatpb.TableSpanStatus{
+		ID:              replicaSet.ID.ToPB(),
+		ComponentStatus: heartbeatpb.ComponentState_Working,
+		CheckpointTs:    2000,
+	}
+	op.Check(nodeB, workingStatus)
+	require.True(t, op.IsFinished())
+}
+
+// TestMoveOperator_OriginNodeRemovedAfterOriginStopped tests the scenario where:
+// 1. Dispatcher 'a' is on node A
+// 2. A move operation is initiated to move 'a' from node A to node B
+// 3. Node A reports non-working status first
+// 4. Then node A is removed
+// 5. Verify that the operator waits for node B to report working status before finishing
+func TestMoveOperator_OriginNodeRemovedAfterOriginStopped(t *testing.T) {
+	spanController, _, replicaSet, nodeA, nodeB := setupTestEnvironment(t)
+
+	op := NewMoveDispatcherOperator(spanController, replicaSet, nodeA, nodeB)
+	require.NotNil(t, op)
+
+	op.Start()
+	require.False(t, op.IsFinished())
+
+	nonWorkingStatus := &heartbeatpb.TableSpanStatus{
+		ID:              replicaSet.ID.ToPB(),
+		ComponentStatus: heartbeatpb.ComponentState_Stopped,
+		CheckpointTs:    1500,
+	}
+	op.Check(nodeA, nonWorkingStatus)
+	require.True(t, op.originNodeStopped.Load())
+
+	op.OnNodeRemove(nodeA)
+
+	require.True(t, op.originNodeStopped.Load())
+	require.Equal(t, nodeA, op.origin)
+	require.Equal(t, nodeB, op.dest)
+
+	msg := op.Schedule()
+	require.NotNil(t, msg)
+	require.Equal(t, messaging.TypeScheduleDispatcherRequest, msg.Type)
+	scheduleMsg, ok := msg.Message[0].(*heartbeatpb.ScheduleDispatcherRequest)
+	require.True(t, ok)
+	require.Equal(t, heartbeatpb.ScheduleAction_Create, scheduleMsg.ScheduleAction)
+	require.Equal(t, nodeB.String(), msg.To.String())
+	require.Equal(t, replicaSet.ID.ToPB(), scheduleMsg.Config.DispatcherID)
+
+	require.False(t, op.IsFinished())
+
+	workingStatus := &heartbeatpb.TableSpanStatus{
+		ID:              replicaSet.ID.ToPB(),
+		ComponentStatus: heartbeatpb.ComponentState_Working,
+		CheckpointTs:    2000,
+	}
+	op.Check(nodeB, workingStatus)
+	require.True(t, op.IsFinished())
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/2444

### What is changed and how it works?

 ### What problem does this PR solve?

Issue: When destination node is removed before origin node reports non-working status during a move operation, the operator incorrectly sets`originNodeStopped = true` at line 143, causing the dispatcher not be scheduling correctly
  
 ####  Code Changes:
  - **operator_move.go:143**: Removed incorrect `m.originNodeStopped.Store(true)`
    - Now the operator correctly waits for origin to report non-working via `Check()` method
    - Only the explicit origin node removal (line 148) or `Check()` callback (line 70) should set this flag

 #### Test Coverage:
  Added comprehensive unit tests in `operator_move_test.go` with 4 scenarios:

  1. **TestMoveOperator_DestNodeRemovedBeforeOriginStopped**:
     - Destination node removed before origin reports non-working
     - Verifies dispatcher can be recreated on origin node after origin stops
     - **This test validates the bug fix**

  2. **TestMoveOperator_DestNodeRemovedAfterOriginStopped**:
     - Destination node removed after origin reports non-working
     - Verifies span is marked as absent for rescheduling

  3. **TestMoveOperator_OriginNodeRemovedBeforeOriginStopped**:
     - Origin node removed before it reports non-working
     - Verifies operator completes successfully on destination node

  4. **TestMoveOperator_OriginNodeRemovedAfterOriginStopped**:
     - Origin node removed after it reports non-working
     - Verifies operator completes successfully on destination node

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
