### PR TITLE
api,sink: mask sink uri secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tools/bin
 tools/include
 tools/workload/bin
 
+.design
 .issue
 .vscode
 .idea

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -67,8 +67,9 @@ func maskSinkURIForError(sinkURI string) string {
 	return util.MaskSensitiveDataInURIForError(sinkURI)
 }
 
-func genSinkURIInvalidError(sinkURI string) error {
-	return errors.ErrSinkURIInvalid.GenWithStackByArgs(maskSinkURIForError(sinkURI))
+func genSinkURIInvalidError(sinkURI string, err error) error {
+	return errors.WrapError(
+		errors.ErrSinkURIInvalid, util.MaskSensitiveDataInURLError(err), maskSinkURIForError(sinkURI))
 }
 
 // CreateChangefeed handles create changefeed request,
@@ -153,7 +154,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 	}
 	sinkURIParsed, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		_ = c.Error(genSinkURIInvalidError(cfg.SinkURI))
+		_ = c.Error(genSinkURIInvalidError(cfg.SinkURI, err))
 		return
 	}
 
@@ -458,7 +459,7 @@ func (h *OpenAPIV2) VerifyTable(c *gin.Context) {
 	// verify replicaConfig
 	sinkURIParsed, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		_ = c.Error(genSinkURIInvalidError(cfg.SinkURI))
+		_ = c.Error(genSinkURIInvalidError(cfg.SinkURI, err))
 		return
 	}
 	err = replicaCfg.ValidateAndAdjust(sinkURIParsed)
@@ -834,7 +835,7 @@ func (h *OpenAPIV2) ResumeChangefeed(c *gin.Context) {
 		)
 		sinkURIParsed, err = url.Parse(cfInfo.SinkURI)
 		if err != nil {
-			_ = c.Error(genSinkURIInvalidError(cfInfo.SinkURI))
+			_ = c.Error(genSinkURIInvalidError(cfInfo.SinkURI, err))
 			return
 		}
 		scheme := sinkURIParsed.Scheme
@@ -980,7 +981,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		// verify replicaConfig
 		sinkURIParsed, err := url.Parse(oldCfInfo.SinkURI)
 		if err != nil {
-			_ = c.Error(genSinkURIInvalidError(oldCfInfo.SinkURI))
+			_ = c.Error(genSinkURIInvalidError(oldCfInfo.SinkURI, err))
 			return
 		}
 		err = oldCfInfo.Config.ValidateAndAdjust(sinkURIParsed)

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -63,6 +63,14 @@ func validateChangefeedIDParam(c *gin.Context) (common.ChangeFeedDisplayName, bo
 	return changefeedDisplayName, true
 }
 
+func maskSinkURIForError(sinkURI string) string {
+	return util.MaskSensitiveDataInURIForError(sinkURI)
+}
+
+func genSinkURIInvalidError(sinkURI string) error {
+	return errors.ErrSinkURIInvalid.GenWithStackByArgs(maskSinkURIForError(sinkURI))
+}
+
 // CreateChangefeed handles create changefeed request,
 // it returns the changefeed's changefeedInfo that it just created
 // CreateChangefeed creates a changefeed
@@ -145,7 +153,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 	}
 	sinkURIParsed, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, cfg.SinkURI))
+		_ = c.Error(genSinkURIInvalidError(cfg.SinkURI))
 		return
 	}
 
@@ -154,7 +162,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 	if config.IsMQScheme(scheme) {
 		topic, err = helper.GetTopic(sinkURIParsed)
 		if err != nil {
-			_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, cfg.SinkURI))
+			_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, maskSinkURIForError(cfg.SinkURI)))
 			return
 		}
 	}
@@ -310,7 +318,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 	}
 	err = sink.Verify(ctx, cfConfig, changefeedID)
 	if err != nil {
-		_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, cfg.SinkURI))
+		_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, maskSinkURIForError(cfg.SinkURI)))
 		return
 	}
 
@@ -450,7 +458,7 @@ func (h *OpenAPIV2) VerifyTable(c *gin.Context) {
 	// verify replicaConfig
 	sinkURIParsed, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, cfg.SinkURI))
+		_ = c.Error(genSinkURIInvalidError(cfg.SinkURI))
 		return
 	}
 	err = replicaCfg.ValidateAndAdjust(sinkURIParsed)
