### PR TITLE
sink/mysql: split DML and control DB pools

### DIFF
--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -50,7 +50,8 @@ type Sink struct {
 	// enableActiveActive is false.
 	progressTableWriter *mysql.ProgressTableWriter
 
-	db         *sql.DB
+	dmlDB      *sql.DB
+	controlDB  *sql.DB
 	statistics *metrics.Statistics
 
 	conflictDetector *causality.ConflictDetector
@@ -91,7 +92,7 @@ func New(
 	config *config.ChangefeedConfig,
 	sinkURI *url.URL,
 ) (*Sink, error) {
-	cfg, db, err := mysql.NewMysqlConfigAndDB(ctx, changefeedID, sinkURI, config)
+	cfg, dmlDB, controlDB, err := mysql.NewMysqlConfigAndDBs(ctx, changefeedID, sinkURI, config)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func New(
 		metrics.ChangefeedDownstreamIsTiDBGauge.DeleteLabelValues(keyspace, name)
 	}
 
-	return NewMySQLSink(ctx, changefeedID, cfg, db, config.BDRMode, config.EnableActiveActive, config.ActiveActiveProgressInterval), nil
+	return NewMySQLSinkWithControlDB(ctx, changefeedID, cfg, dmlDB, controlDB, config.BDRMode, config.EnableActiveActive, config.ActiveActiveProgressInterval), nil
 }
 
 func NewMySQLSink(
@@ -119,11 +120,28 @@ func NewMySQLSink(
 	enableActiveActive bool,
 	progressInterval time.Duration,
 ) *Sink {
+	return NewMySQLSinkWithControlDB(ctx, changefeedID, cfg, db, db, bdrMode, enableActiveActive, progressInterval)
+}
+
+// NewMySQLSinkWithControlDB creates a MySQL sink with separate pools for DML and
+// control-plane operations. The control pool is used by DDL, DDL-ts, syncpoint,
+// and active-active progress metadata paths so they do not wait behind long-lived
+// DML sessions.
+func NewMySQLSinkWithControlDB(
+	ctx context.Context,
+	changefeedID common.ChangeFeedID,
+	cfg *mysql.Config,
+	dmlDB *sql.DB,
+	controlDB *sql.DB,
+	bdrMode bool,
+	enableActiveActive bool,
+	progressInterval time.Duration,
+) *Sink {
 	stat := metrics.NewStatistics(changefeedID, "TxnSink")
 
 	var activeActiveSyncStatsCollector *mysql.ActiveActiveSyncStatsCollector
 	if enableActiveActive && cfg.IsTiDB && cfg.ActiveActiveSyncStatsInterval > 0 {
-		supported, err := mysql.CheckActiveActiveSyncStatsSupported(ctx, db)
+		supported, err := mysql.CheckActiveActiveSyncStatsSupported(ctx, dmlDB)
 		if err != nil {
 			log.Info("failed to check tidb_cdc_active_active_sync_stats support, disable metric collection",
 				zap.String("keyspace", changefeedID.Keyspace()),
@@ -140,7 +158,8 @@ func NewMySQLSink(
 
 	result := &Sink{
 		changefeedID: changefeedID,
-		db:           db,
+		dmlDB:        dmlDB,
+		controlDB:    controlDB,
 		dmlWriter:    make([]*mysql.Writer, cfg.WorkerCount),
 		statistics:   stat,
 		conflictDetector: causality.New(defaultConflictDetectorSlots,
@@ -158,11 +177,11 @@ func NewMySQLSink(
 		activeActiveSyncStatsCollector: activeActiveSyncStatsCollector,
 	}
 	for i := 0; i < len(result.dmlWriter); i++ {
-		result.dmlWriter[i] = mysql.NewWriter(ctx, i, db, cfg, changefeedID, stat, activeActiveSyncStatsCollector)
+		result.dmlWriter[i] = mysql.NewWriter(ctx, i, dmlDB, cfg, changefeedID, stat, activeActiveSyncStatsCollector)
 	}
-	result.ddlWriter = mysql.NewWriter(ctx, len(result.dmlWriter), db, cfg, changefeedID, stat, nil)
+	result.ddlWriter = mysql.NewWriter(ctx, len(result.dmlWriter), controlDB, cfg, changefeedID, stat, nil)
 	if enableActiveActive {
-		result.progressTableWriter = mysql.NewProgressTableWriter(ctx, db, changefeedID, cfg.MaxTxnRow, progressInterval)
+		result.progressTableWriter = mysql.NewProgressTableWriter(ctx, controlDB, changefeedID, cfg.MaxTxnRow, progressInterval)
 	}
 	return result
 }
@@ -409,10 +428,17 @@ func (s *Sink) Close() {
 		w.Close()
 	}
 
-	if err := s.db.Close(); err != nil {
-		log.Warn("close mysql sink db meet error",
+	if err := s.dmlDB.Close(); err != nil {
+		log.Warn("close mysql sink dml db meet error",
 			zap.Any("changefeed", s.changefeedID.String()),
 			zap.Error(err))
+	}
+	if s.controlDB != s.dmlDB {
+		if err := s.controlDB.Close(); err != nil {
+			log.Warn("close mysql sink control db meet error",
+				zap.Any("changefeed", s.changefeedID.String()),
+				zap.Error(err))
+		}
 	}
 	if s.activeActiveSyncStatsCollector != nil {
 		s.activeActiveSyncStatsCollector.Close()

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -50,10 +50,10 @@ type Sink struct {
 	// enableActiveActive is false.
 	progressTableWriter *mysql.ProgressTableWriter
 
-	// ownedDBs contains the DB pools this sink is responsible for closing.
-	// Production sinks own separate DML and control pools, while compatibility
-	// callers built through NewMySQLSink own a single shared pool.
-	ownedDBs   []*sql.DB
+	// dmlDB and controlDB are the DB pools this sink is responsible for closing.
+	// Compatibility callers built through NewMySQLSink use one shared pool.
+	dmlDB      *sql.DB
+	controlDB  *sql.DB
 	statistics *metrics.Statistics
 
 	conflictDetector *causality.ConflictDetector
@@ -124,7 +124,7 @@ func NewMySQLSink(
 	enableActiveActive bool,
 	progressInterval time.Duration,
 ) *Sink {
-	return newMySQLSinkWithOwnedDBs(ctx, changefeedID, cfg, db, db, []*sql.DB{db}, bdrMode, enableActiveActive, progressInterval)
+	return newMySQLSinkWithDBs(ctx, changefeedID, cfg, db, db, bdrMode, enableActiveActive, progressInterval)
 }
 
 // newMySQLSinkWithControlDB creates a MySQL sink with separate pools for DML and
@@ -141,19 +141,15 @@ func newMySQLSinkWithControlDB(
 	enableActiveActive bool,
 	progressInterval time.Duration,
 ) *Sink {
-	return newMySQLSinkWithOwnedDBs(
-		ctx, changefeedID, cfg, dmlDB, controlDB,
-		[]*sql.DB{dmlDB, controlDB},
-		bdrMode, enableActiveActive, progressInterval)
+	return newMySQLSinkWithDBs(ctx, changefeedID, cfg, dmlDB, controlDB, bdrMode, enableActiveActive, progressInterval)
 }
 
-func newMySQLSinkWithOwnedDBs(
+func newMySQLSinkWithDBs(
 	ctx context.Context,
 	changefeedID common.ChangeFeedID,
 	cfg *mysql.Config,
 	dmlDB *sql.DB,
 	controlDB *sql.DB,
-	ownedDBs []*sql.DB,
 	bdrMode bool,
 	enableActiveActive bool,
 	progressInterval time.Duration,
@@ -179,7 +175,8 @@ func newMySQLSinkWithOwnedDBs(
 
 	result := &Sink{
 		changefeedID: changefeedID,
-		ownedDBs:     ownedDBs,
+		dmlDB:        dmlDB,
+		controlDB:    controlDB,
 		dmlWriter:    make([]*mysql.Writer, cfg.WorkerCount),
 		statistics:   stat,
 		conflictDetector: causality.New(defaultConflictDetectorSlots,
@@ -448,13 +445,9 @@ func (s *Sink) Close() {
 		w.Close()
 	}
 
-	for idx, db := range s.ownedDBs {
-		if err := db.Close(); err != nil {
-			log.Warn("failed to close mysql sink db pool",
-				zap.String("changefeed", s.changefeedID.String()),
-				zap.Int("dbIndex", idx),
-				zap.Error(err))
-		}
+	s.closeDBPool("dml", s.dmlDB)
+	if s.controlDB != s.dmlDB {
+		s.closeDBPool("control", s.controlDB)
 	}
 	if s.activeActiveSyncStatsCollector != nil {
 		s.activeActiveSyncStatsCollector.Close()
@@ -462,6 +455,15 @@ func (s *Sink) Close() {
 	s.statistics.Close()
 
 	metrics.ChangefeedDownstreamIsTiDBGauge.DeleteLabelValues(s.changefeedID.Keyspace(), s.changefeedID.Name())
+}
+
+func (s *Sink) closeDBPool(role string, db *sql.DB) {
+	if err := db.Close(); err != nil {
+		log.Warn("failed to close mysql sink db pool",
+			zap.String("changefeed", s.changefeedID.String()),
+			zap.String("dbRole", role),
+			zap.Error(err))
+	}
 }
 
 // CleanupRemovedChangefeed removes ddl_ts state for a deleted changefeed.

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -450,8 +450,8 @@ func (s *Sink) Close() {
 
 	for idx, db := range s.ownedDBs {
 		if err := db.Close(); err != nil {
-			log.Warn("close mysql sink db pool meet error",
-				zap.Any("changefeed", s.changefeedID.String()),
+			log.Warn("failed to close mysql sink db pool",
+				zap.String("changefeed", s.changefeedID.String()),
 				zap.Int("dbIndex", idx),
 				zap.Error(err))
 		}

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -50,8 +50,10 @@ type Sink struct {
 	// enableActiveActive is false.
 	progressTableWriter *mysql.ProgressTableWriter
 
-	dmlDB      *sql.DB
-	controlDB  *sql.DB
+	// ownedDBs contains the DB pools this sink is responsible for closing.
+	// Production sinks own separate DML and control pools, while compatibility
+	// callers built through NewMySQLSink own a single shared pool.
+	ownedDBs   []*sql.DB
 	statistics *metrics.Statistics
 
 	conflictDetector *causality.ConflictDetector
@@ -84,9 +86,7 @@ func Verify(
 		return err
 	}
 	_ = dmlDB.Close()
-	if controlDB != dmlDB {
-		_ = controlDB.Close()
-	}
+	_ = controlDB.Close()
 	return nil
 }
 
@@ -124,7 +124,7 @@ func NewMySQLSink(
 	enableActiveActive bool,
 	progressInterval time.Duration,
 ) *Sink {
-	return newMySQLSinkWithControlDB(ctx, changefeedID, cfg, db, db, bdrMode, enableActiveActive, progressInterval)
+	return newMySQLSinkWithOwnedDBs(ctx, changefeedID, cfg, db, db, []*sql.DB{db}, bdrMode, enableActiveActive, progressInterval)
 }
 
 // newMySQLSinkWithControlDB creates a MySQL sink with separate pools for DML and
@@ -137,6 +137,23 @@ func newMySQLSinkWithControlDB(
 	cfg *mysql.Config,
 	dmlDB *sql.DB,
 	controlDB *sql.DB,
+	bdrMode bool,
+	enableActiveActive bool,
+	progressInterval time.Duration,
+) *Sink {
+	return newMySQLSinkWithOwnedDBs(
+		ctx, changefeedID, cfg, dmlDB, controlDB,
+		[]*sql.DB{dmlDB, controlDB},
+		bdrMode, enableActiveActive, progressInterval)
+}
+
+func newMySQLSinkWithOwnedDBs(
+	ctx context.Context,
+	changefeedID common.ChangeFeedID,
+	cfg *mysql.Config,
+	dmlDB *sql.DB,
+	controlDB *sql.DB,
+	ownedDBs []*sql.DB,
 	bdrMode bool,
 	enableActiveActive bool,
 	progressInterval time.Duration,
@@ -162,8 +179,7 @@ func newMySQLSinkWithControlDB(
 
 	result := &Sink{
 		changefeedID: changefeedID,
-		dmlDB:        dmlDB,
-		controlDB:    controlDB,
+		ownedDBs:     ownedDBs,
 		dmlWriter:    make([]*mysql.Writer, cfg.WorkerCount),
 		statistics:   stat,
 		conflictDetector: causality.New(defaultConflictDetectorSlots,
@@ -432,15 +448,11 @@ func (s *Sink) Close() {
 		w.Close()
 	}
 
-	if err := s.dmlDB.Close(); err != nil {
-		log.Warn("close mysql sink dml db meet error",
-			zap.Any("changefeed", s.changefeedID.String()),
-			zap.Error(err))
-	}
-	if s.controlDB != s.dmlDB {
-		if err := s.controlDB.Close(); err != nil {
-			log.Warn("close mysql sink control db meet error",
+	for idx, db := range s.ownedDBs {
+		if err := db.Close(); err != nil {
+			log.Warn("close mysql sink db pool meet error",
 				zap.Any("changefeed", s.changefeedID.String()),
+				zap.Int("dbIndex", idx),
 				zap.Error(err))
 		}
 	}

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -108,7 +108,7 @@ func New(
 		metrics.ChangefeedDownstreamIsTiDBGauge.DeleteLabelValues(keyspace, name)
 	}
 
-	return NewMySQLSinkWithControlDB(ctx, changefeedID, cfg, dmlDB, controlDB, config.BDRMode, config.EnableActiveActive, config.ActiveActiveProgressInterval), nil
+	return newMySQLSinkWithControlDB(ctx, changefeedID, cfg, dmlDB, controlDB, config.BDRMode, config.EnableActiveActive, config.ActiveActiveProgressInterval), nil
 }
 
 func NewMySQLSink(
@@ -120,14 +120,14 @@ func NewMySQLSink(
 	enableActiveActive bool,
 	progressInterval time.Duration,
 ) *Sink {
-	return NewMySQLSinkWithControlDB(ctx, changefeedID, cfg, db, db, bdrMode, enableActiveActive, progressInterval)
+	return newMySQLSinkWithControlDB(ctx, changefeedID, cfg, db, db, bdrMode, enableActiveActive, progressInterval)
 }
 
-// NewMySQLSinkWithControlDB creates a MySQL sink with separate pools for DML and
+// newMySQLSinkWithControlDB creates a MySQL sink with separate pools for DML and
 // control-plane operations. The control pool is used by DDL, DDL-ts, syncpoint,
 // and active-active progress metadata paths so they do not wait behind long-lived
 // DML sessions.
-func NewMySQLSinkWithControlDB(
+func newMySQLSinkWithControlDB(
 	ctx context.Context,
 	changefeedID common.ChangeFeedID,
 	cfg *mysql.Config,

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -70,19 +70,23 @@ type Sink struct {
 	activeActiveSyncStatsCollector *mysql.ActiveActiveSyncStatsCollector
 }
 
-// Verify is used to verify the sink uri and config is valid
-// Currently, we verify by create a real mysql connection.
+// Verify is used to verify the sink URI and config are valid.
+// It creates the same DML and control DB pools as New so verification covers
+// connection availability for both data and control-plane paths.
 func Verify(
 	ctx context.Context,
 	uri *url.URL,
 	config *config.ChangefeedConfig,
 ) error {
 	testID := common.NewChangefeedID4Test("test", "mysql_create_sink_test")
-	_, db, err := mysql.NewMysqlConfigAndDB(ctx, testID, uri, config)
+	_, dmlDB, controlDB, err := mysql.NewMysqlConfigAndDBs(ctx, testID, uri, config)
 	if err != nil {
 		return err
 	}
-	_ = db.Close()
+	_ = dmlDB.Close()
+	if controlDB != dmlDB {
+		_ = controlDB.Close()
+	}
 	return nil
 }
 

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -59,6 +59,26 @@ func getMysqlSinkWithDDLTs() (context.Context, *Sink, sqlmock.Sqlmock) {
 	return ctx, sink, mock
 }
 
+func getMysqlSinkWithSeparateDBs(t *testing.T) (context.Context, *Sink, sqlmock.Sqlmock, sqlmock.Sqlmock) {
+	t.Helper()
+
+	dmlDB, dmlMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	controlDB, controlMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	changefeedID := common.NewChangefeedID4Test("test", "test")
+	cfg := mysql.New()
+	cfg.WorkerCount = 1
+	cfg.DMLMaxRetry = 1
+	cfg.MaxAllowedPacket = int64(vardef.DefMaxAllowedPacket)
+	cfg.CachePrepStmts = false
+
+	sink := NewMySQLSinkWithControlDB(ctx, changefeedID, cfg, dmlDB, controlDB, false, false, time.Minute)
+	return ctx, sink, dmlMock, controlMock
+}
+
 func MysqlSinkForTest() (*Sink, sqlmock.Sqlmock) {
 	ctx, sink, mock := getMysqlSink()
 	go sink.Run(ctx)
@@ -187,6 +207,86 @@ func TestMysqlSinkBasicFunctionality(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, count.Load(), int64(3))
+}
+
+func TestMysqlSinkUsesSeparateDMLAndControlDBPools(t *testing.T) {
+	ctx, sink, dmlMock, controlMock := getMysqlSinkWithSeparateDBs(t)
+	go sink.Run(ctx)
+	defer sink.Close()
+
+	var count atomic.Int64
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	createTableSQL := "create table t (id int primary key, name varchar(32));"
+	job := helper.DDL2Job(createTableSQL)
+	require.NotNil(t, job)
+
+	ddlEvent := &commonEvent.DDLEvent{
+		Query:      job.Query,
+		SchemaName: job.SchemaName,
+		TableName:  job.TableName,
+		FinishedTs: 1,
+		BlockedTables: &commonEvent.InfluencedTables{
+			InfluenceType: commonEvent.InfluenceTypeNormal,
+			TableIDs:      []int64{0},
+		},
+		NeedAddedTables: []commonEvent.Table{{TableID: 1, SchemaID: 1}},
+		PostTxnFlushed: []func(){
+			func() { count.Add(1) },
+		},
+	}
+
+	dmlEvent := helper.DML2Event("test", "t", "insert into t values (1, 'test')", "insert into t values (2, 'test2');")
+	dmlEvent.PostTxnFlushed = []func(){
+		func() { count.Add(1) },
+	}
+	dmlEvent.CommitTs = 2
+
+	controlMock.ExpectBegin()
+	controlMock.ExpectExec("CREATE DATABASE IF NOT EXISTS tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectExec("USE tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectExec(`CREATE TABLE IF NOT EXISTS ddl_ts_v1
+		(
+			ticdc_cluster_id varchar (255),
+			changefeed varchar(255),
+			ddl_ts varchar(18),
+			table_id bigint(21),
+			finished bool,
+			is_syncpoint bool,
+			INDEX (ticdc_cluster_id, changefeed, table_id),
+			PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
+		);`).WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectCommit()
+
+	controlMock.ExpectBegin()
+	controlMock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 0, 0), ('default', 'test/test', '1', 1, 0, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectCommit()
+
+	controlMock.ExpectBegin()
+	controlMock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectExec("SET TIMESTAMP = DEFAULT").WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectExec("create table t (id int primary key, name varchar(32));").WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectCommit()
+
+	controlMock.ExpectBegin()
+	controlMock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 1, 0), ('default', 'test/test', '1', 1, 1, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	controlMock.ExpectCommit()
+
+	dmlMock.ExpectExec("BEGIN;INSERT INTO `test`.`t` (`id`,`name`) VALUES (?,?),(?,?);COMMIT;").
+		WithArgs(1, "test", 2, "test2").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := sink.WriteBlockEvent(ddlEvent)
+	require.NoError(t, err)
+	require.NoError(t, controlMock.ExpectationsWereMet())
+
+	sink.AddDMLEvent(dmlEvent)
+	require.Eventually(t, func() bool {
+		return dmlMock.ExpectationsWereMet() == nil && count.Load() == 2
+	}, time.Second, 10*time.Millisecond)
 }
 
 // test the situation meets error when executing DML

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -108,6 +108,41 @@ func TestMysqlSinkBatchConfig(t *testing.T) {
 	require.Equal(t, 4096, sink.BatchBytes())
 }
 
+func expectCreateTableDDLFlow(mock sqlmock.Sqlmock) {
+	// Step 1: FlushDDLTsPre - Create ddl_ts table and insert pre-record (finished=0)
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("USE tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS ddl_ts_v1
+		(
+			ticdc_cluster_id varchar (255),
+			changefeed varchar(255),
+			ddl_ts varchar(18),
+			table_id bigint(21),
+			finished bool,
+			is_syncpoint bool,
+			INDEX (ticdc_cluster_id, changefeed, table_id),
+			PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
+		);`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 0, 0), ('default', 'test/test', '1', 1, 0, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	// Step 2: execDDLWithMaxRetries - Execute the actual DDL
+	mock.ExpectBegin()
+	mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SET TIMESTAMP = DEFAULT").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("create table t (id int primary key, name varchar(32));").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	// Step 3: FlushDDLTs - Update ddl_ts record (finished=1)
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 1, 0), ('default', 'test/test', '1', 1, 1, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+}
+
 // Test callback and tableProgress works as expected after AddDMLEvent
 func TestMysqlSinkBasicFunctionality(t *testing.T) {
 	sink, mock := MysqlSinkForTest()
@@ -158,38 +193,7 @@ func TestMysqlSinkBasicFunctionality(t *testing.T) {
 	}
 	dmlEvent.CommitTs = 2
 
-	// Step 1: FlushDDLTsPre - Create ddl_ts table and insert pre-record (finished=0)
-	mock.ExpectBegin()
-	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("USE tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS ddl_ts_v1
-		(
-			ticdc_cluster_id varchar (255),
-			changefeed varchar(255),
-			ddl_ts varchar(18),
-			table_id bigint(21),
-			finished bool,
-			is_syncpoint bool,
-			INDEX (ticdc_cluster_id, changefeed, table_id),
-			PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
-		);`).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
-
-	mock.ExpectBegin()
-	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 0, 0), ('default', 'test/test', '1', 1, 0, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
-
-	// Step 2: execDDLWithMaxRetries - Execute the actual DDL
-	mock.ExpectBegin()
-	mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("SET TIMESTAMP = DEFAULT").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("create table t (id int primary key, name varchar(32));").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
-
-	// Step 3: FlushDDLTs - Update ddl_ts record (finished=1)
-	mock.ExpectBegin()
-	mock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 1, 0), ('default', 'test/test', '1', 1, 1, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	expectCreateTableDDLFlow(mock)
 
 	mock.ExpectExec("BEGIN;INSERT INTO `test`.`t` (`id`,`name`) VALUES (?,?),(?,?);COMMIT;").
 		WithArgs(1, "test", 2, "test2").
@@ -245,35 +249,7 @@ func TestMysqlSinkUsesSeparateDMLAndControlDBPools(t *testing.T) {
 	}
 	dmlEvent.CommitTs = 2
 
-	controlMock.ExpectBegin()
-	controlMock.ExpectExec("CREATE DATABASE IF NOT EXISTS tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectExec("USE tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectExec(`CREATE TABLE IF NOT EXISTS ddl_ts_v1
-		(
-			ticdc_cluster_id varchar (255),
-			changefeed varchar(255),
-			ddl_ts varchar(18),
-			table_id bigint(21),
-			finished bool,
-			is_syncpoint bool,
-			INDEX (ticdc_cluster_id, changefeed, table_id),
-			PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
-		);`).WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectCommit()
-
-	controlMock.ExpectBegin()
-	controlMock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 0, 0), ('default', 'test/test', '1', 1, 0, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectCommit()
-
-	controlMock.ExpectBegin()
-	controlMock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectExec("SET TIMESTAMP = DEFAULT").WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectExec("create table t (id int primary key, name varchar(32));").WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectCommit()
-
-	controlMock.ExpectBegin()
-	controlMock.ExpectExec("INSERT INTO tidb_cdc.ddl_ts_v1 (ticdc_cluster_id, changefeed, ddl_ts, table_id, finished, is_syncpoint) VALUES ('default', 'test/test', '1', 0, 1, 0), ('default', 'test/test', '1', 1, 1, 0) ON DUPLICATE KEY UPDATE finished=VALUES(finished), ddl_ts=VALUES(ddl_ts), is_syncpoint=VALUES(is_syncpoint);").WillReturnResult(sqlmock.NewResult(1, 1))
-	controlMock.ExpectCommit()
+	expectCreateTableDDLFlow(controlMock)
 
 	dmlMock.ExpectExec("BEGIN;INSERT INTO `test`.`t` (`id`,`name`) VALUES (?,?),(?,?);COMMIT;").
 		WithArgs(1, "test", 2, "test2").

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -75,7 +75,7 @@ func getMysqlSinkWithSeparateDBs(t *testing.T) (context.Context, *Sink, sqlmock.
 	cfg.MaxAllowedPacket = int64(vardef.DefMaxAllowedPacket)
 	cfg.CachePrepStmts = false
 
-	sink := NewMySQLSinkWithControlDB(ctx, changefeedID, cfg, dmlDB, controlDB, false, false, time.Minute)
+	sink := newMySQLSinkWithControlDB(ctx, changefeedID, cfg, dmlDB, controlDB, false, false, time.Minute)
 	return ctx, sink, dmlMock, controlMock
 }
 

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -459,6 +459,9 @@ func (ra *RedoApplier) Apply(egCtx context.Context) (err error) {
 	replicaConfig := &config.ChangefeedConfig{
 		SinkURI:    sinkURI.String(),
 		SinkConfig: &config.SinkConfig{},
+		// Redo apply runs without a CDC server instance, so use the default
+		// server timezone for the same sink URI validation as normal changefeeds.
+		TimeZone: config.GetGlobalServerConfig().TZ,
 	}
 	if ra.mysqlSink == nil {
 		ra.mysqlSink, err = mysql.New(egCtx, ra.rd.GetChangefeedID(), replicaConfig, sinkURI)

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -456,12 +456,16 @@ func (ra *RedoApplier) Apply(egCtx context.Context) (err error) {
 		log.Warn("The redo log version is different the current version, enable-ddl-ts will be set to false", zap.Any("logVersion", ra.rd.GetVersion()), zap.Any("currentVersion", misc.Version))
 	}
 	sinkURI.RawQuery = query.Encode()
+	serverTimezone, err := util.GetTimezone(config.GetGlobalServerConfig().TZ)
+	if err != nil {
+		return err
+	}
 	replicaConfig := &config.ChangefeedConfig{
 		SinkURI:    sinkURI.String(),
 		SinkConfig: &config.SinkConfig{},
-		// Redo apply runs without a CDC server instance, so use the default
+		// Redo apply runs without a CDC server instance, so resolve the default
 		// server timezone for the same sink URI validation as normal changefeeds.
-		TimeZone: config.GetGlobalServerConfig().TZ,
+		TimeZone: serverTimezone.String(),
 	}
 	if ra.mysqlSink == nil {
 		ra.mysqlSink, err = mysql.New(egCtx, ra.rd.GetChangefeedID(), replicaConfig, sinkURI)

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -440,18 +440,18 @@ func configureDMLDBConn(db *sql.DB, cfg *Config) {
 	// work uses a separate pool.
 	db.SetMaxIdleConns(cfg.WorkerCount + dmlDBPrepareExtraConns)
 	db.SetMaxOpenConns(cfg.WorkerCount + dmlDBPrepareExtraConns)
-	forceSingleConnectionForTest(db)
 }
 
 func configureControlDBConn(db *sql.DB) {
 	db.SetMaxIdleConns(defaultControlDBConns)
 	db.SetMaxOpenConns(defaultControlDBConns)
-	forceSingleConnectionForTest(db)
+	forceControlDBSingleConnectionForTest(db)
 }
 
-func forceSingleConnectionForTest(db *sql.DB) {
-	// DDL timestamp tests rely on this failpoint forcing every MySQL sink pool
-	// onto one session so session-variable leakage is deterministic.
+func forceControlDBSingleConnectionForTest(db *sql.DB) {
+	// DDL timestamp tests rely on this failpoint forcing the DDL writer to reuse
+	// one downstream session so session-variable leakage is deterministic. Keep
+	// it scoped to the control pool so DML writers can still flush before DDLs.
 	failpoint.Inject("MySQLSinkForceSingleConnection", func() {
 		db.SetMaxIdleConns(1)
 		db.SetMaxOpenConns(1)

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -92,8 +92,8 @@ const (
 
 	slowQuery = 5 * time.Second
 
-	dmlDBExtraConns       = 10
-	defaultControlDBConns = 4
+	dmlDBPrepareExtraConns = 1
+	defaultControlDBConns  = 4
 )
 
 type Config struct {
@@ -435,8 +435,11 @@ func newMysqlConfigAndDB(
 }
 
 func configureDMLDBConn(db *sql.DB, cfg *Config) {
-	db.SetMaxIdleConns(cfg.WorkerCount + dmlDBExtraConns)
-	db.SetMaxOpenConns(cfg.WorkerCount + dmlDBExtraConns)
+	// Keep one spare DML connection so db.Prepare on a statement-cache miss
+	// cannot wait behind all writer-owned transaction sessions. Control-plane
+	// work uses a separate pool.
+	db.SetMaxIdleConns(cfg.WorkerCount + dmlDBPrepareExtraConns)
+	db.SetMaxOpenConns(cfg.WorkerCount + dmlDBPrepareExtraConns)
 	forceSingleConnectionForTest(db)
 }
 

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -91,6 +91,9 @@ const (
 	defaultEnableDDLTs = true
 
 	slowQuery = 5 * time.Second
+
+	dmlDBExtraConns       = 10
+	defaultControlDBConns = 4
 )
 
 type Config struct {
@@ -313,51 +316,76 @@ func (c *Config) Apply(
 func NewMysqlConfigAndDB(
 	ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig,
 ) (*Config, *sql.DB, error) {
+	cfg, db, _, err := newMysqlConfigAndDB(ctx, changefeedID, sinkURI, config)
+	return cfg, db, err
+}
+
+// NewMysqlConfigAndDBs creates the effective MySQL sink config and independent
+// database pools for DML and control-plane work. The DML pool follows the worker
+// based sizing and DML stress failpoints, while the control pool remains small
+// and independent so DDL, DDL-ts, syncpoint, and progress metadata operations
+// cannot be starved by long-lived DML sessions.
+func NewMysqlConfigAndDBs(
+	ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig,
+) (*Config, *sql.DB, *sql.DB, error) {
+	cfg, dmlDB, dsnStr, err := newMysqlConfigAndDB(ctx, changefeedID, sinkURI, config)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	controlDB, err := CreateMysqlDBConn(dsnStr)
+	if err != nil {
+		if closeErr := dmlDB.Close(); closeErr != nil {
+			log.Warn("close mysql dml db after control db creation failed",
+				zap.String("changefeed", changefeedID.String()), zap.Error(closeErr))
+		}
+		return nil, nil, nil, err
+	}
+	configureControlDBConn(controlDB)
+	return cfg, dmlDB, controlDB, nil
+}
+
+func newMysqlConfigAndDB(
+	ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig,
+) (cfg *Config, db *sql.DB, dsnStr string, err error) {
 	log.Info("create db connection", zap.String("sinkURI", sinkURI.String()))
 	// create db connection
-	cfg := New()
-	err := cfg.Apply(sinkURI, changefeedID, config)
+	cfg = New()
+	err = cfg.Apply(sinkURI, changefeedID, config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	cfg.EnableActiveActive = config.EnableActiveActive
 	cfg.ActiveActiveSyncStatsInterval = config.ActiveActiveSyncStatsInterval
 
-	dsnStr, err := GenerateDSN(ctx, cfg)
+	dsnStr, err = GenerateDSN(ctx, cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
-	db, err := CreateMysqlDBConn(dsnStr)
+	db, err = CreateMysqlDBConn(dsnStr)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		if closeErr := db.Close(); closeErr != nil {
+			log.Warn("close mysql db after config creation failed",
+				zap.String("changefeed", changefeedID.String()), zap.Error(closeErr))
+		}
+	}()
 
 	cfg.ServerInfo = getTiDBVersion(db)
 	cfg.HasVectorType = shouldFormatVectorType(cfg)
 
-	// By default, cache-prep-stmts=true, an LRU cache is used for prepared statements,
-	// two connections are required to process a transaction.
-	// The first connection is held in the tx variable, which is used to manage the transaction.
-	// The second connection is requested through a call to s.db.Prepare
-	// in case of a cache miss for the statement query.
-	// The connection pool for CDC is configured with a static size, equal to the number of workers.
-	// CDC may hang at the "Get Connection" call is due to the limited size of the connection pool.
-	// When the connection pool is small,
-	// the chance of all connections being active at the same time increases,
-	// leading to exhaustion of available connections and a hang at the "Get Connection" call.
-	// This issue is less likely to occur when the connection pool is larger,
-	// as there are more connections available for use.
-	// Adding extra connections to the pool helps avoid connection exhaustion.
-	// Each DML writer may hold a dedicated session for a while, and additional
-	// connections are also needed for multiple DDL/progress writers and stmt cache misses.
-	extraConn := 10
-	db.SetMaxIdleConns(cfg.WorkerCount + extraConn)
-	db.SetMaxOpenConns(cfg.WorkerCount + extraConn)
-	failpoint.Inject("MySQLSinkForceSingleConnection", func() {
-		db.SetMaxIdleConns(1)
-		db.SetMaxOpenConns(1)
-	})
+	// By default, cache-prep-stmts=true and DML prepared statements are cached
+	// in an LRU. A DML transaction can need one connection for the transaction
+	// itself and another connection for Prepare on a statement cache miss.
+	// Size the DML pool by worker count plus a small margin so long-lived DML
+	// sessions and prepare misses do not exhaust the pool.
+	configureDMLDBConn(db, cfg)
 
 	// Inherit the default value of the prepared statement cache from the SinkURI Options
 	cachePrepStmts := cfg.CachePrepStmts
@@ -365,7 +393,7 @@ func NewMysqlConfigAndDB(
 		// query the size of the prepared statement cache on serverside
 		maxPreparedStmtCount, err := queryMaxPreparedStmtCount(ctx, db)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 		if maxPreparedStmtCount == -1 {
 			// NOTE: seems TiDB doesn't follow MySQL's specification.
@@ -389,7 +417,7 @@ func NewMysqlConfigAndDB(
 			}
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 	}
 
@@ -402,7 +430,21 @@ func NewMysqlConfigAndDB(
 			zap.Error(err))
 		cfg.MaxAllowedPacket = int64(vardef.DefMaxAllowedPacket)
 	}
-	return cfg, db, nil
+	return cfg, db, dsnStr, nil
+}
+
+func configureDMLDBConn(db *sql.DB, cfg *Config) {
+	db.SetMaxIdleConns(cfg.WorkerCount + dmlDBExtraConns)
+	db.SetMaxOpenConns(cfg.WorkerCount + dmlDBExtraConns)
+	failpoint.Inject("MySQLSinkForceSingleConnection", func() {
+		db.SetMaxIdleConns(1)
+		db.SetMaxOpenConns(1)
+	})
+}
+
+func configureControlDBConn(db *sql.DB) {
+	db.SetMaxIdleConns(defaultControlDBConns)
+	db.SetMaxOpenConns(defaultControlDBConns)
 }
 
 // IsSinkSafeMode returns whether the sink is in safe mode.

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -367,11 +367,12 @@ func newMysqlConfigAndDB(
 	if err != nil {
 		return nil, nil, "", err
 	}
+	openedDB := db
 	defer func() {
 		if err == nil {
 			return
 		}
-		if closeErr := db.Close(); closeErr != nil {
+		if closeErr := openedDB.Close(); closeErr != nil {
 			log.Warn("close mysql db after config creation failed",
 				zap.String("changefeed", changefeedID.String()), zap.Error(closeErr))
 		}

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -437,15 +437,22 @@ func newMysqlConfigAndDB(
 func configureDMLDBConn(db *sql.DB, cfg *Config) {
 	db.SetMaxIdleConns(cfg.WorkerCount + dmlDBExtraConns)
 	db.SetMaxOpenConns(cfg.WorkerCount + dmlDBExtraConns)
-	failpoint.Inject("MySQLSinkForceSingleConnection", func() {
-		db.SetMaxIdleConns(1)
-		db.SetMaxOpenConns(1)
-	})
+	forceSingleConnectionForTest(db)
 }
 
 func configureControlDBConn(db *sql.DB) {
 	db.SetMaxIdleConns(defaultControlDBConns)
 	db.SetMaxOpenConns(defaultControlDBConns)
+	forceSingleConnectionForTest(db)
+}
+
+func forceSingleConnectionForTest(db *sql.DB) {
+	// DDL timestamp tests rely on this failpoint forcing every MySQL sink pool
+	// onto one session so session-variable leakage is deterministic.
+	failpoint.Inject("MySQLSinkForceSingleConnection", func() {
+		db.SetMaxIdleConns(1)
+		db.SetMaxOpenConns(1)
+	})
 }
 
 // IsSinkSafeMode returns whether the sink is in safe mode.

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -367,12 +367,11 @@ func newMysqlConfigAndDB(
 	if err != nil {
 		return nil, nil, "", err
 	}
-	openedDB := db
 	defer func() {
 		if err == nil {
 			return
 		}
-		if closeErr := openedDB.Close(); closeErr != nil {
+		if closeErr := db.Close(); closeErr != nil {
 			log.Warn("close mysql db after config creation failed",
 				zap.String("changefeed", changefeedID.String()), zap.Error(closeErr))
 		}

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -322,9 +322,9 @@ func NewMysqlConfigAndDB(
 
 // NewMysqlConfigAndDBs creates the effective MySQL sink config and independent
 // database pools for DML and control-plane work. The DML pool follows the worker
-// based sizing and DML stress failpoints, while the control pool remains small
-// and independent so DDL, DDL-ts, syncpoint, and progress metadata operations
-// cannot be starved by long-lived DML sessions.
+// based sizing, while the control pool remains small and independent so DDL,
+// DDL-ts, syncpoint, and progress metadata operations cannot be starved by
+// long-lived DML sessions.
 func NewMysqlConfigAndDBs(
 	ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.URL, config *config.ChangefeedConfig,
 ) (*Config, *sql.DB, *sql.DB, error) {
@@ -445,10 +445,6 @@ func configureDMLDBConn(db *sql.DB, cfg *Config) {
 func configureControlDBConn(db *sql.DB) {
 	db.SetMaxIdleConns(defaultControlDBConns)
 	db.SetMaxOpenConns(defaultControlDBConns)
-	forceControlDBSingleConnectionForTest(db)
-}
-
-func forceControlDBSingleConnectionForTest(db *sql.DB) {
 	// DDL timestamp tests rely on this failpoint forcing the DDL writer to reuse
 	// one downstream session so session-variable leakage is deterministic. Keep
 	// it scoped to the control pool so DML writers can still flush before DDLs.

--- a/pkg/sink/mysql/config_test.go
+++ b/pkg/sink/mysql/config_test.go
@@ -259,6 +259,11 @@ func TestConfigureControlDBConn(t *testing.T) {
 }
 
 func TestConfigureDMLDBConn(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkForceSingleConnection", "return(true)"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkForceSingleConnection"))
+	})
+
 	db, _, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close()
@@ -267,6 +272,9 @@ func TestConfigureDMLDBConn(t *testing.T) {
 	cfg.WorkerCount = 3
 	configureDMLDBConn(db, cfg)
 
+	// The DDL timestamp failpoint is scoped to the control pool. DML writers must
+	// keep their worker-based pool size so table-level DDLs are not blocked by
+	// unflushed DML events.
 	require.Equal(t, cfg.WorkerCount+dmlDBPrepareExtraConns, db.Stats().MaxOpenConnections)
 	require.Equal(t, 4, db.Stats().MaxOpenConnections)
 }

--- a/pkg/sink/mysql/config_test.go
+++ b/pkg/sink/mysql/config_test.go
@@ -258,6 +258,19 @@ func TestConfigureControlDBConn(t *testing.T) {
 	require.Equal(t, 1, db.Stats().MaxOpenConnections)
 }
 
+func TestConfigureDMLDBConn(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	cfg := New()
+	cfg.WorkerCount = 3
+	configureDMLDBConn(db, cfg)
+
+	require.Equal(t, cfg.WorkerCount+dmlDBPrepareExtraConns, db.Stats().MaxOpenConnections)
+	require.Equal(t, 4, db.Stats().MaxOpenConnections)
+}
+
 func TestApplySinkURIParamsToConfig(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sink/mysql/config_test.go
+++ b/pkg/sink/mysql/config_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	dmysql "github.com/go-sql-driver/mysql"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -239,6 +240,22 @@ func TestConfigureControlDBConn(t *testing.T) {
 	configureControlDBConn(db)
 
 	require.Equal(t, defaultControlDBConns, db.Stats().MaxOpenConnections)
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkForceSingleConnection", "return(true)"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkForceSingleConnection"))
+	})
+
+	db, _, err = sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	configureControlDBConn(db)
+
+	if db.Stats().MaxOpenConnections != 1 {
+		t.Skip("failpoint rewriting is disabled")
+	}
+	require.Equal(t, 1, db.Stats().MaxOpenConnections)
 }
 
 func TestApplySinkURIParamsToConfig(t *testing.T) {

--- a/pkg/sink/mysql/config_test.go
+++ b/pkg/sink/mysql/config_test.go
@@ -231,6 +231,16 @@ func TestGenerateDSNByConfig(t *testing.T) {
 	testIsolationConfig()
 }
 
+func TestConfigureControlDBConn(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	configureControlDBConn(db)
+
+	require.Equal(t, defaultControlDBConns, db.Stats().MaxOpenConnections)
+}
+
 func TestApplySinkURIParamsToConfig(t *testing.T) {
 	t.Parallel()
 

--- a/tests/integration_tests/ddl_default_current_timestamp/run.sh
+++ b/tests/integration_tests/ddl_default_current_timestamp/run.sh
@@ -98,7 +98,8 @@ function run() {
 		exit 1
 	fi
 
-	cdc redo apply --log-level debug --tmp-dir="$tmp_download_path/apply" \
+	# Redo apply runs in a new process, so set TZ explicitly to match the sink URI.
+	TZ="${TIME_ZONE}" cdc redo apply --log-level debug --tmp-dir="$tmp_download_path/apply" \
 		--storage="$storage_path" \
 		--sink-uri="$SINK_URI" >$WORK_DIR/cdc_redo.log
 

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -38,7 +38,7 @@ mysql_groups=(
 	# G02
 	'new_ci_collation safe_mode savepoint fail_over_ddl_C unsplittable_tables'
 	# G03
-	'capture_suicide_while_balance_table capture_local_fence_on_session_done kv_client_stream_reconnect fail_over_ddl_D'
+	'capture_suicide_while_balance_table capture_local_fence_on_session_done kv_client_stream_reconnect ddl_default_current_timestamp fail_over_ddl_D'
 	# G04
 	'multi_capture ci_collation_compatibility resourcecontrol fail_over_ddl_E'
 	# G05


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5360

The MySQL sink used one shared `*sql.DB` pool for DML writers and control-plane work such as DDL execution, DDL-ts metadata, syncpoint metadata, and active-active progress updates. When a DML writer held the only available connection, control-plane operations could block while waiting for a connection. In the reported failure, the DDL was received and dispatched but did not reach downstream because the DDL path could not acquire a connection from the shared pool.

### What is changed and how it works?

This PR splits the MySQL sink connection usage into two independent bounded pools created from the same effective DSN:

- The DML pool is used by DML writers, DML sessions, prepared statement cache use, and active-active sync stats session queries.
- The control pool is used by the DDL writer, DDL-ts metadata, syncpoint metadata, active-active progress table updates, DDL status queries, and metadata bootstrap.
- The existing `NewMysqlConfigAndDB` single-pool API is preserved for existing callers.
- A new `NewMysqlConfigAndDBs` helper creates the sink-specific DML/control pools and closes the DML pool if control pool creation fails.
- `MySQLSinkForceSingleConnection` now only constrains the DML pool, so the stress path can still simulate DML session starvation without starving DDL/control operations.
- `Sink.Close` closes both pools and avoids double-closing when tests pass the same DB for both.

The control pool is bounded to 4 open and idle connections.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Commands:

- `make fmt`
- `go test --tags=intest ./pkg/sink/mysql ./downstreamadapter/sink/mysql`

Not run:

- `make integration_test_mysql CASE=ddl_default_current_timestamp`, because `make check_third_party_binary` fails in this worktree: the required third-party binaries under `bin/` are not present.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No compatibility break is expected. Existing single-pool factory callers keep the same API. The MySQL sink now opens a small additional control pool, which should reduce DDL/control starvation risk. The DML pool keeps one extra connection for prepared-statement cache misses instead of reserving the historical broader control-plane margin.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a MySQL sink hang where DDL and metadata operations could be blocked by DML sessions when the shared downstream connection pool was exhausted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the MySQL sink to use separate long-lived database connections for data changes versus control-plane tasks (DDL and metadata), reducing contention and improving parallelism.
  * Added configurable connection pool sizing for each path and improved verification to validate both connections.

* **Tests**
  * Added integration-style coverage to confirm DDL/control-plane operations run on the control connection while batched DML runs on the dedicated DML connection.
  * Added a unit test to verify control connection pooling configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->