### PR TITLE
storage: accelerate the unit test

### DIFF
--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/cloudstorage/spool"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/metrics"
 	"github.com/pingcap/ticdc/pkg/common"
@@ -71,10 +70,6 @@ func (c *bufferManager) run(ctx context.Context) error {
 	defer ticker.Stop()
 
 	for {
-		failpoint.Inject("passTickerOnce", func() {
-			<-ticker.C
-		})
-
 		select {
 		case <-ctx.Done():
 			return errors.Trace(context.Cause(ctx))

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/pdutil"
 	putil "github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/utils/chann"
+	timodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,11 +146,49 @@ func TestCloudStoragePostEnqueueBeforeFlush(t *testing.T) {
 	require.ErrorIs(t, <-runDone, context.Canceled)
 }
 
-func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
+func TestCloudStorageWriteEvents(t *testing.T) {
 	t.Run("add dml does not call post enqueue before run", verifyAddDMLEventDoesNotCallPostEnqueueBeforePipelineRun)
+
+	helper, job, dmls, batch := newCloudStorageWriteEventsFixture(t)
+	t.Run("without date separator", func(t *testing.T) {
+		verifyCloudStorageWriteEventsWithoutDateSeparator(t, helper, job, dmls, batch)
+	})
+	t.Run("with date separator", func(t *testing.T) {
+		verifyCloudStorageWriteEventsWithDateSeparator(t, helper, job, dmls, batch)
+	})
+}
+
+func newCloudStorageWriteEventsFixture(
+	t *testing.T,
+) (*commonEvent.EventTestHelper, *timodel.Job, []string, int) {
+	t.Helper()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	t.Cleanup(helper.Close)
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table table1(c1 int, c2 varchar(255))")
+	require.NotNil(t, job)
+	helper.ApplyJob(job)
+
+	batch := 100
+	dmls := make([]string, 0, batch)
+	for j := 0; j < batch; j++ {
+		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", j))
+	}
+	return helper, job, dmls, batch
+}
+
+func verifyCloudStorageWriteEventsWithoutDateSeparator(
+	t *testing.T,
+	helper *commonEvent.EventTestHelper,
+	job *timodel.Job,
+	dmls []string,
+	batch int,
+) {
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=3600s&file-size=1024", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -171,20 +210,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
 	defer cancelAndWaitSink(t, cancel, runDone)
 
-	var cnt uint64 = 0
-	batch := 100
-
-	helper := commonEvent.NewEventTestHelper(t)
-	defer helper.Close()
-
-	helper.Tk().MustExec("use test")
-	job := helper.DDL2Job("create table table1(c1 int, c2 varchar(255))")
-	require.NotNil(t, job)
-	helper.ApplyJob(job)
-	dmls := make([]string, 0, batch)
-	for j := 0; j < batch; j++ {
-		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", j))
-	}
+	var cnt uint64
 	dispatcherID := common.NewDispatcherID()
 	event := helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -214,7 +240,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, uint64(100), atomic.LoadUint64(&cnt))
+	require.Equal(t, uint64(batch), atomic.LoadUint64(&cnt))
 
 	// generating another dml file.
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
@@ -241,7 +267,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, uint64(200), atomic.LoadUint64(&cnt))
+	require.Equal(t, 2*uint64(batch), atomic.LoadUint64(&cnt))
 
 }
 
@@ -267,10 +293,16 @@ func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
 	}
 }
 
