### PR TITLE
coordinator: clean stale owner checkpoint metrics

### DIFF
--- a/coordinator/changefeed/changefeed_db.go
+++ b/coordinator/changefeed/changefeed_db.go
@@ -151,7 +151,7 @@ func (db *ChangefeedDB) StopByChangefeedID(cfID common.ChangeFeedID, remove bool
 	}
 
 	metrics.ChangefeedStatusGauge.DeleteLabelValues(cfID.Keyspace(), cfID.Name())
-	metrics.ChangefeedCheckpointTsLagGauge.DeleteLabelValues(cfID.Keyspace(), cfID.Name())
+	metrics.DeleteChangefeedCheckpointMetrics(cfID.Keyspace(), cfID.Name())
 
 	return nodeID
 }

--- a/coordinator/changefeed/changefeed_db_test.go
+++ b/coordinator/changefeed/changefeed_db_test.go
@@ -136,8 +136,8 @@ func TestRemoveChangefeed(t *testing.T) {
 }
 
 func TestStopByChangefeedIDDeletesCheckpointMetrics(t *testing.T) {
-	metrics.ResetChangefeedCheckpointMetrics()
-	t.Cleanup(metrics.ResetChangefeedCheckpointMetrics)
+	metrics.ResetOwnerChangefeedMetrics()
+	t.Cleanup(metrics.ResetOwnerChangefeedMetrics)
 
 	db := NewChangefeedDB(1216)
 	cf := &Changefeed{ID: common.NewChangeFeedIDWithName("test-metrics", common.DefaultKeyspaceName)}

--- a/coordinator/changefeed/changefeed_db_test.go
+++ b/coordinator/changefeed/changefeed_db_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
@@ -131,6 +133,25 @@ func TestRemoveChangefeed(t *testing.T) {
 	sizeMap := db.GetTaskSizePerNode()
 	_, ok := sizeMap["node1"]
 	require.False(t, ok)
+}
+
+func TestStopByChangefeedIDDeletesCheckpointMetrics(t *testing.T) {
+	metrics.ResetChangefeedCheckpointMetrics()
+	t.Cleanup(metrics.ResetChangefeedCheckpointMetrics)
+
+	db := NewChangefeedDB(1216)
+	cf := &Changefeed{ID: common.NewChangeFeedIDWithName("test-metrics", common.DefaultKeyspaceName)}
+	db.AddReplicatingMaintainer(cf, "node1")
+
+	metrics.ChangefeedCheckpointTsGauge.WithLabelValues(cf.ID.Keyspace(), cf.ID.Name()).Set(100)
+	metrics.ChangefeedCheckpointTsLagGauge.WithLabelValues(cf.ID.Keyspace(), cf.ID.Name()).Set(10)
+	require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
+	require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
+
+	require.Equal(t, node.ID("node1"), db.StopByChangefeedID(cf.ID, true))
+
+	require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
+	require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
 }
 
 func TestGetByID(t *testing.T) {

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -223,6 +223,7 @@ func NewController(
 func (c *Controller) collectMetrics(ctx context.Context) error {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	defer metrics.ResetChangefeedCheckpointMetrics()
 
 	// changefeedDownstreamTypeCache is used to cleanup the previous downstream type
 	// label value when a changefeed's sink-uri is updated.
@@ -265,16 +266,15 @@ func (c *Controller) collectMetrics(ctx context.Context) error {
 
 				metrics.ChangefeedStatusGauge.WithLabelValues(keyspace, name).Set(float64(info.State.ToInt()))
 
-				// don't update checkpoint ts and checkpoint ts lag for stopped changefeed
-				if info.State == config.StateStopped {
+				if !updateChangefeedCheckpointMetrics(
+					keyspace,
+					name,
+					info.State,
+					cf.GetLastSavedCheckPointTs(),
+					c.pdClock.CurrentTime(),
+				) {
 					return
 				}
-
-				pdPhysicalTime := oracle.GetPhysical(c.pdClock.CurrentTime())
-				phyCkpTs := oracle.ExtractPhysical(cf.GetLastSavedCheckPointTs())
-				lag := float64(pdPhysicalTime-phyCkpTs) / 1e3
-				metrics.ChangefeedCheckpointTsGauge.WithLabelValues(keyspace, name).Set(float64(phyCkpTs))
-				metrics.ChangefeedCheckpointTsLagGauge.WithLabelValues(keyspace, name).Set(lag)
 
 				// sync changefeed error metrics
 				currentChangefeeds[cf.ID] = struct{}{}
@@ -319,6 +319,27 @@ func (c *Controller) collectMetrics(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func updateChangefeedCheckpointMetrics(
+	keyspace string,
+	name string,
+	state config.FeedState,
+	checkpointTs uint64,
+	pdTime time.Time,
+) bool {
+	switch state {
+	case config.StateStopped, config.StateFinished, config.StateRemoved:
+		metrics.DeleteChangefeedCheckpointMetrics(keyspace, name)
+		return false
+	}
+
+	pdPhysicalTime := oracle.GetPhysical(pdTime)
+	phyCkpTs := oracle.ExtractPhysical(checkpointTs)
+	lag := float64(pdPhysicalTime-phyCkpTs) / 1e3
+	metrics.ChangefeedCheckpointTsGauge.WithLabelValues(keyspace, name).Set(float64(phyCkpTs))
+	metrics.ChangefeedCheckpointTsLagGauge.WithLabelValues(keyspace, name).Set(lag)
+	return true
 }
 
 // HandleEvent implements the event-driven process mode

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -223,7 +223,7 @@ func NewController(
 func (c *Controller) collectMetrics(ctx context.Context) error {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
-	defer metrics.ResetChangefeedCheckpointMetrics()
+	defer metrics.ResetOwnerChangefeedMetrics()
 
 	// changefeedDownstreamTypeCache is used to cleanup the previous downstream type
 	// label value when a changefeed's sink-uri is updated.

--- a/coordinator/controller_test.go
+++ b/coordinator/controller_test.go
@@ -54,8 +54,8 @@ func (noopScheduler) Name() string {
 }
 
 func TestUpdateChangefeedCheckpointMetricsDeletesFinishedLabels(t *testing.T) {
-	metrics.ResetChangefeedCheckpointMetrics()
-	t.Cleanup(metrics.ResetChangefeedCheckpointMetrics)
+	metrics.ResetOwnerChangefeedMetrics()
+	t.Cleanup(metrics.ResetOwnerChangefeedMetrics)
 
 	keyspace := common.DefaultKeyspaceName
 	name := "finished-metrics"

--- a/coordinator/controller_test.go
+++ b/coordinator/controller_test.go
@@ -32,11 +32,14 @@ import (
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/eventservice"
 	"github.com/pingcap/ticdc/pkg/messaging"
+	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
 	pkgscheduler "github.com/pingcap/ticdc/pkg/scheduler"
 	"github.com/pingcap/ticdc/server/watcher"
 	"github.com/pingcap/ticdc/utils/threadpool"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/atomic"
 )
 
@@ -48,6 +51,36 @@ func (noopScheduler) Execute() time.Time {
 
 func (noopScheduler) Name() string {
 	return pkgscheduler.BasicScheduler
+}
+
+func TestUpdateChangefeedCheckpointMetricsDeletesFinishedLabels(t *testing.T) {
+	metrics.ResetChangefeedCheckpointMetrics()
+	t.Cleanup(metrics.ResetChangefeedCheckpointMetrics)
+
+	keyspace := common.DefaultKeyspaceName
+	name := "finished-metrics"
+	pdTime := time.UnixMilli(2000)
+	checkpointTs := oracle.ComposeTS(1000, 0)
+
+	require.True(t, updateChangefeedCheckpointMetrics(
+		keyspace,
+		name,
+		config.StateNormal,
+		checkpointTs,
+		pdTime,
+	))
+	require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
+	require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
+
+	require.False(t, updateChangefeedCheckpointMetrics(
+		keyspace,
+		name,
+		config.StateFinished,
+		checkpointTs,
+		pdTime,
+	))
+	require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
+	require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
 }
 
 func TestOnPeriodTaskAdvanceLiveness(t *testing.T) {

--- a/pkg/metrics/changefeed.go
+++ b/pkg/metrics/changefeed.go
@@ -144,9 +144,12 @@ func DeleteChangefeedCheckpointMetrics(keyspace, changefeed string) {
 	ChangefeedCheckpointTsLagGauge.DeleteLabelValues(keyspace, changefeed)
 }
 
-func ResetChangefeedCheckpointMetrics() {
+func ResetOwnerChangefeedMetrics() {
+	ChangefeedStatusGauge.Reset()
+	ChangefeedErrorInfoGauge.Reset()
 	ChangefeedCheckpointTsGauge.Reset()
 	ChangefeedCheckpointTsLagGauge.Reset()
+	ChangefeedDownstreamInfoGauge.Reset()
 }
 
 func initChangefeedMetrics(registry *prometheus.Registry) {

--- a/pkg/metrics/changefeed.go
+++ b/pkg/metrics/changefeed.go
@@ -139,6 +139,16 @@ var (
 		}, []string{getKeyspaceLabel(), "changefeed"})
 )
 
+func DeleteChangefeedCheckpointMetrics(keyspace, changefeed string) {
+	ChangefeedCheckpointTsGauge.DeleteLabelValues(keyspace, changefeed)
+	ChangefeedCheckpointTsLagGauge.DeleteLabelValues(keyspace, changefeed)
+}
+
+func ResetChangefeedCheckpointMetrics() {
+	ChangefeedCheckpointTsGauge.Reset()
+	ChangefeedCheckpointTsLagGauge.Reset()
+}
+
 func initChangefeedMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(MaintainerCheckpointTsGauge)
 	registry.MustRegister(MaintainerCheckpointTsLagGauge)

--- a/pkg/metrics/changefeed_test.go
+++ b/pkg/metrics/changefeed_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetOwnerChangefeedMetrics(t *testing.T) {
+	ResetOwnerChangefeedMetrics()
+	t.Cleanup(ResetOwnerChangefeedMetrics)
+
+	keyspace := "default"
+	changefeed := "reset-owner-changefeed-metrics"
+
+	ChangefeedStatusGauge.WithLabelValues(keyspace, changefeed).Set(1)
+	ChangefeedErrorInfoGauge.WithLabelValues(keyspace, changefeed, "failed", "1000", "CDC:ErrTest", "test").Set(1)
+	ChangefeedCheckpointTsGauge.WithLabelValues(keyspace, changefeed).Set(100)
+	ChangefeedCheckpointTsLagGauge.WithLabelValues(keyspace, changefeed).Set(10)
+	ChangefeedDownstreamInfoGauge.WithLabelValues(keyspace, changefeed, "mysql/tidb").Set(1)
+
+	require.Equal(t, 1, testutil.CollectAndCount(ChangefeedStatusGauge))
+	require.Equal(t, 1, testutil.CollectAndCount(ChangefeedErrorInfoGauge))
+	require.Equal(t, 1, testutil.CollectAndCount(ChangefeedCheckpointTsGauge))
+	require.Equal(t, 1, testutil.CollectAndCount(ChangefeedCheckpointTsLagGauge))
+	require.Equal(t, 1, testutil.CollectAndCount(ChangefeedDownstreamInfoGauge))
+
+	ResetOwnerChangefeedMetrics()
+
+	require.Equal(t, 0, testutil.CollectAndCount(ChangefeedStatusGauge))
+	require.Equal(t, 0, testutil.CollectAndCount(ChangefeedErrorInfoGauge))
+	require.Equal(t, 0, testutil.CollectAndCount(ChangefeedCheckpointTsGauge))
+	require.Equal(t, 0, testutil.CollectAndCount(ChangefeedCheckpointTsLagGauge))
+	require.Equal(t, 0, testutil.CollectAndCount(ChangefeedDownstreamInfoGauge))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5490

Finished or removed changefeeds can leave stale `ticdc_owner_checkpoint_ts_lag` series visible. Finished changefeeds remain in the coordinator changefeed DB as stopped metadata, but the owner metrics loop only skipped `StateStopped` and kept setting checkpoint lag for `StateFinished`. Old owner instances could also keep checkpoint labels after ownership stops.

### What is changed and how it works?

This PR deletes owner checkpoint timestamp and lag labels together for stopped, finished, or removed changefeeds instead of recreating them during the metrics loop. It also resets owner checkpoint labels when the coordinator metrics loop exits, so an instance that loses ownership stops exposing stale checkpoint series. The stop/remove path now deletes both `checkpoint_ts` and `checkpoint_ts_lag`.

### Check List

#### Tests

- Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only changes cleanup behavior for owner metrics labels.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix stale owner checkpoint lag metrics for finished or removed changefeeds.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metric cleanup for stopped changefeeds to prevent stale metrics from persisting in monitoring systems.
  * Improved periodic reset of changefeed metrics to ensure monitoring accuracy.

* **Tests**
  * Added tests to verify metrics are properly cleaned up when changefeeds reach terminal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->