### PR TITLE
consumer: skip data file by global checkpointTs in storage consumer

### DIFF
--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -47,6 +47,7 @@ const (
 	defaultChangefeedName         = "storage-consumer"
 	defaultLogInterval            = 5 * time.Second
 	fakePartitionNumForSchemaFile = -1
+	metadataFileName              = "metadata"
 )
 
 type (
@@ -58,6 +59,10 @@ type (
 type indexRange struct {
 	start uint64
 	end   uint64
+}
+
+type storageMetadata struct {
+	CheckpointTs uint64 `json:"checkpoint-ts"`
 }
 
 type consumer struct {
@@ -79,6 +84,8 @@ type consumer struct {
 
 	dmlCount atomic.Int64
 	readSeq  atomic.Uint64
+
+	globalCheckpointTs uint64
 }
 
 func newConsumer(ctx context.Context) (*consumer, error) {
@@ -198,7 +205,30 @@ func diffDMLMaps(
 	return resMap
 }
 
-// getNewFiles returns newly created dml files in specific ranges
+func (c *consumer) getGlobalCheckpointTs(ctx context.Context) error {
+	exists, err := c.externalStorage.FileExists(ctx, metadataFileName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !exists {
+		return nil
+	}
+
+	data, err := c.externalStorage.ReadFile(ctx, metadataFileName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var metadata storageMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return errors.Trace(err)
+	}
+	if metadata.CheckpointTs > c.globalCheckpointTs {
+		c.globalCheckpointTs = metadata.CheckpointTs
+	}
+	return nil
+}
+
+// getNewFiles returns newly created dml files in specific ranges that are visible under checkpointTs.
 func (c *consumer) getNewFiles(
 	ctx context.Context,
 ) (map[cloudstorage.DmlPathKey]fileIndexRange, error) {
@@ -401,6 +431,13 @@ func (c *consumer) parseDMLFilePath(ctx context.Context, path string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if dmlkey.TableVersion > c.globalCheckpointTs {
+		log.Debug("skip dml index file by checkpoint",
+			zap.String("path", path),
+			zap.Uint64("tableVersion", dmlkey.TableVersion),
+			zap.Uint64("checkpointTs", c.globalCheckpointTs))
+		return nil
+	}
 	data, err := c.externalStorage.ReadFile(ctx, path)
 	if err != nil {
 		return errors.Trace(err)
@@ -434,6 +471,13 @@ func (c *consumer) parseSchemaFilePath(ctx context.Context, path string) error {
 	checksumInFile, err := schemaKey.ParseSchemaFilePath(path)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	if schemaKey.TableVersion > c.globalCheckpointTs {
+		log.Debug("skip schema file by checkpoint",
+			zap.String("path", path),
+			zap.Uint64("tableVersion", schemaKey.TableVersion),
+			zap.Uint64("checkpointTs", c.globalCheckpointTs))
+		return nil
 	}
 	key := schemaKey.GetKey()
 	if tableDefs, ok := c.tableDefMap[key]; ok {
@@ -705,12 +749,17 @@ func (c *consumer) handle(ctx context.Context) error {
 		}
 
 		round++
+		err := c.getGlobalCheckpointTs(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		dmlFileMap, err := c.getNewFiles(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		log.Info("storage consumer scan done",
 			zap.Uint64("round", round),
+			zap.Uint64("checkpointTs", c.globalCheckpointTs),
 			zap.Int("dmlPathKeyCount", len(dmlFileMap)))
 
 		err = c.handleNewFiles(ctx, dmlFileMap, round)

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -431,7 +431,7 @@ func (c *consumer) parseDMLFilePath(ctx context.Context, path string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if dmlkey.TableVersion > c.globalCheckpointTs {
+if c.globalCheckpointTs > 0 && dmlkey.TableVersion > c.globalCheckpointTs {
 		log.Debug("skip dml index file by checkpoint",
 			zap.String("path", path),
 			zap.Uint64("tableVersion", dmlkey.TableVersion),
@@ -472,7 +472,7 @@ func (c *consumer) parseSchemaFilePath(ctx context.Context, path string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if schemaKey.TableVersion > c.globalCheckpointTs {
+if c.globalCheckpointTs > 0 && schemaKey.TableVersion > c.globalCheckpointTs {
 		log.Debug("skip schema file by checkpoint",
 			zap.String("path", path),
 			zap.Uint64("tableVersion", schemaKey.TableVersion),

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -431,7 +431,7 @@ func (c *consumer) parseDMLFilePath(ctx context.Context, path string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-if c.globalCheckpointTs > 0 && dmlkey.TableVersion > c.globalCheckpointTs {
+	if c.globalCheckpointTs > 0 && dmlkey.TableVersion > c.globalCheckpointTs {
 		log.Debug("skip dml index file by checkpoint",
 			zap.String("path", path),
 			zap.Uint64("tableVersion", dmlkey.TableVersion),
@@ -472,7 +472,7 @@ func (c *consumer) parseSchemaFilePath(ctx context.Context, path string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-if c.globalCheckpointTs > 0 && schemaKey.TableVersion > c.globalCheckpointTs {
+	if c.globalCheckpointTs > 0 && schemaKey.TableVersion > c.globalCheckpointTs {
 		log.Debug("skip schema file by checkpoint",
 			zap.String("path", path),
 			zap.Uint64("tableVersion", schemaKey.TableVersion),


### PR DESCRIPTION
Added functionality to retrieve and update global checkpoint timestamp from metadata file.

<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4885

### What is changed and how it works?
 file discovery is now fenced by the storage metadata checkpoint, instead of discovering every visible schema.json and .index file immediately.

  - Before this patch, getNewFiles() scanned all visible schema/index files
    and immediately inserted them into the consumer’s in-memory seen state
    (tableDMLIdxMap / tableDefMap), then diffDMLMaps() decided what was “new”.
  - That meant a later-version DDL file could be discovered first, executed in
    cmd/storage-consumer/consumer.go:596, and advance tableDDLWatermark. If an
    older-version DML index was only discovered in the next round, it hit the
    unchanged stale-DML branch at cmd/storage-consumer/consumer.go:678 and got
    dropped.
  - After this patch, discovery itself is checkpoint-aware. Files whose
    TableVersion is ahead of the current global checkpoint are skipped before
    they enter the seen maps.
  - That detail matters: skipped files are not marked as seen. So when the
    checkpoint later advances, those files are discovered for the first time
    and diffDMLMaps() still reports them as genuinely new.
  - The stale DDL/DML logic in cmd/storage-consumer/consumer.go:641 and cmd/
    storage-consumer/consumer.go:680 is unchanged. The fix works by preventing
    future schema versions from being discovered too early, so the watermark
    no longer runs ahead of older-version DML discovery.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
