### PR TITLE
metrics: hide checkpoint lag for failed changefeeds

### DIFF
--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -266,15 +266,13 @@ func (c *Controller) collectMetrics(ctx context.Context) error {
 
 				metrics.ChangefeedStatusGauge.WithLabelValues(keyspace, name).Set(float64(info.State.ToInt()))
 
-				if !updateChangefeedCheckpointMetrics(
+				updateChangefeedCheckpointMetrics(
 					keyspace,
 					name,
 					info.State,
 					cf.GetLastSavedCheckPointTs(),
 					c.pdClock.CurrentTime(),
-				) {
-					return
-				}
+				)
 
 				// sync changefeed error metrics
 				currentChangefeeds[cf.ID] = struct{}{}
@@ -327,11 +325,11 @@ func updateChangefeedCheckpointMetrics(
 	state config.FeedState,
 	checkpointTs uint64,
 	pdTime time.Time,
-) bool {
+) {
 	switch state {
-	case config.StateStopped, config.StateFinished, config.StateRemoved:
+	case config.StateFailed, config.StateStopped, config.StateFinished, config.StateRemoved:
 		metrics.DeleteChangefeedCheckpointMetrics(keyspace, name)
-		return false
+		return
 	}
 
 	pdPhysicalTime := oracle.GetPhysical(pdTime)
@@ -339,7 +337,6 @@ func updateChangefeedCheckpointMetrics(
 	lag := float64(pdPhysicalTime-phyCkpTs) / 1e3
 	metrics.ChangefeedCheckpointTsGauge.WithLabelValues(keyspace, name).Set(float64(phyCkpTs))
 	metrics.ChangefeedCheckpointTsLagGauge.WithLabelValues(keyspace, name).Set(lag)
-	return true
 }
 
 // HandleEvent implements the event-driven process mode

--- a/coordinator/controller_test.go
+++ b/coordinator/controller_test.go
@@ -53,34 +53,44 @@ func (noopScheduler) Name() string {
 	return pkgscheduler.BasicScheduler
 }
 
-func TestUpdateChangefeedCheckpointMetricsDeletesFinishedLabels(t *testing.T) {
-	metrics.ResetOwnerChangefeedMetrics()
+func TestUpdateChangefeedCheckpointMetricsDeletesInactiveLabels(t *testing.T) {
 	t.Cleanup(metrics.ResetOwnerChangefeedMetrics)
 
 	keyspace := common.DefaultKeyspaceName
-	name := "finished-metrics"
 	pdTime := time.UnixMilli(2000)
 	checkpointTs := oracle.ComposeTS(1000, 0)
 
-	require.True(t, updateChangefeedCheckpointMetrics(
-		keyspace,
-		name,
-		config.StateNormal,
-		checkpointTs,
-		pdTime,
-	))
-	require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
-	require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
-
-	require.False(t, updateChangefeedCheckpointMetrics(
-		keyspace,
-		name,
+	for _, state := range []config.FeedState{
+		config.StateFailed,
+		config.StateStopped,
 		config.StateFinished,
-		checkpointTs,
-		pdTime,
-	))
-	require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
-	require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
+		config.StateRemoved,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			metrics.ResetOwnerChangefeedMetrics()
+			name := string(state) + "-metrics"
+
+			updateChangefeedCheckpointMetrics(
+				keyspace,
+				name,
+				config.StateNormal,
+				checkpointTs,
+				pdTime,
+			)
+			require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
+			require.Equal(t, 1, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
+
+			updateChangefeedCheckpointMetrics(
+				keyspace,
+				name,
+				state,
+				checkpointTs,
+				pdTime,
+			)
+			require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsGauge))
+			require.Equal(t, 0, testutil.CollectAndCount(metrics.ChangefeedCheckpointTsLagGauge))
+		})
+	}
 }
 
 func TestOnPeriodTaskAdvanceLiveness(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4053

A failed changefeed no longer advances its checkpoint, but the coordinator kept
publishing checkpoint lag based on the current PD time. As a result, the lag
continued to grow even though it no longer represented active replication
latency.

### What is changed and how it works?

- Delete owner checkpoint timestamp and lag metrics when a changefeed is failed.
- Decouple checkpoint metric publication from the remaining per-changefeed
  metric synchronization, so failed changefeed error information is still
  reported.
- Extend the checkpoint metric test to cover failed, stopped, finished, and
  removed changefeeds.

### Check List

#### Tests

- [x] Unit test
  - `go test ./coordinator -run '^TestUpdateChangefeedCheckpointMetricsDeletesInactiveLabels$' -count=1`
  - `go test ./pkg/metrics -count=1`
  - `go test ./coordinator -count=1`
  - `make unit_test_pkg PKG=./coordinator`

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. The existing dashboard query stops showing the series after Prometheus
marks the deleted metric stale.

### Release note

```release-note
Fix an issue where checkpoint lag continued to be reported for failed changefeeds.
```
