### PR TITLE
kafka: avoid create changefeed failures if can't get a topic from broker

### DIFF
--- a/downstreamadapter/sink/topicmanager/kafka_topic_manager.go
+++ b/downstreamadapter/sink/topicmanager/kafka_topic_manager.go
@@ -287,19 +287,29 @@ func (m *kafkaTopicManager) CreateTopicAndWaitUntilVisible(
 	// which means we should create the topic later.
 	topicDetails, err := m.admin.GetTopicsMeta([]string{topicName}, true)
 	if err != nil {
+		if kafka.IsAdminAuthorizationFailed(err) {
+			return m.useConfiguredPartitionNum(topicName, err), nil
+		}
 		return 0, errors.Trace(err)
 	}
-	if detail, ok := topicDetails[topicName]; ok {
-		numPartition := detail.NumPartitions
-		if topicName == m.defaultTopic {
-			numPartition = m.cfg.PartitionNum
+	if numPartition, ok := m.tryStoreTopicMeta(topicName, topicDetails); ok {
+		return numPartition, nil
+	}
+
+	topicDetails, err = m.admin.GetTopicsMeta([]string{topicName}, false)
+	if err != nil {
+		if kafka.IsAdminAuthorizationFailed(err) {
+			return m.useConfiguredPartitionNum(topicName, err), nil
 		}
-		m.tryUpdatePartitionsAndLogging(topicName, numPartition)
+	} else if numPartition, ok := m.tryStoreTopicMeta(topicName, topicDetails); ok {
 		return numPartition, nil
 	}
 
 	partitionNum, err := m.createTopic(ctx, topicName)
 	if err != nil {
+		if kafka.IsAdminAuthorizationFailed(err) {
+			return m.useConfiguredPartitionNum(topicName, err), nil
+		}
 		return 0, errors.Trace(err)
 	}
 
@@ -309,6 +319,32 @@ func (m *kafkaTopicManager) CreateTopicAndWaitUntilVisible(
 	}
 
 	return partitionNum, nil
+}
+
+func (m *kafkaTopicManager) tryStoreTopicMeta(
+	topicName string, topicDetails map[string]kafka.TopicDetail,
+) (int32, bool) {
+	detail, ok := topicDetails[topicName]
+	if !ok {
+		return 0, false
+	}
+	numPartition := detail.NumPartitions
+	if topicName == m.defaultTopic {
+		numPartition = m.cfg.PartitionNum
+	}
+	m.tryUpdatePartitionsAndLogging(topicName, numPartition)
+	return numPartition, true
+}
+
+func (m *kafkaTopicManager) useConfiguredPartitionNum(topicName string, cause error) int32 {
+	log.Warn("skip Kafka topic creation because topic authorization failed",
+		zap.String("keyspace", m.changefeedID.Keyspace()),
+		zap.String("changefeed", m.changefeedID.Name()),
+		zap.String("topic", topicName),
+		zap.Int32("partitionNumber", m.cfg.PartitionNum),
+		zap.Error(cause))
+	m.tryUpdatePartitionsAndLogging(topicName, m.cfg.PartitionNum)
+	return m.cfg.PartitionNum
 }
 
 // Close exits the background goroutine.

--- a/downstreamadapter/sink/topicmanager/kafka_topic_manager_test.go
+++ b/downstreamadapter/sink/topicmanager/kafka_topic_manager_test.go
@@ -100,6 +100,8 @@ func TestCreateTopic(t *testing.T) {
 			}, nil),
 		adminClient.EXPECT().GetTopicsMeta([]string{"new-topic"}, true).Return(
 			map[string]kafka.TopicDetail{}, nil),
+		adminClient.EXPECT().GetTopicsMeta([]string{"new-topic"}, false).Return(
+			map[string]kafka.TopicDetail{}, nil),
 		adminClient.EXPECT().CreateTopic(gomock.Any(), false).DoAndReturn(
 			func(detail *kafka.TopicDetail, validateOnly bool) error {
 				gotNewTopicDetail = detail
@@ -115,7 +117,11 @@ func TestCreateTopic(t *testing.T) {
 			}, nil),
 		adminClient.EXPECT().GetTopicsMeta([]string{"new-topic2"}, true).Return(
 			map[string]kafka.TopicDetail{}, nil),
+		adminClient.EXPECT().GetTopicsMeta([]string{"new-topic2"}, false).Return(
+			map[string]kafka.TopicDetail{}, nil),
 		adminClient.EXPECT().GetTopicsMeta([]string{"new-topic-failed"}, true).Return(
+			map[string]kafka.TopicDetail{}, nil),
+		adminClient.EXPECT().GetTopicsMeta([]string{"new-topic-failed"}, false).Return(
 			map[string]kafka.TopicDetail{}, nil),
 		adminClient.EXPECT().CreateTopic(gomock.Any(), false).DoAndReturn(
 			func(detail *kafka.TopicDetail, validateOnly bool) error {
@@ -191,6 +197,8 @@ func TestCreateTopicWaitsUntilVisible(t *testing.T) {
 	gomock.InOrder(
 		adminClient.EXPECT().GetTopicsMeta([]string{topic}, true).Return(
 			map[string]kafka.TopicDetail{}, nil),
+		adminClient.EXPECT().GetTopicsMeta([]string{topic}, false).Return(
+			map[string]kafka.TopicDetail{}, nil),
 		adminClient.EXPECT().CreateTopic(gomock.Any(), false).DoAndReturn(
 			func(detail *kafka.TopicDetail, validateOnly bool) error {
 				require.Equal(t, &kafka.TopicDetail{
@@ -231,7 +239,6 @@ func TestCreateTopicWithTopicDescribeDenied(t *testing.T) {
 	adminClient := &mockAdminClientWithDeniedDescribe{
 		MockClusterAdminClient: kafka.NewMockClusterAdminClient(ctrl),
 	}
-	defer adminClient.Close()
 	cfg := &kafka.AutoCreateTopicConfig{
 		AutoCreate:        true,
 		PartitionNum:      2,
@@ -258,10 +265,9 @@ func TestCreateTopicWithCreateDenied(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
-	adminClient := &mockAdminClientWithDeniedDescribe{
+	adminClient := &mockAdminClientWithDeniedCreate{
 		MockClusterAdminClient: kafka.NewMockClusterAdminClient(ctrl),
 	}
-	defer adminClient.Close()
 	cfg := &kafka.AutoCreateTopicConfig{
 		AutoCreate:        true,
 		PartitionNum:      2,

--- a/downstreamadapter/sink/topicmanager/kafka_topic_manager_test.go
+++ b/downstreamadapter/sink/topicmanager/kafka_topic_manager_test.go
@@ -26,6 +26,53 @@ import (
 
 const kafkaTopicManagerTestTopic = "mock_topic"
 
+type mockAdminClientWithDeniedDescribe struct {
+	*kafka.MockClusterAdminClient
+	createTopicCalled bool
+	describeCount     int
+}
+
+func (m *mockAdminClientWithDeniedDescribe) GetTopicsMeta(
+	topics []string,
+	ignoreTopicError bool,
+) (map[string]kafka.TopicDetail, error) {
+	m.describeCount++
+	if ignoreTopicError {
+		return map[string]kafka.TopicDetail{}, nil
+	}
+	return nil, sarama.ErrTopicAuthorizationFailed
+}
+
+func (m *mockAdminClientWithDeniedDescribe) CreateTopic(
+	detail *kafka.TopicDetail,
+	validateOnly bool,
+) error {
+	m.createTopicCalled = true
+	return nil
+}
+
+type mockAdminClientWithDeniedCreate struct {
+	*kafka.MockClusterAdminClient
+	createTopicCalled bool
+	describeCount     int
+}
+
+func (m *mockAdminClientWithDeniedCreate) GetTopicsMeta(
+	topics []string,
+	ignoreTopicError bool,
+) (map[string]kafka.TopicDetail, error) {
+	m.describeCount++
+	return map[string]kafka.TopicDetail{}, nil
+}
+
+func (m *mockAdminClientWithDeniedCreate) CreateTopic(
+	detail *kafka.TopicDetail,
+	validateOnly bool,
+) error {
+	m.createTopicCalled = true
+	return sarama.ErrClusterAuthorizationFailed
+}
+
 func TestCreateTopic(t *testing.T) {
 	t.Parallel()
 
@@ -175,4 +222,64 @@ func TestCreateTopicWaitsUntilVisible(t *testing.T) {
 	partitionNum, err := manager.CreateTopicAndWaitUntilVisible(ctx, topic)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), partitionNum)
+}
+
+func TestCreateTopicWithTopicDescribeDenied(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	adminClient := &mockAdminClientWithDeniedDescribe{
+		MockClusterAdminClient: kafka.NewMockClusterAdminClient(ctrl),
+	}
+	defer adminClient.Close()
+	cfg := &kafka.AutoCreateTopicConfig{
+		AutoCreate:        true,
+		PartitionNum:      2,
+		ReplicationFactor: 1,
+	}
+
+	changefeedID := common.NewChangefeedID4Test("test", "test")
+	ctx := context.Background()
+	manager := newKafkaTopicManager(ctx, "precreated-topic", changefeedID, adminClient, cfg)
+	defer manager.Close()
+
+	partitionNum, err := manager.CreateTopicAndWaitUntilVisible(ctx, "precreated-topic")
+	require.NoError(t, err)
+	require.Equal(t, int32(2), partitionNum)
+	require.False(t, adminClient.createTopicCalled)
+	require.Equal(t, 2, adminClient.describeCount)
+
+	partitions, ok := manager.topics.Load("precreated-topic")
+	require.True(t, ok)
+	require.Equal(t, int32(2), partitions)
+}
+
+func TestCreateTopicWithCreateDenied(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	adminClient := &mockAdminClientWithDeniedDescribe{
+		MockClusterAdminClient: kafka.NewMockClusterAdminClient(ctrl),
+	}
+	defer adminClient.Close()
+	cfg := &kafka.AutoCreateTopicConfig{
+		AutoCreate:        true,
+		PartitionNum:      2,
+		ReplicationFactor: 1,
+	}
+
+	changefeedID := common.NewChangefeedID4Test("test", "test")
+	ctx := context.Background()
+	manager := newKafkaTopicManager(ctx, "precreated-topic", changefeedID, adminClient, cfg)
+	defer manager.Close()
+
+	partitionNum, err := manager.CreateTopicAndWaitUntilVisible(ctx, "precreated-topic")
+	require.NoError(t, err)
+	require.Equal(t, int32(2), partitionNum)
+	require.True(t, adminClient.createTopicCalled)
+	require.Equal(t, 2, adminClient.describeCount)
+
+	partitions, ok := manager.topics.Load("precreated-topic")
+	require.True(t, ok)
+	require.Equal(t, int32(2), partitions)
 }

--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -153,6 +153,16 @@ func (a *saramaAdminClient) GetTopicsMeta(topics []string, ignoreTopicError bool
 	return result, nil
 }
 
+// IsAdminAuthorizationFailed checks whether err is an authorization failure from Kafka admin APIs.
+func IsAdminAuthorizationFailed(err error) bool {
+	return isKafkaError(err, sarama.ErrTopicAuthorizationFailed) ||
+		isKafkaError(err, sarama.ErrClusterAuthorizationFailed)
+}
+
+func isKafkaError(err error, target sarama.KError) bool {
+	return errors.Is(err, target) || errors.Cause(err) == target
+}
+
 func (a *saramaAdminClient) GetTopicsPartitionsNum(topics []string) (map[string]int32, error) {
 	result := make(map[string]int32, len(topics))
 	for _, topic := range topics {

--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -155,12 +155,8 @@ func (a *saramaAdminClient) GetTopicsMeta(topics []string, ignoreTopicError bool
 
 // IsAdminAuthorizationFailed checks whether err is an authorization failure from Kafka admin APIs.
 func IsAdminAuthorizationFailed(err error) bool {
-	return isKafkaError(err, sarama.ErrTopicAuthorizationFailed) ||
-		isKafkaError(err, sarama.ErrClusterAuthorizationFailed)
-}
-
-func isKafkaError(err error, target sarama.KError) bool {
-	return errors.Is(err, target) || errors.Cause(err) == target
+	return errors.Is(err, sarama.ErrTopicAuthorizationFailed) ||
+		errors.Is(err, sarama.ErrClusterAuthorizationFailed)
 }
 
 func (a *saramaAdminClient) GetTopicsPartitionsNum(topics []string) (map[string]int32, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5563

### What is changed and how it works?
If ticdc can't get the topic from kafka broker, still create a changefeed instead of throwing an error.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

| Target | Startup mode | `changefeed create` result | Query after create | Runtime write test | Notes |
| --- | --- | --- | --- | --- | --- |
| `master` | Default, old arch | Failed, exit code `1` | `ErrChangeFeedNotExists` | Not reached | `CreateTopicAndWaitUntilVisible` treated the topic as unavailable and attempted `CreateTopic`; Kafka returned Topic authorization failure |
| Current branch | Default, old arch | Failed, exit code `1` | `ErrChangeFeedNotExists` | Not reached | Same visible behavior after rebuilding `bin/cdc` from `acl-0720 @ 6225925f`; this run did not use the modified `downstreamadapter` implementation |
| Current branch | `cdc server --newarch` | Success, exit code `0` | `state: normal` | `state: warning`, `ErrKafkaSendMessage` after DDL | This run exercised the modified `downstreamadapter` implementation; create passed by skipping topic creation after authorization failure, but runtime write still requires Topic `Write` |


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Kafka authorization failures during topic discovery and creation.
  * Services can now continue using the configured partition count when topic administration is denied.
  * Topic partition information remains available for subsequent operations.
* **Tests**
  * Added coverage for authorization failures during topic metadata retrieval and topic creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->