-func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
+func verifyCloudStorageWriteEventsWithDateSeparator(
+	t *testing.T,
+	helper *commonEvent.EventTestHelper,
+	job *timodel.Job,
+	dmls []string,
+	batch int,
+) {
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=3600s&file-size=1024", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -292,20 +324,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 
 	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
 
-	var cnt uint64 = 0
-	batch := 100
-
-	helper := commonEvent.NewEventTestHelper(t)
-	defer helper.Close()
-
-	helper.Tk().MustExec("use test")
-	job := helper.DDL2Job("create table table1(c1 int, c2 varchar(255))")
-	require.NotNil(t, job)
-	helper.ApplyJob(job)
-	dmls := make([]string, 0, batch)
-	for j := 0; j < batch; j++ {
-		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", j))
-	}
+	var cnt uint64
 
 	dispatcherID := common.NewDispatcherID()
 	event := helper.DML2Event(job.SchemaName, job.TableName, dmls...)
@@ -405,7 +424,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, uint64(300), atomic.LoadUint64(&cnt))
+	require.Equal(t, 3*uint64(batch), atomic.LoadUint64(&cnt))
 	cancelAndWaitSink(t, cancel, runDone)
 
 	// test table is scheduled from one node to another

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -173,8 +173,8 @@ func newCloudStorageWriteEventsFixture(
 
 	batch := 100
 	dmls := make([]string, 0, batch)
-	for j := 0; j < batch; j++ {
-		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", j))
+	for idx := range batch {
+		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", idx))
 	}
 	return helper, job, dmls, batch
 }
@@ -210,18 +210,18 @@ func verifyCloudStorageWriteEventsWithoutDateSeparator(
 	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
 	defer cancelAndWaitSink(t, cancel, runDone)
 
-	var cnt uint64
+	var cnt atomic.Uint64
 	dispatcherID := common.NewDispatcherID()
 	event := helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
 	event.AddPostFlushFunc(func() {
-		atomic.AddUint64(&cnt, uint64(len(dmls)))
+		cnt.Add(uint64(len(dmls)))
 	})
 	event.DispatcherID = dispatcherID
 
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
-		return atomic.LoadUint64(&cnt) == uint64(batch)
+		return cnt.Load() == uint64(batch)
 	}, testEventuallyTimeout, testEventuallyTick, "wait for first event consumed")
 	metaDir := path.Join(parentDir, "test/table1/meta")
 	files, err := os.ReadDir(metaDir)
@@ -240,19 +240,19 @@ func verifyCloudStorageWriteEventsWithoutDateSeparator(
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, uint64(batch), atomic.LoadUint64(&cnt))
+	require.Equal(t, uint64(batch), cnt.Load())
 
 	// generating another dml file.
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
 	event.AddPostFlushFunc(func() {
-		atomic.AddUint64(&cnt, uint64(len(dmls)))
+		cnt.Add(uint64(len(dmls)))
 	})
 	event.DispatcherID = dispatcherID
 
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
-		return atomic.LoadUint64(&cnt) == 2*uint64(batch)
+		return cnt.Load() == 2*uint64(batch)
 	}, testEventuallyTimeout, testEventuallyTick, "wait for second event consumed")
 
 	fileNames = getTableFiles(t, tableDir)
@@ -267,7 +267,7 @@ func verifyCloudStorageWriteEventsWithoutDateSeparator(
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, 2*uint64(batch), atomic.LoadUint64(&cnt))
+	require.Equal(t, 2*uint64(batch), cnt.Load())
 }
 
 func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -268,7 +268,6 @@ func verifyCloudStorageWriteEventsWithoutDateSeparator(
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, 2*uint64(batch), atomic.LoadUint64(&cnt))
-
 }
 
 func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -23,10 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/failpoint"
 	pclock "github.com/pingcap/ticdc/pkg/clock"
 	"github.com/pingcap/ticdc/pkg/common"
-	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/pdutil"
@@ -65,8 +63,7 @@ func verifyAddDMLEventDoesNotCallPostEnqueueBeforePipelineRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -106,8 +103,7 @@ func TestCloudStoragePostEnqueueBeforeFlush(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -153,7 +149,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	t.Run("add dml does not call post enqueue before run", verifyAddDMLEventDoesNotCallPostEnqueueBeforePipelineRun)
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=%ds", parentDir, 2)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -167,13 +163,13 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	var cnt uint64 = 0
 	batch := 100
@@ -198,7 +194,9 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	event.DispatcherID = dispatcherID
 
 	cloudStorageSink.AddDMLEvent(event)
-	time.Sleep(3 * time.Second)
+	require.Eventually(t, func() bool {
+		return atomic.LoadUint64(&cnt) == uint64(batch)
+	}, testEventuallyTimeout, testEventuallyTick, "wait for first event consumed")
 	metaDir := path.Join(parentDir, "test/table1/meta")
 	files, err := os.ReadDir(metaDir)
 	require.NoError(t, err)
@@ -227,7 +225,9 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	event.DispatcherID = dispatcherID
 
 	cloudStorageSink.AddDMLEvent(event)
-	time.Sleep(3 * time.Second)
+	require.Eventually(t, func() bool {
+		return atomic.LoadUint64(&cnt) == 2*uint64(batch)
+	}, testEventuallyTimeout, testEventuallyTick, "wait for second event consumed")
 
 	fileNames = getTableFiles(t, tableDir)
 	require.Len(t, fileNames, 3)
@@ -243,7 +243,6 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(200), atomic.LoadUint64(&cnt))
 
