### PR TITLE
[DNM] redo: support 2 staged ack 

### DIFF
--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -42,8 +42,8 @@ type Sink struct {
 	ddlWriter writer.RedoLogWriter
 	dmlWriter writer.RedoLogWriter
 
-	logBuffer *chann.UnlimitedChannel[*redoLogTask, any]
-	inflight  *inflightRowTracker
+	tasks *chann.UnlimitedChannel[*sinkTask, any]
+	flush *flushTracker
 
 	// isNormal indicate whether the sink is in the normal state.
 	isNormal *atomic.Bool
@@ -52,103 +52,146 @@ type Sink struct {
 	metric *redoSinkMetrics
 }
 
-type redoLogTask struct {
-	event   writer.RedoEvent
-	barrier *flushBarrier
+type sinkTask struct {
+	dispatcherID common.DispatcherID
+	seq          uint64
+	event        writer.RedoEvent
+	barrier      *barrierTask
 }
 
-func newRedoEventTask(event writer.RedoEvent) *redoLogTask {
-	return &redoLogTask{event: event}
+func newRowTask(dispatcherID common.DispatcherID, seq uint64, event writer.RedoEvent) *sinkTask {
+	return &sinkTask{
+		dispatcherID: dispatcherID,
+		seq:          seq,
+		event:        event,
+	}
 }
 
-func newFlushBarrierTask() *redoLogTask {
-	return &redoLogTask{barrier: newFlushBarrier()}
+func newBarrierTask(dispatcherID common.DispatcherID) *sinkTask {
+	return &sinkTask{
+		dispatcherID: dispatcherID,
+		barrier:      newBarrier(dispatcherID),
+	}
 }
 
-func (t *redoLogTask) isBarrier() bool {
+func (t *sinkTask) isBarrier() bool {
 	return t != nil && t.barrier != nil
 }
 
-type flushBarrier struct {
-	done chan struct{}
+type barrierTask struct {
+	dispatcherID common.DispatcherID
+	target       uint64
+	done         chan struct{}
 }
 
-type inflightRowTracker struct {
-	mu      sync.Mutex
-	rows    int
-	drained chan struct{}
+type flushTracker struct {
+	mu     sync.Mutex
+	states map[common.DispatcherID]*dispatcherState
+	err    error
+	errCh  chan struct{}
 }
 
-func newFlushBarrier() *flushBarrier {
-	return &flushBarrier{
-		done: make(chan struct{}),
+type dispatcherState struct {
+	mu         sync.Mutex
+	nextSeq    uint64
+	flushedSeq uint64
+	pending    map[uint64]struct{}
+	changed    chan struct{}
+}
+
+func newBarrier(dispatcherID common.DispatcherID) *barrierTask {
+	return &barrierTask{
+		dispatcherID: dispatcherID,
+		done:         make(chan struct{}),
 	}
 }
 
-func newInflightRowTracker() *inflightRowTracker {
-	drained := make(chan struct{})
-	close(drained)
-	return &inflightRowTracker{
-		drained: drained,
+func newFlushTracker() *flushTracker {
+	return &flushTracker{
+		states: make(map[common.DispatcherID]*dispatcherState),
+		errCh:  make(chan struct{}),
 	}
 }
 
-func (b *flushBarrier) finish() {
-	close(b.done)
+func newDispatcherState() *dispatcherState {
+	return &dispatcherState{
+		changed: make(chan struct{}),
+	}
 }
 
-func (b *flushBarrier) wait(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return errors.Trace(context.Cause(ctx))
-	case <-b.done:
+func (t *flushTracker) state(dispatcherID common.DispatcherID) *dispatcherState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if state, ok := t.states[dispatcherID]; ok {
+		return state
+	}
+
+	state := newDispatcherState()
+	t.states[dispatcherID] = state
+	return state
+}
+
+func (s *dispatcherState) nextRow() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.nextSeq++
+	return s.nextSeq
+}
+
+func (s *dispatcherState) markFlushed(seq uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if seq <= s.flushedSeq {
+		return
+	}
+	if seq == s.flushedSeq+1 {
+		s.flushedSeq = seq
+		for {
+			nextSeq := s.flushedSeq + 1
+			if _, ok := s.pending[nextSeq]; !ok {
+				break
+			}
+			delete(s.pending, nextSeq)
+			s.flushedSeq = nextSeq
+		}
+		close(s.changed)
+		s.changed = make(chan struct{})
+		return
+	}
+	if s.pending == nil {
+		s.pending = make(map[uint64]struct{})
+	}
+	s.pending[seq] = struct{}{}
+}
+
+func (s *dispatcherState) wait(
+	ctx context.Context,
+	errCh <-chan struct{},
+	loadErr func() error,
+	target uint64,
+) error {
+	if target == 0 {
 		return nil
 	}
-}
 
-func (t *inflightRowTracker) add(count int) {
-	if count <= 0 {
-		return
-	}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if t.rows == 0 {
-		t.drained = make(chan struct{})
-	}
-	t.rows += count
-}
-
-func (t *inflightRowTracker) done() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.rows--
-	if t.rows > 0 {
-		return
-	}
-	if t.rows < 0 {
-		t.rows = 0
-		log.Warn("redo sink inflight rows regressed")
-	}
-	close(t.drained)
-}
-
-func (t *inflightRowTracker) waitZero(ctx context.Context) error {
 	for {
-		t.mu.Lock()
-		if t.rows == 0 {
-			t.mu.Unlock()
+		s.mu.Lock()
+		if s.flushedSeq >= target {
+			s.mu.Unlock()
 			return nil
 		}
-		drained := t.drained
-		t.mu.Unlock()
+		changed := s.changed
+		s.mu.Unlock()
 
 		select {
 		case <-ctx.Done():
 			return errors.Trace(context.Cause(ctx))
-		case <-drained:
+		case <-errCh:
+			return errors.Trace(loadErr())
+		case <-changed:
 		}
 	}
 }
@@ -158,6 +201,52 @@ func Verify(ctx context.Context, changefeedID common.ChangeFeedID, cfg *config.C
 		return nil
 	}
 	return nil
+}
+
+func (b *barrierTask) finish(target uint64) {
+	b.target = target
+	close(b.done)
+}
+
+func (t *flushTracker) fail(err error) {
+	if err == nil {
+		err = context.Canceled
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.err != nil {
+		return
+	}
+	t.err = err
+	close(t.errCh)
+}
+
+func (t *flushTracker) loadErr() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.err == nil {
+		return context.Canceled
+	}
+	return t.err
+}
+
+func (t *flushTracker) waitBarrier(
+	ctx context.Context,
+	state *dispatcherState,
+	barrier *barrierTask,
+) error {
+	select {
+	case <-ctx.Done():
+		return errors.Trace(context.Cause(ctx))
+	case <-t.errCh:
+		return errors.Trace(t.loadErr())
+	case <-barrier.done:
+	}
+
+	return state.wait(ctx, t.errCh, t.loadErr, barrier.target)
 }
 
 // New creates a new redo sink.
@@ -172,10 +261,10 @@ func New(ctx context.Context, changefeedID common.ChangeFeedID,
 			ChangeFeedID:      changefeedID,
 			MaxLogSizeInBytes: util.GetOrZero(cfg.MaxLogSize) * redo.Megabyte,
 		},
-		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
-		inflight:  newInflightRowTracker(),
-		isNormal:  atomic.NewBool(true),
-		isClosed:  atomic.NewBool(false),
+		tasks:    chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:    newFlushTracker(),
+		isNormal: atomic.NewBool(true),
+		isClosed: atomic.NewBool(false),
 	}
 	start := time.Now()
 	ddlWriter, err := factory.NewRedoLogWriter(s.ctx, s.cfg, redo.RedoDDLLogFileType)
@@ -205,8 +294,12 @@ func New(ctx context.Context, changefeedID common.ChangeFeedID,
 func (s *Sink) Run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		defer s.logBuffer.Close()
-		return s.dmlWriter.Run(ctx)
+		defer s.tasks.Close()
+		err := s.dmlWriter.Run(ctx)
+		if err != nil && errors.Cause(err) != context.Canceled && errors.Cause(err) != context.DeadlineExceeded {
+			s.flush.fail(err)
+		}
+		return err
 	})
 	g.Go(func() error {
 		return s.sendMessages(ctx)
@@ -220,9 +313,11 @@ func (s *Sink) FlushDMLBeforeBlock(event commonEvent.BlockEvent) error {
 	if event == nil {
 		return nil
 	}
-	barrierTask := newFlushBarrierTask()
-	s.logBuffer.Push(barrierTask)
-	return barrierTask.barrier.wait(s.ctx)
+	dispatcherID := event.GetDispatcherID()
+	state := s.flush.state(dispatcherID)
+	task := newBarrierTask(dispatcherID)
+	s.tasks.Push(task)
+	return s.flush.waitBarrier(s.ctx, state, task.barrier)
 }
 
 func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
@@ -249,7 +344,9 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 		return
 	}
 
-	tasks := make([]*redoLogTask, 0, rowsCount)
+	dispatcherID := event.GetDispatcherID()
+	state := s.flush.state(dispatcherID)
+	tasks := make([]*sinkTask, 0, rowsCount)
 	rowCallback := helper.NewTxnPostFlushRowCallback(event, uint64(rowsCount))
 
 	for {
@@ -258,19 +355,20 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 			event.Rewind()
 			break
 		}
-		tasks = append(tasks, newRedoEventTask(&commonEvent.RedoRowEvent{
+		rowSeq := state.nextRow()
+		tasks = append(tasks, newRowTask(dispatcherID, rowSeq, &commonEvent.RedoRowEvent{
 			StartTs:         event.StartTs,
 			CommitTs:        event.CommitTs,
 			Event:           row,
 			PhysicalTableID: event.PhysicalTableID,
 			TableInfo:       event.TableInfo,
 			Callback: func() {
-				s.inflight.done()
+				state.markFlushed(rowSeq)
 				rowCallback()
 			},
 		}))
 	}
-	s.logBuffer.Push(tasks...)
+	s.tasks.Push(tasks...)
 	event.PostEnqueue()
 }
 
@@ -290,7 +388,8 @@ func (s *Sink) Close(_ bool) {
 	if !s.isClosed.CompareAndSwap(false, true) {
 		return
 	}
-	s.logBuffer.Close()
+	s.flush.fail(context.Canceled)
+	s.tasks.Close()
 	if s.ddlWriter != nil {
 		if err := s.ddlWriter.Close(); err != nil && errors.Cause(err) != context.Canceled {
 			log.Error("redo sink fails to close ddl writer",
@@ -316,25 +415,28 @@ func (s *Sink) Close(_ bool) {
 }
 
 func (s *Sink) sendMessages(ctx context.Context) error {
-	taskBuffer := make([]*redoLogTask, 0, redo.DefaultFlushBatchSize)
-	pendingTasks := make([]*redoLogTask, 0, redo.DefaultFlushBatchSize)
+	taskBuffer := make([]*sinkTask, 0, redo.DefaultFlushBatchSize)
+	pendingTasks := make([]*sinkTask, 0, redo.DefaultFlushBatchSize)
 	eventBuffer := make([]writer.RedoEvent, 0, redo.DefaultFlushBatchSize)
-	flushBufferedEvents := func() error {
-		if len(eventBuffer) == 0 {
+	deferredTasks := make([]*sinkTask, 0, redo.DefaultFlushBatchSize)
+	lastSeenSeq := make(map[common.DispatcherID]uint64)
+	writeRows := func(events []writer.RedoEvent) error {
+		if len(events) == 0 {
 			return nil
 		}
 
-		s.inflight.add(len(eventBuffer))
 		start := time.Now()
-		err := s.dmlWriter.WriteEvents(ctx, eventBuffer...)
+		err := s.dmlWriter.WriteEvents(ctx, events...)
 		if err != nil {
+			if errors.Cause(err) != context.Canceled && errors.Cause(err) != context.DeadlineExceeded {
+				s.flush.fail(err)
+			}
 			return err
 		}
 
 		if s.metric != nil {
-			s.metric.observeRowWrite(len(eventBuffer), time.Since(start))
+			s.metric.observeRowWrite(len(events), time.Since(start))
 		}
-		eventBuffer = eventBuffer[:0]
 		return nil
 	}
 
@@ -345,7 +447,7 @@ func (s *Sink) sendMessages(ctx context.Context) error {
 		default:
 		}
 		var (
-			tasks []*redoLogTask
+			tasks []*sinkTask
 			ok    bool
 		)
 		if len(pendingTasks) > 0 {
@@ -353,40 +455,52 @@ func (s *Sink) sendMessages(ctx context.Context) error {
 			pendingTasks = pendingTasks[:0]
 			ok = true
 		} else {
-			tasks, ok = s.logBuffer.GetMultipleNoGroup(taskBuffer)
+			tasks, ok = s.tasks.GetMultipleNoGroup(taskBuffer)
 		}
 		if !ok {
-			return flushBufferedEvents()
+			return nil
 		}
 		if len(tasks) == 0 {
 			continue
 		}
 
 		barrierIndex := -1
+		barrierDispatcherID := common.DispatcherID{}
+		eventBuffer = eventBuffer[:0]
+		deferredTasks = deferredTasks[:0]
 		for i, task := range tasks {
 			if task.isBarrier() {
 				barrierIndex = i
+				barrierDispatcherID = task.dispatcherID
 				break
 			}
+			lastSeenSeq[task.dispatcherID] = task.seq
 			eventBuffer = append(eventBuffer, task.event)
 		}
 		taskBuffer = tasks[:0]
 
 		if barrierIndex >= 0 {
+			eventBuffer = eventBuffer[:0]
+			for _, task := range tasks[:barrierIndex] {
+				if task.dispatcherID == barrierDispatcherID {
+					eventBuffer = append(eventBuffer, task.event)
+					continue
+				}
+				deferredTasks = append(deferredTasks, task)
+			}
 			if barrierIndex+1 < len(tasks) {
-				pendingTasks = append(pendingTasks, tasks[barrierIndex+1:]...)
+				deferredTasks = append(deferredTasks, tasks[barrierIndex+1:]...)
 			}
-			if err := flushBufferedEvents(); err != nil {
+
+			if err := writeRows(eventBuffer); err != nil {
 				return err
 			}
-			if err := s.inflight.waitZero(s.ctx); err != nil {
-				return err
-			}
-			tasks[barrierIndex].barrier.finish()
+			pendingTasks = append(pendingTasks[:0], deferredTasks...)
+			tasks[barrierIndex].barrier.finish(lastSeenSeq[barrierDispatcherID])
 			continue
 		}
 
-		if err := flushBufferedEvents(); err != nil {
+		if err := writeRows(eventBuffer); err != nil {
 			return err
 		}
 	}

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -15,6 +15,7 @@ package redo
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/pingcap/log"
@@ -41,13 +42,115 @@ type Sink struct {
 	ddlWriter writer.RedoLogWriter
 	dmlWriter writer.RedoLogWriter
 
-	logBuffer *chann.UnlimitedChannel[writer.RedoEvent, any]
+	logBuffer *chann.UnlimitedChannel[*redoLogTask, any]
+	inflight  *inflightRowTracker
 
 	// isNormal indicate whether the sink is in the normal state.
 	isNormal *atomic.Bool
 	isClosed *atomic.Bool
 
 	metric *redoSinkMetrics
+}
+
+type redoLogTask struct {
+	event   writer.RedoEvent
+	barrier *flushBarrier
+}
+
+func newRedoEventTask(event writer.RedoEvent) *redoLogTask {
+	return &redoLogTask{event: event}
+}
+
+func newFlushBarrierTask() *redoLogTask {
+	return &redoLogTask{barrier: newFlushBarrier()}
+}
+
+func (t *redoLogTask) isBarrier() bool {
+	return t != nil && t.barrier != nil
+}
+
+type flushBarrier struct {
+	done chan struct{}
+}
+
+type inflightRowTracker struct {
+	mu      sync.Mutex
+	rows    int
+	drained chan struct{}
+}
+
+func newFlushBarrier() *flushBarrier {
+	return &flushBarrier{
+		done: make(chan struct{}),
+	}
+}
+
+func newInflightRowTracker() *inflightRowTracker {
+	drained := make(chan struct{})
+	close(drained)
+	return &inflightRowTracker{
+		drained: drained,
+	}
+}
+
+func (b *flushBarrier) finish() {
+	close(b.done)
+}
+
+func (b *flushBarrier) wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return errors.Trace(context.Cause(ctx))
+	case <-b.done:
+		return nil
+	}
+}
+
+func (t *inflightRowTracker) add(count int) {
+	if count <= 0 {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.rows == 0 {
+		t.drained = make(chan struct{})
+	}
+	t.rows += count
+}
+
+func (t *inflightRowTracker) done() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.rows--
+	if t.rows > 0 {
+		return
+	}
+	if t.rows < 0 {
+		t.rows = 0
+		log.Warn("redo sink inflight rows regressed")
+	}
+	close(t.drained)
+}
+
+func (t *inflightRowTracker) waitZero(ctx context.Context) error {
+	for {
+		t.mu.Lock()
+		if t.rows == 0 {
+			t.mu.Unlock()
+			return nil
+		}
+		drained := t.drained
+		t.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return errors.Trace(context.Cause(ctx))
+		case <-drained:
+		}
+	}
 }
 
 func Verify(ctx context.Context, changefeedID common.ChangeFeedID, cfg *config.ConsistentConfig) error {
@@ -69,7 +172,8 @@ func New(ctx context.Context, changefeedID common.ChangeFeedID,
 			ChangeFeedID:      changefeedID,
 			MaxLogSizeInBytes: util.GetOrZero(cfg.MaxLogSize) * redo.Megabyte,
 		},
-		logBuffer: chann.NewUnlimitedChannelDefault[writer.RedoEvent](),
+		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
+		inflight:  newInflightRowTracker(),
 		isNormal:  atomic.NewBool(true),
 		isClosed:  atomic.NewBool(false),
 	}
@@ -112,8 +216,13 @@ func (s *Sink) Run(ctx context.Context) error {
 	return err
 }
 
-func (s *Sink) FlushDMLBeforeBlock(_ commonEvent.BlockEvent) error {
-	return nil
+func (s *Sink) FlushDMLBeforeBlock(event commonEvent.BlockEvent) error {
+	if event == nil {
+		return nil
+	}
+	barrierTask := newFlushBarrierTask()
+	s.logBuffer.Push(barrierTask)
+	return barrierTask.barrier.wait(s.ctx)
 }
 
 func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
@@ -134,7 +243,13 @@ func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 
 func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	rowsCount := event.Len()
-	events := make([]writer.RedoEvent, 0, rowsCount)
+	if rowsCount == 0 {
+		event.PostEnqueue()
+		event.PostFlush()
+		return
+	}
+
+	tasks := make([]*redoLogTask, 0, rowsCount)
 	rowCallback := helper.NewTxnPostFlushRowCallback(event, uint64(rowsCount))
 
 	for {
@@ -143,16 +258,20 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 			event.Rewind()
 			break
 		}
-		events = append(events, &commonEvent.RedoRowEvent{
+		tasks = append(tasks, newRedoEventTask(&commonEvent.RedoRowEvent{
 			StartTs:         event.StartTs,
 			CommitTs:        event.CommitTs,
 			Event:           row,
 			PhysicalTableID: event.PhysicalTableID,
 			TableInfo:       event.TableInfo,
-			Callback:        rowCallback,
-		})
+			Callback: func() {
+				s.inflight.done()
+				rowCallback()
+			},
+		}))
 	}
-	s.logBuffer.Push(events...)
+	s.logBuffer.Push(tasks...)
+	event.PostEnqueue()
 }
 
 func (s *Sink) IsNormal() bool {
@@ -197,30 +316,78 @@ func (s *Sink) Close(_ bool) {
 }
 
 func (s *Sink) sendMessages(ctx context.Context) error {
-	buffer := make([]writer.RedoEvent, 0, redo.DefaultFlushBatchSize)
+	taskBuffer := make([]*redoLogTask, 0, redo.DefaultFlushBatchSize)
+	pendingTasks := make([]*redoLogTask, 0, redo.DefaultFlushBatchSize)
+	eventBuffer := make([]writer.RedoEvent, 0, redo.DefaultFlushBatchSize)
+	flushBufferedEvents := func() error {
+		if len(eventBuffer) == 0 {
+			return nil
+		}
+
+		s.inflight.add(len(eventBuffer))
+		start := time.Now()
+		err := s.dmlWriter.WriteEvents(ctx, eventBuffer...)
+		if err != nil {
+			return err
+		}
+
+		if s.metric != nil {
+			s.metric.observeRowWrite(len(eventBuffer), time.Since(start))
+		}
+		eventBuffer = eventBuffer[:0]
+		return nil
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
 		default:
 		}
-		events, ok := s.logBuffer.GetMultipleNoGroup(buffer)
-		if !ok {
-			return nil
+		var (
+			tasks []*redoLogTask
+			ok    bool
+		)
+		if len(pendingTasks) > 0 {
+			tasks = pendingTasks
+			pendingTasks = pendingTasks[:0]
+			ok = true
+		} else {
+			tasks, ok = s.logBuffer.GetMultipleNoGroup(taskBuffer)
 		}
-		if len(events) == 0 {
+		if !ok {
+			return flushBufferedEvents()
+		}
+		if len(tasks) == 0 {
 			continue
 		}
-		buffer = events[:0]
 
-		start := time.Now()
-		err := s.dmlWriter.WriteEvents(ctx, events...)
-		if err != nil {
-			return err
+		barrierIndex := -1
+		for i, task := range tasks {
+			if task.isBarrier() {
+				barrierIndex = i
+				break
+			}
+			eventBuffer = append(eventBuffer, task.event)
+		}
+		taskBuffer = tasks[:0]
+
+		if barrierIndex >= 0 {
+			if barrierIndex+1 < len(tasks) {
+				pendingTasks = append(pendingTasks, tasks[barrierIndex+1:]...)
+			}
+			if err := flushBufferedEvents(); err != nil {
+				return err
+			}
+			if err := s.inflight.waitZero(s.ctx); err != nil {
+				return err
+			}
+			tasks[barrierIndex].barrier.finish()
+			continue
 		}
 
-		if s.metric != nil {
-			s.metric.observeRowWrite(len(events), time.Since(start))
+		if err := flushBufferedEvents(); err != nil {
+			return err
 		}
 	}
 }

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -42,7 +42,7 @@ type Sink struct {
 	ddlWriter writer.RedoLogWriter
 	dmlWriter writer.RedoLogWriter
 
-	tasks *chann.UnlimitedChannel[*sinkTask, any]
+	tasks *chann.UnlimitedChannel[*task, any]
 	flush *flushTracker
 
 	// isNormal indicate whether the sink is in the normal state.
@@ -52,46 +52,45 @@ type Sink struct {
 	metric *redoSinkMetrics
 }
 
-type sinkTask struct {
+type task struct {
 	dispatcherID common.DispatcherID
 	seq          uint64
 	event        writer.RedoEvent
-	barrier      *barrierTask
+	barrier      *barrier
 }
 
-func newRowTask(dispatcherID common.DispatcherID, seq uint64, event writer.RedoEvent) *sinkTask {
-	return &sinkTask{
+func newRowTask(dispatcherID common.DispatcherID, seq uint64, event writer.RedoEvent) *task {
+	return &task{
 		dispatcherID: dispatcherID,
 		seq:          seq,
 		event:        event,
 	}
 }
 
-func newBarrierTask(dispatcherID common.DispatcherID) *sinkTask {
-	return &sinkTask{
+func newBarrierTask(dispatcherID common.DispatcherID) *task {
+	return &task{
 		dispatcherID: dispatcherID,
-		barrier:      newBarrier(dispatcherID),
+		barrier:      newBarrier(),
 	}
 }
 
-func (t *sinkTask) isBarrier() bool {
+func (t *task) isBarrier() bool {
 	return t != nil && t.barrier != nil
 }
 
-type barrierTask struct {
-	dispatcherID common.DispatcherID
-	target       uint64
-	done         chan struct{}
+type barrier struct {
+	target uint64
+	done   chan struct{}
 }
 
 type flushTracker struct {
 	mu     sync.Mutex
-	states map[common.DispatcherID]*dispatcherState
+	states map[common.DispatcherID]*flushState
 	err    error
 	errCh  chan struct{}
 }
 
-type dispatcherState struct {
+type flushState struct {
 	mu         sync.Mutex
 	nextSeq    uint64
 	flushedSeq uint64
@@ -99,27 +98,26 @@ type dispatcherState struct {
 	changed    chan struct{}
 }
 
-func newBarrier(dispatcherID common.DispatcherID) *barrierTask {
-	return &barrierTask{
-		dispatcherID: dispatcherID,
-		done:         make(chan struct{}),
+func newBarrier() *barrier {
+	return &barrier{
+		done: make(chan struct{}),
 	}
 }
 
 func newFlushTracker() *flushTracker {
 	return &flushTracker{
-		states: make(map[common.DispatcherID]*dispatcherState),
+		states: make(map[common.DispatcherID]*flushState),
 		errCh:  make(chan struct{}),
 	}
 }
 
-func newDispatcherState() *dispatcherState {
-	return &dispatcherState{
+func newFlushState() *flushState {
+	return &flushState{
 		changed: make(chan struct{}),
 	}
 }
 
-func (t *flushTracker) state(dispatcherID common.DispatcherID) *dispatcherState {
+func (t *flushTracker) state(dispatcherID common.DispatcherID) *flushState {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -127,12 +125,17 @@ func (t *flushTracker) state(dispatcherID common.DispatcherID) *dispatcherState 
 		return state
 	}
 
-	state := newDispatcherState()
+	state := newFlushState()
 	t.states[dispatcherID] = state
 	return state
 }
 
-func (s *dispatcherState) nextRow() uint64 {
+func (t *flushTracker) alloc(dispatcherID common.DispatcherID) uint64 {
+	state := t.state(dispatcherID)
+	return state.next()
+}
+
+func (s *flushState) next() uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -140,7 +143,11 @@ func (s *dispatcherState) nextRow() uint64 {
 	return s.nextSeq
 }
 
-func (s *dispatcherState) markFlushed(seq uint64) {
+func (t *flushTracker) ack(dispatcherID common.DispatcherID, seq uint64) {
+	t.state(dispatcherID).ack(seq)
+}
+
+func (s *flushState) ack(seq uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -167,7 +174,15 @@ func (s *dispatcherState) markFlushed(seq uint64) {
 	s.pending[seq] = struct{}{}
 }
 
-func (s *dispatcherState) wait(
+func (t *flushTracker) wait(
+	ctx context.Context,
+	dispatcherID common.DispatcherID,
+	target uint64,
+) error {
+	return t.state(dispatcherID).wait(ctx, t.errCh, t.loadErr, target)
+}
+
+func (s *flushState) wait(
 	ctx context.Context,
 	errCh <-chan struct{},
 	loadErr func() error,
@@ -203,7 +218,7 @@ func Verify(ctx context.Context, changefeedID common.ChangeFeedID, cfg *config.C
 	return nil
 }
 
-func (b *barrierTask) finish(target uint64) {
+func (b *barrier) finish(target uint64) {
 	b.target = target
 	close(b.done)
 }
@@ -235,8 +250,8 @@ func (t *flushTracker) loadErr() error {
 
 func (t *flushTracker) waitBarrier(
 	ctx context.Context,
-	state *dispatcherState,
-	barrier *barrierTask,
+	dispatcherID common.DispatcherID,
+	barrier *barrier,
 ) error {
 	select {
 	case <-ctx.Done():
@@ -246,7 +261,7 @@ func (t *flushTracker) waitBarrier(
 	case <-barrier.done:
 	}
 
-	return state.wait(ctx, t.errCh, t.loadErr, barrier.target)
+	return t.wait(ctx, dispatcherID, barrier.target)
 }
 
 // New creates a new redo sink.
@@ -261,7 +276,7 @@ func New(ctx context.Context, changefeedID common.ChangeFeedID,
 			ChangeFeedID:      changefeedID,
 			MaxLogSizeInBytes: util.GetOrZero(cfg.MaxLogSize) * redo.Megabyte,
 		},
-		tasks:    chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:    chann.NewUnlimitedChannelDefault[*task](),
 		flush:    newFlushTracker(),
 		isNormal: atomic.NewBool(true),
 		isClosed: atomic.NewBool(false),
@@ -314,10 +329,9 @@ func (s *Sink) FlushDMLBeforeBlock(event commonEvent.BlockEvent) error {
 		return nil
 	}
 	dispatcherID := event.GetDispatcherID()
-	state := s.flush.state(dispatcherID)
 	task := newBarrierTask(dispatcherID)
 	s.tasks.Push(task)
-	return s.flush.waitBarrier(s.ctx, state, task.barrier)
+	return s.flush.waitBarrier(s.ctx, dispatcherID, task.barrier)
 }
 
 func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
@@ -345,8 +359,7 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	}
 
 	dispatcherID := event.GetDispatcherID()
-	state := s.flush.state(dispatcherID)
-	tasks := make([]*sinkTask, 0, rowsCount)
+	tasks := make([]*task, 0, rowsCount)
 	rowCallback := helper.NewTxnPostFlushRowCallback(event, uint64(rowsCount))
 
 	for {
@@ -355,7 +368,7 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 			event.Rewind()
 			break
 		}
-		rowSeq := state.nextRow()
+		rowSeq := s.flush.alloc(dispatcherID)
 		tasks = append(tasks, newRowTask(dispatcherID, rowSeq, &commonEvent.RedoRowEvent{
 			StartTs:         event.StartTs,
 			CommitTs:        event.CommitTs,
@@ -363,7 +376,7 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 			PhysicalTableID: event.PhysicalTableID,
 			TableInfo:       event.TableInfo,
 			Callback: func() {
-				state.markFlushed(rowSeq)
+				s.flush.ack(dispatcherID, rowSeq)
 				rowCallback()
 			},
 		}))
@@ -415,10 +428,10 @@ func (s *Sink) Close(_ bool) {
 }
 
 func (s *Sink) sendMessages(ctx context.Context) error {
-	taskBuffer := make([]*sinkTask, 0, redo.DefaultFlushBatchSize)
-	pendingTasks := make([]*sinkTask, 0, redo.DefaultFlushBatchSize)
+	taskBuffer := make([]*task, 0, redo.DefaultFlushBatchSize)
+	pendingTasks := make([]*task, 0, redo.DefaultFlushBatchSize)
 	eventBuffer := make([]writer.RedoEvent, 0, redo.DefaultFlushBatchSize)
-	deferredTasks := make([]*sinkTask, 0, redo.DefaultFlushBatchSize)
+	deferredTasks := make([]*task, 0, redo.DefaultFlushBatchSize)
 	lastSeenSeq := make(map[common.DispatcherID]uint64)
 	writeRows := func(events []writer.RedoEvent) error {
 		if len(events) == 0 {
@@ -447,7 +460,7 @@ func (s *Sink) sendMessages(ctx context.Context) error {
 		default:
 		}
 		var (
-			tasks []*sinkTask
+			tasks []*task
 			ok    bool
 		)
 		if len(pendingTasks) > 0 {

--- a/downstreamadapter/sink/redo/sink_test.go
+++ b/downstreamadapter/sink/redo/sink_test.go
@@ -15,6 +15,7 @@ package redo
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -365,8 +366,8 @@ func TestRedoSinkSendMessagesInBatch(t *testing.T) {
 
 	s := &Sink{
 		dmlWriter: mockWriter,
-		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
-		inflight:  newInflightRowTracker(),
+		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:     newFlushTracker(),
 	}
 
 	doneCh := make(chan error, 1)
@@ -375,12 +376,12 @@ func TestRedoSinkSendMessagesInBatch(t *testing.T) {
 	}()
 
 	totalEvents := redo.DefaultFlushBatchSize*2 + 17
-	events := make([]*redoLogTask, 0, totalEvents)
+	events := make([]*sinkTask, 0, totalEvents)
 	for i := 0; i < totalEvents; i++ {
-		events = append(events, newRedoEventTask(&commonEvent.RedoRowEvent{}))
+		events = append(events, newRowTask(common.NewDispatcherID(), uint64(i+1), &commonEvent.RedoRowEvent{}))
 	}
-	s.logBuffer.Push(events...)
-	s.logBuffer.Close()
+	s.tasks.Push(events...)
+	s.tasks.Close()
 
 	err := <-doneCh
 	require.NoError(t, err)
@@ -434,8 +435,8 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsForSameDispatcherFlush(t *testing.T) {
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
-		inflight:  newInflightRowTracker(),
+		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:     newFlushTracker(),
 	}
 
 	sendDone := make(chan error, 1)
@@ -467,7 +468,110 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsForSameDispatcherFlush(t *testing.T) {
 		t.Fatal("dml event was not flushed")
 	}
 
-	s.logBuffer.Close()
+	s.tasks.Close()
+	require.NoError(t, <-sendDone)
+}
+
+func TestRedoSinkFlushDMLBeforeBlockDoesNotWaitForOtherDispatcher(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table t_flush_other_dispatcher (id int primary key, v int)")
+	require.NotNil(t, job)
+
+	firstDispatcherID := common.NewDispatcherID()
+	secondDispatcherID := common.NewDispatcherID()
+
+	firstEvent := helper.DML2Event("test", "t_flush_other_dispatcher", "insert into t_flush_other_dispatcher values (1, 1)")
+	firstEvent.DispatcherID = firstDispatcherID
+	firstEvent.CommitTs = 101
+
+	secondEvent := helper.DML2Event("test", "t_flush_other_dispatcher", "insert into t_flush_other_dispatcher values (2, 2)")
+	secondEvent.DispatcherID = secondDispatcherID
+	secondEvent.CommitTs = 202
+
+	secondFlushedCh := make(chan struct{}, 1)
+	secondEvent.AddPostFlushFunc(func() {
+		secondFlushedCh <- struct{}{}
+	})
+
+	allowSecondFlush := make(chan struct{})
+
+	mockWriter := writer.NewMockRedoLogWriter(ctrl)
+	mockWriter.EXPECT().
+		WriteEvents(gomock.Any(), gomock.Any()).
+		MinTimes(1).
+		DoAndReturn(func(_ context.Context, events ...writer.RedoEvent) error {
+			for _, event := range events {
+				rowEvent, ok := event.(*commonEvent.RedoRowEvent)
+				require.True(t, ok)
+
+				switch rowEvent.CommitTs {
+				case 101:
+					event.PostFlush()
+				case 202:
+					go func(event writer.RedoEvent) {
+						<-allowSecondFlush
+						event.PostFlush()
+					}(event)
+				default:
+					t.Fatalf("unexpected redo row commit ts %d", rowEvent.CommitTs)
+				}
+			}
+			return nil
+		})
+
+	s := &Sink{
+		ctx:       ctx,
+		dmlWriter: mockWriter,
+		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:     newFlushTracker(),
+	}
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- s.sendMessages(ctx)
+	}()
+
+	s.AddDMLEvent(firstEvent)
+	s.AddDMLEvent(secondEvent)
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- s.FlushDMLBeforeBlock(&commonEvent.DDLEvent{DispatcherID: firstDispatcherID})
+	}()
+
+	select {
+	case err := <-flushDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("FlushDMLBeforeBlock waited for unrelated dispatcher")
+	}
+
+	select {
+	case <-secondFlushedCh:
+		t.Fatal("FlushDMLBeforeBlock forced unrelated dispatcher to flush")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowSecondFlush)
+
+	select {
+	case <-secondFlushedCh:
+	case <-time.After(time.Second):
+		t.Fatal("unrelated dispatcher was not flushed")
+	}
+
+	s.tasks.Close()
 	require.NoError(t, <-sendDone)
 }
 
@@ -523,8 +627,8 @@ func TestRedoSinkPostEnqueueBeforeFlush(t *testing.T) {
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
-		inflight:  newInflightRowTracker(),
+		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:     newFlushTracker(),
 	}
 
 	sendDone := make(chan error, 1)
@@ -556,7 +660,7 @@ func TestRedoSinkPostEnqueueBeforeFlush(t *testing.T) {
 		t.Fatal("dml event was not flushed after redo writer completed")
 	}
 
-	s.logBuffer.Close()
+	s.tasks.Close()
 	require.NoError(t, <-sendDone)
 }
 
@@ -629,8 +733,8 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsOnlyForEarlierEnqueuedDML(t *testing.T)
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
-		inflight:  newInflightRowTracker(),
+		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:     newFlushTracker(),
 	}
 
 	sendDone := make(chan error, 1)
@@ -647,7 +751,7 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsOnlyForEarlierEnqueuedDML(t *testing.T)
 	}()
 
 	require.Eventually(t, func() bool {
-		return s.logBuffer.Len() == 1
+		return s.tasks.Len() == 1
 	}, time.Second, 10*time.Millisecond)
 
 	s.AddDMLEvent(secondEvent)
@@ -675,7 +779,7 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsOnlyForEarlierEnqueuedDML(t *testing.T)
 
 	<-secondWriteStarted
 	close(allowSecondFlush)
-	s.logBuffer.Close()
+	s.tasks.Close()
 	require.NoError(t, <-sendDone)
 }
 
@@ -712,8 +816,8 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsForActualRowFlush(t *testing.T) {
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
-		inflight:  newInflightRowTracker(),
+		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:     newFlushTracker(),
 	}
 
 	sendDone := make(chan error, 1)
@@ -746,6 +850,62 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsForActualRowFlush(t *testing.T) {
 		t.Fatal("FlushDMLBeforeBlock did not wait for actual row flush")
 	}
 
-	s.logBuffer.Close()
+	s.tasks.Close()
 	require.NoError(t, <-sendDone)
+}
+
+func TestRedoSinkFlushDMLBeforeBlockReturnsWriterError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table t_flush_writer_error (id int primary key, v int)")
+	require.NotNil(t, job)
+
+	dispatcherID := common.NewDispatcherID()
+	dmlEvent := helper.DML2Event("test", "t_flush_writer_error", "insert into t_flush_writer_error values (1, 1)")
+	dmlEvent.DispatcherID = dispatcherID
+
+	writerErr := stderrors.New("redo writer failed")
+	mockWriter := writer.NewMockRedoLogWriter(ctrl)
+	mockWriter.EXPECT().
+		WriteEvents(gomock.Any(), gomock.Any()).
+		Return(writerErr)
+
+	s := &Sink{
+		ctx:       ctx,
+		dmlWriter: mockWriter,
+		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		flush:     newFlushTracker(),
+	}
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- s.sendMessages(ctx)
+	}()
+
+	s.AddDMLEvent(dmlEvent)
+	require.ErrorIs(t, <-sendDone, writerErr)
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- s.FlushDMLBeforeBlock(&commonEvent.DDLEvent{DispatcherID: dispatcherID})
+	}()
+
+	select {
+	case err := <-flushDone:
+		require.ErrorIs(t, err, writerErr)
+	case <-time.After(time.Second):
+		t.Fatal("FlushDMLBeforeBlock did not return after writer failure")
+	}
+
+	s.tasks.Close()
 }

--- a/downstreamadapter/sink/redo/sink_test.go
+++ b/downstreamadapter/sink/redo/sink_test.go
@@ -366,7 +366,7 @@ func TestRedoSinkSendMessagesInBatch(t *testing.T) {
 
 	s := &Sink{
 		dmlWriter: mockWriter,
-		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:     chann.NewUnlimitedChannelDefault[*task](),
 		flush:     newFlushTracker(),
 	}
 
@@ -376,7 +376,7 @@ func TestRedoSinkSendMessagesInBatch(t *testing.T) {
 	}()
 
 	totalEvents := redo.DefaultFlushBatchSize*2 + 17
-	events := make([]*sinkTask, 0, totalEvents)
+	events := make([]*task, 0, totalEvents)
 	for i := 0; i < totalEvents; i++ {
 		events = append(events, newRowTask(common.NewDispatcherID(), uint64(i+1), &commonEvent.RedoRowEvent{}))
 	}
@@ -435,7 +435,7 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsForSameDispatcherFlush(t *testing.T) {
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:     chann.NewUnlimitedChannelDefault[*task](),
 		flush:     newFlushTracker(),
 	}
 
@@ -533,7 +533,7 @@ func TestRedoSinkFlushDMLBeforeBlockDoesNotWaitForOtherDispatcher(t *testing.T) 
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:     chann.NewUnlimitedChannelDefault[*task](),
 		flush:     newFlushTracker(),
 	}
 
@@ -627,7 +627,7 @@ func TestRedoSinkPostEnqueueBeforeFlush(t *testing.T) {
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:     chann.NewUnlimitedChannelDefault[*task](),
 		flush:     newFlushTracker(),
 	}
 
@@ -733,7 +733,7 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsOnlyForEarlierEnqueuedDML(t *testing.T)
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:     chann.NewUnlimitedChannelDefault[*task](),
 		flush:     newFlushTracker(),
 	}
 
@@ -816,7 +816,7 @@ func TestRedoSinkFlushDMLBeforeBlockWaitsForActualRowFlush(t *testing.T) {
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:     chann.NewUnlimitedChannelDefault[*task](),
 		flush:     newFlushTracker(),
 	}
 
@@ -883,7 +883,7 @@ func TestRedoSinkFlushDMLBeforeBlockReturnsWriterError(t *testing.T) {
 	s := &Sink{
 		ctx:       ctx,
 		dmlWriter: mockWriter,
-		tasks:     chann.NewUnlimitedChannelDefault[*sinkTask](),
+		tasks:     chann.NewUnlimitedChannelDefault[*task](),
 		flush:     newFlushTracker(),
 	}
 

--- a/downstreamadapter/sink/redo/sink_test.go
+++ b/downstreamadapter/sink/redo/sink_test.go
@@ -365,7 +365,8 @@ func TestRedoSinkSendMessagesInBatch(t *testing.T) {
 
 	s := &Sink{
 		dmlWriter: mockWriter,
-		logBuffer: chann.NewUnlimitedChannelDefault[writer.RedoEvent](),
+		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
+		inflight:  newInflightRowTracker(),
 	}
 
 	doneCh := make(chan error, 1)
@@ -374,13 +375,377 @@ func TestRedoSinkSendMessagesInBatch(t *testing.T) {
 	}()
 
 	totalEvents := redo.DefaultFlushBatchSize*2 + 17
-	events := make([]writer.RedoEvent, 0, totalEvents)
+	events := make([]*redoLogTask, 0, totalEvents)
 	for i := 0; i < totalEvents; i++ {
-		events = append(events, &commonEvent.RedoRowEvent{})
+		events = append(events, newRedoEventTask(&commonEvent.RedoRowEvent{}))
 	}
 	s.logBuffer.Push(events...)
 	s.logBuffer.Close()
 
 	err := <-doneCh
 	require.NoError(t, err)
+}
+
+func TestRedoSinkFlushDMLBeforeBlockWaitsForSameDispatcherFlush(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table t_flush_before_block (id int primary key, v int)")
+	require.NotNil(t, job)
+
+	dispatcherID := common.NewDispatcherID()
+	dmlEvent := helper.DML2Event("test", "t_flush_before_block", "insert into t_flush_before_block values (1, 1)")
+	dmlEvent.DispatcherID = dispatcherID
+
+	flushedCh := make(chan struct{}, 1)
+	dmlEvent.AddPostFlushFunc(func() {
+		flushedCh <- struct{}{}
+	})
+
+	writeStarted := make(chan struct{})
+	allowFlush := make(chan struct{})
+
+	mockWriter := writer.NewMockRedoLogWriter(ctrl)
+	mockWriter.EXPECT().
+		WriteEvents(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, events ...writer.RedoEvent) error {
+			require.Len(t, events, 1)
+			select {
+			case <-writeStarted:
+			default:
+				close(writeStarted)
+			}
+			<-allowFlush
+			for _, event := range events {
+				event.PostFlush()
+			}
+			return nil
+		})
+
+	s := &Sink{
+		ctx:       ctx,
+		dmlWriter: mockWriter,
+		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
+		inflight:  newInflightRowTracker(),
+	}
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- s.sendMessages(ctx)
+	}()
+
+	s.AddDMLEvent(dmlEvent)
+	<-writeStarted
+
+	ddlEvent := &commonEvent.DDLEvent{DispatcherID: dispatcherID}
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- s.FlushDMLBeforeBlock(ddlEvent)
+	}()
+
+	select {
+	case err := <-flushDone:
+		t.Fatalf("FlushDMLBeforeBlock returned before DML flush completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowFlush)
+	require.NoError(t, <-flushDone)
+
+	select {
+	case <-flushedCh:
+	case <-time.After(time.Second):
+		t.Fatal("dml event was not flushed")
+	}
+
+	s.logBuffer.Close()
+	require.NoError(t, <-sendDone)
+}
+
+func TestRedoSinkPostEnqueueBeforeFlush(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table t_post_enqueue_before_flush (id int primary key, v int)")
+	require.NotNil(t, job)
+
+	dispatcherID := common.NewDispatcherID()
+	dmlEvent := helper.DML2Event("test", "t_post_enqueue_before_flush", "insert into t_post_enqueue_before_flush values (1, 1)")
+	dmlEvent.DispatcherID = dispatcherID
+
+	enqueuedCh := make(chan struct{}, 1)
+	flushedCh := make(chan struct{}, 1)
+	dmlEvent.AddPostEnqueueFunc(func() {
+		enqueuedCh <- struct{}{}
+	})
+	dmlEvent.AddPostFlushFunc(func() {
+		flushedCh <- struct{}{}
+	})
+
+	writeStarted := make(chan struct{})
+	allowFlush := make(chan struct{})
+
+	mockWriter := writer.NewMockRedoLogWriter(ctrl)
+	mockWriter.EXPECT().
+		WriteEvents(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, events ...writer.RedoEvent) error {
+			require.Len(t, events, 1)
+			select {
+			case <-writeStarted:
+			default:
+				close(writeStarted)
+			}
+			<-allowFlush
+			for _, event := range events {
+				event.PostFlush()
+			}
+			return nil
+		})
+
+	s := &Sink{
+		ctx:       ctx,
+		dmlWriter: mockWriter,
+		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
+		inflight:  newInflightRowTracker(),
+	}
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- s.sendMessages(ctx)
+	}()
+
+	s.AddDMLEvent(dmlEvent)
+
+	select {
+	case <-enqueuedCh:
+	case <-time.After(time.Second):
+		t.Fatal("dml event was not marked enqueued before flush")
+	}
+
+	<-writeStarted
+
+	select {
+	case <-flushedCh:
+		t.Fatal("dml event was flushed before redo writer completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowFlush)
+
+	select {
+	case <-flushedCh:
+	case <-time.After(time.Second):
+		t.Fatal("dml event was not flushed after redo writer completed")
+	}
+
+	s.logBuffer.Close()
+	require.NoError(t, <-sendDone)
+}
+
+func TestRedoSinkFlushDMLBeforeBlockWaitsOnlyForEarlierEnqueuedDML(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table t_flush_barrier_scope (id int primary key, v int)")
+	require.NotNil(t, job)
+
+	dispatcherID := common.NewDispatcherID()
+	firstEvent := helper.DML2Event("test", "t_flush_barrier_scope", "insert into t_flush_barrier_scope values (1, 1)")
+	firstEvent.DispatcherID = dispatcherID
+	secondEvent := helper.DML2Event("test", "t_flush_barrier_scope", "insert into t_flush_barrier_scope values (2, 2)")
+	secondEvent.DispatcherID = dispatcherID
+
+	secondFlushedCh := make(chan struct{}, 1)
+	secondEvent.AddPostFlushFunc(func() {
+		secondFlushedCh <- struct{}{}
+	})
+
+	firstWriteStarted := make(chan struct{})
+	secondWriteStarted := make(chan struct{})
+	allowFirstFlush := make(chan struct{})
+	allowSecondFlush := make(chan struct{})
+
+	mockWriter := writer.NewMockRedoLogWriter(ctrl)
+	gomock.InOrder(
+		mockWriter.EXPECT().
+			WriteEvents(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, events ...writer.RedoEvent) error {
+				require.Len(t, events, 1)
+				select {
+				case <-firstWriteStarted:
+				default:
+					close(firstWriteStarted)
+				}
+				<-allowFirstFlush
+				for _, event := range events {
+					event.PostFlush()
+				}
+				return nil
+			}),
+		mockWriter.EXPECT().
+			WriteEvents(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, events ...writer.RedoEvent) error {
+				require.Len(t, events, 1)
+				select {
+				case <-secondWriteStarted:
+				default:
+					close(secondWriteStarted)
+				}
+				<-allowSecondFlush
+				for _, event := range events {
+					event.PostFlush()
+				}
+				return nil
+			}),
+	)
+
+	s := &Sink{
+		ctx:       ctx,
+		dmlWriter: mockWriter,
+		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
+		inflight:  newInflightRowTracker(),
+	}
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- s.sendMessages(ctx)
+	}()
+
+	s.AddDMLEvent(firstEvent)
+	<-firstWriteStarted
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- s.FlushDMLBeforeBlock(&commonEvent.DDLEvent{DispatcherID: dispatcherID})
+	}()
+
+	require.Eventually(t, func() bool {
+		return s.logBuffer.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	s.AddDMLEvent(secondEvent)
+
+	select {
+	case err := <-flushDone:
+		t.Fatalf("FlushDMLBeforeBlock returned before earlier DML flushed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowFirstFlush)
+
+	select {
+	case err := <-flushDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("FlushDMLBeforeBlock waited for DML enqueued after the barrier")
+	}
+
+	select {
+	case <-secondFlushedCh:
+		t.Fatal("later dml was flushed before the second writer call completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	<-secondWriteStarted
+	close(allowSecondFlush)
+	s.logBuffer.Close()
+	require.NoError(t, <-sendDone)
+}
+
+func TestRedoSinkFlushDMLBeforeBlockWaitsForActualRowFlush(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table t_flush_actual_row_flush (id int primary key, v int)")
+	require.NotNil(t, job)
+
+	dispatcherID := common.NewDispatcherID()
+	dmlEvent := helper.DML2Event("test", "t_flush_actual_row_flush", "insert into t_flush_actual_row_flush values (1, 1)")
+	dmlEvent.DispatcherID = dispatcherID
+
+	rowWrittenCh := make(chan []writer.RedoEvent, 1)
+	mockWriter := writer.NewMockRedoLogWriter(ctrl)
+	mockWriter.EXPECT().
+		WriteEvents(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, events ...writer.RedoEvent) error {
+			require.Len(t, events, 1)
+			rowWrittenCh <- events
+			return nil
+		})
+
+	s := &Sink{
+		ctx:       ctx,
+		dmlWriter: mockWriter,
+		logBuffer: chann.NewUnlimitedChannelDefault[*redoLogTask](),
+		inflight:  newInflightRowTracker(),
+	}
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- s.sendMessages(ctx)
+	}()
+
+	s.AddDMLEvent(dmlEvent)
+	writtenEvents := <-rowWrittenCh
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- s.FlushDMLBeforeBlock(&commonEvent.DDLEvent{DispatcherID: dispatcherID})
+	}()
+
+	select {
+	case err := <-flushDone:
+		t.Fatalf("FlushDMLBeforeBlock returned before row event PostFlush: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	for _, event := range writtenEvents {
+		event.PostFlush()
+	}
+
+	select {
+	case err := <-flushDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("FlushDMLBeforeBlock did not wait for actual row flush")
+	}
+
+	s.logBuffer.Close()
+	require.NoError(t, <-sendDone)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of DML event flushing and synchronization during block transitions with stronger barrier coordination and inflight row tracking.

* **Performance**
  * Optimized message batching and flush handling for more efficient and stable event processing.

* **Tests**
  * Expanded test coverage for flush, barrier, cross-dispatcher sequencing, and error propagation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->