### PR TITLE
maintainer: return zero for equal event keys

### DIFF
--- a/maintainer/barrier_helper.go
+++ b/maintainer/barrier_helper.go
@@ -117,7 +117,10 @@ func compareEventKey(a, b eventKey) int {
 	if !a.isSyncPoint && b.isSyncPoint {
 		return -1
 	}
-	return 1
+	if a.isSyncPoint && !b.isSyncPoint {
+		return 1
+	}
+	return 0
 }
 
 func (b *BlockedEventMap) Range(f func(key eventKey, value *BarrierEvent) bool) {

--- a/maintainer/barrier_helper_test.go
+++ b/maintainer/barrier_helper_test.go
@@ -18,6 +18,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCompareEventKey(t *testing.T) {
+	testCases := []struct {
+		name     string
+		a        eventKey
+		b        eventKey
+		expected int
+	}{
+		{name: "lower block ts", a: getEventKey(1, false), b: getEventKey(2, false), expected: -1},
+		{name: "higher block ts", a: getEventKey(2, false), b: getEventKey(1, false), expected: 1},
+		{name: "ddl before sync point", a: getEventKey(1, false), b: getEventKey(1, true), expected: -1},
+		{name: "sync point after ddl", a: getEventKey(1, true), b: getEventKey(1, false), expected: 1},
+		{name: "equal ddl", a: getEventKey(1, false), b: getEventKey(1, false), expected: 0},
+		{name: "equal sync point", a: getEventKey(1, true), b: getEventKey(1, true), expected: 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, compareEventKey(tc.a, tc.b))
+		})
+	}
+}
+
 func TestPendingScheduleEventMapDeduplicate(t *testing.T) {
 	m := newPendingScheduleEventMap()
 	event1 := &BarrierEvent{commitTs: 10, isSyncPoint: false}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5187

`compareEventKey` returned `1` when both event keys were equal, violating the comparator contract expected by callers such as `slices.SortFunc`.

### What is changed and how it works?

Return `0` when both `blockTs` and `isSyncPoint` are equal. Add table-driven unit coverage for timestamp ordering, sync-point ordering, and both equality cases.

### Check List

#### Tests

- Unit test

Command: `make unit_test_pkg PKG=./maintainer/...`

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tie-breaking logic when comparing two event keys with matching sync-point status, ensuring consistent ordering.
  * Kept behavior that equivalent event keys are treated as equal.
* **Tests**
  * Added table-driven unit tests covering timestamp ordering, DDL vs sync-point precedence (including reverse order), and sync-point equality cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->