### PR TITLE
tests: support cloud-engine next gen startup

### DIFF
--- a/tests/integration_tests/_utils/start_tidb_cluster_nextgen
+++ b/tests/integration_tests/_utils/start_tidb_cluster_nextgen
@@ -96,13 +96,7 @@ if [ -z "$OUT_DIR" ]; then
 fi
 
 echo "Checking TiKV version information..."
-tikvVersionInfo=$(tikv-server -V 2>&1)
-printf '%s\n' "$tikvVersionInfo"
-tikvGitCommitBranch=$(printf '%s\n' "$tikvVersionInfo" | sed -nE 's/^Git Commit Branch:[[:space:]]*([^[:space:]]+).*$/\1/p' | head -n 1)
-tikvNeedsCdcEnable=false
-if [ "$tikvGitCommitBranch" = "cloud-engine" ]; then
-	tikvNeedsCdcEnable=true
-fi
+tikv-server -V
 
 # start minio
 echo "Starting MinIO server..."
@@ -229,13 +223,10 @@ wal-sync-dir = "$TEST_DATA_DIR/wal-sync/upstream/tikv/raft-wal"
 lightweight-backup = true
 target-file-size = "512MB"
 wal-chunk-target-file-size = "128MB"
-EOF
-if [ "$tikvNeedsCdcEnable" = "true" ]; then
-	cat >>"$OUT_DIR/upstream-tikv.toml" <<EOF
+
 [cdc]
 enable = true
 EOF
-fi
 
 touch "$OUT_DIR/downstream-tikv.toml"
 if [ -f "$tikv_config" ]; then
@@ -259,13 +250,10 @@ wal-sync-dir = "$TEST_DATA_DIR/wal-sync/downstream/tikv/raft-wal"
 lightweight-backup = true
 target-file-size = "512MB"
 wal-chunk-target-file-size = "128MB"
-EOF
-if [ "$tikvNeedsCdcEnable" = "true" ]; then
-	cat >>"$OUT_DIR/downstream-tikv.toml" <<EOF
+
 [cdc]
 enable = true
 EOF
-fi
 
 echo "Starting upstream TiKV..."
 mkdir -p "$TEST_DATA_DIR/upstream"

--- a/tests/integration_tests/_utils/start_tidb_cluster_nextgen
+++ b/tests/integration_tests/_utils/start_tidb_cluster_nextgen
@@ -260,6 +260,12 @@ lightweight-backup = true
 target-file-size = "512MB"
 wal-chunk-target-file-size = "128MB"
 EOF
+if [ "$tikvNeedsCdcEnable" = "true" ]; then
+	cat >>"$OUT_DIR/downstream-tikv.toml" <<EOF
+[cdc]
+enable = true
+EOF
+fi
 
 echo "Starting upstream TiKV..."
 mkdir -p "$TEST_DATA_DIR/upstream"

--- a/tests/integration_tests/_utils/start_tidb_cluster_nextgen
+++ b/tests/integration_tests/_utils/start_tidb_cluster_nextgen
@@ -95,6 +95,15 @@ if [ -z "$OUT_DIR" ]; then
 	exit 1
 fi
 
+echo "Checking TiKV version information..."
+tikvVersionInfo=$(tikv-server -V 2>&1)
+printf '%s\n' "$tikvVersionInfo"
+tikvGitCommitBranch=$(printf '%s\n' "$tikvVersionInfo" | sed -nE 's/^Git Commit Branch:[[:space:]]*([^[:space:]]+).*$/\1/p' | head -n 1)
+tikvNeedsCdcEnable=false
+if [ "$tikvGitCommitBranch" = "cloud-engine" ]; then
+	tikvNeedsCdcEnable=true
+fi
+
 # start minio
 echo "Starting MinIO server..."
 mkdir -p "$TEST_DATA_DIR/minio"
@@ -221,6 +230,12 @@ lightweight-backup = true
 target-file-size = "512MB"
 wal-chunk-target-file-size = "128MB"
 EOF
+if [ "$tikvNeedsCdcEnable" = "true" ]; then
+	cat >>"$OUT_DIR/upstream-tikv.toml" <<EOF
+[cdc]
+enable = true
+EOF
+fi
 
 touch "$OUT_DIR/downstream-tikv.toml"
 if [ -f "$tikv_config" ]; then
@@ -249,7 +264,6 @@ EOF
 echo "Starting upstream TiKV..."
 mkdir -p "$TEST_DATA_DIR/upstream"
 mkdir -p "$OUT_DIR/log/upstream/tikv"
-tikv-server --version
 for idx in $(seq 1 3); do
 	host="UP_TIKV_HOST_$idx"
 	port="UP_TIKV_PORT_$idx"
@@ -269,7 +283,6 @@ done
 echo "Starting downstream TiKV..."
 mkdir -p "$TEST_DATA_DIR/downstream"
 mkdir -p "$OUT_DIR/log/downstream/tikv"
