### PR TITLE
eventbroker: fix broker quota release and message validation

### DIFF
--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -706,6 +706,7 @@ func (c *eventBroker) doScan(ctx context.Context, task scanTask) {
 	}
 
 	if uint64(sl.maxDMLBytes) > task.availableMemoryQuota.Load() {
+		releaseQuota(available, uint64(sl.maxDMLBytes))
 		log.Debug("dispatcher available memory quota is not enough, skip scan", zap.Stringer("dispatcher", task.id), zap.Uint64("available", task.availableMemoryQuota.Load()), zap.Int64("required", int64(sl.maxDMLBytes)))
 		c.sendSignalResolvedTs(task)
 		metrics.EventServiceSkipScanCount.WithLabelValues("dispatcher_quota").Inc()
@@ -1017,6 +1018,7 @@ func (c *eventBroker) addDispatcher(info DispatcherInfo) error {
 	status.addDispatcher(id, dispatcherPtr)
 	if span.Equal(common.KeyspaceDDLSpan(span.KeyspaceID)) {
 		c.tableTriggerDispatchers.Store(id, dispatcherPtr)
+		c.metricsCollector.metricDispatcherCount.Inc()
 		log.Info("table trigger dispatcher register dispatcher",
 			zap.Uint64("clusterID", c.tidbClusterID),
 			zap.Stringer("changefeedID", changefeedID),

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -715,23 +715,23 @@ func (c *eventBroker) doScan(ctx context.Context, task scanTask) {
 
 	scanner := newEventScanner(c.eventStore, c.schemaStore, c.mounter, task.info.GetMode())
 	scannedBytes, events, interrupted, err := scanner.scan(ctx, task, dataRange, sl)
-	if scannedBytes < 0 {
-		releaseQuota(available, uint64(sl.maxDMLBytes))
-	} else if scannedBytes >= 0 && scannedBytes < sl.maxDMLBytes {
-		releaseQuota(available, uint64(sl.maxDMLBytes-scannedBytes))
-	}
-
 	if interrupted {
 		metrics.EventServiceInterruptScanCount.Inc()
 	}
 
 	if err != nil {
+		releaseQuota(available, uint64(sl.maxDMLBytes))
 		log.Error("scan events failed",
 			zap.Stringer("changefeedID", task.changefeedStat.changefeedID),
 			zap.Stringer("dispatcherID", task.id), zap.Int64("tableID", task.info.GetTableSpan().GetTableID()),
 			zap.Any("dataRange", dataRange), zap.Uint64("receivedResolvedTs", task.receivedResolvedTs.Load()),
 			zap.Uint64("sentResolvedTs", task.sentResolvedTs.Load()), zap.Error(err))
 		return
+	}
+	if scannedBytes < 0 {
+		releaseQuota(available, uint64(sl.maxDMLBytes))
+	} else if scannedBytes < sl.maxDMLBytes {
+		releaseQuota(available, uint64(sl.maxDMLBytes-scannedBytes))
 	}
 
 	if scannedBytes > int64(c.scanLimitInBytes) {

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -228,6 +228,38 @@ func TestDoScanReleasesChangefeedQuotaOnDispatcherQuotaFailure(t *testing.T) {
 	require.Equal(t, uint64(minScanLimitInBytes*2), changefeedQuota.Load())
 }
 
+func TestDoScanReleasesChangefeedQuotaOnScanError(t *testing.T) {
+	broker, eventStore, schemaStore, _ := newEventBrokerForTest()
+	defer broker.close()
+
+	info := newMockDispatcherInfoForTest(t)
+	info.epoch = 1
+	require.NoError(t, broker.addDispatcher(info))
+
+	disp := broker.getDispatcher(info.GetID()).Load()
+	require.NotNil(t, disp)
+	disp.receivedResolvedTs.Store(102)
+	disp.eventStoreCommitTs.Store(101)
+	disp.availableMemoryQuota.Store(minScanLimitInBytes * 2)
+
+	status := broker.getOrSetChangefeedStatus(info)
+	serverID := node.ID(info.GetServerID())
+	changefeedQuota := atomic.NewUint64(minScanLimitInBytes * 2)
+	status.availableMemoryQuota.Store(serverID, changefeedQuota)
+
+	schemaStore.getTableInfoError = errors.New("mock get table info error")
+	require.NoError(t, eventStore.AppendEvents(info.GetID(), 102, &common.RawKVEntry{
+		StartTs: 101,
+		CRTs:    101,
+		Key:     []byte("key"),
+		Value:   []byte("value"),
+	}))
+
+	broker.doScan(context.Background(), disp)
+
+	require.Equal(t, uint64(minScanLimitInBytes*2), changefeedQuota.Load())
+}
+
 func TestTableTriggerDispatcherMetricCount(t *testing.T) {
 	broker, _, _, _ := newEventBrokerForTest()
 	defer broker.close()

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -28,9 +28,11 @@ import (
 	"github.com/pingcap/ticdc/pkg/filter"
 	"github.com/pingcap/ticdc/pkg/integrity"
 	"github.com/pingcap/ticdc/pkg/messaging"
+	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/pdutil"
 	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/atomic"
@@ -202,6 +204,43 @@ func TestAddDispatcherUnregisterOnSchemaStoreError(t *testing.T) {
 	_, ok := es.spansMap.Load(info.GetTableSpan())
 	require.False(t, ok)
 	require.Equal(t, uint64(1), es.unregisterCount.Load())
+}
+
+func TestDoScanReleasesChangefeedQuotaOnDispatcherQuotaFailure(t *testing.T) {
+	broker, _, _, _ := newEventBrokerForTest()
+	defer broker.close()
+
+	info := newMockDispatcherInfoForTest(t)
+	info.epoch = 1
+	status := broker.getOrSetChangefeedStatus(info)
+
+	disp := newDispatcherStat(info, 1, 1, nil, status)
+	disp.receivedResolvedTs.Store(102)
+	disp.eventStoreCommitTs.Store(101)
+	disp.availableMemoryQuota.Store(minScanLimitInBytes - 1)
+
+	serverID := node.ID(info.GetServerID())
+	changefeedQuota := atomic.NewUint64(minScanLimitInBytes * 2)
+	status.availableMemoryQuota.Store(serverID, changefeedQuota)
+
+	broker.doScan(context.Background(), disp)
+
+	require.Equal(t, uint64(minScanLimitInBytes*2), changefeedQuota.Load())
+}
+
+func TestTableTriggerDispatcherMetricCount(t *testing.T) {
+	broker, _, _, _ := newEventBrokerForTest()
+	defer broker.close()
+
+	info := newMockDispatcherInfo(t, 100, common.NewDispatcherID(), common.DDLSpanTableID, eventpb.ActionType_ACTION_TYPE_REGISTER)
+	info.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
+
+	baseline := testutil.ToFloat64(metrics.EventServiceDispatcherGauge.WithLabelValues("1"))
+	require.NoError(t, broker.addDispatcher(info))
+	require.InDelta(t, baseline+1, testutil.ToFloat64(metrics.EventServiceDispatcherGauge.WithLabelValues("1")), 1e-9)
+
+	broker.removeDispatcher(info)
+	require.InDelta(t, baseline, testutil.ToFloat64(metrics.EventServiceDispatcherGauge.WithLabelValues("1")), 1e-9)
 }
 
 func TestScanRangeCappedByScanWindow(t *testing.T) {

--- a/pkg/eventservice/event_service.go
+++ b/pkg/eventservice/event_service.go
@@ -166,6 +166,7 @@ func (s *eventService) handleMessage(ctx context.Context, msg *messaging.TargetM
 	case messaging.TypeDispatcherHeartbeat:
 		if len(msg.Message) != 1 {
 			log.Warn("invalid dispatcher heartbeat, ignore it", zap.Any("msg", msg))
+			return nil
 		}
 		heartbeat := msg.Message[0].(*event.DispatcherHeartbeat)
 		select {
@@ -179,6 +180,7 @@ func (s *eventService) handleMessage(ctx context.Context, msg *messaging.TargetM
 	case messaging.TypeCongestionControl:
 		if len(msg.Message) != 1 {
 			log.Warn("invalid control message, ignore it", zap.Any("msg", msg))
+			return nil
 		}
 		m := msg.Message[0].(*event.CongestionControl)
 		s.handleCongestionControl(msg.From, m)

--- a/pkg/eventservice/event_service_test.go
+++ b/pkg/eventservice/event_service_test.go
@@ -157,6 +157,26 @@ func TestEventServiceBasic(t *testing.T) {
 	}
 }
 
+func TestHandleMessageIgnoresInvalidSingleMessagePayloads(t *testing.T) {
+	es := &eventService{}
+
+	require.NotPanics(t, func() {
+		err := es.handleMessage(context.Background(), &messaging.TargetMessage{
+			Type:    messaging.TypeDispatcherHeartbeat,
+			Message: nil,
+		})
+		require.NoError(t, err)
+	})
+
+	require.NotPanics(t, func() {
+		err := es.handleMessage(context.Background(), &messaging.TargetMessage{
+			Type:    messaging.TypeCongestionControl,
+			Message: nil,
+		})
+		require.NoError(t, err)
+	})
+}
+
 var _ eventstore.EventStore = &mockEventStore{}
 
 // mockEventStore is a mock implementation of the EventStore interface

--- a/pkg/eventservice/test_helper.go
+++ b/pkg/eventservice/test_helper.go
@@ -39,6 +39,7 @@ type mockSchemaStore struct {
 	maxDDLCommitTs uint64
 
 	registerTableError error
+	getTableInfoError  error
 }
 
 func NewMockSchemaStore() *mockSchemaStore {
@@ -91,6 +92,9 @@ func (m *mockSchemaStore) SetTables(tables []commonEvent.Table) {
 }
 
 func (m *mockSchemaStore) GetTableInfo(keyspaceMeta common.KeyspaceMeta, tableID common.TableID, ts common.Ts) (*common.TableInfo, error) {
+	if m.getTableInfoError != nil {
+		return nil, m.getTableInfoError
+	}
 	if info, ok := m.TableInfo[tableID]; ok {
 		if info.deleteVersion <= uint64(ts) {
 			return nil, &schemastore.TableDeletedError{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5642 

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed changefeed scan quota handling so allocated capacity is properly returned after scan failures, interruptions, and partial scans.
  * Prevented invalid heartbeat and congestion-control messages from causing processing errors.
  * Corrected dispatcher metrics to include table-trigger dispatchers.

* **Tests**
  * Added coverage for quota recovery, scan errors, invalid messages, and dispatcher metric tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->