### PR TITLE
eventservice: avoid deleted table scan loop

### DIFF
--- a/pkg/eventservice/event_scanner.go
+++ b/pkg/eventservice/event_scanner.go
@@ -235,9 +235,11 @@ func (s *eventScanner) scanAndMergeEvents(
 			if err != nil {
 				return false, err
 			}
-			// table is deleted, still append remaining DDL event and resolved event.
+			// The table has been deleted, so the current raw event cannot be
+			// decoded as DML. Resolve to its commit ts to skip it; resolving to
+			// rawEvent.CRTs-1 can equal the scan start and cause a no-progress loop.
 			if tableInfo == nil {
-				err = finalizeScan(merger, processor, session, rawEvent.CRTs-1)
+				err = finalizeScan(merger, processor, session, rawEvent.CRTs)
 				return false, err
 			}
 

--- a/pkg/eventservice/event_scanner_test.go
+++ b/pkg/eventservice/event_scanner_test.go
@@ -450,6 +450,7 @@ func TestEventScannerWithDeleteTable(t *testing.T) {
 	dml0 := kvEvents[0]
 	dml1 := kvEvents[1]
 	dml2 := kvEvents[2]
+	dml3 := kvEvents[3]
 	mockSchemaStore.DeleteTable(tableID, dml2.CRTs)
 	disp.receivedResolvedTs.Store(resolvedTs)
 	ok, dataRange := broker.getScanTaskDataRange(disp)
@@ -481,10 +482,12 @@ func TestEventScannerWithDeleteTable(t *testing.T) {
 	require.Equal(t, batchDML1.DMLEvents[0].GetCommitTs(), dml1.CRTs)
 	require.Equal(t, batchDML1.DMLEvents[1].GetCommitTs(), dml2.CRTs)
 
-	// resolvedTs
+	// resolvedTs skips the first raw event after the table is deleted, so the
+	// next scan range will not keep seeing the same deleted-table event.
 	e = events[3]
 	require.Equal(t, e.GetType(), event.TypeResolvedEvent)
-	require.Equal(t, dml2.CRTs, e.GetCommitTs())
+	require.Equal(t, dml3.CRTs, e.GetCommitTs())
+	require.Greater(t, e.GetCommitTs(), dml2.CRTs)
 }
 
 // TestEventScannerWithDDL tests cases where scanning is interrupted at DDL events
@@ -1566,6 +1569,66 @@ func TestScanAndMergeEventsSingleUKUpdate(t *testing.T) {
 	require.Equal(t, updateEvent.CRTs, merger.lastBatchDMLCommitTs)
 	require.Equal(t, 1, sess.dmlCount)
 	require.True(t, sess.scannedBytes > 0) // Some bytes were processed
+}
+
+func TestScanAndMergeEventsSkipsDeletedTableTxn(t *testing.T) {
+	helper := event.NewEventTestHelper(t)
+	defer helper.Close()
+
+	ddlEvent, kvEvents := genEvents(helper,
+		`create table test.t_deleted(id int primary key, c char(50))`,
+		`insert into test.t_deleted(id,c) values (1, "c1")`)
+	require.Len(t, kvEvents, 1)
+	rawEvent := kvEvents[0]
+	tableID := ddlEvent.GetTableID()
+
+	schemaStore := &schemaStoreWithErr{
+		mockSchemaStore:   NewMockSchemaStore(),
+		getTableInfoError: &schemastore.TableDeletedError{},
+	}
+	scanner := &eventScanner{
+		mounter:      &mockMounter{},
+		schemaGetter: schemaStore,
+	}
+
+	disInfo := newMockDispatcherInfoForTest(t)
+	disInfo.span.TableID = tableID
+	dispatcherID := common.NewDispatcherID()
+	disp := &dispatcherStat{
+		info:      disInfo,
+		id:        dispatcherID,
+		isRemoved: atomic.Bool{},
+	}
+
+	dataRange := common.DataRange{
+		Span: &heartbeatpb.TableSpan{
+			TableID: tableID,
+		},
+		CommitTsStart: rawEvent.CRTs - 1,
+		CommitTsEnd:   rawEvent.CRTs + 100,
+	}
+	sess := &session{
+		ctx:            context.Background(),
+		dispatcherStat: disp,
+		dataRange:      dataRange,
+		startTime:      time.Now(),
+		events:         make([]event.Event, 0),
+	}
+	merger := newEventMerger(nil)
+
+	isInterrupted, err := scanner.scanAndMergeEvents(sess, merger, &mockEventIterator{
+		events: []*common.RawKVEntry{rawEvent},
+	})
+	require.NoError(t, err)
+	require.False(t, isInterrupted)
+	require.Zero(t, sess.dmlCount)
+	require.Len(t, sess.events, 1)
+
+	resolvedEvent, ok := sess.events[0].(event.ResolvedEvent)
+	require.True(t, ok)
+	require.Equal(t, dispatcherID, resolvedEvent.DispatcherID)
+	require.Equal(t, rawEvent.CRTs, resolvedEvent.ResolvedTs)
+	require.Greater(t, resolvedEvent.ResolvedTs, dataRange.CommitTsStart)
 }
 
 type schemaStoreWithErr struct {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5040 

EventService can repeatedly scan the same raw KV event after a table has been deleted. When the raw event cannot be decoded as DML, resolving to `rawEvent.CRTs - 1` can equal the scan start and cause a no-progress loop.

### What is changed and how it works?

When table info is missing because the table is deleted, the scanner now finalizes the scan at the raw event commit ts. This skips the deleted-table transaction while still allowing remaining DDL and resolved events to be emitted.

The deleted-table scanner test now checks that resolved ts advances past the deleted table boundary, and a focused unit test covers the single deleted-table transaction path.

### Check List

#### Tests
- Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only changes EventService scan progress for deleted-table raw events that cannot be decoded as DML.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note
```release-note
Fix EventService scans from repeatedly seeing the same raw event after a table is deleted.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event scanner to correctly handle deleted table cases, preventing potential no-progress loops when scanning transactions after table deletion.

* **Tests**
  * Enhanced test coverage for deleted table handling scenarios in event scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->