### PR TITLE
logCoordinator: use a new etcd key to avoid panic when rollback to old arch ticdc

### DIFF
--- a/pkg/etcd/etcdkey.go
+++ b/pkg/etcd/etcdkey.go
@@ -110,6 +110,14 @@ func BaseKey(clusterID string) string {
 	return fmt.Sprintf("/tidb/cdc/%s", clusterID)
 }
 
+// NewCDCBaseKey is used for keys added by New Arch TiCDC
+// We support rollback from the new architecture to the old architecture,
+// we need to prevent the old architecture from panicking when checking etcd and discovering unknown keys.
+// Therefore, the etcd keys added to the new architecture need to be placed under the new base.
+func NewCDCBaseKey(clusterID string) string {
+	return fmt.Sprintf("/tidb/cdc_new/%s", clusterID)
+}
+
 // KeyspacePrefix returns the etcd prefix of changefeed data
 func KeyspacePrefix(clusterID, keyspace string) string {
 	return BaseKey(clusterID) + "/" + keyspace

--- a/server/module_election.go
+++ b/server/module_election.go
@@ -314,5 +314,5 @@ func (e *elector) resignLogCoordinator() error {
 var metaPrefix = "/__cdc_meta__"
 
 func LogCoordinatorKey(clusterID string) string {
-	return etcd.BaseKey(clusterID) + metaPrefix + "/log_coordinator"
+	return etcd.NewCDCBaseKey(clusterID) + metaPrefix + "/log_coordinator"
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/2493

### What is changed and how it works?

This pull request implements a crucial change to support safe rollbacks from the new TiCDC architecture to the old one. It achieves this by introducing a distinct etcd key prefix for components belonging to the new architecture. Specifically, the logCoordinator's etcd key is now stored under this new prefix, preventing the older TiCDC architecture from encountering and potentially panicking over unfamiliar etcd keys during a rollback scenario. This ensures greater stability and compatibility between different architectural versions.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
