### PR TITLE
logservice: cap resolve lock target ts by PD tso

### DIFF
--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -942,7 +942,7 @@ func (s *subscriptionClient) runResolveLockChecker(ctx context.Context) error {
 	maxCacheSize := 1024
 	subSpanAndTsCache := make([]subscriptionAndTargetTs, 0, maxCacheSize)
 	// getResolvedTargetTs returns the targetTs to resolve stale locks. 0 means no need to resolve.
-	getResolvedTargetTs := func(subSpan *subscribedSpan, currentTime time.Time) uint64 {
+	getResolvedTargetTs := func(subSpan *subscribedSpan, currentTime time.Time, currentTs uint64) uint64 {
 		resolvedTsUpdated := time.Unix(subSpan.resolvedTsUpdated.Load(), 0)
 		if !subSpan.initialized.Load() || time.Since(resolvedTsUpdated) < resolveLockFence {
 			return 0
@@ -952,7 +952,7 @@ func (s *subscriptionClient) runResolveLockChecker(ctx context.Context) error {
 		if currentTime.Sub(resolvedTime) < resolveLockFence {
 			return 0
 		}
-		return oracle.GoTimeToTS(resolvedTime.Add(resolveLockFence))
+		return min(currentTs, oracle.GoTimeToTS(resolvedTime.Add(resolveLockFence)))
 	}
 
 	for {
@@ -961,11 +961,18 @@ func (s *subscriptionClient) runResolveLockChecker(ctx context.Context) error {
 			return ctx.Err()
 		case <-resolveLockTicker.C:
 		}
+
+		physical, logic, err := s.pd.GetTS(ctx)
+		if err != nil {
+			log.Warn("get ts from pd failed", zap.Error(err))
+			continue
+		}
+		currentTs := oracle.ComposeTS(physical, logic)
 		currentTime := s.pdClock.CurrentTime()
 		s.totalSpans.Lock()
 		for _, subSpan := range s.totalSpans.spanMap {
 			if subSpan != nil {
-				targetTs := getResolvedTargetTs(subSpan, currentTime)
+				targetTs := getResolvedTargetTs(subSpan, currentTime, currentTs)
 				if targetTs > 0 {
 					subSpanAndTsCache = append(subSpanAndTsCache, subscriptionAndTargetTs{
 						subSpan:  subSpan,

--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -693,3 +693,93 @@ func TestErrCacheDispatchBatch(t *testing.T) {
 		})
 	}
 }
+
+func TestGetResolvedTargetTs(t *testing.T) {
+	client := &subscriptionClient{
+		resolveLockTaskCh:      make(chan resolveLockTask, 10),
+		resolveLockRateLimiter: newResolveLockRateLimiter(),
+	}
+	client.ctx, client.cancel = context.WithCancel(context.Background())
+	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
+	advanceResolvedTs := func(ts uint64) {}
+
+	span := client.newSubscribedSpan(SubscriptionID(1), heartbeatpb.TableSpan{
+		TableID:  1,
+		StartKey: []byte{'a'},
+		EndKey:   []byte{'z'},
+	}, 100, consumeKVEvents, advanceResolvedTs, 0, false)
+	span.initialized.Store(true)
+
+	// Replicate the getResolvedTargetTs closure from runResolveLockChecker
+	getResolvedTargetTs := func(subSpan *subscribedSpan, currentTime time.Time, currentTs uint64) uint64 {
+		resolvedTsUpdated := time.Unix(subSpan.resolvedTsUpdated.Load(), 0)
+		if !subSpan.initialized.Load() || time.Since(resolvedTsUpdated) < resolveLockFence {
+			return 0
+		}
+		resolvedTs := subSpan.resolvedTs.Load()
+		resolvedTime := oracle.GetTimeFromTS(resolvedTs)
+		if currentTime.Sub(resolvedTime) < resolveLockFence {
+			return 0
+		}
+		return min(currentTs, oracle.GoTimeToTS(resolvedTime.Add(resolveLockFence)))
+	}
+
+	// Simulate clock skew: local pdClock is 30s ahead of PD.
+	// In the real scenario:
+	//   - currentTs comes from pd.GetTS (PD time)
+	//   - currentTime comes from pdClock.CurrentTime() (local clock, could be ahead)
+	//   - resolvedTs is a TiKV/PD timestamp
+	pdNow := time.Now()
+	localClockNow := pdNow.Add(30 * time.Second) // local clock 30s ahead
+	currentTs := oracle.GoTimeToTS(pdNow)
+
+	// resolvedTime is 2 seconds ago in PD time, so:
+	//   resolvedTime + resolveLockFence = pdNow - 2s + 4s = pdNow + 2s > pdNow
+	//   => oracle.GoTimeToTS(resolvedTime + resolveLockFence) > currentTs
+	// But currentTime (local) - resolvedTime = 32s > 4s (resolveLockFence), so the check passes
+	resolvedTime := pdNow.Add(-2 * time.Second)
+	resolvedTs := oracle.GoTimeToTS(resolvedTime)
+	span.resolvedTs.Store(resolvedTs)
+	span.resolvedTsUpdated.Store(pdNow.Add(-10 * time.Second).Unix())
+
+	// Verify the setup: resolvedTime + resolveLockFence should exceed currentTs
+	tsIfUncapped := oracle.GoTimeToTS(resolvedTime.Add(resolveLockFence))
+	require.True(t, tsIfUncapped > currentTs,
+		"setup: resolvedTime+resolveLockFence TS (%d) should exceed currentTs (%d)", tsIfUncapped, currentTs)
+
+	// With the fix (min), targetTs should be capped at currentTs
+	targetTs := getResolvedTargetTs(span, localClockNow, currentTs)
+	require.Equal(t, currentTs, targetTs,
+		"targetTs should be capped at currentTs when resolvedTime+resolveLockFence exceeds it")
+
+	// Test case 2: resolvedTime + resolveLockFence is in the past (< currentTs)
+	// resolvedTime = 20s ago, +4s = 16s ago < pdNow, so tsIfUncapped < currentTs
+	resolvedTime2 := pdNow.Add(-20 * time.Second)
+	span.resolvedTs.Store(oracle.GoTimeToTS(resolvedTime2))
+	tsIfUncapped2 := oracle.GoTimeToTS(resolvedTime2.Add(resolveLockFence))
+	require.True(t, tsIfUncapped2 < currentTs,
+		"setup: resolvedTime+resolveLockFence TS (%d) should be less than currentTs (%d)", tsIfUncapped2, currentTs)
+
+	targetTs2 := getResolvedTargetTs(span, localClockNow, currentTs)
+	require.Equal(t, tsIfUncapped2, targetTs2,
+		"targetTs should be resolvedTime+resolveLockFence when it's less than currentTs")
+
+	// Test case 3: span not initialized
+	span.initialized.Store(false)
+	targetTs3 := getResolvedTargetTs(span, localClockNow, currentTs)
+	require.Equal(t, uint64(0), targetTs3, "targetTs should be 0 when span is not initialized")
+
+	// Test case 4: resolvedTsUpdated is recent (within resolveLockFence)
+	span.initialized.Store(true)
+	span.resolvedTsUpdated.Store(time.Now().Unix())
+	targetTs4 := getResolvedTargetTs(span, localClockNow, currentTs)
+	require.Equal(t, uint64(0), targetTs4, "targetTs should be 0 when resolvedTsUpdated is recent")
+
+	// Test case 5: currentTime - resolvedTime < resolveLockFence (should return 0)
+	span.resolvedTsUpdated.Store(pdNow.Add(-10 * time.Second).Unix())
+	recentResolvedTime := localClockNow.Add(-2 * time.Second) // 2s ago in local time
+	span.resolvedTs.Store(oracle.GoTimeToTS(recentResolvedTime))
+	targetTs5 := getResolvedTargetTs(span, localClockNow, currentTs)
+	require.Equal(t, uint64(0), targetTs5,
+		"targetTs should be 0 when currentTime - resolvedTime < resolveLockFence")
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5418

TiCDC stale-lock resolving could choose a `ScanLock` target timestamp from local time instead of the latest PD TSO. In the async-commit case described in #5418, this can advance TiKV local `MaxTS`, make a residual lock's `min_commit_ts` exceed the primary commit timestamp, and cause later lock resolving to fail with `commit_ts_expired`.

### What is changed and how it works?

This PR changes the resolve-lock checker to fetch the current TSO from PD before scanning stale locks and cap the scan target timestamp by that PD `currentTs`.

The checker keeps the freshness fence for `resolvedTsUpdated` on the CDC node's local clock, because `resolvedTsUpdated` is written with `time.Now()`. It uses the PD-derived time only to check whether the span resolved-ts is stale enough and to provide the `ScanLock` target timestamp.

It also extracts the target timestamp calculation into a small helper and adds unit coverage for the cap, fence conditions, and CDC/PD clock skew cases.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

```console
go test ./logservice/logpuller -run 'TestGetResolveLockTargetTs' -count=1 -vet=off
go test ./logservice/logpuller -count=1
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No compatibility impact is expected. The checker now performs one PD `GetTS` call per resolve-lock tick before scheduling stale-lock scans.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a TiCDC stale-lock resolving issue where the ScanLock target timestamp could advance TiKV local MaxTS beyond the latest PD TSO and make async-commit residual locks fail to resolve.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale lock resolution in the subscription client with enhanced timestamp computation logic.

* **Tests**
  * Added comprehensive unit tests for lock resolution timestamp calculation across various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->