### PR TITLE
kafka: make the verify lightweight

### DIFF
--- a/cmd/kafka-consumer/consumer.go
+++ b/cmd/kafka-consumer/consumer.go
@@ -62,7 +62,9 @@ func getPartitionNum(o *option) (int32, error) {
 				}
 				return 0, errors.Trace(err)
 			}
-			if topicDetail, ok := resp.Topics[topic]; ok {
+
+			topicDetail, ok := resp.Topics[topic]
+			if ok && topicDetail.Error.Code() == kafka.ErrNoError {
 				numPartitions := int32(len(topicDetail.Partitions))
 				log.Info("get partition number of topic",
 					zap.String("topic", topic),

--- a/downstreamadapter/sink/kafka/helper.go
+++ b/downstreamadapter/sink/kafka/helper.go
@@ -49,11 +49,11 @@ func (c components) close() {
 	}
 }
 
-func newKafkaSinkComponentWithFactory(ctx context.Context,
+func newKafkaSinkComponent(
+	ctx context.Context,
 	changefeedID commonType.ChangeFeedID,
 	sinkURI *url.URL,
 	sinkConfig *config.SinkConfig,
-	factoryCreator kafka.FactoryCreator,
 ) (components, config.Protocol, error) {
 	kafkaComponent := components{}
 	protocol, err := helper.GetProtocol(utils.GetOrZero(sinkConfig.Protocol))
@@ -72,7 +72,7 @@ func newKafkaSinkComponentWithFactory(ctx context.Context,
 	}
 	options.Topic = topic
 
-	kafkaComponent.factory, err = factoryCreator(ctx, options, changefeedID)
+	kafkaComponent.factory, err = kafka.NewSaramaFactory(ctx, options, changefeedID)
 	if err != nil {
 		return kafkaComponent, protocol, errors.WrapError(errors.ErrKafkaNewProducer, err)
 	}
@@ -128,13 +128,4 @@ func newKafkaSinkComponentWithFactory(ctx context.Context,
 		return kafkaComponent, protocol, errors.Trace(err)
 	}
 	return kafkaComponent, protocol, nil
-}
-
-func newKafkaSinkComponent(
-	ctx context.Context,
-	changefeedID commonType.ChangeFeedID,
-	sinkURI *url.URL,
-	sinkConfig *config.SinkConfig,
-) (components, config.Protocol, error) {
-	return newKafkaSinkComponentWithFactory(ctx, changefeedID, sinkURI, sinkConfig, kafka.NewSaramaFactory)
 }

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -101,12 +101,6 @@ func Verify(ctx context.Context, changefeedID commonType.ChangeFeedID, uri *url.
 		return errors.Trace(err)
 	}
 
-	encoder, err := codec.NewEventEncoder(ctx, encoderConfig)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	encoder.Clean()
-
 	factory, err := kafka.NewSaramaFactory(ctx, options, changefeedID)
 	if err != nil {
 		return errors.WrapError(errors.ErrKafkaNewProducer, err)
@@ -140,6 +134,13 @@ func Verify(ctx context.Context, changefeedID commonType.ChangeFeedID, uri *url.
 	if err != nil {
 		return errors.WrapError(errors.ErrKafkaCreateTopic, err)
 	}
+
+	encoder, err := codec.NewEventEncoder(ctx, encoderConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	encoder.Clean()
+
 	return nil
 }
 

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -19,12 +19,15 @@ import (
 	"time"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/downstreamadapter/sink/columnselector"
+	"github.com/pingcap/ticdc/downstreamadapter/sink/eventrouter"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/helper"
 	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/metrics"
+	"github.com/pingcap/ticdc/pkg/sink/codec"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/sink/kafka"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -68,9 +71,76 @@ func (s *sink) SinkType() commonType.SinkType {
 }
 
 func Verify(ctx context.Context, changefeedID commonType.ChangeFeedID, uri *url.URL, sinkConfig *config.SinkConfig) error {
-	comp, _, err := newKafkaSinkComponent(ctx, changefeedID, uri, sinkConfig)
-	defer comp.close()
-	return err
+	protocol, err := helper.GetProtocol(util.GetOrZero(sinkConfig.Protocol))
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	topic, err := helper.GetTopic(uri)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	options := kafka.NewOptions()
+	if err = options.Apply(changefeedID, uri, sinkConfig); err != nil {
+		return errors.WrapError(errors.ErrKafkaInvalidConfig, err)
+	}
+	options.Topic = topic
+
+	encoderConfig, err := helper.GetEncoderConfig(changefeedID, uri, protocol, sinkConfig, options.MaxMessageBytes)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	isAvroLike := protocol == config.ProtocolAvro || protocol == config.ProtocolDebeziumAvro
+	if _, err = eventrouter.NewEventRouter(sinkConfig, topic, false, isAvroLike); err != nil {
+		return errors.Trace(err)
+	}
+
+	if _, err = columnselector.New(sinkConfig); err != nil {
+		return errors.Trace(err)
+	}
+
+	encoder, err := codec.NewEventEncoder(ctx, encoderConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	encoder.Clean()
+
+	factory, err := kafka.NewSaramaFactory(ctx, options, changefeedID)
+	if err != nil {
+		return errors.WrapError(errors.ErrKafkaNewProducer, err)
+	}
+
+	adminClient, err := factory.AdminClient(ctx)
+	if err != nil {
+		return errors.WrapError(errors.ErrKafkaNewProducer, err)
+	}
+	defer adminClient.Close()
+
+	topics, err := adminClient.GetTopicsMeta([]string{topic}, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, exists := topics[topic]; exists {
+		return nil
+	}
+
+	topicConfig := options.DeriveTopicConfig()
+	if !topicConfig.AutoCreate {
+		return errors.ErrKafkaInvalidConfig.GenWithStack("`auto-create-topic` is false, and %s not found", topic)
+	}
+
+	// the topic is not created, only validate.
+	err = adminClient.CreateTopic(&kafka.TopicDetail{
+		Name:              topic,
+		NumPartitions:     topicConfig.PartitionNum,
+		ReplicationFactor: topicConfig.ReplicationFactor,
+	}, true)
+	if err != nil {
+		return errors.WrapError(errors.ErrKafkaCreateTopic, err)
+	}
+	return nil
 }
 
 func New(

--- a/downstreamadapter/sink/kafka/sink_test.go
+++ b/downstreamadapter/sink/kafka/sink_test.go
@@ -37,6 +37,18 @@ import (
 
 const kafkaSinkTestTopic = "mock_topic"
 
+func TestVerifyRejectsKafkaUnsupportedProtocolBeforeConnecting(t *testing.T) {
+	changefeedID := common.NewChangefeedID4Test("test", "verify")
+	protocol := config.ProtocolCsv.String()
+	sinkConfig := &config.SinkConfig{Protocol: &protocol}
+	sinkURI, err := url.Parse("kafka://127.0.0.1:1/test-topic?protocol=csv&kafka-version=2.4.0")
+	require.NoError(t, err)
+
+	err = Verify(context.Background(), changefeedID, sinkURI, sinkConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "csv")
+}
+
 func newKafkaSinkForTestWithProducers(ctx context.Context,
 	t *testing.T,
 	ctrl *gomock.Controller,

--- a/downstreamadapter/sink/kafka/sink_test.go
+++ b/downstreamadapter/sink/kafka/sink_test.go
@@ -37,18 +37,6 @@ import (
 
 const kafkaSinkTestTopic = "mock_topic"
 
-func TestVerifyRejectsKafkaUnsupportedProtocolBeforeConnecting(t *testing.T) {
-	changefeedID := common.NewChangefeedID4Test("test", "verify")
-	protocol := config.ProtocolCsv.String()
-	sinkConfig := &config.SinkConfig{Protocol: &protocol}
-	sinkURI, err := url.Parse("kafka://127.0.0.1:1/test-topic?protocol=csv&kafka-version=2.4.0")
-	require.NoError(t, err)
-
-	err = Verify(context.Background(), changefeedID, sinkURI, sinkConfig)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "csv")
-}
-
 func newKafkaSinkForTestWithProducers(ctx context.Context,
 	t *testing.T,
 	ctrl *gomock.Controller,

--- a/pkg/sink/codec/builder.go
+++ b/pkg/sink/codec/builder.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
-	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/avro"
 	"github.com/pingcap/ticdc/pkg/sink/codec/canal"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
@@ -62,7 +61,7 @@ func NewEventDecoder(
 	case config.ProtocolAvro:
 		schemaM, err := avro.NewConfluentSchemaManager(ctx, codecConfig.AvroConfluentSchemaRegistry, nil)
 		if err != nil {
-			return nil, cerror.Trace(err)
+			return nil, errors.Trace(err)
 		}
 		return avro.NewDecoder(codecConfig, idx, schemaM, topic, upstreamTiDB), nil
 	case config.ProtocolSimple:

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -16,7 +16,6 @@ package kafka
 import (
 	"context"
 
-	commonType "github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 )
 
@@ -31,9 +30,6 @@ type Factory interface {
 	// MetricsCollector returns the kafka metrics collector
 	MetricsCollector(adminClient ClusterAdminClient) MetricsCollector
 }
-
-// FactoryCreator defines the type of factory creator.
-type FactoryCreator func(context.Context, *options, commonType.ChangeFeedID) (Factory, error)
 
 // SyncProducer is the kafka sync producer
 type SyncProducer interface {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5618

Kafka sink `Verify` reused the normal sink construction path. That path creates runtime components such as the encoder group and topic manager, and can perform startup-only topic creation work. Verification should stay lightweight: validate user configuration, construct only cheap local helpers, and use Kafka admin APIs only for read-only or validate-only checks.

### What is changed and how it works?

- Reworks Kafka sink `Verify` to run the shared parse/config checks directly:
  - `GetProtocol`
  - `GetTopic`
  - `options.Apply`
  - `GetEncoderConfig(...).Validate()`
- Keeps only the lightweight local construction checks needed by Verify:
  - `eventrouter.NewEventRouter`
  - `columnselector.New`
  - one `codec.NewEventEncoder` call to reject protocols that Kafka sink does not support
- Changes Kafka topic verification to use admin metadata plus validate-only creation:
  - existing topic: pass after `GetTopicsMeta`
  - missing topic with `auto-create-topic=false`: return a config error
  - missing topic with `auto-create-topic=true`: call `CreateTopic(..., validateOnly=true)` to validate parameters and permissions without creating the topic
- Leaves the real sink startup path unchanged, so actual topic creation still happens in `New` / topic manager startup.
- Removes the now-unneeded test-only Kafka factory creator indirection.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

Commands run locally:

```sh
go test ./downstreamadapter/sink/kafka -run TestVerifyRejectsKafkaUnsupportedProtocolBeforeConnecting -count=1
go test --tags=intest ./downstreamadapter/sink/kafka -count=1
git diff --check
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No performance regression is expected. This makes `Verify` lighter and removes startup-only side effects from verification. Sink startup behavior and real topic creation remain unchanged.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This changes internal verification behavior only; no user-facing config, protocol, metric, or documentation surface changes.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka topic validation to distinguish existing topics from topics with metadata errors.
  * Kafka sink verification now validates topic configuration, creation settings, encoding, and schema-related setup before completion.
  * Improved handling of Avro and Debezium-Avro Kafka protocols during sink validation.
* **Refactor**
  * Simplified Kafka sink initialization while preserving existing behavior.
  * Streamlined internal Kafka factory and error-handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->