### PR TITLE
coordinator: handle fast-fail errors before checkpoint progress

### DIFF
--- a/coordinator/changefeed/backoff.go
+++ b/coordinator/changefeed/backoff.go
@@ -120,11 +120,27 @@ func (m *Backoff) resetErrRetry() {
 //
 // The method handles several cases:
 //  1. If the changefeed is marked as failed, returns Failed state
-//  2. If checkpoint has advanced (making progress), resets any retry attempts and returns Normal state
-//  3. If there are errors and checkpoint hasn't advanced, initiates the retry mechanism
+//  2. If a fast-fail error is reported, returns Failed state
+//  3. If checkpoint has advanced (making progress), resets any retry attempts and returns Normal state
+//  4. If there are errors and checkpoint hasn't advanced, initiates the retry mechanism
 func (m *Backoff) CheckStatus(status *heartbeatpb.MaintainerStatus) (bool, config.FeedState, *heartbeatpb.RunningError) {
 	if m.failed.Load() {
 		return false, config.StateFailed, nil
+	}
+
+	if err := findFastFailError(status.Err); err != nil {
+		if m.checkpointTs < status.CheckpointTs {
+			m.checkpointTs = status.CheckpointTs
+		}
+		log.Error("changefeed maintainer report a fast fail error",
+			zap.Stringer("changefeed", m.id),
+			zap.Uint64("checkpointTs", m.checkpointTs),
+			zap.String("node", err.Node),
+			zap.String("code", err.Code),
+			zap.String("state", string(config.StateFailed)),
+			zap.Any("error", err))
+		m.failed.Store(true)
+		return true, config.StateFailed, err
 	}
 
 	if m.checkpointTs < status.CheckpointTs {
@@ -182,16 +198,15 @@ func (m *Backoff) StartFinished() {
 
 // ShouldFailChangefeed return true if a running error contains a changefeed not retry error.
 func ShouldFailChangefeed(e *heartbeatpb.RunningError) bool {
+	if e == nil {
+		return false
+	}
 	return cerrors.ShouldFailChangefeed(errors.New(e.Message + e.Code))
 }
 
 func (m *Backoff) HandleError(errs []*heartbeatpb.RunningError) (bool, *heartbeatpb.RunningError) {
-	// if there are a fastFail error in errs, we can just fastFail the changefeed
-	for _, err := range errs {
-		if cerrors.IsChangefeedGCFastFailErrorCode(errors.RFCErrorCode(err.Code)) ||
-			ShouldFailChangefeed(err) {
-			return true, err
-		}
+	if err := findFastFailError(errs); err != nil {
+		return true, err
 	}
 
 	lastError := errs[len(errs)-1]
@@ -224,4 +239,17 @@ func (m *Backoff) HandleError(errs []*heartbeatpb.RunningError) (bool, *heartbea
 		zap.Any("error", errs))
 	// patch the last error to changefeed info
 	return false, lastError
+}
+
+func findFastFailError(errs []*heartbeatpb.RunningError) *heartbeatpb.RunningError {
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		if cerrors.IsChangefeedGCFastFailErrorCode(errors.RFCErrorCode(err.Code)) ||
+			ShouldFailChangefeed(err) {
+			return err
+		}
+	}
+	return nil
 }

--- a/coordinator/changefeed/backoff.go
+++ b/coordinator/changefeed/backoff.go
@@ -17,12 +17,11 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
-	cerrors "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/errors"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
@@ -201,7 +200,7 @@ func ShouldFailChangefeed(e *heartbeatpb.RunningError) bool {
 	if e == nil {
 		return false
 	}
-	return cerrors.ShouldFailChangefeed(errors.New(e.Message + e.Code))
+	return errors.ShouldFailChangefeed(errors.New(e.Message + e.Code))
 }
 
 func (m *Backoff) HandleError(errs []*heartbeatpb.RunningError) (bool, *heartbeatpb.RunningError) {
@@ -246,7 +245,7 @@ func findFastFailError(errs []*heartbeatpb.RunningError) *heartbeatpb.RunningErr
 		if err == nil {
 			continue
 		}
-		if cerrors.IsChangefeedGCFastFailErrorCode(errors.RFCErrorCode(err.Code)) ||
+		if errors.IsChangefeedGCFastFailErrorCode(errors.RFCErrorCode(err.Code)) ||
 			ShouldFailChangefeed(err) {
 			return err
 		}

--- a/coordinator/changefeed/backoff.go
+++ b/coordinator/changefeed/backoff.go
@@ -110,19 +110,7 @@ func (m *Backoff) resetErrRetry() {
 	m.retrying.Store(false)
 }
 
-// CheckStatus checks the current status of a changefeed and determines its state transition.
-// It takes a MaintainerStatus which contains the current checkpoint timestamp and any errors.
-// Returns:
-//   - bool: whether the state has changed and needs to be updated
-//   - config.FeedState: the new state of the changefeed (Normal, Warning, or Failed)
-//   - *heartbeatpb.RunningError: any error that occurred during processing
-//
-// The method handles several cases:
-//  1. If the changefeed is marked as failed, returns Failed state
-//  2. If a fast-fail error is reported, returns Failed state
-//  3. If checkpoint has advanced (making progress), resets any retry attempts and returns Normal state
-//  4. If there are errors and checkpoint hasn't advanced, initiates the retry mechanism
-func (m *Backoff) CheckStatus(status *heartbeatpb.MaintainerStatus) (bool, config.FeedState, *heartbeatpb.RunningError) {
+func (m *Backoff) checkFailedStatus(status *heartbeatpb.MaintainerStatus) (bool, config.FeedState, *heartbeatpb.RunningError) {
 	if m.failed.Load() {
 		return false, config.StateFailed, nil
 	}
@@ -140,6 +128,26 @@ func (m *Backoff) CheckStatus(status *heartbeatpb.MaintainerStatus) (bool, confi
 			zap.Any("error", err))
 		m.failed.Store(true)
 		return true, config.StateFailed, err
+	}
+
+	return false, config.StateNormal, nil
+}
+
+// CheckStatus checks the current status of a changefeed and determines its state transition.
+// It takes a MaintainerStatus which contains the current checkpoint timestamp and any errors.
+// Returns:
+//   - bool: whether the state has changed and needs to be updated
+//   - config.FeedState: the new state of the changefeed (Normal, Warning, or Failed)
+//   - *heartbeatpb.RunningError: any error that occurred during processing
+//
+// The method handles several cases:
+//  1. If the changefeed is marked as failed, returns Failed state
+//  2. If a fast-fail error is reported, returns Failed state
+//  3. If checkpoint has advanced (making progress), resets any retry attempts and returns Normal state
+//  4. If there are errors and checkpoint hasn't advanced, initiates the retry mechanism
+func (m *Backoff) CheckStatus(status *heartbeatpb.MaintainerStatus) (bool, config.FeedState, *heartbeatpb.RunningError) {
+	if changed, state, err := m.checkFailedStatus(status); state == config.StateFailed {
+		return changed, state, err
 	}
 
 	if m.checkpointTs < status.CheckpointTs {

--- a/coordinator/changefeed/backoff_test.go
+++ b/coordinator/changefeed/backoff_test.go
@@ -147,6 +147,11 @@ func TestTableRoutingErrorsFastFail(t *testing.T) {
 			code:    string(errors.ErrTableRoutingFailed.RFCCode()),
 			message: "table routing failed",
 		},
+		{
+			name:    "table route conflict",
+			code:    string(errors.ErrTableRouteConflict.RFCCode()),
+			message: "table route conflict",
+		},
 	}
 
 	for _, tc := range tests {
@@ -171,6 +176,36 @@ func TestTableRoutingErrorsFastFail(t *testing.T) {
 			require.False(t, backoff.retrying.Load())
 		})
 	}
+}
+
+func TestFastFailErrorWinsOverCheckpointProgress(t *testing.T) {
+	backoff := NewBackoff(common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName), time.Minute*30, 1)
+	require.True(t, backoff.ShouldRun())
+
+	changed, state, err := backoff.CheckStatus(&heartbeatpb.MaintainerStatus{
+		CheckpointTs: 2,
+		Err: []*heartbeatpb.RunningError{
+			{
+				Code:    string(errors.ErrTableRouteConflict.RFCCode()),
+				Message: "table route conflict",
+			},
+		},
+	})
+
+	require.True(t, changed)
+	require.Equal(t, config.StateFailed, state)
+	require.NotNil(t, err)
+	require.Equal(t, uint64(2), backoff.checkpointTs)
+	require.False(t, backoff.ShouldRun())
+	require.False(t, backoff.retrying.Load())
+
+	changed, state, err = backoff.CheckStatus(&heartbeatpb.MaintainerStatus{
+		CheckpointTs: 3,
+	})
+	require.False(t, changed)
+	require.Equal(t, config.StateFailed, state)
+	require.Nil(t, err)
+	require.Equal(t, uint64(2), backoff.checkpointTs)
 }
 
 func TestFailedWhenRetry(t *testing.T) {

--- a/coordinator/changefeed/changefeed.go
+++ b/coordinator/changefeed/changefeed.go
@@ -174,7 +174,7 @@ func (c *Changefeed) UpdateStatus(newStatus *heartbeatpb.MaintainerStatus) (bool
 	if newStatus != nil && newStatus.CheckpointTs >= old.CheckpointTs {
 		c.status.Store(newStatus)
 
-		changed, state, err := c.backoff.CheckStatus(newStatus)
+		changed, state, err := c.backoff.checkFailedStatus(newStatus)
 		if state == config.StateFailed {
 			return changed, state, err
 		}
@@ -192,7 +192,7 @@ func (c *Changefeed) UpdateStatus(newStatus *heartbeatpb.MaintainerStatus) (bool
 			return true, config.StateFinished, nil
 		}
 
-		return changed, state, err
+		return c.backoff.CheckStatus(newStatus)
 	}
 
 	return false, config.StateNormal, nil

--- a/coordinator/changefeed/changefeed.go
+++ b/coordinator/changefeed/changefeed.go
@@ -173,6 +173,12 @@ func (c *Changefeed) UpdateStatus(newStatus *heartbeatpb.MaintainerStatus) (bool
 
 	if newStatus != nil && newStatus.CheckpointTs >= old.CheckpointTs {
 		c.status.Store(newStatus)
+
+		changed, state, err := c.backoff.CheckStatus(newStatus)
+		if changed || err != nil || state == config.StateFailed {
+			return changed, state, err
+		}
+
 		if old.BootstrapDone != newStatus.BootstrapDone {
 			log.Info("Received changefeed status with bootstrapDone",
 				zap.Stringer("changefeed", c.ID),
@@ -186,7 +192,7 @@ func (c *Changefeed) UpdateStatus(newStatus *heartbeatpb.MaintainerStatus) (bool
 			return true, config.StateFinished, nil
 		}
 
-		return c.backoff.CheckStatus(newStatus)
+		return changed, state, err
 	}
 
 	return false, config.StateNormal, nil

--- a/coordinator/changefeed/changefeed.go
+++ b/coordinator/changefeed/changefeed.go
@@ -175,7 +175,7 @@ func (c *Changefeed) UpdateStatus(newStatus *heartbeatpb.MaintainerStatus) (bool
 		c.status.Store(newStatus)
 
 		changed, state, err := c.backoff.CheckStatus(newStatus)
-		if changed || err != nil || state == config.StateFailed {
+		if state == config.StateFailed {
 			return changed, state, err
 		}
 

--- a/coordinator/changefeed/changefeed_test.go
+++ b/coordinator/changefeed/changefeed_test.go
@@ -119,6 +119,52 @@ func TestChangefeed_UpdateStatusFastFailWhenBootstrapDoneChanges(t *testing.T) {
 	require.False(t, cf.ShouldRun())
 }
 
+func TestChangefeed_UpdateStatusRetryableErrorWhenBootstrapDoneChanges(t *testing.T) {
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+	info := &config.ChangeFeedInfo{
+		SinkURI: "kafka://127.0.0.1:9092",
+		State:   config.StateNormal,
+		Config:  config.GetDefaultReplicaConfig(),
+	}
+	cf := NewChangefeed(cfID, info, 100, true)
+
+	retryableErr := &heartbeatpb.RunningError{
+		Node:    "node-1",
+		Code:    "CDC:ErrChangefeedRetryable",
+		Message: "retryable error",
+	}
+	newStatus := &heartbeatpb.MaintainerStatus{
+		CheckpointTs:  100,
+		BootstrapDone: true,
+		Err:           []*heartbeatpb.RunningError{retryableErr},
+	}
+	updated, state, err := cf.UpdateStatus(newStatus)
+
+	require.True(t, updated)
+	require.Equal(t, config.StateNormal, state)
+	require.Nil(t, err)
+	require.Equal(t, newStatus, cf.GetStatus())
+	require.True(t, cf.ShouldRun())
+	require.False(t, cf.backoff.retrying.Load())
+	require.False(t, cf.backoff.isRestarting.Load())
+	require.True(t, cf.backoff.nextRetryTime.Load().IsZero())
+
+	nextStatus := &heartbeatpb.MaintainerStatus{
+		CheckpointTs:  100,
+		BootstrapDone: true,
+		Err:           []*heartbeatpb.RunningError{retryableErr},
+	}
+	updated, state, err = cf.UpdateStatus(nextStatus)
+
+	require.True(t, updated)
+	require.Equal(t, config.StateWarning, state)
+	require.Same(t, retryableErr, err)
+	require.Equal(t, nextStatus, cf.GetStatus())
+	require.False(t, cf.ShouldRun())
+	require.True(t, cf.backoff.retrying.Load())
+	require.True(t, cf.backoff.isRestarting.Load())
+}
+
 func TestChangefeed_IsMQSink(t *testing.T) {
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	info := &config.ChangeFeedInfo{

--- a/coordinator/changefeed/changefeed_test.go
+++ b/coordinator/changefeed/changefeed_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/stretchr/testify/require"
@@ -88,6 +89,34 @@ func TestChangefeed_UpdateStatus(t *testing.T) {
 	require.Equal(t, config.StateNormal, state)
 	require.Nil(t, err)
 	require.Equal(t, newStatus, cf.GetStatus())
+}
+
+func TestChangefeed_UpdateStatusFastFailWhenBootstrapDoneChanges(t *testing.T) {
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+	info := &config.ChangeFeedInfo{
+		SinkURI: "kafka://127.0.0.1:9092",
+		State:   config.StateNormal,
+		Config:  config.GetDefaultReplicaConfig(),
+	}
+	cf := NewChangefeed(cfID, info, 100, true)
+
+	fastFailErr := &heartbeatpb.RunningError{
+		Node:    "node-1",
+		Code:    string(errors.ErrTableRouteConflict.RFCCode()),
+		Message: "table route conflict",
+	}
+	newStatus := &heartbeatpb.MaintainerStatus{
+		CheckpointTs:  200,
+		BootstrapDone: true,
+		Err:           []*heartbeatpb.RunningError{fastFailErr},
+	}
+	updated, state, err := cf.UpdateStatus(newStatus)
+
+	require.True(t, updated)
+	require.Equal(t, config.StateFailed, state)
+	require.Same(t, fastFailErr, err)
+	require.Equal(t, newStatus, cf.GetStatus())
+	require.False(t, cf.ShouldRun())
 }
 
 func TestChangefeed_IsMQSink(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #5246

Maintainer heartbeat can carry both checkpoint progress and an unretryable error in the same `MaintainerStatus`. Before this PR, `Backoff.CheckStatus` handled checkpoint progress before checking `status.Err`, so a fast-fail error such as `ErrTableRouteConflict` could be ignored when the checkpoint advanced in the same report. Since maintainer-reported errors are transient, the changefeed could remain normal instead of moving to failed.

This was observed in the table route conflict detection flow: the route conflict was detected and reported by the maintainer, but coordinator treated the heartbeat as normal progress and only persisted the checkpoint.

### What is changed and how it works?

- Check fast-fail / unretryable errors before checkpoint progress in `Backoff.CheckStatus`.
- Keep the backoff checkpoint monotonic when a fast-fail status also reports a newer checkpoint.
- Reuse one helper for fast-fail classification in both `CheckStatus` and `HandleError`.
- Add regression coverage for `ErrTableRouteConflict` and for fast-fail errors reported together with checkpoint progress.

This PR intentionally does not change retryable-error precedence. Retryable errors that arrive with checkpoint progress still follow the existing recovery semantics; that broader behavior should be handled separately if needed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. The change only reorders coordinator-side classification for fast-fail / unretryable errors in maintainer status handling.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that unretryable changefeed errors could be ignored when checkpoint advances in the same maintainer heartbeat.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved fast-fail handling so critical errors immediately transition the changefeed to **Failed**, stopping retries and preventing checkpoint/progress updates from overriding the failed state.
  * Prevented possible issues by safely handling missing heartbeat error details during fast-fail decisions.
* **Tests**
  * Added fast-fail coverage for table route conflicts, including verifying failed-state persistence across checkpoint advancement.
  * Added tests for fast-fail and retryable behavior when bootstrap completion status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->