-tikv-server --version
 tikv-server \
 	--pd "${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
 	-A "${DOWN_TIKV_HOST}:${DOWN_TIKV_PORT}" \

--- a/tests/integration_tests/_utils/start_tls_tidb_cluster_impl_nextgen
+++ b/tests/integration_tests/_utils/start_tls_tidb_cluster_impl_nextgen
@@ -68,6 +68,15 @@ else
 	echo "Bucket tls-cse-test already exists, skipping creation"
 fi
 
+echo "Checking TiKV version information..."
+tikvVersionInfo=$(tikv-server -V 2>&1)
+printf '%s\n' "$tikvVersionInfo"
+tikvGitCommitBranch=$(printf '%s\n' "$tikvVersionInfo" | sed -nE 's/^Git Commit Branch:[[:space:]]*([^[:space:]]+).*$/\1/p' | head -n 1)
+tikvNeedsCdcEnable=false
+if [ "$tikvGitCommitBranch" = "cloud-engine" ]; then
+	tikvNeedsCdcEnable=true
+fi
+
 # Tries to limit the max number of open files under the system limit
 cat - >"$OUT_DIR/tikv-config-tls.toml" <<EOF
 [storage]
@@ -93,6 +102,12 @@ ca-path = "$TLS_DIR/ca.pem"
 cert-path = "$TLS_DIR/server.pem"
 key-path = "$TLS_DIR/server-key.pem"
 EOF
+if [ "$tikvNeedsCdcEnable" = "true" ]; then
+	cat >>"$OUT_DIR/tikv-config-tls.toml" <<EOF
+[cdc]
+enable = true
+EOF
+fi
 
 cat >"$OUT_DIR/tikv-worker-tls.toml" <<EOF
 [dfs]
@@ -176,7 +191,6 @@ cluster-ssl-key = "$TLS_DIR/server-key.pem"
 EOF
 
 echo "Starting TLS TiKV..."
-tikv-server --version
 # Uncomment to turn on grpc versbose log.
 # GRPC_VERBOSITY=debug \
 # GRPC_TRACE=server_channel,call_error,handshaker,tsi \

--- a/tests/integration_tests/_utils/start_tls_tidb_cluster_impl_nextgen
+++ b/tests/integration_tests/_utils/start_tls_tidb_cluster_impl_nextgen
@@ -69,13 +69,7 @@ else
 fi
 
 echo "Checking TiKV version information..."
-tikvVersionInfo=$(tikv-server -V 2>&1)
-printf '%s\n' "$tikvVersionInfo"
-tikvGitCommitBranch=$(printf '%s\n' "$tikvVersionInfo" | sed -nE 's/^Git Commit Branch:[[:space:]]*([^[:space:]]+).*$/\1/p' | head -n 1)
-tikvNeedsCdcEnable=false
-if [ "$tikvGitCommitBranch" = "cloud-engine" ]; then
-	tikvNeedsCdcEnable=true
-fi
+tikv-server -V
 
 # Tries to limit the max number of open files under the system limit
 cat - >"$OUT_DIR/tikv-config-tls.toml" <<EOF
@@ -101,13 +95,10 @@ wal-chunk-target-file-size = "128MB"
 ca-path = "$TLS_DIR/ca.pem"
 cert-path = "$TLS_DIR/server.pem"
 key-path = "$TLS_DIR/server-key.pem"
-EOF
-if [ "$tikvNeedsCdcEnable" = "true" ]; then
-	cat >>"$OUT_DIR/tikv-config-tls.toml" <<EOF
+
 [cdc]
 enable = true
 EOF
-fi
 
 cat >"$OUT_DIR/tikv-worker-tls.toml" <<EOF
 [dfs]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4660

### What is changed and how it works?

This PR updates next-gen integration test cluster startup scripts to support TiKV binaries built from the `cloud-engine` branch.

Before generating the TiKV config, the scripts now run `tikv-server -V` and parse `Git Commit Branch`. When the branch is `cloud-engine`, the scripts append:

```toml
[cdc]
enable = true
```

The non-TLS next-gen startup only applies this to `upstream-tikv.toml`, while the TLS next-gen startup applies it to its generated TiKV config.

### Check List

#### Tests

- Manual test (add detailed scripts or steps below)

Manual verification:
- `bash -n tests/integration_tests/_utils/start_tidb_cluster_nextgen tests/integration_tests/_utils/start_tls_tidb_cluster_impl_nextgen`

#### Questions

##### Will it cause performance regression or break compatibility?

No. The change only affects next-gen integration test startup scripts and only appends `cdc.enable = true` when `tikv-server -V` reports `Git Commit Branch: cloud-engine`.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Detect TiKV build/version earlier during test cluster startup and surface its details.
  * Always enable change data capture (CDC) in generated TiKV configurations for upstream and downstream nodes.
  * Removed redundant TiKV version checks to streamline startup and configuration generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->