### PR TITLE
kafka: prevent CPU/memory runaway when topic missing

### DIFF
--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -267,8 +267,7 @@ func NewDispatcherManager(
 	manager.wg.Add(1)
 	go func() {
 		defer manager.wg.Done()
-		err := manager.sink.Run(ctx)
-		manager.handleError(ctx, err)
+		manager.runSinkWithExitHandling(ctx)
 	}()
 
 	// collect errors from error channel
@@ -500,6 +499,63 @@ func (e *DispatcherManager) handleError(ctx context.Context, err error) {
 			)
 		}
 	}
+}
+
+// runSinkWithExitHandling runs the sink and handles its exit.
+//
+// The sink is expected to run until the dispatcher manager is closed and `ctx` is canceled.
+// If the sink exits earlier (for example, due to an unrecoverable Kafka error like missing
+// topic / authorization), dispatchers may still keep pulling events from upstream and enqueue
+// them into the sink's internal unbounded channels. This results in unbounded memory growth,
+// GC/CPU runaway, and eventual OOM. To avoid this, we report the error and close the dispatcher
+// manager proactively.
+func (e *DispatcherManager) runSinkWithExitHandling(ctx context.Context) {
+	err := e.sink.Run(ctx)
+	e.handleError(ctx, err)
+
+	// Normal shutdown: the manager is closing and the sink exits due to context cancellation.
+	if errors.Is(errors.Cause(err), context.Canceled) {
+		return
+	}
+
+	// Sink exited unexpectedly. Report once and stop the manager to avoid buffering more events.
+	if err != nil {
+		e.reportErrorToMaintainer(err)
+	} else {
+		log.Error("sink exited without error", zap.Stringer("changefeedID", e.changefeedID))
+	}
+	e.TryClose(false)
+}
+
+// reportErrorToMaintainer enqueues an error message to maintainer immediately.
+//
+// Motivation: When the sink exits with an error, the dispatcher manager will be closed proactively
+// to avoid unbounded buffering of events. Closing cancels the manager context, which would make
+// the background `collectErrors` goroutine exit early and potentially drop the first (and most
+// important) error. We send the error once here to ensure it is visible to the maintainer.
+func (e *DispatcherManager) reportErrorToMaintainer(err error) {
+	if err == nil || errors.Is(errors.Cause(err), context.Canceled) {
+		return
+	}
+	if e.heartbeatRequestQueue == nil {
+		log.Error("heartbeat request queue is not initialized, skip reporting error",
+			zap.Stringer("changefeedID", e.changefeedID),
+			zap.Error(err),
+		)
+		return
+	}
+	var message heartbeatpb.HeartBeatRequest
+	message.ChangefeedID = e.changefeedID.ToPB()
+	message.Err = &heartbeatpb.RunningError{
+		Time:    time.Now().String(),
+		Node:    appcontext.GetID(),
+		Code:    string(errors.ErrorCode(err)),
+		Message: err.Error(),
+	}
+	e.heartbeatRequestQueue.Enqueue(&HeartBeatRequestWithTargetID{
+		TargetID: e.GetMaintainerID(),
+		Request:  &message,
+	})
 }
 
 // collectErrors collect the errors from the error channel and report to the maintainer.

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/ticdc/downstreamadapter/dispatcher"
 	"github.com/pingcap/ticdc/downstreamadapter/eventcollector"
 	"github.com/pingcap/ticdc/downstreamadapter/sink"
@@ -37,6 +38,26 @@ import (
 )
 
 var mockSink = sink.NewMockSink(common.BlackHoleSinkType)
