### PR TITLE
ci: check next gen grafana only for grafana json changes

### DIFF
--- a/.github/workflows/check_next_gen_grafana.yaml
+++ b/.github/workflows/check_next_gen_grafana.yaml
@@ -1,0 +1,37 @@
+name: Check Next Gen Grafana
+
+on:
+  push:
+    branches:
+      - master
+      - "release-[0-9].[0-9]*"
+      - "release-nextgen-[0-9]*"
+    paths:
+      - 'metrics/grafana/*.json'
+      - 'metrics/grafana/**/*.json'
+
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - master
+      - "release-[0-9].[0-9]*"
+      - "release-nextgen-[0-9]*"
+    paths:
+      - 'metrics/grafana/*.json'
+      - 'metrics/grafana/**/*.json'
+
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  check-next-gen-grafana:
+    name: Check Next Gen Grafana
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Check Next Gen Grafana
+        run: make check-next-gen-grafana

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 	cdc kafka_consumer storage_consumer pulsar_consumer filter_helper \
 	prepare_test_binaries \
 	unit_test_in_verify_ci integration_test_build integration_test_build_fast integration_test_mysql integration_test_kafka integration_test_storage integration_test_pulsar \
-	generate-next-gen-grafana
+	generate-next-gen-grafana check-next-gen-grafana
 
 
 FAIL_ON_STDOUT := awk "{ print } END { if (NR > 0) { exit 1  }  }"
@@ -328,7 +328,7 @@ check-makefiles: format-makefiles
 format-makefiles: $(MAKE_FILES)
 	$(SED_IN_PLACE) -e 's/^\(\t*\)  /\1\t/g' -e 's/^\(\t*\) /\1/' -- $?
 
-check: check-copyright fmt tidy generate_mock go-generate check-diff-line-width check-ticdc-dashboard check-makefiles generate-next-gen-grafana
+check: check-copyright fmt tidy generate_mock go-generate check-diff-line-width check-ticdc-dashboard check-makefiles
 	@git --no-pager diff --exit-code || (echo "Please add changed files!" && false)
 
 clean:
@@ -342,3 +342,6 @@ workload: tools/bin/workload
 
 generate-next-gen-grafana:
 	./scripts/generate-next-gen-metrics.sh
+
+check-next-gen-grafana: generate-next-gen-grafana
+	@git --no-pager diff --exit-code -- metrics/nextgengrafana || (echo "Please run 'make generate-next-gen-grafana' and add changed files!" && false)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5010

The current PR workflow does not validate next-gen Grafana dashboard generation when a JSON file under `metrics/grafana` is modified. Because `make generate-next-gen-grafana` is coupled with `make check` while the PR workflow excludes `*.json` changes, updates to Grafana JSON files can bypass the generation check and leave `metrics/nextgengrafana` stale.

### What is changed and how it works?

- remove `generate-next-gen-grafana` from the generic `make check` target
- add `check-next-gen-grafana` to regenerate and verify `metrics/nextgengrafana`
- add a dedicated GitHub Actions workflow that runs only for `metrics/grafana/*.json` changes

### Check List

#### Tests

- Manual test (add detailed scripts or steps below)

```bash
make check-next-gen-grafana
```

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Improved continuous integration process with enhanced validation checks for Grafana dashboard configurations to ensure consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->