### PR TITLE
eventstore: avoid useless scan when dispatcher for empty tables initialize

### DIFF
--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -570,7 +570,7 @@ func (e *eventStore) RegisterDispatcher(
 	})
 	subStat.checkpointTs.Store(startTs)
 	subStat.resolvedTs.Store(startTs)
-	subStat.maxEventCommitTs.Store(startTs)
+	subStat.maxEventCommitTs.Store(0)
 	if stat.subStat == nil {
 		stat.subStat = subStat
 	} else {

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -389,6 +389,17 @@ func (c *eventBroker) getScanTaskDataRange(task scanTask) (bool, common.DataRang
 	// so we take the risk to do a useless scan.
 	noDMLEvent := dataRange.CommitTsStart > task.eventStoreCommitTs.Load()
 	noDDLEvent := dataRange.CommitTsStart >= ddlState.MaxEventCommitTs
+	log.Info("get scan task data range",
+		zap.Stringer("dispatcherID", task.id),
+		zap.Int64("tableID", task.info.GetTableSpan().GetTableID()),
+		zap.Uint64("eventStoreCommitTs", task.eventStoreCommitTs.Load()),
+		zap.Uint64("ddlStateMaxEventCommitTs", ddlState.MaxEventCommitTs),
+		zap.Uint64("ddlStateResolvedTs", ddlState.ResolvedTs),
+		zap.Uint64("dataRangeStart", dataRange.CommitTsStart),
+		zap.Uint64("dataRangeEnd", dataRange.CommitTsEnd),
+		zap.Bool("noDMLEvent", noDMLEvent),
+		zap.Bool("noDDLEvent", noDDLEvent),
+	)
 	if noDMLEvent && noDDLEvent {
 		// The dispatcher has no new events. In such case, we don't need to scan the event store.
 		// We just send the watermark to the dispatcher.

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -389,17 +389,6 @@ func (c *eventBroker) getScanTaskDataRange(task scanTask) (bool, common.DataRang
 	// so we take the risk to do a useless scan.
 	noDMLEvent := dataRange.CommitTsStart > task.eventStoreCommitTs.Load()
 	noDDLEvent := dataRange.CommitTsStart >= ddlState.MaxEventCommitTs
-	log.Info("get scan task data range",
-		zap.Stringer("dispatcherID", task.id),
-		zap.Int64("tableID", task.info.GetTableSpan().GetTableID()),
-		zap.Uint64("eventStoreCommitTs", task.eventStoreCommitTs.Load()),
-		zap.Uint64("ddlStateMaxEventCommitTs", ddlState.MaxEventCommitTs),
-		zap.Uint64("ddlStateResolvedTs", ddlState.ResolvedTs),
-		zap.Uint64("dataRangeStart", dataRange.CommitTsStart),
-		zap.Uint64("dataRangeEnd", dataRange.CommitTsEnd),
-		zap.Bool("noDMLEvent", noDMLEvent),
-		zap.Bool("noDDLEvent", noDDLEvent),
-	)
 	if noDMLEvent && noDDLEvent {
 		// The dispatcher has no new events. In such case, we don't need to scan the event store.
 		// We just send the watermark to the dispatcher.


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2492

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
