### PR TITLE
release: skip auto release for v26 tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         id: check
         run: |
           VERSION="${{ steps.tag.outputs.version }}"
-          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-release\.[0-9]+)?$ ]]; then
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-release\.[0-9]+)?$ && "$VERSION" != v26* ]]; then
             echo "is_release=true" >> $GITHUB_OUTPUT
           else
             echo "is_release=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5364

The auto release workflow should not create GitHub releases for tags that start with `v26`, such as `v26.y.z` and `v26.y.z-release.n`.

### What is changed and how it works?

This updates the release tag classification in `.github/workflows/release.yaml` so `is_release` is only set to `true` for supported semantic release tags that do not start with `v26`.

The `release` job continues to depend only on `needs.tag.outputs.is_release == 'true'`, keeping the release decision centralized in the tag-checking step.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  - `git diff --check origin/master..HEAD -- .github/workflows/release.yaml`
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest -shellcheck '' .github/workflows/release.yaml`
  - Verified sample tag matching locally: `v25.1.2` and `v25.1.2-release.1` return true; `v26.1.2`, `v26.1.2-release.1`, and `test` return false.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This only changes whether the release workflow creates GitHub releases for `v26` tags.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow tag filtering to exclude specific version patterns from release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->