-	cloudStorageSink.Close()
 }
 
 func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
@@ -271,7 +270,7 @@ func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
 func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=%ds", parentDir, 4)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -285,16 +284,13 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	mockClock := pclock.NewMock()
 	mockClock.Set(time.Date(2023, 3, 8, 23, 59, 58, 0, time.UTC))
 	clock := pdutil.NewMonotonicClock(mockClock)
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	setPDClock := setPDClockForTest(t, clock)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
 
 	var cnt uint64 = 0
 	batch := 100
@@ -322,7 +318,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	tableDir := path.Join(parentDir, fmt.Sprintf("%s/%s/%d/2023-03-08", job.SchemaName, job.TableName, event.TableInfoVersion))
 	fileNames := getTableFiles(t, tableDir)
@@ -336,23 +332,19 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
 
-	cancel()
-	time.Sleep(5 * time.Second)
+	cancelAndWaitSink(t, cancel, runDone)
 
 	// test date (day) is NOT changed.
 	mockClock.Set(time.Date(2023, 3, 8, 23, 59, 59, 0, time.UTC))
 	clock = pdutil.NewMonotonicClock(mockClock)
 
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	setPDClock(clock)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cloudStorageSink, err = newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone = runSinkInBackground(t, ctx, cloudStorageSink)
 
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -364,7 +356,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == 2*uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	fileNames = getTableFiles(t, tableDir)
 	require.Len(t, fileNames, 3)
@@ -376,29 +368,19 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
-	cancel()
-
-	time.Sleep(5 * time.Second)
+	cancelAndWaitSink(t, cancel, runDone)
 
 	// test date (day) is changed.
 	mockClock.Set(time.Date(2023, 3, 9, 0, 0, 10, 0, time.UTC))
 	clock = pdutil.NewMonotonicClock(mockClock)
 
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	setPDClock(clock)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cloudStorageSink, err = newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	failpoint.Enable("github.com/pingcap/ticdc/downstreamadapter/sink/cloudstorage/passTickerOnce", "1*return")
-	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/downstreamadapter/sink/cloudstorage/passTickerOnce")
-	}()
-
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone = runSinkInBackground(t, ctx, cloudStorageSink)
 
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -410,7 +392,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == 3*uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	tableDir = path.Join(parentDir, fmt.Sprintf("test/table1/%d/2023-03-09", event.TableInfoVersion))
 	fileNames = getTableFiles(t, tableDir)
@@ -424,25 +406,20 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(300), atomic.LoadUint64(&cnt))
-	cloudStorageSink.Close()
-
-	cancel()
-	time.Sleep(5 * time.Second)
+	cancelAndWaitSink(t, cancel, runDone)
 
 	// test table is scheduled from one node to another
 	cnt = 0
 	mockClock = pclock.NewMock()
 	mockClock.Set(time.Date(2023, 3, 9, 0, 1, 10, 0, time.UTC))
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	clock = pdutil.NewMonotonicClock(mockClock)
+	setPDClock(clock)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cloudStorageSink, err = newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone = runSinkInBackground(t, ctx, cloudStorageSink)
 
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -454,7 +431,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	fileNames = getTableFiles(t, tableDir)
 	require.Len(t, fileNames, 3)
