### PR TITLE
eventstore&eventbroker: fix dead lock

### DIFF
--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -968,7 +968,10 @@ func (e *eventStore) addSubscriberToSubStat(subStat *subscriptionStat, dispatche
 	subStat.idleTime.Store(0)
 	for {
 		oldMapPtr := subStat.subscribers.Load()
-		oldMap := *oldMapPtr
+		var oldMap map[common.DispatcherID]*Subscriber
+		if oldMapPtr != nil {
+			oldMap = *oldMapPtr
+		}
 		newMap := make(map[common.DispatcherID]*Subscriber, len(oldMap)+1)
 		for id, sub := range oldMap {
 			newMap[id] = sub

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -501,7 +501,6 @@ func (e *eventStore) RegisterDispatcher(
 				if subStat.tableSpan.Equal(dispatcherSpan) {
 					stat.subStat = subStat
 					e.dispatcherMeta.dispatcherStats[dispatcherID] = stat
-					subStat.idleTime.Store(0)
 					e.addSubscriberToSubStat(subStat, dispatcherID, &Subscriber{notifyFunc: wrappedNotifier})
 					e.dispatcherMeta.Unlock()
 					log.Info("reuse existing subscription with exact span match",
@@ -530,7 +529,6 @@ func (e *eventStore) RegisterDispatcher(
 	if bestMatch != nil {
 		stat.subStat = bestMatch
 		e.dispatcherMeta.dispatcherStats[dispatcherID] = stat
-		bestMatch.idleTime.Store(0)
 		e.addSubscriberToSubStat(bestMatch, dispatcherID, &Subscriber{notifyFunc: wrappedNotifier})
 		e.dispatcherMeta.Unlock()
 		log.Info("reuse existing subscription with smallest containing span",
@@ -967,6 +965,7 @@ func (e *eventStore) stopReceiveEventFromSubStat(dispatcherID common.DispatcherI
 }
 
 func (e *eventStore) addSubscriberToSubStat(subStat *subscriptionStat, dispatcherID common.DispatcherID, subscriber *Subscriber) {
+	subStat.idleTime.Store(0)
 	for {
 		oldMapPtr := subStat.subscribers.Load()
 		oldMap := *oldMapPtr

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -917,10 +917,11 @@ func (e *eventStore) detachFromSubStat(dispatcherID common.DispatcherID, subStat
 				newMap[id] = sub
 			}
 		}
-		newData := &subscribersWithIdleTime{subscribers: newMap, idleTime: oldData.idleTime}
+		idleTime := int64(0)
 		if len(newMap) == 0 {
-			newData.idleTime = time.Now().UnixMilli()
+			idleTime = time.Now().UnixMilli()
 		}
+		newData := &subscribersWithIdleTime{subscribers: newMap, idleTime: idleTime}
 		if subStat.subscribers.CompareAndSwap(oldData, newData) {
 			return
 		}

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -146,8 +146,6 @@ type subscriptionStat struct {
 	// data span of the subscription, it can support dispatchers with smaller span
 	tableSpan   *heartbeatpb.TableSpan
 	subscribers atomic.Pointer[subscribersWithIdleTime]
-	// deleting is true if the subscription is marked for deletion.
-	deleting atomic.Bool
 	// markedDeleteTime is the time when the subscription is marked for deletion.
 	markedDeleteTime atomic.Int64
 	// the index of the db which stores the data of the subscription
@@ -495,11 +493,6 @@ func (e *eventStore) RegisterDispatcher(
 			// Check if this subStat's span contains the dispatcherSpan
 			if bytes.Compare(subStat.tableSpan.StartKey, dispatcherSpan.StartKey) <= 0 &&
 				bytes.Compare(subStat.tableSpan.EndKey, dispatcherSpan.EndKey) >= 0 {
-
-				// Skip subscriptions that are marked for deletion.
-				if subStat.deleting.Load() {
-					continue
-				}
 
 				// Check whether the subStat ts range contains startTs
 				if subStat.checkpointTs.Load() > startTs || startTs > subStat.resolvedTs.Load() {
@@ -980,11 +973,6 @@ func (e *eventStore) addSubscriberToSubStat(subStat *subscriptionStat, dispatche
 			oldMap = oldData.subscribers
 		}
 
-		// A subscription is not idle if a new subscriber is added.
-		// So, clear the deleting mark.
-		subStat.deleting.Store(false)
-		subStat.markedDeleteTime.Store(0)
-
 		newMap := make(map[common.DispatcherID]*Subscriber, len(oldMap)+1)
 		for id, sub := range oldMap {
 			newMap[id] = sub
@@ -1005,9 +993,6 @@ func (e *eventStore) addSubscriberToSubStat(subStat *subscriptionStat, dispatche
 func (e *eventStore) cleanObsoleteSubscriptions(ctx context.Context) error {
 	ticker := time.NewTicker(1 * time.Minute)
 	ttlInMsForMarkDeletion := int64(60 * 1000) // 1min
-	// ttlInMsBeforeDeletion defines a grace period before deletion
-	// to ensure no new dispatchers start depending on this subscription while it is being removed.
-	ttlInMsBeforeDeletion := int64(10 * 1000) // 10s
 	for {
 		select {
 		case <-ctx.Done():
@@ -1017,36 +1002,25 @@ func (e *eventStore) cleanObsoleteSubscriptions(ctx context.Context) error {
 			e.dispatcherMeta.Lock()
 			for tableID, subStats := range e.dispatcherMeta.tableStats {
 				for subID, subStat := range subStats {
-					if subStat.deleting.Load() {
-						// This subscription is already marked for deletion.
-						// If it has been marked for a while, proceed with physical deletion.
-						if now-subStat.markedDeleteTime.Load() > ttlInMsBeforeDeletion {
-							log.Info("clean obsolete subscription",
-								zap.Uint64("subscriptionID", uint64(subID)),
-								zap.Int("dbIndex", subStat.dbIndex),
-								zap.Int64("tableID", subStat.tableSpan.TableID))
-							e.subClient.Unsubscribe(subID)
-							if err := e.deleteEvents(subStat.dbIndex, uint64(subID), subStat.tableSpan.TableID, 0, math.MaxUint64); err != nil {
-								log.Warn("fail to delete events", zap.Error(err))
-							}
-							delete(subStats, subID)
-							e.subscriptionChangeCh.In() <- SubscriptionChange{
-								ChangeType: SubscriptionChangeTypeRemove,
-								SubID:      uint64(subStat.subID),
-								Span:       subStat.tableSpan,
-							}
-							metrics.EventStoreSubscriptionGauge.Dec()
-							if len(subStats) == 0 {
-								delete(e.dispatcherMeta.tableStats, tableID)
-							}
+					subData := subStat.subscribers.Load()
+					if subData != nil && len(subData.subscribers) == 0 && subData.idleTime > 0 && now-subData.idleTime > ttlInMsForMarkDeletion {
+						log.Info("clean obsolete subscription",
+							zap.Uint64("subscriptionID", uint64(subID)),
+							zap.Int("dbIndex", subStat.dbIndex),
+							zap.Int64("tableID", subStat.tableSpan.TableID))
+						e.subClient.Unsubscribe(subID)
+						if err := e.deleteEvents(subStat.dbIndex, uint64(subID), subStat.tableSpan.TableID, 0, math.MaxUint64); err != nil {
+							log.Warn("fail to delete events", zap.Error(err))
 						}
-					} else {
-						// This subscription is not marked for deletion yet. Check if it's idle.
-						subData := subStat.subscribers.Load()
-						if subData != nil && len(subData.subscribers) == 0 && subData.idleTime > 0 && now-subData.idleTime > ttlInMsForMarkDeletion {
-							log.Info("mark subscription as deleting", zap.Uint64("subscriptionID", uint64(subID)))
-							subStat.deleting.Store(true)
-							subStat.markedDeleteTime.Store(now)
+						delete(subStats, subID)
+						e.subscriptionChangeCh.In() <- SubscriptionChange{
+							ChangeType: SubscriptionChangeTypeRemove,
+							SubID:      uint64(subStat.subID),
+							Span:       subStat.tableSpan,
+						}
+						metrics.EventStoreSubscriptionGauge.Dec()
+						if len(subStats) == 0 {
+							delete(e.dispatcherMeta.tableStats, tableID)
 						}
 					}
 				}

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1005,7 +1005,9 @@ func (e *eventStore) addSubscriberToSubStat(subStat *subscriptionStat, dispatche
 func (e *eventStore) cleanObsoleteSubscriptions(ctx context.Context) error {
 	ticker := time.NewTicker(1 * time.Minute)
 	ttlInMsForMarkDeletion := int64(60 * 1000) // 1min
-	ttlInMsBeforeDeletion := int64(10 * 1000)  // 10s
+	// ttlInMsBeforeDeletion defines a grace period before deletion
+	// to ensure no new dispatchers start depending on this subscription while it is being removed.
+	ttlInMsBeforeDeletion := int64(10 * 1000) // 10s
 	for {
 		select {
 		case <-ctx.Done():

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -194,10 +194,14 @@ func TestEventStoreOnlyReuseDispatcher(t *testing.T) {
 		// because there is only one subStat, we know its subID is 1
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		require.Equal(t, 1, len(subStat.dispatchers.subscribers))
+		subscribers := subStat.subscribers.Load()
+		require.NotNil(t, subscribers)
+		require.Equal(t, 1, len(*subscribers))
 		require.Equal(t, int64(0), subStat.idleTime.Load())
 		store.UnregisterDispatcher(cfID, dispatcherID3)
-		require.Equal(t, 0, len(subStat.dispatchers.subscribers))
+		subscribers = subStat.subscribers.Load()
+		require.NotNil(t, subscribers)
+		require.Equal(t, 0, len(*subscribers))
 		require.NotEqual(t, int64(0), subStat.idleTime.Load())
 	}
 }
@@ -330,7 +334,9 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		// subStat with subID 1 should have three dispatchers
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		require.Equal(t, 3, len(subStat.dispatchers.subscribers))
+		subscribers := subStat.subscribers.Load()
+		require.NotNil(t, subscribers)
+		require.Equal(t, 3, len(*subscribers))
 	}
 	// test unregister dispatcherID3 can remove its dependency on two subscriptions
 	{
@@ -340,12 +346,16 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 2, len(subStat.dispatchers.subscribers))
+			subscribers := subStat.subscribers.Load()
+			require.NotNil(t, subscribers)
+			require.Equal(t, 2, len(*subscribers))
 		}
 		{
 			subStat := subStats[logpuller.SubscriptionID(3)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 0, len(subStat.dispatchers.subscribers))
+			subscribers := subStat.subscribers.Load()
+			require.NotNil(t, subscribers)
+			require.Equal(t, 0, len(*subscribers))
 		}
 	}
 }
@@ -510,8 +520,10 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 2, len(subStat.dispatchers.subscribers))
-			require.Equal(t, true, subStat.dispatchers.subscribers[dispatcherID2].isStopped.Load())
+			subscribers := subStat.subscribers.Load()
+			require.NotNil(t, subscribers)
+			require.Equal(t, 2, len(*subscribers))
+			require.Equal(t, true, (*subscribers)[dispatcherID2].isStopped)
 		}
 	}
 
@@ -535,8 +547,10 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 2, len(subStat.dispatchers.subscribers))
-			require.Equal(t, true, subStat.dispatchers.subscribers[dispatcherID2].isStopped.Load())
+			subscribers := subStat.subscribers.Load()
+			require.NotNil(t, subscribers)
+			require.Equal(t, 2, len(*subscribers))
+			require.Equal(t, true, (*subscribers)[dispatcherID2].isStopped)
 		}
 	}
 	{
@@ -567,7 +581,9 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			require.Equal(t, 1, len(subStat.dispatchers.subscribers))
+			subscribers := subStat.subscribers.Load()
+			require.NotNil(t, subscribers)
+			require.Equal(t, 1, len(*subscribers))
 		}
 	}
 	{

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -318,7 +318,9 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		// subStat with subID 1 should have two dispatchers
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		require.Equal(t, 2, len(subStat.dispatchers.subscribers))
+		subscribers := subStat.subscribers.Load()
+		require.NotNil(t, subscribers)
+		require.Equal(t, 2, len(*subscribers))
 	}
 	// add a dispatcher(onlyReuse=false) with the same span
 	{

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -194,15 +194,15 @@ func TestEventStoreOnlyReuseDispatcher(t *testing.T) {
 		// because there is only one subStat, we know its subID is 1
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		subscribers := subStat.subscribers.Load()
-		require.NotNil(t, subscribers)
-		require.Equal(t, 1, len(*subscribers))
-		require.Equal(t, int64(0), subStat.idleTime.Load())
+		subData := subStat.subscribers.Load()
+		require.NotNil(t, subData)
+		require.Equal(t, 1, len(subData.subscribers))
+		require.Equal(t, int64(0), subData.idleTime)
 		store.UnregisterDispatcher(cfID, dispatcherID3)
-		subscribers = subStat.subscribers.Load()
-		require.NotNil(t, subscribers)
-		require.Equal(t, 0, len(*subscribers))
-		require.NotEqual(t, int64(0), subStat.idleTime.Load())
+		subData = subStat.subscribers.Load()
+		require.NotNil(t, subData)
+		require.Equal(t, 0, len(subData.subscribers))
+		require.NotEqual(t, int64(0), subData.idleTime)
 	}
 }
 
@@ -318,9 +318,9 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		// subStat with subID 1 should have two dispatchers
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		subscribers := subStat.subscribers.Load()
-		require.NotNil(t, subscribers)
-		require.Equal(t, 2, len(*subscribers))
+		subData := subStat.subscribers.Load()
+		require.NotNil(t, subData)
+		require.Equal(t, 2, len(subData.subscribers))
 	}
 	// add a dispatcher(onlyReuse=false) with the same span
 	{
@@ -336,9 +336,9 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		// subStat with subID 1 should have three dispatchers
 		subStat := subStats[logpuller.SubscriptionID(1)]
 		require.NotNil(t, subStat)
-		subscribers := subStat.subscribers.Load()
-		require.NotNil(t, subscribers)
-		require.Equal(t, 3, len(*subscribers))
+		subData := subStat.subscribers.Load()
+		require.NotNil(t, subData)
+		require.Equal(t, 3, len(subData.subscribers))
 	}
 	// test unregister dispatcherID3 can remove its dependency on two subscriptions
 	{
@@ -348,16 +348,16 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			subscribers := subStat.subscribers.Load()
-			require.NotNil(t, subscribers)
-			require.Equal(t, 2, len(*subscribers))
+			subData := subStat.subscribers.Load()
+			require.NotNil(t, subData)
+			require.Equal(t, 2, len(subData.subscribers))
 		}
 		{
 			subStat := subStats[logpuller.SubscriptionID(3)]
 			require.NotNil(t, subStat)
-			subscribers := subStat.subscribers.Load()
-			require.NotNil(t, subscribers)
-			require.Equal(t, 0, len(*subscribers))
+			subData := subStat.subscribers.Load()
+			require.NotNil(t, subData)
+			require.Equal(t, 0, len(subData.subscribers))
 		}
 	}
 }
@@ -522,10 +522,10 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			subscribers := subStat.subscribers.Load()
-			require.NotNil(t, subscribers)
-			require.Equal(t, 2, len(*subscribers))
-			require.Equal(t, true, (*subscribers)[dispatcherID2].isStopped)
+			subData := subStat.subscribers.Load()
+			require.NotNil(t, subData)
+			require.Equal(t, 2, len(subData.subscribers))
+			require.Equal(t, true, subData.subscribers[dispatcherID2].isStopped)
 		}
 	}
 
@@ -549,10 +549,10 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			subscribers := subStat.subscribers.Load()
-			require.NotNil(t, subscribers)
-			require.Equal(t, 2, len(*subscribers))
-			require.Equal(t, true, (*subscribers)[dispatcherID2].isStopped)
+			subData := subStat.subscribers.Load()
+			require.NotNil(t, subData)
+			require.Equal(t, 2, len(subData.subscribers))
+			require.Equal(t, true, subData.subscribers[dispatcherID2].isStopped)
 		}
 	}
 	{
@@ -583,9 +583,9 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
-			subscribers := subStat.subscribers.Load()
-			require.NotNil(t, subscribers)
-			require.Equal(t, 1, len(*subscribers))
+			subData := subStat.subscribers.Load()
+			require.NotNil(t, subData)
+			require.Equal(t, 1, len(subData.subscribers))
 		}
 	}
 	{


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2458 

### What is changed and how it works?

* **Concurrency Model Overhaul**: Replaced a mutex-protected map of subscribers with an "atomic.Pointer" holding a "subscribersWithIdleTime" struct, enabling lock-free concurrent management of dispatchers.
* **Deadlock Mitigation**: The shift from mutex-based locking to atomic operations directly addresses and prevents potential deadlocks that could occur during frequent updates and notifications to dispatchers.
* **Streamlined Subscriber State**: The "isStopped" field in the "Subscriber" struct was simplified from "atomic.Bool" to a plain "bool", as its state is now managed within the atomically updated subscriber map.
* **Atomic Map Operations**: Introduced a new helper "addSubscriberToSubStat" and refactored existing functions ("RegisterDispatcher", "detachFromSubStat", "stopReceiveEventFromSubStat", "UpdateDispatcherCheckpointTs") to utilize atomic operations for thread-safe map modifications.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
