### PR TITLE
*: check Go version before building cdc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ GITHASH := $(shell git rev-parse HEAD)
 GITBRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GOVERSION := $(shell go version)
 REQUIRED_GO_MINOR := $(shell awk '/^go / { split($$2, v, "."); print v[1]"."v[2]; exit }' go.mod)
-CURRENT_GO_VERSION := $(shell go env GOVERSION 2>/dev/null)
-CURRENT_GO_MINOR := $(shell printf '%s\n' '$(CURRENT_GO_VERSION)' | sed -E 's/^go([0-9]+\.[0-9]+).*/\1/')
+CURRENT_GO_VERSION := $(shell go env GOVERSION 2>/dev/null | sed -E 's/^go//')
+CURRENT_GO_MINOR := $(shell printf '%s\n' '$(CURRENT_GO_VERSION)' | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
 
 # Since TiDB add a new dependency on github.com/cloudfoundry/gosigar,
 # We need to add CGO_ENABLED=1 to make it work when build TiCDC in Darwin OS.
@@ -172,7 +172,7 @@ check-go-version:
 		exit 1; \
 	fi
 	@if [ "$(CURRENT_GO_MINOR)" != "$(REQUIRED_GO_MINOR)" ]; then \
-		echo "Error: TiCDC must be built with Go $(REQUIRED_GO_MINOR).x; found $(CURRENT_GO_VERSION)."; \
+		echo "Error: TiCDC must be built with Go $(REQUIRED_GO_MINOR).x; found Go $(CURRENT_GO_VERSION)."; \
 		echo "Install Go $(REQUIRED_GO_MINOR).x or update PATH before running make cdc."; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Phony targets are targets that are not associated with files.
 # Add new phony targets here to make them available in the `make` command.
 .PHONY: clean fmt check check-static local-static-check tidy \
+	check-go-version \
 	generate-protobuf generate_mock \
 	cdc kafka_consumer storage_consumer pulsar_consumer filter_helper \
 	prepare_test_binaries \
@@ -36,6 +37,9 @@ BUILDTS := $(shell date -u '+%Y-%m-%d %H:%M:%S')
 GITHASH := $(shell git rev-parse HEAD)
 GITBRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GOVERSION := $(shell go version)
+REQUIRED_GO_MINOR := $(shell awk '/^go / { split($$2, v, "."); print v[1]"."v[2]; exit }' go.mod)
+CURRENT_GO_VERSION := $(shell go env GOVERSION 2>/dev/null)
+CURRENT_GO_MINOR := $(shell printf '%s\n' '$(CURRENT_GO_VERSION)' | sed -E 's/^go([0-9]+\.[0-9]+).*/\1/')
 
 # Since TiDB add a new dependency on github.com/cloudfoundry/gosigar,
 # We need to add CGO_ENABLED=1 to make it work when build TiCDC in Darwin OS.
@@ -162,13 +166,24 @@ generate_mock: ## Generate mock code.
 generate_mock: tools/bin/mockgen
 	scripts/generate-mock.sh
 
-build-cdc-with-failpoint: check_failpoint_ctl
+check-go-version:
+	@if [ -z "$(CURRENT_GO_VERSION)" ]; then \
+		echo "Error: go is not available in PATH"; \
+		exit 1; \
+	fi
+	@if [ "$(CURRENT_GO_MINOR)" != "$(REQUIRED_GO_MINOR)" ]; then \
+		echo "Error: TiCDC must be built with Go $(REQUIRED_GO_MINOR).x; found $(CURRENT_GO_VERSION)."; \
+		echo "Install Go $(REQUIRED_GO_MINOR).x or update PATH before running make cdc."; \
+		exit 1; \
+	fi
+
+build-cdc-with-failpoint: check-go-version check_failpoint_ctl
 build-cdc-with-failpoint: ## Build cdc with failpoint enabled.
 	$(FAILPOINT_ENABLE)
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc/main.go
 	$(FAILPOINT_DISABLE)
 
-cdc:
+cdc: check-go-version
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc
 
 kafka_consumer:

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,10 @@ check-go-version:
 		echo "Error: go is not available in PATH"; \
 		exit 1; \
 	fi
+	@if [ -z "$(REQUIRED_GO_MINOR)" ]; then \
+		echo "Error: failed to read required Go version from go.mod"; \
+		exit 1; \
+	fi
 	@if [ "$(CURRENT_GO_MINOR)" != "$(REQUIRED_GO_MINOR)" ]; then \
 		echo "Error: TiCDC must be built with Go $(REQUIRED_GO_MINOR).x; found Go $(CURRENT_GO_VERSION)."; \
 		echo "Install Go $(REQUIRED_GO_MINOR).x or update PATH before running make cdc."; \


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5415 

### What is changed and how it works?

This pull request enhances the build process for TiCDC by enforcing strict Go version compatibility. By validating the installed Go version against the project's requirements defined in go.mod before compilation, it prevents potential build errors and runtime inconsistencies caused by mismatched toolchain versions.

### Highlights

* **Go Version Validation**: Introduced a mandatory Go version check in the Makefile to ensure the build environment matches the version specified in go.mod.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Go toolchain version validation to the build workflow.
  * Build steps now verify the installed Go minor version against the required version from the project configuration and stop with a clear error if there’s a mismatch or missing Go installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->