@@ -464,7 +472,7 @@ func (h *OpenAPIV2) VerifyTable(c *gin.Context) {
 	if config.IsMQScheme(scheme) {
 		topic, err = helper.GetTopic(sinkURIParsed)
 		if err != nil {
-			_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, cfg.SinkURI))
+			_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, maskSinkURIForError(cfg.SinkURI)))
 			return
 		}
 	}
@@ -826,14 +834,14 @@ func (h *OpenAPIV2) ResumeChangefeed(c *gin.Context) {
 		)
 		sinkURIParsed, err = url.Parse(cfInfo.SinkURI)
 		if err != nil {
-			_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, cfInfo.SinkURI))
+			_ = c.Error(genSinkURIInvalidError(cfInfo.SinkURI))
 			return
 		}
 		scheme := sinkURIParsed.Scheme
 		if config.IsMQScheme(scheme) {
 			topic, err = helper.GetTopic(sinkURIParsed)
 			if err != nil {
-				_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, cfInfo.SinkURI))
+				_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, maskSinkURIForError(cfInfo.SinkURI)))
 				return
 			}
 		}
@@ -972,7 +980,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		// verify replicaConfig
 		sinkURIParsed, err := url.Parse(oldCfInfo.SinkURI)
 		if err != nil {
-			_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, oldCfInfo.SinkURI))
+			_ = c.Error(genSinkURIInvalidError(oldCfInfo.SinkURI))
 			return
 		}
 		err = oldCfInfo.Config.ValidateAndAdjust(sinkURIParsed)
@@ -986,7 +994,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		if config.IsMQScheme(scheme) {
 			topic, err = helper.GetTopic(sinkURIParsed)
 			if err != nil {
-				_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, oldCfInfo.SinkURI))
+				_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, maskSinkURIForError(oldCfInfo.SinkURI)))
 				return
 			}
 		}
@@ -1036,7 +1044,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 
 	err = sink.Verify(ctx, oldCfInfo.ToChangefeedConfig(), oldCfInfo.ChangefeedID)
 	if err != nil {
-		_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, oldCfInfo.SinkURI))
+		_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err, maskSinkURIForError(oldCfInfo.SinkURI)))
 		return
 	}
 

--- a/api/v2/changefeed_test.go
+++ b/api/v2/changefeed_test.go
@@ -14,6 +14,7 @@
 package v2
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,7 +34,17 @@ func TestMaskSinkURIForError(t *testing.T) {
 	invalidURI := "mysql://root:verysecure@127.0.0.1/%zz"
 	require.Equal(t, "<invalid uri>", maskSinkURIForError(invalidURI))
 
-	err := genSinkURIInvalidError(invalidURI)
+	err := genSinkURIInvalidError(invalidURI, mustParseURLError(t, invalidURI))
 	require.NotContains(t, err.Error(), "verysecure")
 	require.Contains(t, err.Error(), "<invalid uri>")
+	require.Contains(t, err.Error(), `parse "<invalid uri>"`)
+	require.Contains(t, err.Error(), "invalid URL escape")
+}
+
+func mustParseURLError(t *testing.T, rawURL string) error {
+	t.Helper()
+
+	_, err := url.Parse(rawURL)
+	require.Error(t, err)
+	return err
 }