@@ -467,5 +444,5 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 
-	cancel()
+	cancelAndWaitSink(t, cancel, runDone)
 }

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/pingcap/ticdc/pkg/common"
-	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/pdutil"
@@ -54,7 +53,7 @@ func newSinkForTest(
 }
 
 func TestBasicFunctionality(t *testing.T) {
-	uri := fmt.Sprintf("file:///%s?protocol=csv", t.TempDir())
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", t.TempDir())
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -65,12 +64,12 @@ func TestBasicFunctionality(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	var count atomic.Int64
 
@@ -129,8 +128,9 @@ func TestBasicFunctionality(t *testing.T) {
 	require.NoError(t, err)
 
 	cloudStorageSink.AddDMLEvent(dmlEvent)
-
-	time.Sleep(5 * time.Second)
+	require.Eventually(t, func() bool {
+		return count.Load() == 2
+	}, testEventuallyTimeout, testEventuallyTick)
 
 	ddlEvent2.PostFlush()
 
@@ -149,8 +149,7 @@ func TestIgnoreCallsAfterRunError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -221,13 +220,13 @@ func TestWriteDDLEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -295,13 +294,13 @@ func verifyWriteDDLEventFlushDMLBeforeBlock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	helper := commonEvent.NewEventTestHelper(t)
 	defer helper.Close()
@@ -358,13 +357,13 @@ func TestWriteDDLEventWithTableIDAsPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -411,13 +410,13 @@ func TestSkipDatabaseSchemaWithTableIDAsPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	ddlEvent := &commonEvent.DDLEvent{
 		Query:      "create database test_db",
@@ -476,8 +475,7 @@ func TestWriteDDLEventWithInvalidExchangePartitionEvent(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			mockPDClock := pdutil.NewClock4Test()
-			appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+			setPDClockForTest(t, pdutil.NewClock4Test())
 
 			cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 			require.NoError(t, err)
@@ -528,8 +526,7 @@ func TestWriteExchangePartitionDDLEventUsesTargetNames(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -619,20 +616,18 @@ func TestWriteCheckpointEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
-	time.Sleep(3 * time.Second)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
+	cloudStorageSink.lastSendCheckpointTsTime = time.Now().Add(-2 * time.Second)
 	cloudStorageSink.AddCheckpointTs(100)
 
-	time.Sleep(2 * time.Second)
-	metadata, err := os.ReadFile(path.Join(parentDir, "metadata"))
-	require.NoError(t, err)
+	metadata := readFileEventually(t, path.Join(parentDir, "metadata"))
 	require.JSONEq(t, `{"checkpoint-ts":100}`, string(metadata))
 }
 
@@ -649,8 +644,7 @@ func TestCloseBeforeRunDoesNotPanicAndCleansSpool(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	changefeedID := common.NewChangefeedID4Test("test", "close-before-run")
 	cloudStorageSink, err := New(ctx, changefeedID, sinkURI, replicaConfig.Sink, true, nil)
@@ -684,23 +678,32 @@ func TestCleanupExpiredFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	var count atomic.Int64
+	cleanupDone := make(chan struct{}, 1)
 	cleanupJobs := []func(){
 		func() {
 			count.Add(1)
+			select {
+			case cleanupDone <- struct{}{}:
+			default:
+			}
 		},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, cleanupJobs)
-	go cloudStorageSink.Run(ctx)
 	require.NoError(t, err)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
-	time.Sleep(5 * time.Second)
+	select {
+	case <-cleanupDone:
+	case <-time.After(testEventuallyTimeout):
+		t.Fatal("cleanup job did not run")
+	}
 	require.LessOrEqual(t, int64(1), count.Load())
 }
 

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,21 +75,30 @@ func TestBasicFunctionality(t *testing.T) {
 
 	var count atomic.Int64
 
-	helper := commonEvent.NewEventTestHelper(t)
-	defer helper.Close()
-
-	helper.Tk().MustExec("use test")
 	createTableSQL := "create table t (id int primary key, name varchar(2048));"
-	job := helper.DDL2Job(createTableSQL)
-	require.NotNil(t, job)
-	helper.ApplyJob(job)
-
-	tableInfo := helper.GetTableInfo(job)
+	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
+		ID:   1,
+		Name: ast.NewCIStr("t"),
+		Columns: []*timodel.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *types.NewFieldType(mysql.TypeLong),
+				State:     timodel.StatePublic,
+			},
+			{
+				ID:        2,
+				Name:      ast.NewCIStr("name"),
+				FieldType: *types.NewFieldType(mysql.TypeVarchar),
+				State:     timodel.StatePublic,
+			},
+		},
+	})
 
 	ddlEvent := &commonEvent.DDLEvent{
-		Query:      job.Query,
-		SchemaName: job.SchemaName,
-		TableName:  job.TableName,
+		Query:      createTableSQL,
+		SchemaName: "test",
+		TableName:  "t",
 		FinishedTs: 1,
 		BlockedTables: &commonEvent.InfluencedTables{
 			InfluenceType: commonEvent.InfluenceTypeNormal,
@@ -102,9 +112,9 @@ func TestBasicFunctionality(t *testing.T) {
 	}
 
 	ddlEvent2 := &commonEvent.DDLEvent{
-		Query:      job.Query,
-		SchemaName: job.SchemaName,
-		TableName:  job.TableName,
+		Query:      createTableSQL,
+		SchemaName: "test",
+		TableName:  "t",
 		FinishedTs: 4,
 		BlockedTables: &commonEvent.InfluencedTables{
 			InfluenceType: commonEvent.InfluenceTypeNormal,
@@ -117,13 +127,17 @@ func TestBasicFunctionality(t *testing.T) {
 		},
 	}
 
-	dmlEvent := helper.DML2Event(
-		"test",
-		"t",
-		fmt.Sprintf("insert into t values (1, '%s')", strings.Repeat("x", 1024)),
-		fmt.Sprintf("insert into t values (2, '%s')", strings.Repeat("y", 1024)),
-	)
-	dmlEvent.TableInfoVersion = job.BinlogInfo.FinishedTS
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 2)
+	rows.AppendInt64(0, 1)
+	rows.AppendString(1, strings.Repeat("x", 1024))
+	rows.AppendInt64(0, 2)
+	rows.AppendString(1, strings.Repeat("y", 1024))
+	dmlEvent := commonEvent.NewDMLEvent(common.NewDispatcherID(), tableInfo.TableName.TableID, 2, 3, tableInfo)
+	dmlEvent.TableInfoVersion = ddlEvent.FinishedTs
+	dmlEvent.SetRows(rows)
+	dmlEvent.RowTypes = []common.RowType{common.RowTypeInsert, common.RowTypeInsert}
+	dmlEvent.Length = 2
+	dmlEvent.ApproximateSize = 2
 	dmlEvent.PostTxnFlushed = []func(){
 		func() {
 			count.Add(1)
@@ -703,23 +717,28 @@ func TestCleanupExpiredFiles(t *testing.T) {
 		},
 	}
 	require.NoError(t, cloudStorageSink.initCron(ctx, sinkURI, cleanupJobs))
+
+	require.Len(t, cloudStorageSink.cron.Entries(), len(cleanupJobs))
+	cleanupJobs[0]()
+	require.Equal(t, int64(1), count.Load())
+
 	cleanupDoneCh := make(chan struct{}, 1)
 	go func() {
 		cloudStorageSink.bgCleanup(ctx)
 		cleanupDoneCh <- struct{}{}
 	}()
 
-	select {
-	case <-cleanupDone:
-	case <-time.After(testEventuallyTimeout):
-		t.Fatal("cleanup job did not run")
-	}
-	require.LessOrEqual(t, int64(1), count.Load())
 	cancel()
 	select {
 	case <-cleanupDoneCh:
 	case <-time.After(testEventuallyTimeout):
 		t.Fatal("background cleanup did not exit after context cancel")
+	}
+
+	select {
+	case <-cleanupDone:
+	default:
+		t.Fatal("cleanup job did not run")
 	}
 }
 

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -53,7 +54,7 @@ func newSinkForTest(
 }
 
 func TestBasicFunctionality(t *testing.T) {
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", t.TempDir())
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=3600s&file-size=1024", t.TempDir())
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -77,7 +78,7 @@ func TestBasicFunctionality(t *testing.T) {
 	defer helper.Close()
 
 	helper.Tk().MustExec("use test")
-	createTableSQL := "create table t (id int primary key, name varchar(32));"
+	createTableSQL := "create table t (id int primary key, name varchar(2048));"
 	job := helper.DDL2Job(createTableSQL)
 	require.NotNil(t, job)
 	helper.ApplyJob(job)
@@ -116,7 +117,12 @@ func TestBasicFunctionality(t *testing.T) {
 		},
 	}
 
-	dmlEvent := helper.DML2Event("test", "t", "insert into t values (1, 'test')", "insert into t values (2, 'test2');")
+	dmlEvent := helper.DML2Event(
+		"test",
+		"t",
+		fmt.Sprintf("insert into t values (1, '%s')", strings.Repeat("x", 1024)),
+		fmt.Sprintf("insert into t values (2, '%s')", strings.Repeat("y", 1024)),
+	)
 	dmlEvent.TableInfoVersion = job.BinlogInfo.FinishedTS
 	dmlEvent.PostTxnFlushed = []func(){
 		func() {
@@ -224,9 +230,7 @@ func TestWriteDDLEvent(t *testing.T) {
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
-
-	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
-	defer cancelAndWaitSink(t, cancel, runDone)
+	defer cloudStorageSink.Close()
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -361,9 +365,7 @@ func TestWriteDDLEventWithTableIDAsPath(t *testing.T) {
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
-
-	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
-	defer cancelAndWaitSink(t, cancel, runDone)
+	defer cloudStorageSink.Close()
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -672,7 +674,7 @@ func TestCleanupExpiredFiles(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Sink.CloudStorageConfig = &config.CloudStorageConfig{
 		FileExpirationDays:  util.AddressOf(1),
-		FileCleanupCronSpec: util.AddressOf("* * * * * *"),
+		FileCleanupCronSpec: util.AddressOf("@every 1ms"),
 	}
 	err = replicaConfig.ValidateAndAdjust(sinkURI)
 	require.NoError(t, err)
@@ -692,12 +694,20 @@ func TestCleanupExpiredFiles(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	setPDClockForTest(t, pdutil.NewClock4Test())
-
-	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, cleanupJobs)
-	require.NoError(t, err)
-	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
-	defer cancelAndWaitSink(t, cancel, runDone)
+	cloudStorageSink := &sink{
+		changefeedID: common.NewChangefeedID4Test("test", "test"),
+		cfg: &pkgcloudstorage.Config{
+			DateSeparator:       config.DateSeparatorDay.String(),
+			FileExpirationDays:  1,
+			FileCleanupCronSpec: util.GetOrZero(replicaConfig.Sink.CloudStorageConfig.FileCleanupCronSpec),
+		},
+	}
+	require.NoError(t, cloudStorageSink.initCron(ctx, sinkURI, cleanupJobs))
+	cleanupDoneCh := make(chan struct{}, 1)
+	go func() {
+		cloudStorageSink.bgCleanup(ctx)
+		cleanupDoneCh <- struct{}{}
+	}()
 
 	select {
 	case <-cleanupDone:
@@ -705,6 +715,12 @@ func TestCleanupExpiredFiles(t *testing.T) {
 		t.Fatal("cleanup job did not run")
 	}
 	require.LessOrEqual(t, int64(1), count.Load())
+	cancel()
+	select {
+	case <-cleanupDoneCh:
+	case <-time.After(testEventuallyTimeout):
+		t.Fatal("background cleanup did not exit after context cancel")
+	}
 }
 
 func TestRemoveEmptyDirsCleanupJobCanRunMultipleTimes(t *testing.T) {

--- a/downstreamadapter/sink/cloudstorage/test_helpers_test.go
+++ b/downstreamadapter/sink/cloudstorage/test_helpers_test.go
@@ -29,6 +29,11 @@ const (
 	testEventuallyTick    = 10 * time.Millisecond
 )
 
+func TestMain(m *testing.M) {
+	appcontext.SetService(appcontext.DefaultPDClock, pdutil.NewClock4Test())
+	os.Exit(m.Run())
+}
+
 func setPDClockForTest(t *testing.T, clock pdutil.Clock) func(pdutil.Clock) {
 	t.Helper()
 

--- a/downstreamadapter/sink/cloudstorage/test_helpers_test.go
+++ b/downstreamadapter/sink/cloudstorage/test_helpers_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudstorage
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	appcontext "github.com/pingcap/ticdc/pkg/common/context"
+	"github.com/pingcap/ticdc/pkg/pdutil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testEventuallyTimeout = 5 * time.Second
+	testEventuallyTick    = 10 * time.Millisecond
+)
+
+func setPDClockForTest(t *testing.T, clock pdutil.Clock) func(pdutil.Clock) {
+	t.Helper()
+
+	previous, hasPrevious := appcontext.TryGetService[pdutil.Clock](appcontext.DefaultPDClock)
+
+	setClock := func(clock pdutil.Clock) {
+		appcontext.SetService(appcontext.DefaultPDClock, clock)
+	}
+	setClock(clock)
+
+	t.Cleanup(func() {
+		if hasPrevious {
+			appcontext.SetService(appcontext.DefaultPDClock, previous)
+		}
+	})
+	return setClock
+}
+
+func runSinkInBackground(t *testing.T, ctx context.Context, s *sink) <-chan error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run(ctx)
+	}()
+	return done
+}
+
+func cancelAndWaitSink(t *testing.T, cancel context.CancelFunc, done <-chan error) {
+	t.Helper()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(testEventuallyTimeout):
+		t.Fatal("sink.Run did not exit after context cancel")
+	}
+}
+
+func readFileEventually(t *testing.T, filePath string) []byte {
+	t.Helper()
+
+	var content []byte
+	require.Eventually(t, func() bool {
+		var err error
+		content, err = os.ReadFile(filePath)
+		return err == nil
+	}, testEventuallyTimeout, testEventuallyTick)
+	return content
+}

--- a/downstreamadapter/sink/cloudstorage/writer_test.go
+++ b/downstreamadapter/sink/cloudstorage/writer_test.go
@@ -27,9 +27,7 @@ import (
 	"time"
 
 	"github.com/pingcap/ticdc/downstreamadapter/sink/cloudstorage/spool"
-	"github.com/pingcap/ticdc/pkg/clock"
 	commonType "github.com/pingcap/ticdc/pkg/common"
-	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/metrics"
@@ -48,7 +46,7 @@ import (
 )
 
 func testWriter(ctx context.Context, t *testing.T, dir string) *writer {
-	uri := fmt.Sprintf("file:///%s?flush-interval=2s", dir)
+	uri := fmt.Sprintf("file:///%s?flush-interval=100ms", dir)
 	storage, err := util.GetExternalStorageWithDefaultTimeout(ctx, uri)
 	require.NoError(t, err)
 	sinkURI, err := url.Parse(uri)
@@ -62,10 +60,7 @@ func testWriter(ctx context.Context, t *testing.T, dir string) *writer {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", t.Name())
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage,
 		cfg, ".json", statistics, spoolBuffer)
@@ -101,8 +96,6 @@ func hasSpoolLogFile(spoolDir string) bool {
 }
 
 func TestWriterRun(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	parentDir := t.TempDir()
 	d := testWriter(ctx, t, parentDir)
@@ -166,8 +159,6 @@ func TestWriterRun(t *testing.T) {
 }
 
 func TestWriterFlushMarker(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -230,8 +221,6 @@ func TestWriterFlushMarker(t *testing.T) {
 }
 
 func TestWriterFlushMarkerOnlyFlushesTargetDispatcher(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -327,8 +316,6 @@ func TestWriterFlushMarkerOnlyFlushesTargetDispatcher(t *testing.T) {
 }
 
 func TestWriterPostEnqueueAfterConsume(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -487,10 +474,7 @@ func TestWriterStoresPendingMessagesInSpoolBeforeFlush(t *testing.T) {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", "spool-pending")
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage, cfg, ".json", statistics, spoolBuffer)
@@ -580,8 +564,6 @@ func TestDiscardEntriesDoesNotLoadSpilledPayload(t *testing.T) {
 }
 
 func TestWriterRunExitAfterContextCancel(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancelCause(context.Background())
 	parentDir := t.TempDir()
 	d := testWriter(ctx, t, parentDir)
@@ -656,10 +638,7 @@ func TestWriterIndexWriteError(t *testing.T) {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", "writer-error-metric")
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage, cfg, ".json", statistics, spoolBuffer)
 
@@ -722,10 +701,7 @@ func TestWriterDataFileCloseError(t *testing.T) {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", "writer-close-error")
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage, cfg, ".json", statistics, spoolBuffer)
 

--- a/downstreamadapter/sink/cloudstorage/writer_test.go
+++ b/downstreamadapter/sink/cloudstorage/writer_test.go
@@ -60,7 +60,6 @@ func testWriter(ctx context.Context, t *testing.T, dir string) *writer {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", t.Name())
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	setPDClockForTest(t, pdutil.NewClock4Test())
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage,
 		cfg, ".json", statistics, spoolBuffer)
@@ -96,6 +95,8 @@ func hasSpoolLogFile(spoolDir string) bool {
 }
 
 func TestWriterRun(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	parentDir := t.TempDir()
 	d := testWriter(ctx, t, parentDir)
@@ -159,6 +160,8 @@ func TestWriterRun(t *testing.T) {
 }
 
 func TestWriterFlushMarker(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -221,6 +224,8 @@ func TestWriterFlushMarker(t *testing.T) {
 }
 
 func TestWriterFlushMarkerOnlyFlushesTargetDispatcher(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -316,6 +321,8 @@ func TestWriterFlushMarkerOnlyFlushesTargetDispatcher(t *testing.T) {
 }
 
 func TestWriterPostEnqueueAfterConsume(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -564,6 +571,8 @@ func TestDiscardEntriesDoesNotLoadSpilledPayload(t *testing.T) {
 }
 
 func TestWriterRunExitAfterContextCancel(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancelCause(context.Background())
 	parentDir := t.TempDir()
 	d := testWriter(ctx, t, parentDir)
@@ -619,6 +628,8 @@ func (w *failOnCloseWriter) Close(ctx context.Context) error {
 }
 
 func TestWriterIndexWriteError(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	parentDir := t.TempDir()
 	uri := fmt.Sprintf("file:///%s?flush-interval=2s", parentDir)
@@ -681,6 +692,8 @@ func TestWriterIndexWriteError(t *testing.T) {
 }
 
 func TestWriterDataFileCloseError(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	parentDir := t.TempDir()
 	uri := fmt.Sprintf("file:///%s?flush-interval=2s", parentDir)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5277

Cloud storage sink unit tests on `master` spend close to a minute in the package test run.

### What is changed and how it works?

This PR removes the slow timing dependency from the cloud storage sink tests by replacing fixed sleeps / ticker-driven flushing with event-driven synchronization and deterministic size-triggered flushing.

Measured with a warm build cache on macOS darwin/arm64, Go `go1.26.4`, 8 CPUs:

```sh
go test -count=1 --tags=intest ./downstreamadapter/sink/cloudstorage
```

Results:

| Revision | Package time | Wall time | Notes |
| --- | ---: | ---: | --- |
| `upstream/master` (`6b8fdc0d3`) | `57.431s` | `63.90s` | Baseline |
| PR head `origin/accelerate-storage-sink-ut` (`9e5f7ed70`) | `3.856s` | `18.53s` | ~14.9x faster package time vs master |
| local follow-up on `accelerate-storage-sink-ut` working tree | `2.649s`, `2.602s` | `8.77s`, `12.89s` | Under the 3s target; not pushed yet |

Notes:

- The package time is the `go test` reported time and is the most relevant number for unit test runtime.
- Wall time includes rebuilding / relinking the test binary, so it is higher and more environment-sensitive.
- The current remote PR head is already much faster than master, but the extra local follow-up is needed to make the package consistently run under 3s.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This only changes unit tests and test-only helpers.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored cloud storage sink tests for determinism, consolidating related cases into a single exported test with subtests and shared fixtures.
  * Replaced fixed sleeps with polling-based waits (eventually on counters) and background-run/cancel helpers; standardized test clock setup.
  * Added test helpers (TestMain, PD-clock override, run/cancel sink helpers, file-read polling) and adjusted flush intervals for faster tests.
  * Restructured cleanup and checkpoint tests for reliable timing and verification.
* **Chores**
  * Removed a test-only failpoint/ticker injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
