### PR TITLE
message center: handler no need to return error since it's only context cancel

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -145,9 +145,9 @@ func New(node *node.Info,
 	return c
 }
 
-func (c *coordinator) recvMessages(ctx context.Context, msg *messaging.TargetMessage) error {
+func (c *coordinator) recvMessages(ctx context.Context, msg *messaging.TargetMessage) {
 	if c.closed.Load() {
-		return nil
+		return
 	}
 
 	defer func() {
@@ -168,12 +168,10 @@ func (c *coordinator) recvMessages(ctx context.Context, msg *messaging.TargetMes
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return
 	default:
 		c.eventCh.In() <- &Event{message: msg}
 	}
-
-	return nil
 }
 
 // Run spawns two goroutines to handle messages and run the coordinator.

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -118,7 +118,7 @@ func New(node *node.Info,
 		backend:            backend,
 	}
 	// handle messages from message center
-	mc.RegisterHandler(messaging.CoordinatorTopic, c.recvMessages)
+	mc.RegisterHandler(messaging.CoordinatorTopic, c.recvMessage)
 	c.controller = NewController(
 		c.version,
 		c.nodeInfo,
@@ -145,7 +145,7 @@ func New(node *node.Info,
 	return c
 }
 
-func (c *coordinator) recvMessages(ctx context.Context, msg *messaging.TargetMessage) {
+func (c *coordinator) recvMessage(ctx context.Context, msg *messaging.TargetMessage) {
 	if c.closed.Load() {
 		return
 	}

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -125,7 +125,7 @@ func (m *mockMaintainerManager) sendMessages(msg *heartbeatpb.MaintainerHeartbea
 	}
 }
 
-func (m *mockMaintainerManager) recvMessages(ctx context.Context, msg *messaging.TargetMessage) error {
+func (m *mockMaintainerManager) recvMessages(ctx context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	// receive message from coordinator
 	case messaging.TypeAddMaintainerRequest, messaging.TypeRemoveMaintainerRequest:
@@ -133,14 +133,12 @@ func (m *mockMaintainerManager) recvMessages(ctx context.Context, msg *messaging
 	case messaging.TypeCoordinatorBootstrapRequest:
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return
 		case m.msgCh <- msg:
 		}
-		return nil
 	default:
 		log.Panic("unknown message type", zap.Any("message", msg.Message))
 	}
-	return nil
 }
 
 func (m *mockMaintainerManager) onCoordinatorBootstrapRequest(msg *messaging.TargetMessage) {

--- a/downstreamadapter/dispatchermanager/heartbeat_collector.go
+++ b/downstreamadapter/dispatchermanager/heartbeat_collector.go
@@ -239,7 +239,7 @@ func (c *HeartBeatCollector) sendBlockStatusMessages(ctx context.Context) error 
 	}
 }
 
-func (c *HeartBeatCollector) RecvMessages(_ context.Context, msg *messaging.TargetMessage) error {
+func (c *HeartBeatCollector) RecvMessages(_ context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	case messaging.TypeHeartBeatResponse:
 		// TODO: Change a more appropriate name for HeartBeatResponse. It should be BlockStatusResponse or something else.
@@ -272,7 +272,6 @@ func (c *HeartBeatCollector) RecvMessages(_ context.Context, msg *messaging.Targ
 	default:
 		log.Panic("unknown message type", zap.Any("message", msg.Message))
 	}
-	return nil
 }
 
 func (c *HeartBeatCollector) Close() {

--- a/downstreamadapter/dispatchermanager/heartbeat_collector.go
+++ b/downstreamadapter/dispatchermanager/heartbeat_collector.go
@@ -78,7 +78,7 @@ func NewHeartBeatCollector(serverId node.ID) *HeartBeatCollector {
 		mergeDispatcherRequestDynamicStream:     newMergeDispatcherRequestDynamicStream(),
 		mc:                                      appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter),
 	}
-	heartBeatCollector.mc.RegisterHandler(messaging.HeartbeatCollectorTopic, heartBeatCollector.RecvMessages)
+	heartBeatCollector.mc.RegisterHandler(messaging.HeartbeatCollectorTopic, heartBeatCollector.recvMessage)
 
 	return &heartBeatCollector
 }
@@ -239,7 +239,7 @@ func (c *HeartBeatCollector) sendBlockStatusMessages(ctx context.Context) error 
 	}
 }
 
-func (c *HeartBeatCollector) RecvMessages(_ context.Context, msg *messaging.TargetMessage) {
+func (c *HeartBeatCollector) recvMessage(_ context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	case messaging.TypeHeartBeatResponse:
 		// TODO: Change a more appropriate name for HeartBeatResponse. It should be BlockStatusResponse or something else.

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -52,7 +52,7 @@ func New() *DispatcherOrchestrator {
 		dispatcherManagers: make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
 		msgChan:            make(chan *messaging.TargetMessage, 1024), // buffer size 1024
 	}
-	m.mc.RegisterHandler(messaging.DispatcherManagerManagerTopic, m.RecvMaintainerRequest)
+	m.mc.RegisterHandler(messaging.DispatcherManagerManagerTopic, m.recvMessage)
 	return m
 }
 
@@ -73,9 +73,9 @@ func (m *DispatcherOrchestrator) Run(ctx context.Context) {
 	}()
 }
 
-// RecvMaintainerRequest is the handler for the maintainer request message.
+// recvMessage is the handler for the maintainer request message.
 // It puts the message into a channel for asynchronous processing to avoid blocking the message center.
-func (m *DispatcherOrchestrator) RecvMaintainerRequest(
+func (m *DispatcherOrchestrator) recvMessage(
 	_ context.Context,
 	msg *messaging.TargetMessage,
 ) {

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -78,15 +78,15 @@ func (m *DispatcherOrchestrator) Run(ctx context.Context) {
 func (m *DispatcherOrchestrator) RecvMaintainerRequest(
 	_ context.Context,
 	msg *messaging.TargetMessage,
-) error {
+) {
 	// Put message into channel for asynchronous processing by another goroutine
 	select {
 	case m.msgChan <- msg:
-		return nil
+		return
 	default:
 		// Channel is full, log warning and drop the message
 		log.Warn("message channel is full, dropping message", zap.Any("message", msg.Message))
-		return nil
+		return
 	}
 }
 

--- a/downstreamadapter/eventcollector/log_coordinator_client.go
+++ b/downstreamadapter/eventcollector/log_coordinator_client.go
@@ -50,11 +50,11 @@ func newLogCoordinatorClient(eventCollector *EventCollector) *LogCoordinatorClie
 		logCoordinatorRequestChan: chann.NewAutoDrainChann[*logservicepb.ReusableEventServiceRequest](),
 		enableRemoteEventService:  config.GetGlobalServerConfig().Debug.EventService.EnableRemoteEventService,
 	}
-	client.mc.RegisterHandler(logCoordinatorClientTopic, client.MessageCenterHandler)
+	client.mc.RegisterHandler(logCoordinatorClientTopic, client.recvMessage)
 	return client
 }
 
-func (l *LogCoordinatorClient) MessageCenterHandler(_ context.Context, targetMessage *messaging.TargetMessage) {
+func (l *LogCoordinatorClient) recvMessage(_ context.Context, targetMessage *messaging.TargetMessage) {
 	for _, msg := range targetMessage.Message {
 		switch msg := msg.(type) {
 		case *common.LogCoordinatorBroadcastRequest:

--- a/downstreamadapter/eventcollector/log_coordinator_client.go
+++ b/downstreamadapter/eventcollector/log_coordinator_client.go
@@ -54,7 +54,7 @@ func newLogCoordinatorClient(eventCollector *EventCollector) *LogCoordinatorClie
 	return client
 }
 
-func (l *LogCoordinatorClient) MessageCenterHandler(_ context.Context, targetMessage *messaging.TargetMessage) error {
+func (l *LogCoordinatorClient) MessageCenterHandler(_ context.Context, targetMessage *messaging.TargetMessage) {
 	for _, msg := range targetMessage.Message {
 		switch msg := msg.(type) {
 		case *common.LogCoordinatorBroadcastRequest:
@@ -69,7 +69,6 @@ func (l *LogCoordinatorClient) MessageCenterHandler(_ context.Context, targetMes
 			log.Panic("invalid message type", zap.Any("msg", msg))
 		}
 	}
-	return nil
 }
 
 func (l *LogCoordinatorClient) run(ctx context.Context) error {

--- a/logservice/coordinator/coordinator.go
+++ b/logservice/coordinator/coordinator.go
@@ -97,7 +97,7 @@ func New() LogCoordinator {
 	c.changefeedStates.m = make(map[common.GID]*changefeedState)
 
 	// recv and handle messages
-	messageCenter.RegisterHandler(logCoordinatorTopic, c.handleMessage)
+	messageCenter.RegisterHandler(logCoordinatorTopic, c.recvMessage)
 	// watch node changes
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodes := nodeManager.GetAliveNodes()
@@ -149,7 +149,7 @@ func (c *logCoordinator) Run(ctx context.Context) error {
 	}
 }
 
-func (c *logCoordinator) handleMessage(_ context.Context, targetMessage *messaging.TargetMessage) {
+func (c *logCoordinator) recvMessage(_ context.Context, targetMessage *messaging.TargetMessage) {
 	for _, msg := range targetMessage.Message {
 		switch msg := msg.(type) {
 		case *logservicepb.EventStoreState:

--- a/logservice/coordinator/coordinator.go
+++ b/logservice/coordinator/coordinator.go
@@ -149,7 +149,7 @@ func (c *logCoordinator) Run(ctx context.Context) error {
 	}
 }
 
-func (c *logCoordinator) handleMessage(_ context.Context, targetMessage *messaging.TargetMessage) error {
+func (c *logCoordinator) handleMessage(_ context.Context, targetMessage *messaging.TargetMessage) {
 	for _, msg := range targetMessage.Message {
 		switch msg := msg.(type) {
 		case *logservicepb.EventStoreState:
@@ -167,7 +167,6 @@ func (c *logCoordinator) handleMessage(_ context.Context, targetMessage *messagi
 			log.Panic("invalid message type", zap.Any("msg", msg))
 		}
 	}
-	return nil
 }
 
 func (c *logCoordinator) sendResolvedTsToCoordinator(id node.ID, changefeedID common.ChangeFeedID) {

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1219,7 +1219,7 @@ func (iter *eventStoreIter) Close() (int64, error) {
 	return iter.rowCount, err
 }
 
-func (e *eventStore) handleMessage(_ context.Context, targetMessage *messaging.TargetMessage) error {
+func (e *eventStore) handleMessage(_ context.Context, targetMessage *messaging.TargetMessage) {
 	for _, msg := range targetMessage.Message {
 		switch msg.(type) {
 		case *common.LogCoordinatorBroadcastRequest:
@@ -1228,7 +1228,6 @@ func (e *eventStore) handleMessage(_ context.Context, targetMessage *messaging.T
 			log.Panic("invalid message type", zap.Any("msg", msg))
 		}
 	}
-	return nil
 }
 
 type SubscriptionChangeType int

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -280,7 +280,7 @@ func New(
 	store.dispatcherMeta.dispatcherStats = make(map[common.DispatcherID]*dispatcherStat)
 	store.dispatcherMeta.tableStats = make(map[int64]subscriptionStats)
 
-	store.messageCenter.RegisterHandler(messaging.EventStoreTopic, store.handleMessage)
+	store.messageCenter.RegisterHandler(messaging.EventStoreTopic, store.recvMessage)
 	return store
 }
 
@@ -1219,7 +1219,7 @@ func (iter *eventStoreIter) Close() (int64, error) {
 	return iter.rowCount, err
 }
 
-func (e *eventStore) handleMessage(_ context.Context, targetMessage *messaging.TargetMessage) {
+func (e *eventStore) recvMessage(_ context.Context, targetMessage *messaging.TargetMessage) {
 	for _, msg := range targetMessage.Message {
 		switch msg.(type) {
 		case *common.LogCoordinatorBroadcastRequest:

--- a/maintainer/maintainer_manager.go
+++ b/maintainer/maintainer_manager.go
@@ -91,7 +91,6 @@ func (m *Manager) recvMessage(ctx context.Context, msg *messaging.TargetMessage)
 			return
 		case m.msgCh <- msg:
 		}
-		return
 	// receive bootstrap response message from the dispatcher manager
 	case messaging.TypeMaintainerBootstrapResponse:
 		req := msg.Message[0].(*heartbeatpb.MaintainerBootstrapResponse)

--- a/maintainer/maintainer_manager.go
+++ b/maintainer/maintainer_manager.go
@@ -70,7 +70,7 @@ func NewMaintainerManager(
 		taskScheduler: threadpool.NewThreadPoolDefault(),
 	}
 
-	mc.RegisterHandler(messaging.MaintainerManagerTopic, m.recvMessages)
+	mc.RegisterHandler(messaging.MaintainerManagerTopic, m.recvMessage)
 	mc.RegisterHandler(messaging.MaintainerTopic,
 		func(ctx context.Context, msg *messaging.TargetMessage) {
 			req := msg.Message[0].(*heartbeatpb.MaintainerCloseResponse)
@@ -79,8 +79,8 @@ func NewMaintainerManager(
 	return m
 }
 
-// recvMessages is the message handler for maintainer manager
-func (m *Manager) recvMessages(ctx context.Context, msg *messaging.TargetMessage) {
+// recvMessage is the message handler for maintainer manager
+func (m *Manager) recvMessage(ctx context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	// Coordinator related messages
 	case messaging.TypeAddMaintainerRequest,

--- a/maintainer/maintainer_manager_test.go
+++ b/maintainer/maintainer_manager_test.go
@@ -90,9 +90,7 @@ func TestMaintainerSchedulesNodeChanges(t *testing.T) {
 	startDispatcherNode(t, ctx, selfNode, mc, nodeManager)
 	nodeManager.RegisterNodeChangeHandler(appcontext.MessageCenter, mc.OnNodeChanges)
 	// Discard maintainer manager messages, cuz we don't need to handle them in this test
-	mc.RegisterHandler(messaging.CoordinatorTopic, func(ctx context.Context, msg *messaging.TargetMessage) error {
-		return nil
-	})
+	mc.RegisterHandler(messaging.CoordinatorTopic, func(ctx context.Context, msg *messaging.TargetMessage) {})
 	schedulerConf := &config.SchedulerConfig{
 		AddTableBatchSize:    1000,
 		CheckBalanceInterval: 0,
@@ -316,9 +314,7 @@ func TestMaintainerBootstrapWithTablesReported(t *testing.T) {
 	startDispatcherNode(t, ctx, selfNode, mc, nodeManager)
 	nodeManager.RegisterNodeChangeHandler(appcontext.MessageCenter, mc.OnNodeChanges)
 	// discard maintainer manager messages
-	mc.RegisterHandler(messaging.CoordinatorTopic, func(ctx context.Context, msg *messaging.TargetMessage) error {
-		return nil
-	})
+	mc.RegisterHandler(messaging.CoordinatorTopic, func(ctx context.Context, msg *messaging.TargetMessage) {})
 	manager := NewMaintainerManager(selfNode, config.GetGlobalServerConfig().Debug.Scheduler)
 	msg := messaging.NewSingleTargetMessage(selfNode.ID,
 		messaging.MaintainerManagerTopic,
@@ -452,9 +448,7 @@ func TestStopNotExistsMaintainer(t *testing.T) {
 	startDispatcherNode(t, ctx, selfNode, mc, nodeManager)
 	nodeManager.RegisterNodeChangeHandler(appcontext.MessageCenter, mc.OnNodeChanges)
 	// discard maintainer manager messages
-	mc.RegisterHandler(messaging.CoordinatorTopic, func(ctx context.Context, msg *messaging.TargetMessage) error {
-		return nil
-	})
+	mc.RegisterHandler(messaging.CoordinatorTopic, func(ctx context.Context, msg *messaging.TargetMessage) {})
 	schedulerConf := &config.SchedulerConfig{AddTableBatchSize: 1000}
 	manager := NewMaintainerManager(selfNode, schedulerConf)
 	msg := messaging.NewSingleTargetMessage(selfNode.ID,

--- a/maintainer/maintainer_test.go
+++ b/maintainer/maintainer_test.go
@@ -62,8 +62,8 @@ func MockDispatcherManager(mc messaging.MessageCenter, self node.ID) *mockDispat
 		dispatchersMap: make(map[heartbeatpb.DispatcherID]*heartbeatpb.TableSpanStatus, 2000001),
 		self:           self,
 	}
-	mc.RegisterHandler(messaging.DispatcherManagerManagerTopic, m.recvMessages)
-	mc.RegisterHandler(messaging.HeartbeatCollectorTopic, m.recvMessages)
+	mc.RegisterHandler(messaging.DispatcherManagerManagerTopic, m.recvMessage)
+	mc.RegisterHandler(messaging.HeartbeatCollectorTopic, m.recvMessage)
 	return m
 }
 
@@ -108,7 +108,7 @@ func (m *mockDispatcherManager) sendMessages(msg *heartbeatpb.HeartBeatRequest) 
 	}
 }
 
-func (m *mockDispatcherManager) recvMessages(ctx context.Context, msg *messaging.TargetMessage) {
+func (m *mockDispatcherManager) recvMessage(ctx context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	// receive message from maintainer
 	case messaging.TypeScheduleDispatcherRequest,
@@ -336,7 +336,6 @@ func TestMaintainerSchedule(t *testing.T) {
 				eventType:    EventMessage,
 				message:      msg,
 			}
-			return
 		})
 
 	// send bootstrap message

--- a/maintainer/maintainer_test.go
+++ b/maintainer/maintainer_test.go
@@ -108,7 +108,7 @@ func (m *mockDispatcherManager) sendMessages(msg *heartbeatpb.HeartBeatRequest) 
 	}
 }
 
-func (m *mockDispatcherManager) recvMessages(ctx context.Context, msg *messaging.TargetMessage) error {
+func (m *mockDispatcherManager) recvMessages(ctx context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	// receive message from maintainer
 	case messaging.TypeScheduleDispatcherRequest,
@@ -117,14 +117,12 @@ func (m *mockDispatcherManager) recvMessages(ctx context.Context, msg *messaging
 		messaging.TypeMaintainerCloseRequest:
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return
 		case m.msgCh <- msg:
 		}
-		return nil
 	default:
 		log.Panic("unknown message type", zap.Any("message", msg.Message), zap.Any("type", msg.Type))
 	}
-	return nil
 }
 
 func (m *mockDispatcherManager) onBootstrapRequest(msg *messaging.TargetMessage) {
@@ -332,13 +330,13 @@ func TestMaintainerSchedule(t *testing.T) {
 		}, n, taskScheduler, 10, true, common.DefaultKeyspaceID)
 
 	mc.RegisterHandler(messaging.MaintainerManagerTopic,
-		func(ctx context.Context, msg *messaging.TargetMessage) error {
+		func(ctx context.Context, msg *messaging.TargetMessage) {
 			maintainer.eventCh.In() <- &Event{
 				changefeedID: cfID,
 				eventType:    EventMessage,
 				message:      msg,
 			}
-			return nil
+			return
 		})
 
 	// send bootstrap message

--- a/pkg/eventservice/event_service.go
+++ b/pkg/eventservice/event_service.go
@@ -89,7 +89,7 @@ func New(eventStore eventstore.EventStore, schemaStore schemastore.SchemaStore) 
 		dispatcherInfoChan:  make(chan DispatcherInfo, 32),
 		dispatcherHeartbeat: make(chan *DispatcherHeartBeatWithServerID, 32),
 	}
-	es.mc.RegisterHandler(messaging.EventServiceTopic, es.handleMessage)
+	es.mc.RegisterHandler(messaging.EventServiceTopic, es.recvMessage)
 	return es
 }
 
@@ -140,7 +140,7 @@ func (s *eventService) Close(_ context.Context) error {
 	return nil
 }
 
-func (s *eventService) handleMessage(ctx context.Context, msg *messaging.TargetMessage) {
+func (s *eventService) recvMessage(ctx context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	case messaging.TypeDispatcherRequest:
 		infos := msgToDispatcherInfo(msg)

--- a/pkg/eventservice/event_service.go
+++ b/pkg/eventservice/event_service.go
@@ -140,14 +140,14 @@ func (s *eventService) Close(_ context.Context) error {
 	return nil
 }
 
-func (s *eventService) handleMessage(ctx context.Context, msg *messaging.TargetMessage) error {
+func (s *eventService) handleMessage(ctx context.Context, msg *messaging.TargetMessage) {
 	switch msg.Type {
 	case messaging.TypeDispatcherRequest:
 		infos := msgToDispatcherInfo(msg)
 		for _, info := range infos {
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return
 			case s.dispatcherInfoChan <- info:
 			}
 		}
@@ -158,7 +158,7 @@ func (s *eventService) handleMessage(ctx context.Context, msg *messaging.TargetM
 		heartbeat := msg.Message[0].(*event.DispatcherHeartbeat)
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return
 		case s.dispatcherHeartbeat <- &DispatcherHeartBeatWithServerID{
 			serverID:  msg.From.String(),
 			heartbeat: heartbeat,
@@ -173,7 +173,6 @@ func (s *eventService) handleMessage(ctx context.Context, msg *messaging.TargetM
 	default:
 		log.Panic("unknown message type", zap.String("type", msg.Type.String()), zap.Any("message", msg))
 	}
-	return nil
 }
 
 func (s *eventService) registerDispatcher(ctx context.Context, info DispatcherInfo) {

--- a/pkg/messaging/message_center_integration_test.go
+++ b/pkg/messaging/message_center_integration_test.go
@@ -52,10 +52,9 @@ func setupMessageCenters(t *testing.T) (*messageCenter, *messageCenter, *message
 
 func registerHandler(mc *messageCenter, topic string) chan *TargetMessage {
 	ch := make(chan *TargetMessage, 1)
-	mc.RegisterHandler(topic, func(ctx context.Context, msg *TargetMessage) error {
+	mc.RegisterHandler(topic, func(ctx context.Context, msg *TargetMessage) {
 		ch <- msg
 		log.Info(fmt.Sprintf("%s received message", mc.id), zap.Any("msg", msg))
-		return nil
 	})
 	return ch
 }
@@ -83,9 +82,8 @@ func waitForTargetsReady(mc *messageCenter) {
 func sendAndReceiveMessage(t *testing.T, sender *messageCenter, receiver *messageCenter, topic string, event *commonEvent.BatchDMLEvent) {
 	targetMsg := NewSingleTargetMessage(receiver.id, topic, event)
 	ch := make(chan *TargetMessage, 1)
-	receiver.RegisterHandler(topic, func(ctx context.Context, msg *TargetMessage) error {
+	receiver.RegisterHandler(topic, func(ctx context.Context, msg *TargetMessage) {
 		ch <- msg
-		return nil
 	})
 
 	timeoutCh := time.After(30 * time.Second)

--- a/pkg/messaging/remote_target.go
+++ b/pkg/messaging/remote_target.go
@@ -36,15 +36,8 @@ import (
 )
 
 const (
-	reconnectInterval = 2 * time.Second
 	streamTypeEvent   = "event"
 	streamTypeCommand = "command"
-
-	eventRecvCh   = "eventRecvCh"
-	commandRecvCh = "commandRecvCh"
-
-	eventSendCh   = "eventSendCh"
-	commandSendCh = "commandSendCh"
 )
 
 type streamSession struct {

--- a/pkg/messaging/router.go
+++ b/pkg/messaging/router.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type MessageHandler func(ctx context.Context, msg *TargetMessage) error
+type MessageHandler func(ctx context.Context, msg *TargetMessage)
 
 type router struct {
 	mu       sync.RWMutex

--- a/pkg/messaging/router.go
+++ b/pkg/messaging/router.go
@@ -64,7 +64,7 @@ func (r *router) runDispatch(ctx context.Context, out <-chan *TargetMessage) {
 				continue
 			}
 			start := time.Now()
-			err := handler(ctx, msg)
+			handler(ctx, msg)
 			now := time.Now()
 			if now.Sub(start) > 100*time.Millisecond {
 				// Rate limit logging: only log once every 10 seconds
@@ -79,9 +79,6 @@ func (r *router) runDispatch(ctx context.Context, out <-chan *TargetMessage) {
 
 				// Always increment metrics counter for slow message handling
 				metrics.MessagingSlowHandleCounter.WithLabelValues(msg.Type.String()).Inc()
-			}
-			if err != nil {
-				log.Error("Handle message failed", zap.Error(err), zap.Any("msg", msg))
 			}
 		}
 	}

--- a/pkg/messaging/stream.go
+++ b/pkg/messaging/stream.go
@@ -14,8 +14,6 @@
 package messaging
 
 import (
-	"sync/atomic"
-
 	"github.com/pingcap/ticdc/pkg/messaging/proto"
 )
 
@@ -27,21 +25,10 @@ type grpcStream interface {
 	Recv() (*proto.Message, error)
 }
 
-var streamGenerator atomic.Uint64
-
 type streamWrapper struct {
 	grpcStream
 	id         uint64
 	streamType string
-}
-
-// newStreamWrapper creates a new stream wrapper.
-func newStreamWrapper(stream grpcStream, streamType string) *streamWrapper {
-	return &streamWrapper{
-		grpcStream: stream,
-		id:         streamGenerator.Add(1),
-		streamType: streamType,
-	}
 }
 
 func (s *streamWrapper) Send(msg *proto.Message) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2911 

### What is changed and how it works?

The returned error must be nil or context.cancel, and the context is passed from the server, so can be removed.

* Refactored Message Handlers: The signature of MessageHandler functions across the codebase has been updated to no longer return an error, simplifying their implementation.
* Simplified Error Handling: Explicit error returns, particularly for context.Canceled, have been removed from message handler implementations, indicating that such conditions are now handled internally or are not propagated as errors.
* Standardized Function Naming: Message receiving functions have been consistently renamed from recvMessages or handleMessage to recvMessage (or recvRedoMessage for specific cases) for improved clarity and consistency.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