+
+type errorSink struct {
+	err error
+}
+
+func (s *errorSink) SinkType() common.SinkType { return common.KafkaSinkType }
+
+func (s *errorSink) IsNormal() bool { return false }
+
+func (s *errorSink) AddDMLEvent(*event.DMLEvent) {}
+
+func (s *errorSink) WriteBlockEvent(event.BlockEvent) error { return s.err }
+
+func (s *errorSink) AddCheckpointTs(uint64) {}
+
+func (s *errorSink) SetTableSchemaStore(*event.TableSchemaStore) {}
+
+func (s *errorSink) Close(bool) {}
+
+func (s *errorSink) Run(context.Context) error { return s.err }
 
 // createTestDispatcher creates a test dispatcher with given parameters
 func createTestDispatcher(t *testing.T, manager *DispatcherManager, id common.DispatcherID, tableID int64, startKey, endKey []byte) *dispatcher.EventDispatcher {
@@ -127,6 +148,27 @@ func createTestManager(t *testing.T) *DispatcherManager {
 	ec := eventcollector.New(nodeID)
 	appcontext.SetService(appcontext.EventCollector, ec)
 	return manager
+}
+
+func TestDispatcherManagerCloseOnSinkError(t *testing.T) {
+	// Scenario: the sink exits with a non-canceled error (e.g., Kafka topic missing / auth failures).
+	// Steps:
+	// 1) Run the sink with exit handling enabled.
+	// 2) Expect the dispatcher manager to close itself to prevent unbounded buffering into the sink.
+	manager := createTestManager(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	manager.ctx = ctx
+	manager.cancel = cancel
+	manager.sink = &errorSink{err: perrors.New("sink error")}
+
+	hbCollector := NewHeartBeatCollector(node.NewID())
+	appcontext.SetService(appcontext.HeartbeatCollector, hbCollector)
+	require.NoError(t, hbCollector.RegisterDispatcherManager(manager))
+
+	go manager.runSinkWithExitHandling(ctx)
+
+	require.Eventually(t, func() bool { return manager.closed.Load() }, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestCollectComponentStatusWhenChangedWatermarkSeqNoFallback(t *testing.T) {

--- a/pkg/leakutil/leak_helper.go
+++ b/pkg/leakutil/leak_helper.go
@@ -24,11 +24,17 @@ var defaultOpts = []goleak.Option{
 	goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
 	goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 	goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
+	// Some systemd helpers keep a long-lived dbus connection with a background worker goroutine.
+	// The stack top is usually runtime_pollWait, so match by any-frame.
+	goleak.IgnoreAnyFunction("github.com/godbus/dbus.(*Conn).inWorker"),
+	goleak.IgnoreAnyFunction("github.com/godbus/dbus/v5.(*Conn).inWorker"),
 	// library used by sarama, ref: https://github.com/rcrowley/go-metrics/pull/266
 	goleak.IgnoreTopFunction("github.com/rcrowley/go-metrics.(*meterArbiter).tick"),
 	// Because we close the sarama producer asynchronously, so we have to ignore these funcs.
 	goleak.IgnoreTopFunction("github.com/Shopify/sarama.(*client).backgroundMetadataUpdater"),
 	goleak.IgnoreTopFunction("github.com/Shopify/sarama.(*Broker).responseReceiver"),
+	goleak.IgnoreTopFunction("github.com/IBM/sarama.(*client).backgroundMetadataUpdater"),
+	goleak.IgnoreTopFunction("github.com/IBM/sarama.(*Broker).responseReceiver"),
 	goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
 }
 

--- a/pkg/sink/kafka/admin_test.go
+++ b/pkg/sink/kafka/admin_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/stretchr/testify/require"
+)
+
+type testSaramaClient struct {
+	closed bool
+}
+
+func (c *testSaramaClient) Brokers() []*sarama.Broker {
+	return nil
+}
+
+func (c *testSaramaClient) Partitions(string) ([]int32, error) {
+	return nil, nil
+}
+
+func (c *testSaramaClient) Close() error {
+	c.closed = true
+	return nil
+}
+
+type testSaramaClusterAdmin struct {
+	closed bool
+}
+
+func (a *testSaramaClusterAdmin) DescribeCluster() ([]*sarama.Broker, int32, error) {
+	return nil, 0, nil
+}
+
+func (a *testSaramaClusterAdmin) DescribeConfig(sarama.ConfigResource) ([]sarama.ConfigEntry, error) {
+	return nil, nil
+}
+
+func (a *testSaramaClusterAdmin) DescribeTopics([]string) ([]*sarama.TopicMetadata, error) {
+	return nil, nil
+}
+
+func (a *testSaramaClusterAdmin) CreateTopic(string, *sarama.TopicDetail, bool) error {
+	return nil
+}
+
+func (a *testSaramaClusterAdmin) Close() error {
+	a.closed = true
+	return nil
+}
+
+func TestSaramaAdminClientCloseClosesAdminAndClient(t *testing.T) {
+	// Scenario: Closing the admin wrapper must close both the sarama admin and the
+	// underlying sarama client, otherwise sarama background goroutines (metadata updater)
+	// and their in-memory caches/metrics can be leaked across changefeed restarts.
+	//
+	// Steps:
+	// 1. Create a wrapper with a fake admin and fake client.
+	// 2. Call Close().
+	// 3. Verify both Close calls are executed.
+	client := &testSaramaClient{}
+	admin := &testSaramaClusterAdmin{}
+	a := &saramaAdminClient{
+		changefeed: common.NewChangeFeedIDWithName("test", "default"),
+		client:     client,
+		admin:      admin,
+	}
+	a.Close()
+	require.True(t, admin.closed)
+	require.True(t, client.closed)
+}
+
+func TestSaramaAdminClientCloseToleratesNilFields(t *testing.T) {
+	// Scenario: Close should be safe even if admin/client has already been cleared.
+	//
+	// Steps:
+	// 1. Call Close() on wrappers with nil admin or nil client.
+	// 2. Ensure Close does not panic and still closes the non-nil field.
+	client := &testSaramaClient{}
+	a := &saramaAdminClient{
+		changefeed: common.NewChangeFeedIDWithName("test", "default"),
+		client:     client,
+		admin:      nil,
+	}
+	require.NotPanics(t, func() { a.Close() })
+	require.True(t, client.closed)
+
+	admin := &testSaramaClusterAdmin{}
+	b := &saramaAdminClient{
+		changefeed: common.NewChangeFeedIDWithName("test", "default"),
+		client:     nil,
+		admin:      admin,
+	}
+	require.NotPanics(t, func() { b.Close() })
+	require.True(t, admin.closed)
+}

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -88,6 +88,9 @@ func newAdminClient(changefeedID common.ChangeFeedID, endpoints []string, config
 			zap.Any("duration", duration), zap.Stringer("changefeedID", changefeedID))
 	}
 	if err != nil {
+		// `sarama.NewClusterAdminFromClient` does not take ownership of the client,
+		// so we need to close it on failures to avoid leaking background goroutines.
+		_ = client.Close()
 		return nil, errors.Trace(err)
 	}
 	return &saramaAdminClient{


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #4064

### What is changed and how it works?

When the downstream Kafka topic is missing (and `auto-create-topic` is disabled), changefeed staying in `warning` / retrying is expected. However, TiCDC could still hit CPU/memory runaway and OOM.

This PR fixes the runaway from two angles:

1. Close DispatcherManager when the sink goroutine exits unexpectedly
   - Run the sink via `runSinkWithExitHandling`.
   - If `sink.Run(ctx)` returns with a non-cancel error, report the error to maintainer and close the DispatcherManager proactively, so dispatchers stop pulling/enqueuing events instead of buffering into unbounded channels.

2. Release sarama admin resources reliably on close
   - `saramaAdminClient.Close()` now closes the underlying `sarama.Client` in addition to `ClusterAdmin`, which stops sarama background goroutines (metadata updater, broker receivers) and releases associated metrics/metadata caches.
   - Close the sarama client on `NewClusterAdminFromClient` failure to avoid leaking on error paths.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. The new close path only triggers when the sink exits unexpectedly. The admin close change only makes resource cleanup more complete.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix TiCDC Kafka sink CPU/memory runaway when downstream topic is missing by stopping buffering on sink exit and properly closing sarama admin clients.
```
