### PR TITLE
eventservice,schemastore: avoid stalls after dispatcher reset

### DIFF
--- a/logservice/schemastore/gc_keeper_test.go
+++ b/logservice/schemastore/gc_keeper_test.go
@@ -97,6 +97,51 @@ func TestCloseSchemaStoreGCKeeperUsesFreshContext(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestAcquireInitialGCSafePointCleansStaleKeeperService(t *testing.T) {
+	if !kerneltype.IsClassic() {
+		t.Skip("stale classic service safepoints only affect classic mode")
+	}
+
+	originalConfig := config.GetGlobalServerConfig()
+	cfg := originalConfig.Clone()
+	cfg.AdvertiseAddr = "127.0.0.1:8301"
+	config.StoreGlobalServerConfig(cfg)
+	defer config.StoreGlobalServerConfig(originalConfig)
+
+	pdCli, state := newMockGCServiceClientForSchemaStoreGC(t)
+	keeper := newSchemaStoreGCKeeper(pdCli, common.DefaultKeyspace)
+	serviceID := keeper.serviceID()
+
+	state.serviceSafePoint[serviceID] = 100
+	state.serviceSafePoint["ticdc-default-changefeed"] = 200
+	pdCli.UpdateServiceGCSafePointFunc = func(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		if ttl == 0 && safePoint == math.MaxUint64 {
+			delete(state.serviceSafePoint, serviceID)
+			return minSchemaStoreServiceSafePoint(state), nil
+		}
+		if serviceID == defaultSchemaStoreGcServiceID && ttl == 0 && safePoint == 0 {
+			return minSchemaStoreServiceSafePoint(state), nil
+		}
+
+		minBefore := minSchemaStoreServiceSafePoint(state)
+		_, existed := state.serviceSafePoint[serviceID]
+		state.serviceSafePoint[serviceID] = safePoint
+		if existed {
+			return minSchemaStoreServiceSafePoint(state), nil
+		}
+		return minBefore, nil
+	}
+
+	s := &schemaStore{pdCli: pdCli}
+	gcSafePoint, err := s.acquireInitialGCSafePoint(context.Background(), common.DefaultKeyspace, keeper)
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), gcSafePoint)
+	require.Equal(t, uint64(201), state.serviceSafePoint[serviceID])
+}
+
 func TestSanitizeSchemaStoreNodeID(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -153,6 +198,16 @@ func assertSchemaStoreBarrierTS(t *testing.T, state *schemaStoreGCMockState, ser
 		return
 	}
 	require.Equal(t, expected, state.gcBarriers[serviceID])
+}
+
+func minSchemaStoreServiceSafePoint(state *schemaStoreGCMockState) uint64 {
+	minSafePoint := uint64(math.MaxUint64)
+	for _, ts := range state.serviceSafePoint {
+		if ts < minSafePoint {
+			minSafePoint = ts
+		}
+	}
+	return minSafePoint
 }
 
 type schemaStoreGCMockState struct {

--- a/logservice/schemastore/schema_store.go
+++ b/logservice/schemastore/schema_store.go
@@ -597,6 +597,21 @@ func (s *schemaStore) acquireInitialGCSafePoint(
 	gcKeeper *schemaStoreGCKeeper,
 ) (uint64, error) {
 	for {
+		// A previous CDC process with the same advertise address can leave its
+		// schema-store GC service behind after a crash or kill. Remove it before
+		// reading the lower bound, otherwise initialization can keep advancing its
+		// own stale service by one ts and fail the start-ts safety check forever.
+		if err := gcKeeper.close(ctx); err != nil {
+			log.Warn("cleanup stale schema store gc keeper failed, will retry in 1s",
+				zap.Any("keyspace", keyspaceMeta), zap.Error(err))
+			select {
+			case <-ctx.Done():
+				return 0, errors.Trace(err)
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+
 		// Read the current lower bound first, then install a dedicated GC barrier
 		// for this schema store instance before any snapshot or incremental pull starts.
 		gcSafePoint, err := gc.UnifyGetServiceGCSafepoint(ctx, s.pdCli, keyspaceMeta.ID, defaultSchemaStoreGcServiceID)

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -513,6 +513,11 @@ func (c *eventBroker) getScanTaskDataRange(task scanTask) (bool, common.DataRang
 // Note: A true return value only indicates potential scanning need,
 // final determination occurs when the scanTask is actully processed.
 func (c *eventBroker) scanReady(task scanTask) bool {
+	span := task.info.GetTableSpan()
+	if span.Equal(common.KeyspaceDDLSpan(span.KeyspaceID)) {
+		return false
+	}
+
 	if task.isRemoved.Load() {
 		return false
 	}

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -1229,6 +1229,10 @@ func (c *eventBroker) resetDispatcher(dispatcherInfo DispatcherInfo) error {
 		zap.Uint64("newEpoch", newStat.epoch),
 		zap.Duration("resetTime", time.Since(start)))
 
+	if c.scanReady(newStat) {
+		c.pushTask(newStat, false)
+	}
+
 	return nil
 }
 

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -544,6 +544,38 @@ func TestResetDispatcher(t *testing.T) {
 	require.Equal(t, dispInfo.GetID(), newStat.id)
 }
 
+func TestResetDispatcherSendsHandshakeWithoutNextNotify(t *testing.T) {
+	broker, _, schemaStore, _ := newEventBrokerForTest()
+
+	dispInfo := newMockDispatcherInfoForTest(t)
+	require.NoError(t, broker.addDispatcher(dispInfo))
+	broker.close()
+
+	dispPtr := broker.getDispatcher(dispInfo.GetID())
+	require.NotNil(t, dispPtr)
+	oldStat := dispPtr.Load()
+	oldStat.receivedResolvedTs.Store(500)
+	oldStat.hasReceivedFirstResolvedTs.Store(true)
+	schemaStore.resolvedTs = 500
+	schemaStore.maxDDLCommitTs = 0
+
+	resetInfo := newMockDispatcherInfo(t, dispInfo.GetStartTs(), dispInfo.GetID(), dispInfo.GetTableSpan().TableID, eventpb.ActionType_ACTION_TYPE_RESET)
+	resetInfo.epoch = oldStat.epoch + 1
+	require.NoError(t, broker.resetDispatcher(resetInfo))
+
+	newStat := dispPtr.Load()
+	require.NotSame(t, oldStat, newStat)
+	require.Equal(t, uint64(1), newStat.seq.Load())
+
+	handshake := <-broker.messageCh[newStat.messageWorkerIndex]
+	require.Equal(t, event.TypeHandshakeEvent, handshake.msgType)
+	require.Equal(t, resetInfo.GetEpoch(), handshake.e.(*event.HandshakeEvent).GetEpoch())
+
+	resolved := <-broker.messageCh[newStat.messageWorkerIndex]
+	require.Equal(t, event.TypeResolvedEvent, resolved.msgType)
+	require.Equal(t, uint64(500), resolved.resolvedTsEvent.GetCommitTs())
+}
+
 func TestResetDispatcherConcurrently(t *testing.T) {
 	broker, _, _, _ := newEventBrokerForTest()
 	defer broker.close()

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -615,6 +615,36 @@ func TestResetDispatcherSendsHandshakeWithoutNextNotify(t *testing.T) {
 	require.Equal(t, uint64(500), resolved.resolvedTsEvent.GetCommitTs())
 }
 
+func TestResetTableTriggerDispatcherDoesNotUseNormalScan(t *testing.T) {
+	broker, _, schemaStore, _ := newEventBrokerForTest()
+
+	dispInfo := newMockDispatcherInfo(t, 100, common.NewDispatcherID(), common.DDLSpanTableID, eventpb.ActionType_ACTION_TYPE_REGISTER)
+	dispInfo.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
+	require.NoError(t, broker.addDispatcher(dispInfo))
+	broker.close()
+
+	dispPtr := broker.getDispatcher(dispInfo.GetID())
+	require.NotNil(t, dispPtr)
+	oldStat := dispPtr.Load()
+	oldStat.receivedResolvedTs.Store(500)
+	oldStat.hasReceivedFirstResolvedTs.Store(true)
+	schemaStore.resolvedTs = 500
+	schemaStore.maxDDLCommitTs = 0
+
+	resetInfo := newMockDispatcherInfo(t, 100, dispInfo.GetID(), common.DDLSpanTableID, eventpb.ActionType_ACTION_TYPE_RESET)
+	resetInfo.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
+	resetInfo.epoch = oldStat.epoch + 1
+	require.NoError(t, broker.resetDispatcher(resetInfo))
+
+	newStat := dispPtr.Load()
+	require.NotSame(t, oldStat, newStat)
+	require.Equal(t, uint64(0), newStat.seq.Load())
+	require.Equal(t, uint64(100), newStat.sentResolvedTs.Load())
+	require.Equal(t, uint64(100), newStat.lastScannedCommitTs.Load())
+	require.False(t, newStat.isTaskScanning.Load())
+	require.Empty(t, broker.messageCh[newStat.messageWorkerIndex])
+}
+
 func TestResetDispatcherConcurrently(t *testing.T) {
 	broker, _, _, _ := newEventBrokerForTest()
 	defer broker.close()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5553

Two field stalls are addressed: schema store bootstrap can be blocked by a stale schema-store GC keeper service left by a failed CDC process with the same advertise address, and a reset dispatcher can wait for the next eventstore notify before sending its handshake.

### What is changed and how it works?

The schema store now closes any stale keeper service before reading the initial GC safe point and installing its fresh barrier.

After `eventBroker.resetDispatcher` replaces the dispatcher state, it immediately checks scan readiness and pushes one scan task so ready/handshake/resolved messages do not depend on a later notify.

### Check List

#### Tests

- Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No. The cleanup is limited to the schema-store keeper service for the current advertise address, and reset only schedules the same scan path earlier.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix changefeed stalls after CDC failover or dispatcher reset in the new architecture.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization to close and clean up leftover GC-related keeper state from prior runs, avoiding incorrect safe-point handling when reusing the same advertise address.
  * Fixed dispatcher reset behavior so resets correctly trigger the needed scan/handshake/resolved workflow, while preventing normal scanning for special DDL/table-trigger spans.
* **Tests**
  * Added test coverage for stale keeper safe-point cleanup and for dispatcher reset messaging/scan semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->