### PR TITLE
common: update TiDB TableInfo shared schema guard

### DIFF
--- a/pkg/common/table_info_shared_schema_guard_test.go
+++ b/pkg/common/table_info_shared_schema_guard_test.go
@@ -83,7 +83,9 @@ func TestLatestTiDBTableInfoSharedSchemaGuard(t *testing.T) {
 				"Partition", "Compression", "View", "Sequence", "Lock", "Version", "TiFlashReplica", "IsColumnar",
 				"TempTableType", "TableCacheStatusType", "PlacementPolicyRef", "StatsOptions",
 				"ExchangePartitionInfo", "TTLInfo", "IsActiveActive", "SoftdeleteInfo", "Affinity",
-				"Revision", "DBID", "Mode",
+				"Revision", "DBID",
+				// These table-level storage settings do not affect the shared column schema.
+				"EngineAttribute", "StorageClassTier", "StorageClassTransitions", "Mode",
 			},
 		},
 		{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5740

Background:
The `pull-unit-test` job for PR #5643 fails in
`TestLatestTiDBTableInfoSharedSchemaGuard` after TiDB added
`EngineAttribute`, `StorageClassTier`, and `StorageClassTransitions` to
`model.TableInfo`.

Motivation:
The guard intentionally tracks upstream struct changes so each new field is
reviewed before TiCDC accepts the contract. These fields describe table-level
engine and storage-class settings. They do not affect columns, indexes, handle
flags, row decoding, or the shared column schema used by TiCDC.

### What is changed and how it works?

- Add the three reviewed TiDB fields to the expected `TableInfo` contract.
- Document why the fields do not need to participate in shared column schema
  hashing or equality.

### Check List

#### Tests

- Unit test
  - `go test ./pkg/common -run '^TestLatestTiDBTableInfoSharedSchemaGuard$' -count=1`
  - `go test ./pkg/common -count=1`
  - `make fmt`

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only updates a test guard after reviewing table-level metadata that is
outside TiCDC's shared column schema.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated schema compatibility checks to include newly supported table storage settings.
  * Adjusted field ordering validation for table metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->