--- a/api/v2/changefeed_test.go
+++ b/api/v2/changefeed_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaskSinkURIForError(t *testing.T) {
+	sinkURI := "kafka://127.0.0.1:9092/topic?protocol=canal-json" +
+		"&sasl-user=ticdc&sasl-password=verysecure&secret-access-key=rawsecret"
+
+	maskedURI := maskSinkURIForError(sinkURI)
+	require.NotContains(t, maskedURI, "verysecure")
+	require.NotContains(t, maskedURI, "rawsecret")
+	require.Contains(t, maskedURI, "sasl-password=xxxxx")
+	require.Contains(t, maskedURI, "secret-access-key=xxxxx")
+	require.Contains(t, maskedURI, "sasl-user=ticdc")
+
+	invalidURI := "mysql://root:verysecure@127.0.0.1/%zz"
+	require.Equal(t, "<invalid uri>", maskSinkURIForError(invalidURI))
+
+	err := genSinkURIInvalidError(invalidURI)
+	require.NotContains(t, err.Error(), "verysecure")
+	require.Contains(t, err.Error(), "<invalid uri>")
+}

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -26,6 +26,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/util"
 )
 
 type Sink interface {
@@ -52,7 +53,8 @@ type Sink interface {
 func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) (Sink, error) {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		return nil, errors.WrapError(errors.ErrSinkURIInvalid, err)
+		return nil, errors.ErrSinkURIInvalid.GenWithStackByArgs(
+			util.MaskSensitiveDataInURIForError(cfg.SinkURI))
 	}
 	scheme := config.GetScheme(sinkURI)
 	switch scheme {
@@ -67,13 +69,15 @@ func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.
 	case config.BlackHoleScheme:
 		return blackhole.New(changefeedID)
 	}
-	return nil, errors.ErrSinkURIInvalid.GenWithStackByArgs(sinkURI)
+	return nil, errors.ErrSinkURIInvalid.GenWithStackByArgs(
+		util.MaskSensitiveDataInURIForError(sinkURI.String()))
 }
 
 func Verify(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) error {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		return errors.WrapError(errors.ErrSinkURIInvalid, err)
+		return errors.ErrSinkURIInvalid.GenWithStackByArgs(
+			util.MaskSensitiveDataInURIForError(cfg.SinkURI))
 	}
 	scheme := config.GetScheme(sinkURI)
 	switch scheme {
@@ -88,5 +92,6 @@ func Verify(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID comm
 	case config.BlackHoleScheme:
 		return nil
 	}
-	return errors.ErrSinkURIInvalid.GenWithStackByArgs(sinkURI)
+	return errors.ErrSinkURIInvalid.GenWithStackByArgs(
+		util.MaskSensitiveDataInURIForError(sinkURI.String()))
 }

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -53,7 +53,9 @@ type Sink interface {
 func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) (Sink, error) {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		return nil, errors.ErrSinkURIInvalid.GenWithStackByArgs(
+		return nil, errors.WrapError(
+			errors.ErrSinkURIInvalid,
+			util.MaskSensitiveDataInURLError(err),
 			util.MaskSensitiveDataInURIForError(cfg.SinkURI))
 	}
 	scheme := config.GetScheme(sinkURI)
@@ -76,7 +78,9 @@ func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.
 func Verify(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) error {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	if err != nil {
-		return errors.ErrSinkURIInvalid.GenWithStackByArgs(
+		return errors.WrapError(
+			errors.ErrSinkURIInvalid,
+			util.MaskSensitiveDataInURLError(err),
 			util.MaskSensitiveDataInURIForError(cfg.SinkURI))
 	}
 	scheme := config.GetScheme(sinkURI)

--- a/downstreamadapter/sink/sink_test.go
+++ b/downstreamadapter/sink/sink_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnknownSchemeMasksSensitiveSinkURI(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := common.NewChangefeedID(common.DefaultKeyspaceName)
+	cfg := &config.ChangefeedConfig{
+		SinkURI: "unknown://127.0.0.1:9092/topic?sasl-password=verysecure&access-key=rawkey",
+	}
+
+	_, err := New(context.Background(), cfg, changefeedID)
+	require.Error(t, err)
+	requireMaskedSinkURIError(t, err)
+
+	err = Verify(context.Background(), cfg, changefeedID)
+	require.Error(t, err)
+	requireMaskedSinkURIError(t, err)
+}
+
+func TestParseErrorMasksSensitiveSinkURI(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := common.NewChangefeedID(common.DefaultKeyspaceName)
+	cfg := &config.ChangefeedConfig{
+		SinkURI: "mysql://root:verysecure@127.0.0.1/%zz",
+	}
+
+	_, err := New(context.Background(), cfg, changefeedID)
+	require.Error(t, err)
+	requireInvalidSinkURIError(t, err)
+
+	err = Verify(context.Background(), cfg, changefeedID)
+	require.Error(t, err)
+	requireInvalidSinkURIError(t, err)
+}
+
+func requireMaskedSinkURIError(t *testing.T, err error) {
+	t.Helper()
+
+	errMsg := err.Error()
+	require.NotContains(t, errMsg, "verysecure")
+	require.NotContains(t, errMsg, "rawkey")
+	require.Contains(t, errMsg, "sasl-password=xxxxx")
+	require.Contains(t, errMsg, "access-key=xxxxx")
+}
+
+func requireInvalidSinkURIError(t *testing.T, err error) {
+	t.Helper()
+
+	errMsg := err.Error()
+	require.NotContains(t, errMsg, "verysecure")
+	require.Contains(t, errMsg, "<invalid uri>")
+}

--- a/downstreamadapter/sink/sink_test.go
+++ b/downstreamadapter/sink/sink_test.go
@@ -72,4 +72,6 @@ func requireInvalidSinkURIError(t *testing.T, err error) {
 	errMsg := err.Error()
 	require.NotContains(t, errMsg, "verysecure")
 	require.Contains(t, errMsg, "<invalid uri>")
+	require.Contains(t, errMsg, `parse "<invalid uri>"`)
+	require.Contains(t, errMsg, "invalid URL escape")
 }

--- a/pkg/check/active_active_tso_indexes.go
+++ b/pkg/check/active_active_tso_indexes.go
@@ -63,7 +63,9 @@ func ValidateActiveActiveTSOIndexes(
 
 	sinkURI, err := url.Parse(changefeedCfg.SinkURI)
 	if err != nil {
-		return errors.ErrSinkURIInvalid.GenWithStackByArgs(
+		return errors.WrapError(
+			errors.ErrSinkURIInvalid,
+			util.MaskSensitiveDataInURLError(err),
 			util.MaskSensitiveDataInURIForError(changefeedCfg.SinkURI))
 	}
 	if !config.IsMySQLCompatibleScheme(config.GetScheme(sinkURI)) {

--- a/pkg/check/active_active_tso_indexes.go
+++ b/pkg/check/active_active_tso_indexes.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/pdutil"
+	"github.com/pingcap/ticdc/pkg/util"
 	pd "github.com/tikv/pd/client"
 	pdhttp "github.com/tikv/pd/client/http"
 )
@@ -62,7 +63,8 @@ func ValidateActiveActiveTSOIndexes(
 
 	sinkURI, err := url.Parse(changefeedCfg.SinkURI)
 	if err != nil {
-		return errors.WrapError(errors.ErrSinkURIInvalid, err, changefeedCfg.SinkURI)
+		return errors.ErrSinkURIInvalid.GenWithStackByArgs(
+			util.MaskSensitiveDataInURIForError(changefeedCfg.SinkURI))
 	}
 	if !config.IsMySQLCompatibleScheme(config.GetScheme(sinkURI)) {
 		return nil

--- a/pkg/check/cluster.go
+++ b/pkg/check/cluster.go
@@ -103,7 +103,9 @@ func getClusterIDBySinkURI(
 ) (uint64, string, bool, error) {
 	uri, err := url.Parse(sinkURI)
 	if err != nil {
-		return 0, "", false, cerrors.ErrSinkURIInvalid.GenWithStackByArgs(
+		return 0, "", false, cerrors.WrapError(
+			cerrors.ErrSinkURIInvalid,
+			util.MaskSensitiveDataInURLError(err),
 			util.MaskSensitiveDataInURIForError(sinkURI))
 	}
 

--- a/pkg/check/cluster.go
+++ b/pkg/check/cluster.go
@@ -103,7 +103,8 @@ func getClusterIDBySinkURI(
 ) (uint64, string, bool, error) {
 	uri, err := url.Parse(sinkURI)
 	if err != nil {
-		return 0, "", false, cerrors.WrapError(cerrors.ErrSinkURIInvalid, err, sinkURI)
+		return 0, "", false, cerrors.ErrSinkURIInvalid.GenWithStackByArgs(
+			util.MaskSensitiveDataInURIForError(sinkURI))
 	}
 
 	scheme := config.GetScheme(uri)

--- a/pkg/util/uri.go
+++ b/pkg/util/uri.go
@@ -118,3 +118,19 @@ func MaskSensitiveDataInURIForError(uri string) string {
 	}
 	return maskedURI
 }
+
+// MaskSensitiveDataInURLError masks the URL carried by net/url errors.
+func MaskSensitiveDataInURLError(err error) error {
+	if err == nil {
+		return nil
+	}
+	urlErr, ok := err.(*url.Error)
+	if !ok {
+		return err
+	}
+	return &url.Error{
+		Op:  urlErr.Op,
+		URL: MaskSensitiveDataInURIForError(urlErr.URL),
+		Err: urlErr.Err,
+	}
+}

--- a/pkg/util/uri.go
+++ b/pkg/util/uri.go
@@ -17,9 +17,6 @@ import (
 	"net"
 	"net/url"
 	"strings"
-
-	"github.com/pingcap/log"
-	"go.uber.org/zap"
 )
 
 // IsValidIPv6AddressFormatInURI reports whether hostPort is a valid IPv6 address in URI.
@@ -70,7 +67,6 @@ func validOptionalPort(port string) bool {
 func MaskSinkURI(uri string) (string, error) {
 	uriParsed, err := url.Parse(uri)
 	if err != nil {
-		log.Error("failed to parse sink URI", zap.Error(err))
 		return "", err
 	}
 	queries := uriParsed.Query()
@@ -99,7 +95,6 @@ var sensitiveQueryParameterNames = []string{
 func MaskSensitiveDataInURI(uri string) string {
 	uriParsed, err := url.Parse(uri)
 	if err != nil {
-		log.Error("failed to parse sink URI", zap.Error(err))
 		return ""
 	}
 	queries := uriParsed.Query()
@@ -113,4 +108,13 @@ func MaskSensitiveDataInURI(uri string) string {
 	}
 	uriParsed.RawQuery = queries.Encode()
 	return uriParsed.Redacted()
+}
+
+// MaskSensitiveDataInURIForError masks sensitive data in a URI for error messages.
+func MaskSensitiveDataInURIForError(uri string) string {
+	maskedURI := MaskSensitiveDataInURI(uri)
+	if maskedURI == "" && uri != "" {
+		return "<invalid uri>"
+	}
+	return maskedURI
 }

--- a/pkg/util/uri_test.go
+++ b/pkg/util/uri_test.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -142,4 +143,15 @@ func TestMaskSensitiveDataInURIForError(t *testing.T) {
 		"mysql://root:xxxxx@127.0.0.1:3306/?sasl-password=xxxxx",
 		MaskSensitiveDataInURIForError("mysql://root:verysecure@127.0.0.1:3306/?sasl-password=rawsecret"))
 	require.Equal(t, "<invalid uri>", MaskSensitiveDataInURIForError("mysql://root:verysecure@127.0.0.1/%zz"))
+}
+
+func TestMaskSensitiveDataInURLError(t *testing.T) {
+	rawURL := "mysql://root:verysecure@127.0.0.1/%zz"
+	_, err := url.Parse(rawURL)
+	require.Error(t, err)
+
+	maskedErr := MaskSensitiveDataInURLError(err)
+	require.NotContains(t, maskedErr.Error(), "verysecure")
+	require.Contains(t, maskedErr.Error(), `parse "<invalid uri>"`)
+	require.Contains(t, maskedErr.Error(), "invalid URL escape")
 }

--- a/pkg/util/uri_test.go
+++ b/pkg/util/uri_test.go
@@ -134,3 +134,12 @@ func TestMaskSensitiveDataInURI(t *testing.T) {
 		require.Equal(t, tt.masked, maskedURI)
 	}
 }
+
+func TestMaskSensitiveDataInURIForError(t *testing.T) {
+	require.Equal(t, "", MaskSensitiveDataInURIForError(""))
+	require.Equal(t, "abc", MaskSensitiveDataInURIForError("abc"))
+	require.Equal(t,
+		"mysql://root:xxxxx@127.0.0.1:3306/?sasl-password=xxxxx",
+		MaskSensitiveDataInURIForError("mysql://root:verysecure@127.0.0.1:3306/?sasl-password=rawsecret"))
+	require.Equal(t, "<invalid uri>", MaskSensitiveDataInURIForError("mysql://root:verysecure@127.0.0.1/%zz"))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5094 

### What is changed and how it works?

This PR masks sensitive sink URI data before sink validation errors reach the OpenAPI request log. It covers changefeed create, update, resume, verify-table, and shared sink parse/unknown scheme paths. It also avoids logging parse errors inside URI masking helpers and adds tests for masked query secrets and malformed
URIs containing userinfo passwords.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced error handling to automatically mask sensitive sink URI credentials including passwords and API keys in error messages, preventing accidental exposure in system logs and error responses.

* **Tests**
  * Added comprehensive test coverage validating credential masking across all changefeed operations and sink configuration validation endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5093?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->