### PR TITLE
server, dispatcher: improve node liveness self fence

### DIFF
--- a/downstreamadapter/dispatcher/event_dispatcher.go
+++ b/downstreamadapter/dispatcher/event_dispatcher.go
@@ -154,9 +154,10 @@ func (d *EventDispatcher) Remove() {
 	d.removeDispatcher()
 }
 
-// EmitBootstrap emits the table bootstrap event in a blocking way after changefeed started
-// It will return after the bootstrap event is sent.
-func (d *EventDispatcher) EmitBootstrap() bool {
+// EmitBootstrap emits the table bootstrap event in a blocking way after changefeed started.
+// It will return after the bootstrap event is sent, or when shouldStop asks it
+// to stop because the local write path has been fenced.
+func (d *EventDispatcher) EmitBootstrap(shouldStop func() bool) bool {
 	bootstrap := loadBootstrapState(&d.BootstrapState)
 	switch bootstrap {
 	case BootstrapFinished:
@@ -206,9 +207,15 @@ func (d *EventDispatcher) EmitBootstrap() bool {
 		if table.IsView() {
 			continue
 		}
+		if shouldStop != nil && shouldStop() {
+			return false
+		}
 		ddlEvent := codec.NewBootstrapDDLEvent(table)
 		err := d.sink.WriteBlockEvent(ddlEvent)
 		if err != nil {
+			if shouldStop != nil && shouldStop() {
+				return false
+			}
 			log.Error("send bootstrap message failed",
 				zap.Stringer("changefeed", d.sharedInfo.changefeedID),
 				zap.Int("tables", len(currentTables)),
@@ -217,6 +224,9 @@ func (d *EventDispatcher) EmitBootstrap() bool {
 				zap.Error(err))
 			d.HandleError(errors.ErrExecDDLFailed.GenWithStackByArgs())
 			return true
+		}
+		if shouldStop != nil && shouldStop() {
+			return false
 		}
 	}
 	storeBootstrapState(&d.BootstrapState, BootstrapFinished)

--- a/downstreamadapter/dispatcher/event_dispatcher.go
+++ b/downstreamadapter/dispatcher/event_dispatcher.go
@@ -207,13 +207,13 @@ func (d *EventDispatcher) EmitBootstrap(shouldStop func() bool) bool {
 		if table.IsView() {
 			continue
 		}
-		if shouldStop != nil && shouldStop() {
+		if shouldStop() {
 			return false
 		}
 		ddlEvent := codec.NewBootstrapDDLEvent(table)
 		err := d.sink.WriteBlockEvent(ddlEvent)
 		if err != nil {
-			if shouldStop != nil && shouldStop() {
+			if shouldStop() {
 				return false
 			}
 			log.Error("send bootstrap message failed",
@@ -225,7 +225,7 @@ func (d *EventDispatcher) EmitBootstrap(shouldStop func() bool) bool {
 			d.HandleError(errors.ErrExecDDLFailed.GenWithStackByArgs())
 			return true
 		}
-		if shouldStop != nil && shouldStop() {
+		if shouldStop() {
 			return false
 		}
 	}

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -16,7 +16,6 @@ package dispatchermanager
 import (
 	"context"
 	"math"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -53,8 +52,7 @@ const (
 	// manager batching drains it. Longer retries are absorbed by the request
 	// queue dedupe, so keeping this queue modest avoids preallocating a large
 	// value-retention window in front of the manager.
-	blockStatusBufferSize                   = 16 * 1024
-	dispatcherManagerWritePathClosedMessage = "dispatcher manager write path is closed"
+	blockStatusBufferSize = 16 * 1024
 )
 
 // IsWritePathClosedError reports whether err means the local write path has
@@ -65,15 +63,11 @@ func IsWritePathClosedError(err error) bool {
 		return false
 	}
 	code, ok := errors.RFCCode(err)
-	if !ok || code != errors.ErrChangefeedInitTableTriggerDispatcherFailed.RFCCode() {
-		return false
-	}
-	return strings.Contains(err.Error(), dispatcherManagerWritePathClosedMessage)
+	return ok && code == errors.ErrDispatcherManagerWritePathClosed.RFCCode()
 }
 
 func newWritePathClosedError() error {
-	return errors.ErrChangefeedInitTableTriggerDispatcherFailed.
-		FastGenByArgs(dispatcherManagerWritePathClosedMessage)
+	return errors.ErrDispatcherManagerWritePathClosed.FastGenByArgs()
 }
 
 /*

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -141,8 +141,10 @@ type DispatcherManager struct {
 	latestWatermark     Watermark
 	latestRedoWatermark Watermark
 
-	closing atomic.Bool
-	closed  atomic.Bool
+	closing         atomic.Bool
+	closed          atomic.Bool
+	writePathMu     sync.Mutex
+	writePathClosed atomic.Bool
 	// removeChangefeedRequested is sticky once any close request asks for removed=true.
 	// A later removed=false request must not downgrade the final cleanup semantics.
 	removeChangefeedRequested atomic.Bool
@@ -454,6 +456,9 @@ func (e *DispatcherManager) getTableRecoveryInfoFromMysqlSink(tableIds, startTsL
 // 1. newEventDispatchers is called by NewTableTriggerEventDispatcher(just means when creating table trigger event dispatcher)
 // 2. changefeed is total new created, or resumed with overwriteCheckpointTs
 func (e *DispatcherManager) newEventDispatchers(infos map[common.DispatcherID]dispatcherCreateInfo, removeDDLTs bool) error {
+	if e.writePathClosed.Load() {
+		return nil
+	}
 	start := time.Now()
 	currentPdTs := e.pdClock.CurrentTS()
 
@@ -517,6 +522,12 @@ func (e *DispatcherManager) newEventDispatchers(infos map[common.DispatcherID]di
 			e.heartBeatTask = newHeartBeatTask(e)
 		}
 
+		e.writePathMu.Lock()
+		if e.writePathClosed.Load() {
+			e.writePathMu.Unlock()
+			d.Remove()
+			return nil
+		}
 		if d.IsTableTriggerDispatcher() {
 			if util.GetOrZero(e.config.SinkConfig.SendAllBootstrapAtStart) {
 				d.BootstrapState = dispatcher.BootstrapNotStarted
@@ -532,6 +543,7 @@ func (e *DispatcherManager) newEventDispatchers(infos map[common.DispatcherID]di
 
 		seq := e.dispatcherMap.Set(id, d)
 		d.SetSeq(seq)
+		e.writePathMu.Unlock()
 
 		if d.IsTableTriggerDispatcher() {
 			e.metricTableTriggerEventDispatcherCount.Inc()
@@ -902,7 +914,14 @@ func (e *DispatcherManager) mergeEventDispatcher(dispatcherIDs []common.Dispatch
 		zap.Stringer("dispatcherID", mergedDispatcherID),
 		zap.String("tableSpan", common.FormatTableSpan(mergedSpan)))
 
+	e.writePathMu.Lock()
+	if e.writePathClosed.Load() {
+		e.writePathMu.Unlock()
+		mergedDispatcher.Remove()
+		return nil
+	}
 	registerMergeDispatcher(e.changefeedID, dispatcherIDs, e.dispatcherMap, mergedDispatcherID, mergedDispatcher, e.schemaIDToDispatchers, e.metricEventDispatcherCount, e.sinkQuota)
+	e.writePathMu.Unlock()
 	return newMergeCheckTask(e, mergedDispatcher, dispatcherIDs)
 }
 
@@ -916,45 +935,87 @@ func (e *DispatcherManager) TryClose(removeChangefeed bool) bool {
 		e.tryScheduleRemoveChangefeedCleanup()
 		return true
 	}
-	if e.closing.Load() {
+	if !e.closing.CompareAndSwap(false, true) {
 		return e.closed.Load()
 	}
 
-	e.closing.Store(true)
 	go e.close()
 	return false
+}
+
+// LocalFence stops the local write path immediately without waiting for
+// dispatcher progress to drain. The remaining cleanup continues asynchronously.
+func (e *DispatcherManager) LocalFence() {
+	if e.closed.Load() {
+		return
+	}
+	startClose := e.closing.CompareAndSwap(false, true)
+	e.stopWritePath(true)
+	if startClose {
+		go e.finishClose()
+	}
 }
 
 func (e *DispatcherManager) close() {
 	log.Info("closing event dispatcher manager",
 		zap.Stringer("changefeedID", e.changefeedID))
 
-	defer e.closing.Store(false)
+	e.stopWritePath(false)
+	e.finishClose()
+}
+
+func (e *DispatcherManager) stopWritePath(cancelFirst bool) {
+	e.writePathMu.Lock()
+	defer e.writePathMu.Unlock()
+	if e.writePathClosed.Load() {
+		return
+	}
+	e.writePathClosed.Store(true)
+
+	log.Info("stopping dispatcher manager write path",
+		zap.Stringer("changefeedID", e.changefeedID))
+
+	if cancelFirst && e.cancel != nil {
+		e.cancel()
+	}
+
 	if e.IsRedoEnabled() {
 		closeAllDispatchers(e.changefeedID, e.redoDispatcherMap, e.redoSink.SinkType())
 		log.Info("closed all redo dispatchers",
 			zap.Stringer("changefeedID", e.changefeedID))
-		err := appcontext.GetService[*HeartBeatCollector](appcontext.HeartbeatCollector).RemoveRedoMessage(e.changefeedID)
-		if err != nil {
-			log.Error("remove redo message failed",
+		if heartbeatCollector, ok := appcontext.TryGetService[*HeartBeatCollector](appcontext.HeartbeatCollector); ok {
+			err := heartbeatCollector.RemoveRedoMessage(e.changefeedID)
+			if err != nil {
+				log.Error("remove redo message failed",
+					zap.Stringer("changefeedID", e.changefeedID),
+					zap.Error(err),
+				)
+			}
+		} else {
+			log.Warn("heartbeat collector is not available when stopping redo write path",
 				zap.Stringer("changefeedID", e.changefeedID),
-				zap.Error(err),
 			)
-			return
 		}
 	}
 
-	closeAllDispatchers(e.changefeedID, e.dispatcherMap, e.sink.SinkType())
+	if e.sink != nil {
+		closeAllDispatchers(e.changefeedID, e.dispatcherMap, e.sink.SinkType())
+	}
 	log.Info("closed all event dispatchers",
 		zap.Stringer("changefeedID", e.changefeedID))
 
-	err := appcontext.GetService[*HeartBeatCollector](appcontext.HeartbeatCollector).RemoveDispatcherManager(e.changefeedID)
-	if err != nil {
-		log.Error("remove dispatcher manager from heartbeat collector failed",
+	if heartbeatCollector, ok := appcontext.TryGetService[*HeartBeatCollector](appcontext.HeartbeatCollector); ok {
+		err := heartbeatCollector.RemoveDispatcherManager(e.changefeedID)
+		if err != nil {
+			log.Error("remove dispatcher manager from heartbeat collector failed",
+				zap.Stringer("changefeedID", e.changefeedID),
+				zap.Error(err),
+			)
+		}
+	} else {
+		log.Warn("heartbeat collector is not available when stopping dispatcher manager write path",
 			zap.Stringer("changefeedID", e.changefeedID),
-			zap.Error(err),
 		)
-		return
 	}
 
 	// heartbeatTask only will be generated when create new dispatchers.
@@ -965,10 +1026,9 @@ func (e *DispatcherManager) close() {
 		e.heartBeatTask.Cancel()
 	}
 
-	// Cancel the context to signal all dependent components to stop.
-	// This is important to prevent `e.sink.Close() / e.sharedInfo.Close()` from blocking,
-	// especially when a long-running DDL is being executed by the sink.
-	e.cancel()
+	if !cancelFirst && e.cancel != nil {
+		e.cancel()
+	}
 
 	if e.sharedInfo != nil {
 		e.sharedInfo.Close()
@@ -979,10 +1039,18 @@ func (e *DispatcherManager) close() {
 	if e.IsRedoEnabled() {
 		e.redoSink.Close()
 	}
-	e.sink.Close()
+	if e.sink != nil {
+		e.sink.Close()
+	}
 	log.Info("sink closed", zap.Stringer("changefeedID", e.changefeedID))
+}
 
+func (e *DispatcherManager) finishClose() {
+	defer e.closing.Store(false)
 	e.wg.Wait()
+	if !e.closed.CompareAndSwap(false, true) {
+		return
+	}
 
 	e.removeTaskHandles.Range(func(key, value interface{}) bool {
 		handle := value.(*threadpool.TaskHandle)
@@ -992,7 +1060,6 @@ func (e *DispatcherManager) close() {
 
 	e.cleanMetrics()
 
-	e.closed.Store(true)
 	e.tryScheduleRemoveChangefeedCleanup()
 	log.Info("event dispatcher manager closed",
 		zap.Stringer("changefeedID", e.changefeedID))

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -979,7 +979,7 @@ func (e *DispatcherManager) stopWritePath(cancelFirst bool) {
 		e.cancel()
 	}
 
-	if e.IsRedoEnabled() {
+	if e.IsRedoEnabled() && e.redoSink != nil {
 		closeAllDispatchers(e.changefeedID, e.redoDispatcherMap, e.redoSink.SinkType())
 		log.Info("closed all redo dispatchers",
 			zap.Stringer("changefeedID", e.changefeedID))
@@ -1036,7 +1036,7 @@ func (e *DispatcherManager) stopWritePath(cancelFirst bool) {
 
 	log.Info("shared info closed", zap.Stringer("changefeedID", e.changefeedID))
 
-	if e.IsRedoEnabled() {
+	if e.IsRedoEnabled() && e.redoSink != nil {
 		e.redoSink.Close()
 	}
 	if e.sink != nil {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -16,6 +16,7 @@ package dispatchermanager
 import (
 	"context"
 	"math"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -52,8 +53,28 @@ const (
 	// manager batching drains it. Longer retries are absorbed by the request
 	// queue dedupe, so keeping this queue modest avoids preallocating a large
 	// value-retention window in front of the manager.
-	blockStatusBufferSize = 16 * 1024
+	blockStatusBufferSize                   = 16 * 1024
+	dispatcherManagerWritePathClosedMessage = "dispatcher manager write path is closed"
 )
+
+// IsWritePathClosedError reports whether err means the local write path has
+// already been fenced. Callers should stop the in-flight local request instead
+// of treating it as a successful dispatcher creation.
+func IsWritePathClosedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	code, ok := errors.RFCCode(err)
+	if !ok || code != errors.ErrChangefeedInitTableTriggerDispatcherFailed.RFCCode() {
+		return false
+	}
+	return strings.Contains(err.Error(), dispatcherManagerWritePathClosedMessage)
+}
+
+func newWritePathClosedError() error {
+	return errors.ErrChangefeedInitTableTriggerDispatcherFailed.
+		FastGenByArgs(dispatcherManagerWritePathClosedMessage)
+}
 
 /*
 DispatcherManager manages dispatchers for a changefeed instance with responsibilities including:
@@ -388,19 +409,33 @@ func (e *DispatcherManager) NewTableTriggerEventDispatcher(id *heartbeatpb.Dispa
 	if err != nil {
 		return errors.Trace(err)
 	}
+	tableTriggerDispatcher := e.GetTableTriggerEventDispatcher()
+	if tableTriggerDispatcher == nil {
+		if e.writePathClosed.Load() {
+			return newWritePathClosedError()
+		}
+		return errors.ErrChangefeedInitTableTriggerDispatcherFailed.
+			FastGenByArgs("table trigger event dispatcher was not created")
+	}
 	log.Info("table trigger event dispatcher created",
 		zap.Stringer("changefeedID", e.changefeedID),
-		zap.Stringer("dispatcherID", e.GetTableTriggerEventDispatcher().GetId()),
-		zap.Uint64("startTs", e.GetTableTriggerEventDispatcher().GetStartTs()),
+		zap.Stringer("dispatcherID", tableTriggerDispatcher.GetId()),
+		zap.Uint64("startTs", tableTriggerDispatcher.GetStartTs()),
 	)
 	return nil
 }
 
 func (e *DispatcherManager) InitalizeTableTriggerEventDispatcher(schemaInfo []*heartbeatpb.SchemaInfo) error {
-	if e.GetTableTriggerEventDispatcher() == nil {
+	e.writePathMu.Lock()
+	defer e.writePathMu.Unlock()
+	if e.writePathClosed.Load() {
+		return newWritePathClosedError()
+	}
+	tableTriggerDispatcher := e.GetTableTriggerEventDispatcher()
+	if tableTriggerDispatcher == nil {
 		return nil
 	}
-	needAddDispatcher, err := e.GetTableTriggerEventDispatcher().InitializeTableSchemaStore(schemaInfo)
+	needAddDispatcher, err := tableTriggerDispatcher.InitializeTableSchemaStore(schemaInfo)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -408,13 +443,13 @@ func (e *DispatcherManager) InitalizeTableTriggerEventDispatcher(schemaInfo []*h
 		return nil
 	}
 	// before bootstrap finished, cannot send any event.
-	success := e.GetTableTriggerEventDispatcher().EmitBootstrap()
+	success := tableTriggerDispatcher.EmitBootstrap()
 	if !success {
 		return errors.ErrDispatcherFailed.GenWithStackByArgs()
 	}
 
 	// table trigger event dispatcher can register to event collector to receive events after finish the initial table schema store from the maintainer.
-	appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector).AddDispatcher(e.GetTableTriggerEventDispatcher(), e.sinkQuota)
+	appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector).AddDispatcher(tableTriggerDispatcher, e.sinkQuota)
 
 	// The table trigger event dispatcher needs changefeed-level checkpoint updates only
 	// when downstream components must maintain table names (for non-MySQL sinks), or
@@ -457,7 +492,7 @@ func (e *DispatcherManager) getTableRecoveryInfoFromMysqlSink(tableIds, startTsL
 // 2. changefeed is total new created, or resumed with overwriteCheckpointTs
 func (e *DispatcherManager) newEventDispatchers(infos map[common.DispatcherID]dispatcherCreateInfo, removeDDLTs bool) error {
 	if e.writePathClosed.Load() {
-		return nil
+		return newWritePathClosedError()
 	}
 	start := time.Now()
 	currentPdTs := e.pdClock.CurrentTS()
@@ -526,7 +561,7 @@ func (e *DispatcherManager) newEventDispatchers(infos map[common.DispatcherID]di
 		if e.writePathClosed.Load() {
 			e.writePathMu.Unlock()
 			d.Remove()
-			return nil
+			return newWritePathClosedError()
 		}
 		if d.IsTableTriggerDispatcher() {
 			if util.GetOrZero(e.config.SinkConfig.SendAllBootstrapAtStart) {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -209,7 +209,8 @@ func NewDispatcherManager(
 	startTs uint64,
 	maintainerID node.ID,
 	newChangefeed bool,
-) (*DispatcherManager, error) {
+	registerInitializing func(*DispatcherManager) bool,
+) (manager *DispatcherManager, err error) {
 	failpoint.Inject("NewDispatcherManagerDelay", nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -225,7 +226,7 @@ func NewDispatcherManager(
 		integrityCfg = cfConfig.SinkConfig.Integrity.ToPB()
 	}
 
-	manager := &DispatcherManager{
+	manager = &DispatcherManager{
 		ctx:                   ctx,
 		dispatcherMap:         newDispatcherMap[*dispatcher.EventDispatcher](),
 		currentOperatorMap:    sync.Map{},
@@ -257,6 +258,17 @@ func NewDispatcherManager(
 	// Set the epoch and maintainerID of the event dispatcher manager
 	manager.meta.maintainerEpoch = cfConfig.Epoch
 	manager.meta.maintainerID = maintainerID
+	cleanupManager := manager
+	defer func() {
+		if err != nil && cleanupManager != nil {
+			cleanupManager.LocalFence()
+			manager = nil
+		}
+	}()
+	// The manager must be fenceable before any write-capable resource is initialized.
+	if registerInitializing != nil && !registerInitializing(manager) {
+		return nil, newWritePathClosedError()
+	}
 
 	// Set Sync Point Config
 	var syncPointConfig *syncpoint.SyncPointConfig
@@ -268,11 +280,18 @@ func NewDispatcherManager(
 		}
 	}
 
-	var err error
-	manager.sink, err = sink.New(ctx, manager.config, manager.changefeedID)
+	createdSink, err := sink.New(ctx, manager.config, manager.changefeedID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	manager.writePathMu.Lock()
+	if manager.writePathClosed.Load() {
+		manager.writePathMu.Unlock()
+		createdSink.Close()
+		return nil, newWritePathClosedError()
+	}
+	manager.sink = createdSink
+	manager.writePathMu.Unlock()
 
 	// Determine outputRawChangeEvent based on sink type
 	var outputRawChangeEvent bool
@@ -294,7 +313,7 @@ func NewDispatcherManager(
 
 	batchCounts, batchBytes := manager.getEventCollectorBatchCountAndBytes(manager.sink)
 	// Create shared info for all dispatchers
-	manager.sharedInfo = dispatcher.NewSharedInfo(
+	sharedInfo := dispatcher.NewSharedInfo(
 		manager.changefeedID,
 		manager.config.TimeZone,
 		manager.config.BDRMode,
@@ -312,10 +331,24 @@ func NewDispatcherManager(
 		blockStatusBufferSize,
 		make(chan error, 1),
 	)
+	manager.writePathMu.Lock()
+	if manager.writePathClosed.Load() {
+		manager.writePathMu.Unlock()
+		sharedInfo.Close()
+		return nil, newWritePathClosedError()
+	}
+	manager.sharedInfo = sharedInfo
+	manager.writePathMu.Unlock()
 
 	// Register Event Dispatcher Manager in HeartBeatCollector,
 	// which is responsible for communication with the maintainer.
+	manager.writePathMu.Lock()
+	if manager.writePathClosed.Load() {
+		manager.writePathMu.Unlock()
+		return nil, newWritePathClosedError()
+	}
 	err = appcontext.GetService[*HeartBeatCollector](appcontext.HeartbeatCollector).RegisterDispatcherManager(manager)
+	manager.writePathMu.Unlock()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -421,27 +421,41 @@ func (e *DispatcherManager) NewTableTriggerEventDispatcher(id *heartbeatpb.Dispa
 
 func (e *DispatcherManager) InitalizeTableTriggerEventDispatcher(schemaInfo []*heartbeatpb.SchemaInfo) error {
 	e.writePathMu.Lock()
-	defer e.writePathMu.Unlock()
 	if e.writePathClosed.Load() {
+		e.writePathMu.Unlock()
 		return newWritePathClosedError()
 	}
 	tableTriggerDispatcher := e.GetTableTriggerEventDispatcher()
 	if tableTriggerDispatcher == nil {
+		e.writePathMu.Unlock()
 		return nil
 	}
 	needAddDispatcher, err := tableTriggerDispatcher.InitializeTableSchemaStore(schemaInfo)
 	if err != nil {
+		e.writePathMu.Unlock()
 		return errors.Trace(err)
 	}
+	e.writePathMu.Unlock()
 	if !needAddDispatcher {
 		return nil
 	}
+	if e.writePathClosed.Load() {
+		return newWritePathClosedError()
+	}
 	// before bootstrap finished, cannot send any event.
-	success := tableTriggerDispatcher.EmitBootstrap()
+	success := tableTriggerDispatcher.EmitBootstrap(e.writePathClosed.Load)
+	if e.writePathClosed.Load() {
+		return newWritePathClosedError()
+	}
 	if !success {
 		return errors.ErrDispatcherFailed.GenWithStackByArgs()
 	}
 
+	e.writePathMu.Lock()
+	defer e.writePathMu.Unlock()
+	if e.writePathClosed.Load() {
+		return newWritePathClosedError()
+	}
 	// table trigger event dispatcher can register to event collector to receive events after finish the initial table schema store from the maintainer.
 	appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector).AddDispatcher(tableTriggerDispatcher, e.sinkQuota)
 
@@ -995,11 +1009,12 @@ func (e *DispatcherManager) close() {
 
 func (e *DispatcherManager) stopWritePath(cancelFirst bool) {
 	e.writePathMu.Lock()
-	defer e.writePathMu.Unlock()
 	if e.writePathClosed.Load() {
+		e.writePathMu.Unlock()
 		return
 	}
 	e.writePathClosed.Store(true)
+	e.writePathMu.Unlock()
 
 	log.Info("stopping dispatcher manager write path",
 		zap.Stringer("changefeedID", e.changefeedID))
@@ -1072,6 +1087,19 @@ func (e *DispatcherManager) stopWritePath(cancelFirst bool) {
 		e.sink.Close()
 	}
 	log.Info("sink closed", zap.Stringer("changefeedID", e.changefeedID))
+}
+
+func (e *DispatcherManager) addCheckpointTs(checkpointTs uint64) {
+	if e.writePathClosed.Load() {
+		return
+	}
+	if e.GetTableTriggerEventDispatcher() == nil || e.sink == nil {
+		return
+	}
+	if e.writePathClosed.Load() {
+		return
+	}
+	e.sink.AddCheckpointTs(checkpointTs)
 }
 
 func (e *DispatcherManager) finishClose() {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -113,6 +113,13 @@ func (e *DispatcherManager) NewTableTriggerRedoDispatcher(id *heartbeatpb.Dispat
 	// redo meta should keep the same node with table trigger event dispatcher
 	// table trigger event dispatcher and table trigger redo dispatcher must exist on the same node
 	redoDispatcher := e.GetTableTriggerRedoDispatcher()
+	if redoDispatcher == nil {
+		if e.writePathClosed.Load() {
+			return newWritePathClosedError()
+		}
+		return errors.ErrChangefeedInitTableTriggerDispatcherFailed.
+			FastGenByArgs("table trigger redo dispatcher was not created")
+	}
 	redoDispatcher.SetRedoMeta(e.ctx, e.config.Consistent)
 	e.wg.Add(1)
 	go func() {
@@ -141,7 +148,7 @@ func (e *DispatcherManager) getRedoEventCollectorBatchCountAndBytes(redoSink *re
 
 func (e *DispatcherManager) newRedoDispatchers(infos map[common.DispatcherID]dispatcherCreateInfo, _ bool) error {
 	if e.writePathClosed.Load() {
-		return nil
+		return newWritePathClosedError()
 	}
 	start := time.Now()
 	batchCount, batchBytes := e.getRedoEventCollectorBatchCountAndBytes(e.redoSink)
@@ -187,7 +194,7 @@ func (e *DispatcherManager) newRedoDispatchers(infos map[common.DispatcherID]dis
 		if e.writePathClosed.Load() {
 			e.writePathMu.Unlock()
 			rd.Remove()
-			return nil
+			return newWritePathClosedError()
 		}
 		if rd.IsTableTriggerDispatcher() {
 			e.SetTableTriggerRedoDispatcher(rd)
@@ -307,17 +314,23 @@ func (e *DispatcherManager) closeRedoMeta(removeChangefeed bool) error {
 }
 
 func (e *DispatcherManager) InitalizeTableTriggerRedoDispatcher(schemaInfo []*heartbeatpb.SchemaInfo) error {
-	if e.GetTableTriggerRedoDispatcher() == nil {
+	e.writePathMu.Lock()
+	defer e.writePathMu.Unlock()
+	if e.writePathClosed.Load() {
+		return newWritePathClosedError()
+	}
+	tableTriggerRedoDispatcher := e.GetTableTriggerRedoDispatcher()
+	if tableTriggerRedoDispatcher == nil {
 		return nil
 	}
-	needAddDispatcher, err := e.GetTableTriggerRedoDispatcher().InitializeTableSchemaStore(schemaInfo)
+	needAddDispatcher, err := tableTriggerRedoDispatcher.InitializeTableSchemaStore(schemaInfo)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if !needAddDispatcher {
 		return nil
 	}
-	appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector).AddDispatcher(e.GetTableTriggerRedoDispatcher(), e.redoQuota)
+	appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector).AddDispatcher(tableTriggerRedoDispatcher, e.redoQuota)
 	return nil
 }
 

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -140,6 +140,9 @@ func (e *DispatcherManager) getRedoEventCollectorBatchCountAndBytes(redoSink *re
 }
 
 func (e *DispatcherManager) newRedoDispatchers(infos map[common.DispatcherID]dispatcherCreateInfo, _ bool) error {
+	if e.writePathClosed.Load() {
+		return nil
+	}
 	start := time.Now()
 	batchCount, batchBytes := e.getRedoEventCollectorBatchCountAndBytes(e.redoSink)
 
@@ -180,6 +183,12 @@ func (e *DispatcherManager) newRedoDispatchers(infos map[common.DispatcherID]dis
 			e.heartBeatTask = newHeartBeatTask(e)
 		}
 
+		e.writePathMu.Lock()
+		if e.writePathClosed.Load() {
+			e.writePathMu.Unlock()
+			rd.Remove()
+			return nil
+		}
 		if rd.IsTableTriggerDispatcher() {
 			e.SetTableTriggerRedoDispatcher(rd)
 		} else {
@@ -189,6 +198,7 @@ func (e *DispatcherManager) newRedoDispatchers(infos map[common.DispatcherID]dis
 
 		redoSeq := e.redoDispatcherMap.Set(rd.GetId(), rd)
 		rd.SetSeq(redoSeq)
+		e.writePathMu.Unlock()
 
 		if rd.IsTableTriggerDispatcher() {
 			e.metricTableTriggerRedoDispatcherCount.Inc()
@@ -249,7 +259,14 @@ func (e *DispatcherManager) mergeRedoDispatcher(dispatcherIDs []common.Dispatche
 		zap.Stringer("dispatcherID", mergedDispatcherID),
 		zap.String("tableSpan", common.FormatTableSpan(mergedSpan)))
 
+	e.writePathMu.Lock()
+	if e.writePathClosed.Load() {
+		e.writePathMu.Unlock()
+		mergedDispatcher.Remove()
+		return nil
+	}
 	registerMergeDispatcher(e.changefeedID, dispatcherIDs, e.redoDispatcherMap, mergedDispatcherID, mergedDispatcher, e.redoSchemaIDToDispatchers, e.metricRedoEventDispatcherCount, e.redoQuota)
+	e.writePathMu.Unlock()
 	return newMergeCheckTask(e, mergedDispatcher, dispatcherIDs)
 }
 

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -335,6 +335,9 @@ func (e *DispatcherManager) InitalizeTableTriggerRedoDispatcher(schemaInfo []*he
 }
 
 func (e *DispatcherManager) UpdateRedoMeta(checkpointTs, resolvedTs uint64) {
+	if e.writePathClosed.Load() {
+		return
+	}
 	// only update meta on the one node
 	d := e.GetTableTriggerRedoDispatcher()
 	if d == nil {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -52,21 +52,36 @@ func initRedoComponet(
 	if !manager.IsRedoEnabled() {
 		return nil
 	}
+	if manager.writePathClosed.Load() {
+		return newWritePathClosedError()
+	}
 	var err error
-	manager.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()
-	manager.redoSink, err = redo.New(ctx, changefeedID, manager.config.Consistent)
+	redoDispatcherMap := newDispatcherMap[*dispatcher.RedoDispatcher]()
+	redoSink, err := redo.New(ctx, changefeedID, manager.config.Consistent)
 	if err != nil {
 		return err
 	}
-	manager.redoSchemaIDToDispatchers = dispatcher.NewSchemaIDToDispatchers()
+	redoSchemaIDToDispatchers := dispatcher.NewSchemaIDToDispatchers()
 
 	totalQuota := manager.sinkQuota
 	consistentMemoryUsage := manager.config.Consistent.MemoryUsage
 	if consistentMemoryUsage == nil {
 		consistentMemoryUsage = config.GetDefaultReplicaConfig().Consistent.MemoryUsage
 	}
-	manager.redoQuota = totalQuota * consistentMemoryUsage.MemoryQuotaPercentage / 100
-	manager.sinkQuota = totalQuota - manager.redoQuota
+	redoQuota := totalQuota * consistentMemoryUsage.MemoryQuotaPercentage / 100
+
+	manager.writePathMu.Lock()
+	if manager.writePathClosed.Load() {
+		manager.writePathMu.Unlock()
+		redoSink.Close()
+		return newWritePathClosedError()
+	}
+	manager.redoDispatcherMap = redoDispatcherMap
+	manager.redoSink = redoSink
+	manager.redoSchemaIDToDispatchers = redoSchemaIDToDispatchers
+	manager.redoQuota = redoQuota
+	manager.sinkQuota = totalQuota - redoQuota
+	manager.writePathMu.Unlock()
 
 	// init table trigger redo dispatcher when tableTriggerRedoDispatcherID is not nil
 	if tableTriggerRedoDispatcherID != nil {
@@ -81,7 +96,16 @@ func initRedoComponet(
 	manager.metricRedoCreateDispatcherDuration = metrics.CreateDispatcherDuration.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name(), "redoDispatcher")
 
 	// RedoMessageDs need register on every node
+	manager.writePathMu.Lock()
+	if manager.writePathClosed.Load() {
+		manager.writePathMu.Unlock()
+		return newWritePathClosedError()
+	}
 	appcontext.GetService[*HeartBeatCollector](appcontext.HeartbeatCollector).RegisterRedoMessageDs(manager)
+	manager.writePathMu.Unlock()
+	if manager.writePathClosed.Load() {
+		return newWritePathClosedError()
+	}
 	manager.wg.Add(1)
 	go func() {
 		defer manager.wg.Done()

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -595,6 +595,48 @@ func TestLocalFenceDoesNotWaitForBootstrapWriteBlockEvent(t *testing.T) {
 	require.False(t, appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector).HasDispatcher(dispatcherID))
 }
 
+func TestNewDispatcherManagerReturnsFenceErrorWhenInitializingRegistrationRejected(t *testing.T) {
+	appcontext.SetService(appcontext.DefaultPDClock, pdutil.NewClock4Test())
+
+	replicaConfig := config.GetDefaultReplicaConfig()
+	cfConfig := &config.ChangefeedConfig{
+		SinkURI:     "blackhole://",
+		SinkConfig:  replicaConfig.Sink,
+		Filter:      replicaConfig.Filter,
+		MemoryQuota: util.GetOrZero(replicaConfig.MemoryQuota),
+		TimeZone:    "system",
+		Consistent:  replicaConfig.Consistent,
+	}
+	changefeedID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+	var hookCalled atomic.Bool
+	var initializingManager *DispatcherManager
+
+	manager, err := NewDispatcherManager(
+		common.DefaultKeyspaceID,
+		changefeedID,
+		cfConfig,
+		nil,
+		nil,
+		1,
+		node.ID("maintainer"),
+		true,
+		func(manager *DispatcherManager) bool {
+			hookCalled.Store(true)
+			initializingManager = manager
+			return false
+		},
+	)
+
+	require.Nil(t, manager)
+	require.True(t, hookCalled.Load())
+	require.NotNil(t, initializingManager)
+	require.True(t, IsWritePathClosedError(err))
+	require.True(t, initializingManager.writePathClosed.Load())
+	require.Eventually(t, func() bool {
+		return initializingManager.TryClose(false)
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestCheckpointTsMessageHandlerSkipsWriteAfterLocalFence(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -401,6 +401,32 @@ func TestTryCloseRemovedRequestAfterClosedReturnsImmediatelyAndTriggersCleanup(t
 	require.True(t, manager.TryClose(true))
 }
 
+func TestLocalFenceCancelsWritePathWithoutWaitingForCleanup(t *testing.T) {
+	manager := createTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	manager.ctx = ctx
+	manager.cancel = cancel
+
+	manager.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		manager.LocalFence()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow(t, "local fence should not wait for dispatcher manager cleanup")
+	}
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+
+	manager.wg.Done()
+	require.Eventually(t, func() bool {
+		return manager.TryClose(false)
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestMergeDispatcherExistingID(t *testing.T) {
 	manager := createTestManager(t)
 

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -427,6 +427,19 @@ func TestLocalFenceCancelsWritePathWithoutWaitingForCleanup(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestLocalFenceWithRedoEnabledBeforeRedoSinkInitialized(t *testing.T) {
+	manager := createTestManager(t)
+	manager.redoEnabled = true
+	manager.redoSink = nil
+
+	require.NotPanics(t, func() {
+		manager.LocalFence()
+	})
+	require.Eventually(t, func() bool {
+		return manager.TryClose(false)
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestMergeDispatcherExistingID(t *testing.T) {
 	manager := createTestManager(t)
 

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -27,10 +27,12 @@ import (
 	"github.com/pingcap/ticdc/downstreamadapter/sink/mock"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/mysql"
 	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/pingcap/ticdc/logservice/schemastore"
 	"github.com/pingcap/ticdc/pkg/common"
 	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	"github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
@@ -144,6 +146,86 @@ func createTestManager(t *testing.T) *DispatcherManager {
 	ec := eventcollector.New(nodeID)
 	appcontext.SetService(appcontext.EventCollector, ec)
 	return manager
+}
+
+type bootstrapSchemaStoreForTest struct{}
+
+func (s *bootstrapSchemaStoreForTest) Name() string { return "bootstrap-schema-store-for-test" }
+
+func (s *bootstrapSchemaStoreForTest) Run(ctx context.Context) error { return nil }
+
+func (s *bootstrapSchemaStoreForTest) Close(ctx context.Context) error { return nil }
+
+func (s *bootstrapSchemaStoreForTest) GetAllPhysicalTables(
+	keyspaceMeta common.KeyspaceMeta,
+	snapTs uint64,
+	filter filter.Filter,
+) ([]event.Table, error) {
+	return nil, nil
+}
+
+func (s *bootstrapSchemaStoreForTest) RegisterTable(
+	keyspaceMeta common.KeyspaceMeta,
+	tableID int64,
+	startTs uint64,
+) error {
+	return nil
+}
+
+func (s *bootstrapSchemaStoreForTest) UnregisterTable(
+	keyspaceMeta common.KeyspaceMeta,
+	tableID int64,
+) error {
+	return nil
+}
+
+func (s *bootstrapSchemaStoreForTest) GetTableInfo(
+	keyspaceMeta common.KeyspaceMeta,
+	tableID int64,
+	ts uint64,
+) (*common.TableInfo, error) {
+	return &common.TableInfo{
+		TableName: common.TableName{
+			Schema:  "test",
+			Table:   "t",
+			TableID: tableID,
+		},
+	}, nil
+}
+
+func (s *bootstrapSchemaStoreForTest) GetTableDDLEventState(
+	keyspaceMeta common.KeyspaceMeta,
+	tableID int64,
+) (schemastore.DDLEventState, error) {
+	return schemastore.DDLEventState{}, nil
+}
+
+func (s *bootstrapSchemaStoreForTest) FetchTableDDLEvents(
+	keyspaceMeta common.KeyspaceMeta,
+	dispatcherID common.DispatcherID,
+	tableID int64,
+	tableFilter filter.Filter,
+	start uint64,
+	end uint64,
+) ([]event.DDLEvent, error) {
+	return nil, nil
+}
+
+func (s *bootstrapSchemaStoreForTest) FetchTableTriggerDDLEvents(
+	keyspaceMeta common.KeyspaceMeta,
+	dispatcherID common.DispatcherID,
+	tableFilter filter.Filter,
+	start uint64,
+	limit int,
+) ([]event.DDLEvent, uint64, error) {
+	return nil, 0, nil
+}
+
+func (s *bootstrapSchemaStoreForTest) RegisterKeyspace(
+	ctx context.Context,
+	keyspaceMeta common.KeyspaceMeta,
+) error {
+	return nil
 }
 
 func TestCollectComponentStatusWhenChangedWatermarkSeqNoFallback(t *testing.T) {
@@ -425,6 +507,136 @@ func TestLocalFenceCancelsWritePathWithoutWaitingForCleanup(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return manager.TryClose(false)
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestLocalFenceDoesNotWaitForBootstrapWriteBlockEvent(t *testing.T) {
+	manager := createTestManager(t)
+	appcontext.SetService(appcontext.SchemaStore, &bootstrapSchemaStoreForTest{})
+	heartbeatCollector := &HeartBeatCollector{}
+	heartbeatCollector.isClosed.Store(true)
+	appcontext.SetService(appcontext.HeartbeatCollector, heartbeatCollector)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	writeStarted := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	mockSink := mock.NewMockSink(ctrl)
+	mockSink.EXPECT().SinkType().Return(common.KafkaSinkType).AnyTimes()
+	mockSink.EXPECT().IsNormal().Return(true).AnyTimes()
+	mockSink.EXPECT().SetTableSchemaStore(gomock.Any()).AnyTimes()
+	mockSink.EXPECT().Close().AnyTimes()
+	mockSink.EXPECT().WriteBlockEvent(gomock.Any()).DoAndReturn(func(blockEvent event.BlockEvent) error {
+		close(writeStarted)
+		<-releaseWrite
+		blockEvent.PostFlush()
+		return nil
+	}).Times(1)
+	manager.sink = mockSink
+
+	dispatcherID := common.NewDispatcherID()
+	var redoTs atomic.Uint64
+	redoTs.Store(math.MaxUint64)
+	tableTriggerDispatcher := dispatcher.NewEventDispatcher(
+		dispatcherID,
+		common.KeyspaceDDLSpan(common.DefaultKeyspaceID),
+		1,
+		0,
+		manager.schemaIDToDispatchers,
+		false,
+		false,
+		0,
+		manager.sink,
+		manager.sharedInfo,
+		false,
+		&redoTs,
+	)
+	tableTriggerDispatcher.BootstrapState = dispatcher.BootstrapNotStarted
+	manager.SetTableTriggerEventDispatcher(tableTriggerDispatcher)
+	manager.dispatcherMap.Set(dispatcherID, tableTriggerDispatcher)
+
+	initErrCh := make(chan error, 1)
+	go func() {
+		initErrCh <- manager.InitalizeTableTriggerEventDispatcher([]*heartbeatpb.SchemaInfo{
+			{
+				SchemaID:   1,
+				SchemaName: "test",
+				Tables: []*heartbeatpb.TableInfo{
+					{TableID: 11, TableName: "t"},
+				},
+			},
+		})
+	}()
+
+	select {
+	case <-writeStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "bootstrap should reach WriteBlockEvent")
+	}
+
+	fenceDone := make(chan struct{})
+	go func() {
+		manager.LocalFence()
+		close(fenceDone)
+	}()
+	select {
+	case <-fenceDone:
+	case <-time.After(100 * time.Millisecond):
+		require.FailNow(t, "local fence should not wait for blocked bootstrap WriteBlockEvent")
+	}
+
+	close(releaseWrite)
+	select {
+	case err := <-initErrCh:
+		require.True(t, IsWritePathClosedError(err))
+	case <-time.After(time.Second):
+		require.FailNow(t, "bootstrap initialization should return after write unblocks")
+	}
+	require.False(t, appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector).HasDispatcher(dispatcherID))
+}
+
+func TestCheckpointTsMessageHandlerSkipsWriteAfterLocalFence(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSink := mock.NewMockSink(ctrl)
+	mockSink.EXPECT().SinkType().Return(common.MysqlSinkType).AnyTimes()
+	mockSink.EXPECT().Close().AnyTimes()
+	mockSink.EXPECT().AddCheckpointTs(gomock.Any()).Times(0)
+
+	manager := createTestManager(t)
+	manager.sink = mockSink
+	manager.SetTableTriggerEventDispatcher(&dispatcher.EventDispatcher{})
+	heartbeatCollector := &HeartBeatCollector{}
+	heartbeatCollector.isClosed.Store(true)
+	appcontext.SetService(appcontext.HeartbeatCollector, heartbeatCollector)
+
+	handlerStarted := make(chan struct{})
+	proceed := make(chan struct{})
+	handlerDone := make(chan struct{})
+	go func() {
+		close(handlerStarted)
+		<-proceed
+		handler := &CheckpointTsMessageHandler{}
+		handler.Handle(manager, NewCheckpointTsMessage(&heartbeatpb.CheckpointTsMessage{
+			ChangefeedID: manager.changefeedID.ToPB(),
+			CheckpointTs: 100,
+		}))
+		close(handlerDone)
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "handler goroutine should start")
+	}
+	manager.LocalFence()
+	close(proceed)
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "handler should return without writing checkpoint ts")
+	}
 }
 
 func TestLocalFenceWithRedoEnabledBeforeRedoSinkInitialized(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -440,6 +440,95 @@ func TestLocalFenceWithRedoEnabledBeforeRedoSinkInitialized(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestNewTableTriggerDispatchersReturnFenceErrorWhenWritePathClosed(t *testing.T) {
+	manager := createTestManager(t)
+	manager.writePathClosed.Store(true)
+
+	dispatcherID := common.NewDispatcherID()
+	require.NotPanics(t, func() {
+		err := manager.NewTableTriggerEventDispatcher(dispatcherID.ToPB(), 1, false)
+		require.True(t, IsWritePathClosedError(err))
+	})
+	require.Nil(t, manager.GetTableTriggerEventDispatcher())
+
+	redoDispatcherID := common.NewDispatcherID()
+	require.NotPanics(t, func() {
+		err := manager.NewTableTriggerRedoDispatcher(redoDispatcherID.ToPB(), 1, false)
+		require.True(t, IsWritePathClosedError(err))
+	})
+	require.Nil(t, manager.GetTableTriggerRedoDispatcher())
+}
+
+func TestInitializeTableTriggerEventDispatcherReturnsFenceErrorWhenWritePathClosed(t *testing.T) {
+	manager := createTestManager(t)
+	dispatcherID := common.NewDispatcherID()
+	var redoTs atomic.Uint64
+	redoTs.Store(math.MaxUint64)
+	tableTriggerDispatcher := dispatcher.NewEventDispatcher(
+		dispatcherID,
+		common.KeyspaceDDLSpan(common.DefaultKeyspaceID),
+		1,
+		0,
+		manager.schemaIDToDispatchers,
+		false,
+		false,
+		0,
+		manager.sink,
+		manager.sharedInfo,
+		false,
+		&redoTs,
+	)
+	manager.SetTableTriggerEventDispatcher(tableTriggerDispatcher)
+	manager.dispatcherMap.Set(dispatcherID, tableTriggerDispatcher)
+	manager.writePathClosed.Store(true)
+
+	err := manager.InitalizeTableTriggerEventDispatcher(nil)
+	require.True(t, IsWritePathClosedError(err))
+
+	err = manager.InitalizeTableTriggerRedoDispatcher(nil)
+	require.True(t, IsWritePathClosedError(err))
+
+	eventCollector := appcontext.GetService[*eventcollector.EventCollector](appcontext.EventCollector)
+	require.False(t, eventCollector.HasDispatcher(dispatcherID))
+}
+
+func TestCreateDispatcherByInfoKeepsCreateOperatorWhenFenced(t *testing.T) {
+	manager := createTestManager(t)
+	manager.writePathClosed.Store(true)
+	dispatcherID := common.NewDispatcherID()
+	createReq := NewSchedulerDispatcherRequest(&heartbeatpb.ScheduleDispatcherRequest{
+		ChangefeedID: manager.changefeedID.ToPB(),
+		Config: &heartbeatpb.DispatcherConfig{
+			DispatcherID: dispatcherID.ToPB(),
+			Span: &heartbeatpb.TableSpan{
+				TableID: 1,
+			},
+			StartTs: 1,
+			Mode:    common.DefaultMode,
+		},
+		ScheduleAction: heartbeatpb.ScheduleAction_Create,
+		OperatorType:   heartbeatpb.OperatorType_O_Add,
+	})
+	manager.currentOperatorMap.Store(dispatcherID, createReq)
+
+	createDispatcherByInfo(manager, map[common.DispatcherID]dispatcherCreateInfo{
+		dispatcherID: {
+			Id: dispatcherID,
+			TableSpan: &heartbeatpb.TableSpan{
+				TableID: 1,
+			},
+			StartTs:  1,
+			SchemaID: 1,
+		},
+	}, nil)
+
+	_, dispatcherExists := manager.dispatcherMap.Get(dispatcherID)
+	require.False(t, dispatcherExists)
+	operator, operatorExists := manager.currentOperatorMap.Load(dispatcherID)
+	require.True(t, operatorExists)
+	require.Equal(t, createReq, operator)
+}
+
 func TestMergeDispatcherExistingID(t *testing.T) {
 	manager := createTestManager(t)
 

--- a/downstreamadapter/dispatchermanager/helper.go
+++ b/downstreamadapter/dispatchermanager/helper.go
@@ -619,7 +619,7 @@ func (h *CheckpointTsMessageHandler) Handle(dispatcherManager *DispatcherManager
 	}
 	if dispatcherManager.GetTableTriggerEventDispatcher() != nil {
 		checkpointTsMessage := messages[0]
-		dispatcherManager.sink.AddCheckpointTs(checkpointTsMessage.CheckpointTs)
+		dispatcherManager.addCheckpointTs(checkpointTsMessage.CheckpointTs)
 	}
 	return false
 }

--- a/downstreamadapter/dispatchermanager/helper.go
+++ b/downstreamadapter/dispatchermanager/helper.go
@@ -408,40 +408,57 @@ func createDispatcherByInfo(
 	if len(redoInfos) > 0 {
 		err := dispatcherManager.newRedoDispatchers(redoInfos, false)
 		if err != nil {
+			if IsWritePathClosedError(err) {
+				log.Info("dispatcher manager write path closed, keep add operators for redo dispatchers",
+					zap.String("changefeedID", dispatcherManager.changefeedID.String()),
+					zap.Int("count", len(redoInfos)),
+					zap.Error(err),
+				)
+				return
+			}
 			dispatcherManager.handleError(context.Background(), err)
 		}
-		for _, info := range redoInfos {
-			// Create requests are stored in currentOperatorMap before creation and should be deleted once the dispatcher is created.
-			if v, ok := dispatcherManager.currentOperatorMap.Load(info.Id); ok {
-				req := v.(SchedulerDispatcherRequest)
-				if req.ScheduleAction == heartbeatpb.ScheduleAction_Create {
-					log.Debug("delete current working add operator for redo dispatcher",
-						zap.String("changefeedID", dispatcherManager.changefeedID.String()),
-						zap.String("dispatcherID", info.Id.String()),
-						zap.Any("operator", req),
-					)
-					dispatcherManager.currentOperatorMap.Delete(info.Id)
-				}
-			}
-		}
+		deleteCreatedOperators(dispatcherManager, redoInfos, dispatcherManager.redoDispatcherMap, "redo dispatcher")
 	}
 	if len(infos) > 0 {
 		err := dispatcherManager.newEventDispatchers(infos, false)
 		if err != nil {
+			if IsWritePathClosedError(err) {
+				log.Info("dispatcher manager write path closed, keep add operators",
+					zap.String("changefeedID", dispatcherManager.changefeedID.String()),
+					zap.Int("count", len(infos)),
+					zap.Error(err),
+				)
+				return
+			}
 			dispatcherManager.handleError(context.Background(), err)
 		}
-		for _, info := range infos {
-			// Create requests are stored in currentOperatorMap before creation and should be deleted once the dispatcher is created.
-			if v, ok := dispatcherManager.currentOperatorMap.Load(info.Id); ok {
-				req := v.(SchedulerDispatcherRequest)
-				if req.ScheduleAction == heartbeatpb.ScheduleAction_Create {
-					log.Debug("delete current working add operator",
-						zap.String("changefeedID", dispatcherManager.changefeedID.String()),
-						zap.String("dispatcherID", info.Id.String()),
-						zap.Any("operator", req),
-					)
-					dispatcherManager.currentOperatorMap.Delete(info.Id)
-				}
+		deleteCreatedOperators(dispatcherManager, infos, dispatcherManager.dispatcherMap, "dispatcher")
+	}
+}
+
+func deleteCreatedOperators[T dispatcher.Dispatcher](
+	dispatcherManager *DispatcherManager,
+	infos map[common.DispatcherID]dispatcherCreateInfo,
+	dispatcherMap *DispatcherMap[T],
+	dispatcherKind string,
+) {
+	for _, info := range infos {
+		if _, exists := dispatcherMap.Get(info.Id); !exists {
+			continue
+		}
+		// Create requests are stored in currentOperatorMap before creation and
+		// should be deleted only after the dispatcher is actually created.
+		if v, ok := dispatcherManager.currentOperatorMap.Load(info.Id); ok {
+			req := v.(SchedulerDispatcherRequest)
+			if req.ScheduleAction == heartbeatpb.ScheduleAction_Create {
+				log.Debug("delete current working add operator",
+					zap.String("changefeedID", dispatcherManager.changefeedID.String()),
+					zap.String("dispatcherID", info.Id.String()),
+					zap.String("dispatcherKind", dispatcherKind),
+					zap.Any("operator", req),
+				)
+				dispatcherManager.currentOperatorMap.Delete(info.Id)
 			}
 		}
 	}

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -49,6 +49,9 @@ type DispatcherOrchestrator struct {
 
 	// closed indicates Close has been invoked and no more messages should be enqueued.
 	closed atomic.Bool
+	// fenced indicates this capture has lost local liveness and must stop local
+	// downstream writes without waiting for graceful dispatcher draining.
+	fenced atomic.Bool
 	// msgGuardWaitGroup waits for in-flight RecvMaintainerRequest handlers before shutdown.
 	msgGuardWaitGroup util.GuardedWaitGroup
 }
@@ -87,7 +90,7 @@ func (m *DispatcherOrchestrator) RecvMaintainerRequest(
 	_ context.Context,
 	msg *messaging.TargetMessage,
 ) error {
-	if !m.msgGuardWaitGroup.AddIf(func() bool { return !m.closed.Load() }) {
+	if !m.msgGuardWaitGroup.AddIf(func() bool { return !m.closed.Load() && !m.fenced.Load() }) {
 		log.Debug("dispatcher orchestrator already closed, drop message", zap.Any("message", msg.Message))
 		return nil
 	}
@@ -139,6 +142,12 @@ func getPendingMessageKey(msg *messaging.TargetMessage) (pendingMessageKey, bool
 // processMessage dispatches a queued control message to the existing handler
 // implementation. Shards only change concurrency, not per-message behavior.
 func (m *DispatcherOrchestrator) processMessage(msg *messaging.TargetMessage) {
+	if m.fenced.Load() {
+		log.Info("dispatcher orchestrator is fenced, drop pending message",
+			zap.String("type", msg.Type.String()))
+		return
+	}
+
 	switch req := msg.Message[0].(type) {
 	case *heartbeatpb.MaintainerBootstrapRequest:
 		if err := m.handleBootstrapRequest(msg.From, req); err != nil {
@@ -164,6 +173,9 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 	from node.ID,
 	req *heartbeatpb.MaintainerBootstrapRequest,
 ) error {
+	if m.fenced.Load() {
+		return nil
+	}
 	cfId := common.NewChangefeedIDFromPB(req.ChangefeedID)
 
 	cfConfig := &config.ChangefeedConfig{}
@@ -214,10 +226,18 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 			return m.sendResponse(from, messaging.MaintainerManagerTopic, response)
 		}
 		m.mutex.Lock()
+		if m.fenced.Load() || m.closed.Load() {
+			m.mutex.Unlock()
+			manager.LocalFence()
+			return nil
+		}
 		m.dispatcherManagers[cfId] = manager
 		m.mutex.Unlock()
 		metrics.DispatcherManagerGauge.WithLabelValues(cfId.Keyspace(), cfId.Name()).Inc()
 	} else {
+		if m.fenced.Load() {
+			return nil
+		}
 		// Check and potentially add a table trigger event dispatcher.
 		// This is necessary during maintainer node migration, as the existing
 		// dispatcher manager on the new node may not have a table trigger
@@ -375,6 +395,36 @@ func (m *DispatcherOrchestrator) handleCloseRequest(
 	log.Info("try close dispatcher manager",
 		zap.String("changefeed", cfId.String()), zap.Bool("success", response.Success))
 	return m.sendResponse(from, messaging.MaintainerTopic, response)
+}
+
+// LocalFence stops all local dispatcher managers from writing downstream without
+// waiting for dispatcher drain. Full resource cleanup is still handled by Close.
+func (m *DispatcherOrchestrator) LocalFence() {
+	if !m.fenced.CompareAndSwap(false, true) {
+		m.localFenceManagers()
+		return
+	}
+	log.Warn("dispatcher orchestrator local fence triggered")
+
+	m.mc.DeRegisterHandler(messaging.DispatcherManagerManagerTopic)
+	m.msgGuardWaitGroup.Wait()
+	for _, shard := range m.shards {
+		shard.CloseAsync()
+	}
+	m.localFenceManagers()
+}
+
+func (m *DispatcherOrchestrator) localFenceManagers() {
+	m.mutex.Lock()
+	managers := make([]*dispatchermanager.DispatcherManager, 0, len(m.dispatcherManagers))
+	for _, manager := range m.dispatcherManagers {
+		managers = append(managers, manager)
+	}
+	m.mutex.Unlock()
+
+	for _, manager := range managers {
+		manager.LocalFence()
+	}
 }
 
 func createBootstrapResponse(

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -41,6 +41,9 @@ type DispatcherOrchestrator struct {
 	mc                 messaging.MessageCenter
 	mutex              sync.Mutex // protect dispatcherManagers
 	dispatcherManagers map[common.ChangeFeedID]*dispatchermanager.DispatcherManager
+	// initializingDispatcherManagers tracks managers that have been allocated
+	// but are not yet visible in dispatcherManagers.
+	initializingDispatcherManagers map[common.ChangeFeedID]*dispatchermanager.DispatcherManager
 
 	// shards partition changefeed control messages by changefeed ID. Each shard keeps
 	// the existing FIFO queue semantics, while different shards can process messages
@@ -65,9 +68,10 @@ const (
 
 func New() *DispatcherOrchestrator {
 	m := &DispatcherOrchestrator{
-		mc:                 appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter),
-		dispatcherManagers: make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
-		shards:             make([]*orchestratorShard, dispatcherOrchestratorShardCount),
+		mc:                             appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter),
+		dispatcherManagers:             make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
+		initializingDispatcherManagers: make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
+		shards:                         make([]*orchestratorShard, dispatcherOrchestratorShardCount),
 	}
 	for i := range m.shards {
 		m.shards[i] = newOrchestratorShard(m.processMessage)
@@ -194,6 +198,7 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 	var err error
 	if !exists {
 		start := time.Now()
+		var initializingManager *dispatchermanager.DispatcherManager
 		manager, err = dispatchermanager.NewDispatcherManager(
 			req.KeyspaceId,
 			cfId,
@@ -203,9 +208,21 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 			req.StartTs,
 			from,
 			req.IsNewChangefeed,
+			func(manager *dispatchermanager.DispatcherManager) bool {
+				initializingManager = manager
+				return m.registerInitializingDispatcherManager(cfId, manager)
+			},
 		)
+		if initializingManager != nil {
+			m.removeInitializingDispatcherManager(cfId, initializingManager)
+		}
 		// Fast return the error to maintainer.
 		if err != nil {
+			if dispatchermanager.IsWritePathClosedError(err) || m.fenced.Load() || m.closed.Load() {
+				log.Info("dispatcher manager write path closed while creating dispatcher manager",
+					zap.Stringer("changefeedID", cfId), zap.Duration("duration", time.Since(start)), zap.Error(err))
+				return nil
+			}
 			log.Error("failed to create new dispatcher manager",
 				zap.Any("changefeedID", cfId.Name()), zap.Duration("duration", time.Since(start)), zap.Error(err))
 
@@ -450,14 +467,47 @@ func (m *DispatcherOrchestrator) LocalFence() {
 
 func (m *DispatcherOrchestrator) localFenceManagers() {
 	m.mutex.Lock()
-	managers := make([]*dispatchermanager.DispatcherManager, 0, len(m.dispatcherManagers))
+	managers := make([]*dispatchermanager.DispatcherManager, 0,
+		len(m.dispatcherManagers)+len(m.initializingDispatcherManagers))
 	for _, manager := range m.dispatcherManagers {
+		managers = append(managers, manager)
+	}
+	for _, manager := range m.initializingDispatcherManagers {
 		managers = append(managers, manager)
 	}
 	m.mutex.Unlock()
 
 	for _, manager := range managers {
 		manager.LocalFence()
+	}
+}
+
+func (m *DispatcherOrchestrator) registerInitializingDispatcherManager(
+	cfID common.ChangeFeedID,
+	manager *dispatchermanager.DispatcherManager,
+) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.fenced.Load() || m.closed.Load() {
+		return false
+	}
+	if m.initializingDispatcherManagers == nil {
+		m.initializingDispatcherManagers = make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager)
+	}
+	m.initializingDispatcherManagers[cfID] = manager
+	return true
+}
+
+func (m *DispatcherOrchestrator) removeInitializingDispatcherManager(
+	cfID common.ChangeFeedID,
+	manager *dispatchermanager.DispatcherManager,
+) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.initializingDispatcherManagers[cfID] == manager {
+		delete(m.initializingDispatcherManagers, cfID)
 	}
 }
 

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -251,6 +251,11 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 					false,
 				)
 				if err != nil {
+					if dispatchermanager.IsWritePathClosedError(err) {
+						log.Info("dispatcher manager write path closed while creating table trigger event dispatcher",
+							zap.Stringer("changefeedID", cfId), zap.Error(err))
+						return nil
+					}
 					log.Error("failed to create new table trigger event dispatcher",
 						zap.Stringer("changefeedID", cfId), zap.Error(err))
 					return m.handleDispatcherError(from, req.ChangefeedID, err)
@@ -266,6 +271,11 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 					false,
 				)
 				if err != nil {
+					if dispatchermanager.IsWritePathClosedError(err) {
+						log.Info("dispatcher manager write path closed while creating table trigger redo dispatcher",
+							zap.Stringer("changefeedID", cfId), zap.Error(err))
+						return nil
+					}
 					log.Error("failed to create new table trigger redo dispatcher",
 						zap.Stringer("changefeedID", cfId), zap.Error(err))
 					return m.handleDispatcherError(from, req.ChangefeedID, err)
@@ -285,6 +295,11 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 	if manager.GetMaintainerEpoch() != cfConfig.Epoch {
 		log.Error("maintainer epoch changed, this should not happen, please report this issue",
 			zap.String("changefeed", cfId.Name()), zap.Uint64("epoch", cfConfig.Epoch))
+	}
+
+	if m.fenced.Load() {
+		manager.LocalFence()
+		return nil
 	}
 
 	var (
@@ -311,6 +326,9 @@ func (m *DispatcherOrchestrator) handlePostBootstrapRequest(
 	from node.ID,
 	req *heartbeatpb.MaintainerPostBootstrapRequest,
 ) error {
+	if m.fenced.Load() {
+		return nil
+	}
 	cfId := common.NewChangefeedIDFromPB(req.ChangefeedID)
 
 	m.mutex.Lock()
@@ -350,6 +368,11 @@ func (m *DispatcherOrchestrator) handlePostBootstrapRequest(
 	// init table schema store
 	err := manager.InitalizeTableTriggerEventDispatcher(req.Schemas)
 	if err != nil {
+		if dispatchermanager.IsWritePathClosedError(err) {
+			log.Info("dispatcher manager write path closed while initializing table trigger event dispatcher",
+				zap.Any("changefeedID", cfId.Name()), zap.Error(err))
+			return nil
+		}
 		log.Error("failed to initialize table trigger event dispatcher",
 			zap.Any("changefeedID", cfId.Name()), zap.Error(err))
 		return m.handleDispatcherError(from, req.ChangefeedID, err)
@@ -357,10 +380,20 @@ func (m *DispatcherOrchestrator) handlePostBootstrapRequest(
 	if manager.IsRedoReady() {
 		err := manager.InitalizeTableTriggerRedoDispatcher(req.RedoSchemas)
 		if err != nil {
+			if dispatchermanager.IsWritePathClosedError(err) {
+				log.Info("dispatcher manager write path closed while initializing table trigger redo dispatcher",
+					zap.Any("changefeedID", cfId.Name()), zap.Error(err))
+				return nil
+			}
 			log.Error("failed to initialize table trigger redo dispatcher",
 				zap.Any("changefeedID", cfId.Name()), zap.Error(err))
 			return m.handleDispatcherError(from, req.ChangefeedID, err)
 		}
+	}
+
+	if m.fenced.Load() {
+		manager.LocalFence()
+		return nil
 	}
 
 	response := &heartbeatpb.MaintainerPostBootstrapResponse{
@@ -407,6 +440,7 @@ func (m *DispatcherOrchestrator) LocalFence() {
 	log.Warn("dispatcher orchestrator local fence triggered")
 
 	m.mc.DeRegisterHandler(messaging.DispatcherManagerManagerTopic)
+	m.localFenceManagers()
 	m.msgGuardWaitGroup.Wait()
 	for _, shard := range m.shards {
 		shard.CloseAsync()

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -425,3 +425,39 @@ func TestGetPendingMessageKey_SupportedTypes(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, pendingMessageKey{changefeedID: cfID, msgType: messaging.TypeMaintainerCloseRequest}, key)
 }
+
+func TestDispatcherOrchestratorLocalFenceDropsNewMessages(t *testing.T) {
+	mc, _, stop := messaging.NewMessageCenterForTest(t)
+	defer stop()
+
+	orchestrator := &DispatcherOrchestrator{
+		mc:                 mc,
+		dispatcherManagers: make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
+		shards:             make([]*orchestratorShard, dispatcherOrchestratorShardCount),
+	}
+	processed := make(chan struct{}, 1)
+	for i := range orchestrator.shards {
+		orchestrator.shards[i] = newOrchestratorShard(func(msg *messaging.TargetMessage) {
+			processed <- struct{}{}
+		})
+		orchestrator.shards[i].Run()
+	}
+	orchestrator.LocalFence()
+	for _, shard := range orchestrator.shards {
+		shard.Wait()
+	}
+
+	cfID := common.NewChangeFeedIDWithName("cf", "default")
+	msg := messaging.NewSingleTargetMessage(
+		node.ID("to"),
+		messaging.DispatcherManagerManagerTopic,
+		&heartbeatpb.MaintainerCloseRequest{ChangefeedID: cfID.ToPB()},
+	)
+	require.NoError(t, orchestrator.RecvMaintainerRequest(context.Background(), msg))
+
+	select {
+	case <-processed:
+		require.FailNow(t, "local fence should drop new maintainer messages")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -171,8 +171,9 @@ func newTestDispatcherOrchestrator() *DispatcherOrchestrator {
 	// This test only exercises local routing through RecvMaintainerRequest, so it
 	// needs shard state and the dispatcher manager map but not a message center.
 	orchestrator := &DispatcherOrchestrator{
-		dispatcherManagers: make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
-		shards:             make([]*orchestratorShard, dispatcherOrchestratorShardCount),
+		dispatcherManagers:             make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
+		initializingDispatcherManagers: make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
+		shards:                         make([]*orchestratorShard, dispatcherOrchestratorShardCount),
 	}
 	for i := range orchestrator.shards {
 		orchestrator.shards[i] = newOrchestratorShard(func(msg *messaging.TargetMessage) {})
@@ -474,6 +475,33 @@ func TestDispatcherOrchestratorLocalFenceFencesManagersImmediately(t *testing.T)
 			cfID: manager,
 		},
 		shards: make([]*orchestratorShard, dispatcherOrchestratorShardCount),
+	}
+	for i := range orchestrator.shards {
+		orchestrator.shards[i] = newOrchestratorShard(func(msg *messaging.TargetMessage) {})
+		orchestrator.shards[i].Run()
+	}
+	orchestrator.LocalFence()
+	for _, shard := range orchestrator.shards {
+		shard.Wait()
+	}
+
+	err := manager.InitalizeTableTriggerEventDispatcher(nil)
+	require.True(t, dispatchermanager.IsWritePathClosedError(err))
+}
+
+func TestDispatcherOrchestratorLocalFenceFencesInitializingManagersImmediately(t *testing.T) {
+	mc, _, stop := messaging.NewMessageCenterForTest(t)
+	defer stop()
+
+	cfID := common.NewChangeFeedIDWithName("cf", "default")
+	manager := &dispatchermanager.DispatcherManager{}
+	orchestrator := &DispatcherOrchestrator{
+		mc: mc,
+		initializingDispatcherManagers: map[common.ChangeFeedID]*dispatchermanager.DispatcherManager{
+			cfID: manager,
+		},
+		dispatcherManagers: make(map[common.ChangeFeedID]*dispatchermanager.DispatcherManager),
+		shards:             make([]*orchestratorShard, dispatcherOrchestratorShardCount),
 	}
 	for i := range orchestrator.shards {
 		orchestrator.shards[i] = newOrchestratorShard(func(msg *messaging.TargetMessage) {})

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -461,3 +461,29 @@ func TestDispatcherOrchestratorLocalFenceDropsNewMessages(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 }
+
+func TestDispatcherOrchestratorLocalFenceFencesManagersImmediately(t *testing.T) {
+	mc, _, stop := messaging.NewMessageCenterForTest(t)
+	defer stop()
+
+	cfID := common.NewChangeFeedIDWithName("cf", "default")
+	manager := &dispatchermanager.DispatcherManager{}
+	orchestrator := &DispatcherOrchestrator{
+		mc: mc,
+		dispatcherManagers: map[common.ChangeFeedID]*dispatchermanager.DispatcherManager{
+			cfID: manager,
+		},
+		shards: make([]*orchestratorShard, dispatcherOrchestratorShardCount),
+	}
+	for i := range orchestrator.shards {
+		orchestrator.shards[i] = newOrchestratorShard(func(msg *messaging.TargetMessage) {})
+		orchestrator.shards[i].Run()
+	}
+	orchestrator.LocalFence()
+	for _, shard := range orchestrator.shards {
+		shard.Wait()
+	}
+
+	err := manager.InitalizeTableTriggerEventDispatcher(nil)
+	require.True(t, dispatchermanager.IsWritePathClosedError(err))
+}

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -790,6 +790,10 @@ var (
 		"failed to init table trigger dispatcher",
 		errors.RFCCodeText("CDC:ErrChangefeedInitTableTriggerDispatcherFailed"),
 	)
+	ErrDispatcherManagerWritePathClosed = errors.Normalize(
+		"dispatcher manager write path is closed",
+		errors.RFCCodeText("CDC:ErrDispatcherManagerWritePathClosed"),
+	)
 	ErrDDLEventError = errors.Normalize(
 		"ddl event meets error",
 		errors.RFCCodeText("CDC:ErrDDLEventError"),

--- a/pkg/sink/mysql/mysql_writer_dml_exec.go
+++ b/pkg/sink/mysql/mysql_writer_dml_exec.go
@@ -99,7 +99,10 @@ func (w *Writer) execDMLWithMaxRetries(dmls *preparedDMLs) error {
 			failpoint.Return(err)
 		})
 
-		failpoint.Inject("MySQLSinkHangLongTime", func() { _ = util.Hang(w.ctx, time.Hour) })
+		failpoint.Inject("MySQLSinkHangLongTime", func() {
+			log.Warn("inject MySQLSinkHangLongTime")
+			_ = util.Hang(w.ctx, time.Hour)
+		})
 
 		failpoint.Inject("MySQLDuplicateEntryError", func() {
 			log.Warn("inject MySQLDuplicateEntryError")

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/upstream"
 	"github.com/pingcap/ticdc/server/watcher"
 	pd "github.com/tikv/pd/client"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -57,9 +58,14 @@ const (
 	closeServiceTimeout  = 15 * time.Second
 	cleanMetaDuration    = 10 * time.Second
 	oldArchCheckInterval = 100 * time.Millisecond
+	sessionWatchInterval = time.Second
 	// GracefulShutdownTimeout is used to prevent the CDC process from hanging for an extended period due to certain modules don't exit immediately.
 	GracefulShutdownTimeout = 30 * time.Second
 )
+
+type localFencer interface {
+	LocalFence()
+}
 
 // server represents the main TiCDC server with carefully orchestrated module lifecycle management.
 //
@@ -137,6 +143,8 @@ type server struct {
 	subModules []common.SubModule
 
 	closed atomic.Bool
+
+	localFenceOnce atomic.Bool
 }
 
 // New returns a new Server instance
@@ -337,7 +345,9 @@ func (c *server) Run(ctx context.Context) error {
 		}(sub)
 	}
 
-	g, gctx := errgroup.WithContext(egctx)
+	groupCtx, cancelGroup := context.WithCancel(egctx)
+	defer cancelGroup()
+	g, gctx := errgroup.WithContext(groupCtx)
 	// start all subCommonModules
 	for _, sub := range c.nodeModules {
 		func(m common.SubModule) {
@@ -371,6 +381,14 @@ func (c *server) Run(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 
+	fatalErrCh := make(chan error, 1)
+	go func() {
+		if err := c.runSessionWatchdog(gctx, sessionWatchInterval); err != nil {
+			fatalErrCh <- err
+			cancelGroup()
+		}
+	}()
+
 	// if it takes too long for all sub modules to exit, then exit directly to avoid hanging.
 	ch := make(chan error, 1)
 	go func() {
@@ -381,8 +399,72 @@ func (c *server) Run(ctx context.Context) error {
 	go func() {
 		ch <- g.Wait()
 	}()
-	err = <-ch
+	select {
+	case err = <-fatalErrCh:
+	case err = <-ch:
+	}
 	return err
+}
+
+func (c *server) runSessionWatchdog(ctx context.Context, checkInterval time.Duration) error {
+	if c.session == nil {
+		return nil
+	}
+	return c.watchEtcdSession(ctx, c.session.Done(), c.session.Lease(), checkInterval)
+}
+
+func (c *server) watchEtcdSession(
+	ctx context.Context,
+	sessionDone <-chan struct{},
+	leaseID clientv3.LeaseID,
+	checkInterval time.Duration,
+) error {
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-sessionDone:
+			if ctx.Err() != nil {
+				return nil
+			}
+			c.localFence("etcd session done")
+			return errors.ErrCaptureSuicide.GenWithStackByArgs()
+		case <-ticker.C:
+			ttl, err := c.EtcdClient.GetEtcdClient().TimeToLive(ctx, leaseID)
+			if err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				log.Warn("check etcd session ttl failed", zap.Error(err))
+				continue
+			}
+			if ttl != nil && ttl.TTL == -1 {
+				c.localFence("etcd lease expired")
+				return errors.ErrCaptureSuicide.GenWithStackByArgs()
+			}
+		}
+	}
+}
+
+func (c *server) localFence(reason string) {
+	if !c.localFenceOnce.CompareAndSwap(false, true) {
+		return
+	}
+
+	log.Warn("local fence triggered", zap.String("reason", reason))
+
+	c.liveness.Store(liveness.CaptureDraining)
+	c.liveness.Store(liveness.CaptureStopping)
+
+	fencer, ok := appctx.TryGetService[localFencer](appctx.DispatcherOrchestrator)
+	if !ok {
+		log.Warn("dispatcher orchestrator is not available when local fence triggered")
+		return
+	}
+	fencer.LocalFence()
 }
 
 // validCheck checks whether the environment is valid to start the server

--- a/server/server_session_watchdog_test.go
+++ b/server/server_session_watchdog_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	appctx "github.com/pingcap/ticdc/pkg/common/context"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/etcd"
+	"github.com/pingcap/ticdc/pkg/liveness"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type testLocalFencer struct {
+	count atomic.Int32
+}
+
+func (f *testLocalFencer) LocalFence() {
+	f.count.Add(1)
+}
+
+func TestSessionWatchdogFencesOnSessionDone(t *testing.T) {
+	fencer := &testLocalFencer{}
+	appctx.SetService(appctx.DispatcherOrchestrator, fencer)
+
+	c := &server{}
+	sessionDone := make(chan struct{})
+	close(sessionDone)
+
+	err := c.watchEtcdSession(context.Background(), sessionDone, 1, time.Hour)
+
+	require.True(t, cerror.ErrCaptureSuicide.Equal(err), err)
+	require.Equal(t, int32(1), fencer.count.Load())
+	require.Equal(t, liveness.CaptureStopping, c.liveness.Load())
+}
+
+func TestSessionWatchdogFencesOnExpiredLease(t *testing.T) {
+	fencer := &testLocalFencer{}
+	appctx.SetService(appctx.DispatcherOrchestrator, fencer)
+
+	ctrl := gomock.NewController(t)
+	cdcEtcdClient := etcd.NewMockCDCEtcdClient(ctrl)
+	rawEtcdClient := etcd.NewMockClient(ctrl)
+	cdcEtcdClient.EXPECT().GetEtcdClient().Return(rawEtcdClient).AnyTimes()
+	rawEtcdClient.EXPECT().
+		TimeToLive(gomock.Any(), clientv3.LeaseID(100)).
+		Return(&clientv3.LeaseTimeToLiveResponse{TTL: -1}, nil)
+
+	c := &server{EtcdClient: cdcEtcdClient}
+	sessionDone := make(chan struct{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := c.watchEtcdSession(ctx, sessionDone, 100, time.Millisecond)
+
+	require.True(t, cerror.ErrCaptureSuicide.Equal(err), err)
+	require.Equal(t, int32(1), fencer.count.Load())
+	require.Equal(t, liveness.CaptureStopping, c.liveness.Load())
+}
+
+func TestLocalFenceIsIdempotent(t *testing.T) {
+	fencer := &testLocalFencer{}
+	appctx.SetService(appctx.DispatcherOrchestrator, fencer)
+
+	c := &server{}
+	c.localFence("first")
+	c.localFence("second")
+
+	require.Equal(t, int32(1), fencer.count.Load())
+	require.Equal(t, liveness.CaptureStopping, c.liveness.Load())
+}

--- a/server/server_session_watchdog_test.go
+++ b/server/server_session_watchdog_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	appctx "github.com/pingcap/ticdc/pkg/common/context"
-	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/liveness"
 	"github.com/stretchr/testify/require"
@@ -46,7 +46,7 @@ func TestSessionWatchdogFencesOnSessionDone(t *testing.T) {
 
 	err := c.watchEtcdSession(context.Background(), sessionDone, 1, time.Hour)
 
-	require.True(t, cerror.ErrCaptureSuicide.Equal(err), err)
+	require.True(t, errors.ErrCaptureSuicide.Equal(err), err)
 	require.Equal(t, int32(1), fencer.count.Load())
 	require.Equal(t, liveness.CaptureStopping, c.liveness.Load())
 }
@@ -70,7 +70,7 @@ func TestSessionWatchdogFencesOnExpiredLease(t *testing.T) {
 	defer cancel()
 	err := c.watchEtcdSession(ctx, sessionDone, 100, time.Millisecond)
 
-	require.True(t, cerror.ErrCaptureSuicide.Equal(err), err)
+	require.True(t, errors.ErrCaptureSuicide.Equal(err), err)
 	require.Equal(t, int32(1), fencer.count.Load())
 	require.Equal(t, liveness.CaptureStopping, c.liveness.Load())
 }

--- a/tests/integration_tests/capture_local_fence_on_session_done/conf/diff_config.toml
+++ b/tests/integration_tests/capture_local_fence_on_session_done/conf/diff_config.toml
@@ -1,0 +1,29 @@
+# diff Configuration.
+
+check-thread-count = 4
+
+export-fix-sql = true
+
+check-struct-only = false
+
+[task]
+    output-dir = "/tmp/tidb_cdc_test/capture_local_fence_on_session_done/sync_diff/output"
+
+    source-instances = ["mysql1"]
+
+    target-instance = "tidb0"
+
+    target-check-tables = ["capture_local_fence_on_session_done.?*"]
+
+[data-sources]
+[data-sources.mysql1]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+
+[data-sources.tidb0]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/integration_tests/capture_local_fence_on_session_done/run.sh
+++ b/tests/integration_tests/capture_local_fence_on_session_done/run.sh
@@ -24,7 +24,7 @@ function get_capture_addr_by_port() {
 
 	for ((i = 0; i < 30; i++)); do
 		local addr
-		addr=$(curl -s "http://${api_addr}/api/v2/captures" |
+		addr=$(curl -sS --connect-timeout 2 --max-time 5 "http://${api_addr}/api/v2/captures" |
 			jq -r --arg suffix "$suffix" '.items[] | select(.address | endswith($suffix)) | .address' | head -n1)
 		if [ -n "$addr" ] && [ "$addr" != "null" ]; then
 			echo "$addr"
@@ -40,7 +40,7 @@ function get_capture_addr_by_port() {
 function get_capture_id_by_addr() {
 	local api_addr=$1
 	local target_addr=$2
-	curl -s "http://${api_addr}/api/v2/captures" |
+	curl -sS --connect-timeout 2 --max-time 5 "http://${api_addr}/api/v2/captures" |
 		jq -r --arg addr "$target_addr" '.items[] | select(.address==$addr) | .id' | head -n1
 }
 
@@ -48,7 +48,7 @@ function get_table_node_id() {
 	local api_addr=$1
 	local changefeed_id=$2
 	local table_id=$3
-	curl -s "http://${api_addr}/api/v2/changefeeds/${changefeed_id}/tables?keyspace=$KEYSPACE_NAME" |
+	curl -sS --connect-timeout 2 --max-time 5 "http://${api_addr}/api/v2/changefeeds/${changefeed_id}/tables?keyspace=$KEYSPACE_NAME" |
 		jq -r --argjson tid "$table_id" '.items[] | select(.table_ids | index($tid)) | .node_id' | head -n1
 }
 
@@ -165,6 +165,6 @@ function run() {
 }
 
 trap 'stop_test $WORK_DIR' EXIT
-run $*
+run "$@"
 check_logs $WORK_DIR
 echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/capture_local_fence_on_session_done/run.sh
+++ b/tests/integration_tests/capture_local_fence_on_session_done/run.sh
@@ -10,9 +10,29 @@ SINK_TYPE=$1
 
 DB_NAME="capture_local_fence_on_session_done"
 TABLE_NAME="t"
-CAPTURE1_ADDR="127.0.0.1:8300"
-CAPTURE2_ADDR="127.0.0.1:8301"
+CAPTURE1_LISTEN_ADDR="127.0.0.1:8300"
+CAPTURE2_LISTEN_ADDR="127.0.0.1:8301"
 HANG_FAILPOINT="github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkHangLongTime"
+
+function get_capture_addr_by_port() {
+	local api_addr=$1
+	local port=$2
+	local suffix=":$port"
+
+	for ((i = 0; i < 30; i++)); do
+		local addr
+		addr=$(curl -s "http://${api_addr}/api/v2/captures" |
+			jq -r --arg suffix "$suffix" '.items[] | select(.address | endswith($suffix)) | .address' | head -n1)
+		if [ -n "$addr" ] && [ "$addr" != "null" ]; then
+			echo "$addr"
+			return 0
+		fi
+		sleep 2
+	done
+
+	echo "capture with port $port not found" >&2
+	return 1
+}
 
 function get_capture_id_by_addr() {
 	local api_addr=$1
@@ -96,10 +116,11 @@ function run() {
 	start_tidb_cluster --workdir $WORK_DIR
 
 	pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
-	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr --logsuffix 1 --addr "$CAPTURE1_ADDR"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr --logsuffix 1 --addr "$CAPTURE1_LISTEN_ADDR"
 	export GO_FAILPOINTS="${HANG_FAILPOINT}=return(true)"
-	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr --logsuffix 2 --addr "$CAPTURE2_ADDR"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr --logsuffix 2 --addr "$CAPTURE2_LISTEN_ADDR"
 	export GO_FAILPOINTS=''
+	capture2_addr=$(get_capture_addr_by_port "$CAPTURE1_LISTEN_ADDR" "${CAPTURE2_LISTEN_ADDR#*:}")
 
 	SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1&worker-count=1"
 
@@ -112,15 +133,15 @@ function run() {
 	changefeed_id=$(cdc_cli_changefeed create --pd=$pd_addr --start-ts=$start_ts --sink-uri="$SINK_URI" | grep '^ID:' | head -n1 | awk '{print $2}')
 	table_id=$(get_table_id "$DB_NAME" "$TABLE_NAME")
 
-	move_table_with_retry "$CAPTURE2_ADDR" $table_id "$changefeed_id" 10
-	wait_for_table_on_addr "$CAPTURE1_ADDR" "$changefeed_id" "$table_id" "$CAPTURE2_ADDR"
+	move_table_with_retry "$capture2_addr" $table_id "$changefeed_id" 10
+	wait_for_table_on_addr "$CAPTURE1_LISTEN_ADDR" "$changefeed_id" "$table_id" "$capture2_addr"
 
-	capture2_id=$(get_capture_id_by_addr "$CAPTURE1_ADDR" "$CAPTURE2_ADDR")
+	capture2_id=$(get_capture_id_by_addr "$CAPTURE1_LISTEN_ADDR" "$capture2_addr")
 	if [ -z "$capture2_id" ] || [ "$capture2_id" == "null" ]; then
-		echo "failed to get capture id for $CAPTURE2_ADDR" >&2
+		echo "failed to get capture id for $capture2_addr" >&2
 		exit 1
 	fi
-	cdc2_pid=$(get_cdc_pid "127.0.0.1" "8301")
+	cdc2_pid=$(get_cdc_pid "${CAPTURE2_LISTEN_ADDR%:*}" "${CAPTURE2_LISTEN_ADDR#*:}")
 
 	run_sql "INSERT INTO ${DB_NAME}.${TABLE_NAME} VALUES (1, 10), (2, 20), (3, 30), (4, 40);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	ensure 30 "grep -Eq 'inject MySQLSinkHangLongTime' '$WORK_DIR/cdc2.log'"

--- a/tests/integration_tests/capture_local_fence_on_session_done/run.sh
+++ b/tests/integration_tests/capture_local_fence_on_session_done/run.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+set -eu
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+DB_NAME="capture_local_fence_on_session_done"
+TABLE_NAME="t"
+CAPTURE1_ADDR="127.0.0.1:8300"
+CAPTURE2_ADDR="127.0.0.1:8301"
+HANG_FAILPOINT="github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkHangLongTime"
+
+function get_capture_id_by_addr() {
+	local api_addr=$1
+	local target_addr=$2
+	curl -s "http://${api_addr}/api/v2/captures" |
+		jq -r --arg addr "$target_addr" '.items[] | select(.address==$addr) | .id' | head -n1
+}
+
+function get_table_node_id() {
+	local api_addr=$1
+	local changefeed_id=$2
+	local table_id=$3
+	curl -s "http://${api_addr}/api/v2/changefeeds/${changefeed_id}/tables?keyspace=$KEYSPACE_NAME" |
+		jq -r --argjson tid "$table_id" '.items[] | select(.table_ids | index($tid)) | .node_id' | head -n1
+}
+
+function wait_for_table_on_addr() {
+	local api_addr=$1
+	local changefeed_id=$2
+	local table_id=$3
+	local target_addr=$4
+
+	for ((i = 0; i < 30; i++)); do
+		local target_id
+		target_id=$(get_capture_id_by_addr "$api_addr" "$target_addr")
+		if [ -z "$target_id" ] || [ "$target_id" == "null" ]; then
+			sleep 2
+			continue
+		fi
+
+		local node_id
+		node_id=$(get_table_node_id "$api_addr" "$changefeed_id" "$table_id")
+		if [ "$node_id" == "$target_id" ]; then
+			return 0
+		fi
+		sleep 2
+	done
+
+	echo "table $table_id not scheduled on $target_addr" >&2
+	return 1
+}
+
+function revoke_capture_lease() {
+	local capture_id=$1
+	local capture_key="/tidb/cdc/default/__cdc_meta__/capture/${capture_id}"
+	local lease
+	lease=$(ETCDCTL_API=3 etcdctl get "$capture_key" -w json | grep -o 'lease":[0-9]*' | awk -F: '{print $2}')
+	if [ -z "$lease" ]; then
+		echo "failed to get etcd lease for capture $capture_id" >&2
+		return 1
+	fi
+
+	local lease_hex
+	lease_hex=$(printf '%x\n' "$lease")
+	ETCDCTL_API=3 etcdctl lease revoke "$lease_hex"
+}
+
+function wait_for_downstream_row_count() {
+	local expected=$1
+	for ((i = 0; i < 30; i++)); do
+		local count
+		count=$(mysql -h${DOWN_TIDB_HOST} -P${DOWN_TIDB_PORT} -uroot -N \
+			-e "select count(*) from ${DB_NAME}.${TABLE_NAME};" 2>/dev/null || true)
+		if [ "$count" == "$expected" ]; then
+			return 0
+		fi
+		sleep 2
+	done
+
+	echo "downstream row count is not $expected" >&2
+	return 1
+}
+
+function run() {
+	# This case depends on the MySQL sink DML failpoint.
+	if [ "$SINK_TYPE" != "mysql" ]; then
+		return
+	fi
+
+	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+	start_tidb_cluster --workdir $WORK_DIR
+
+	pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr --logsuffix 1 --addr "$CAPTURE1_ADDR"
+	export GO_FAILPOINTS="${HANG_FAILPOINT}=return(true)"
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr --logsuffix 2 --addr "$CAPTURE2_ADDR"
+	export GO_FAILPOINTS=''
+
+	SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1&worker-count=1"
+
+	run_sql "CREATE DATABASE ${DB_NAME};" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "CREATE TABLE ${DB_NAME}.${TABLE_NAME} (id int primary key, v int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "CREATE DATABASE ${DB_NAME};" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	run_sql "CREATE TABLE ${DB_NAME}.${TABLE_NAME} (id int primary key, v int);" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	start_ts=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
+
+	changefeed_id=$(cdc_cli_changefeed create --pd=$pd_addr --start-ts=$start_ts --sink-uri="$SINK_URI" | grep '^ID:' | head -n1 | awk '{print $2}')
+	table_id=$(get_table_id "$DB_NAME" "$TABLE_NAME")
+
+	move_table_with_retry "$CAPTURE2_ADDR" $table_id "$changefeed_id" 10
+	wait_for_table_on_addr "$CAPTURE1_ADDR" "$changefeed_id" "$table_id" "$CAPTURE2_ADDR"
+
+	capture2_id=$(get_capture_id_by_addr "$CAPTURE1_ADDR" "$CAPTURE2_ADDR")
+	if [ -z "$capture2_id" ] || [ "$capture2_id" == "null" ]; then
+		echo "failed to get capture id for $CAPTURE2_ADDR" >&2
+		exit 1
+	fi
+	cdc2_pid=$(get_cdc_pid "127.0.0.1" "8301")
+
+	run_sql "INSERT INTO ${DB_NAME}.${TABLE_NAME} VALUES (1, 10), (2, 20), (3, 30), (4, 40);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	ensure 30 "grep -Eq 'inject MySQLSinkHangLongTime' '$WORK_DIR/cdc2.log'"
+	wait_for_downstream_row_count 0
+
+	revoke_capture_lease "$capture2_id"
+
+	ensure 15 "! ps -p $cdc2_pid"
+	check_logs_contains $WORK_DIR "local fence triggered" 2
+	check_logs_contains $WORK_DIR "dispatcher orchestrator local fence triggered" 2
+	check_logs_contains $WORK_DIR "stopping dispatcher manager write path" 2
+	check_logs_contains $WORK_DIR "server closed" 2
+
+	run_sql "INSERT INTO ${DB_NAME}.${TABLE_NAME} VALUES (5, 50), (6, 60);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+	cleanup_process $CDC_BINARY
+}
+
+trap 'stop_test $WORK_DIR' EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/capture_local_fence_on_session_done/run.sh
+++ b/tests/integration_tests/capture_local_fence_on_session_done/run.sh
@@ -10,8 +10,11 @@ SINK_TYPE=$1
 
 DB_NAME="capture_local_fence_on_session_done"
 TABLE_NAME="t"
-CAPTURE1_LISTEN_ADDR="127.0.0.1:8300"
-CAPTURE2_LISTEN_ADDR="127.0.0.1:8301"
+CAPTURE1_PORT=${CDC_PORT:-8300}
+CAPTURE2_PORT=${CAPTURE2_PORT:-8301}
+CAPTURE1_LISTEN_ADDR="127.0.0.1:${CAPTURE1_PORT}"
+CAPTURE2_LISTEN_ADDR="127.0.0.1:${CAPTURE2_PORT}"
+export CDC_PORT=$CAPTURE1_PORT
 HANG_FAILPOINT="github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkHangLongTime"
 
 function get_capture_addr_by_port() {

--- a/tests/integration_tests/capture_session_done_during_task/run.sh
+++ b/tests/integration_tests/capture_session_done_during_task/run.sh
@@ -57,7 +57,7 @@ function run() {
 	# ensure server exit
 	ensure 30 "! ps -p $cdc_pid"
 	check_logs_contains $WORK_DIR "local fence triggered"
-	check_logs_contains $WORK_DIR "etcd lease expired"
+	ensure 30 "grep -Eq 'etcd lease expired|etcd session done' '$WORK_DIR/cdc.log'"
 	check_logs_contains $WORK_DIR "server closed"
 	echo "cdc server already exit"
 
@@ -76,6 +76,6 @@ function run() {
 }
 
 trap 'stop_test $WORK_DIR' EXIT
-run $*
+run "$@"
 check_logs $WORK_DIR
 echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/capture_session_done_during_task/run.sh
+++ b/tests/integration_tests/capture_session_done_during_task/run.sh
@@ -57,7 +57,7 @@ function run() {
 	# ensure server exit
 	ensure 30 "! ps -p $cdc_pid"
 	check_logs_contains $WORK_DIR "local fence triggered"
-	check_logs_contains $WORK_DIR "etcd session done"
+	check_logs_contains $WORK_DIR "etcd lease expired"
 	check_logs_contains $WORK_DIR "server closed"
 	echo "cdc server already exit"
 

--- a/tests/integration_tests/capture_session_done_during_task/run.sh
+++ b/tests/integration_tests/capture_session_done_during_task/run.sh
@@ -56,7 +56,8 @@ function run() {
 
 	# ensure server exit
 	ensure 30 "! ps -p $cdc_pid"
-	check_logs_contains $WORK_DIR "the etcd session is done"
+	check_logs_contains $WORK_DIR "local fence triggered"
+	check_logs_contains $WORK_DIR "etcd session done"
 	check_logs_contains $WORK_DIR "server closed"
 	echo "cdc server already exit"
 

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -38,7 +38,7 @@ mysql_groups=(
 	# G02
 	'new_ci_collation safe_mode savepoint fail_over_ddl_C unsplittable_tables'
 	# G03
-	'capture_suicide_while_balance_table kv_client_stream_reconnect fail_over_ddl_D'
+	'capture_suicide_while_balance_table capture_local_fence_on_session_done kv_client_stream_reconnect fail_over_ddl_D'
 	# G04
 	'multi_capture ci_collation_compatibility resourcecontrol fail_over_ddl_E'
 	# G05


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #5202

When a TiCDC capture loses its etcd session or lease, it can no longer prove that it still owns local dispatcher work. The previous shutdown path did not immediately fence local write paths, so a stale capture could still accept maintainer requests or continue writing downstream while failover was already in progress. This created a short but unsafe window for duplicate or out-of-date downstream writes before normal cleanup finished.

### What is changed and how it works?

This PR adds a local fence path for session-done and lease-expired events. The server watches the etcd session, triggers local fencing before shutdown, and the dispatcher orchestrator stops accepting new maintainer requests. Dispatcher managers cancel local write paths immediately, close local dispatchers asynchronously, and continue cleanup without waiting for progress draining. The redo cleanup path is also guarded so partially initialized managers do not panic when fencing. New integration coverage simulates capture session loss and verifies the local fence behavior and downstream consistency.

### Check List

#### Tests
- Unit test
- Integration test
- Manual test: dev-machine MySQL integration cases and GitHub `/test all`

#### Questions

##### Will it cause performance regression or break compatibility?

No. The new path only runs when a local capture loses its session or is being fenced.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note
```release-note
Locally fences stale captures after etcd session loss to avoid unsafe downstream writes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side etcd session watchdog and explicit local-fence controls to quickly close local write paths across orchestrator and managers.

* **Bug Fixes**
  * Prevented races during dispatcher/redo creation, merge and shutdown; avoid registering partially-initialized dispatchers and short-circuit operations when the write path is fenced.
  * Improved close lifecycle to ensure single close launch and reliable finalization.

* **Tests**
  * Added unit and integration tests covering fencing, shutdown, and session-watchdog scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->