### PR TITLE
sink: capture schema registry failure

### DIFF
--- a/pkg/sink/codec/avro/confluent_schema_registry.go
+++ b/pkg/sink/codec/avro/confluent_schema_registry.go
@@ -181,7 +181,9 @@ func (m *confluentSchemaManager) Register(
 			zap.ByteString("requestBody", payload),
 			zap.ByteString("responseBody", body),
 		)
-		return id, errors.ErrAvroSchemaAPIError.GenWithStackByArgs()
+		return id, errors.ErrAvroSchemaAPIError.GenWithStackByArgs(
+			"register schema failed with status " + strconv.Itoa(resp.StatusCode),
+		)
 	}
 
 	var jsonResp registerResponse

--- a/pkg/sink/codec/avro/confluent_schema_registry.go
+++ b/pkg/sink/codec/avro/confluent_schema_registry.go
@@ -38,7 +38,10 @@ import (
 
 // confluent avro wire format, the first byte is always 0
 // https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
-const magicByte = uint8(0)
+const (
+	magicByte                    = uint8(0)
+	schemaRegistryRequestTimeout = 30 * time.Second
+)
 
 // confluentSchemaManager is used to register Avro Schemas to the confluent Registry server,
 // look up local cache according to the table's name, and fetch from the Registry
@@ -81,6 +84,9 @@ func NewConfluentSchemaManager(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	httpCli.SetTimeout(schemaRegistryRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, schemaRegistryRequestTimeout)
+	defer cancel()
 	resp, err := httpCli.Get(ctx, registryURL)
 	if err != nil {
 		log.Error("Test connection to Schema Registry failed",
@@ -422,7 +428,12 @@ func httpRetry(
 
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.MaxInterval = time.Second * 30
+	expBackoff.MaxElapsedTime = schemaRegistryRequestTimeout
 	httpCli, err := httputil.NewClient(credential)
+	if err != nil {
+		return nil, errors.WrapError(errors.ErrAvroSchemaAPIError, err)
+	}
+	httpCli.SetTimeout(schemaRegistryRequestTimeout)
 
 	if r.Body != nil {
 		data, err = io.ReadAll(r.Body)
@@ -443,9 +454,9 @@ func httpRetry(
 			goto checkCtx
 		}
 
-		// retry 4xx codes like 409 & 422 has no meaning since it's non-recoverable
-		if resp.StatusCode >= 200 && resp.StatusCode < 300 ||
-			(resp.StatusCode >= 400 && resp.StatusCode < 500) {
+		// Return HTTP responses to callers so they can report registry status
+		// codes. Retrying 5xx here can hide downstream failures indefinitely.
+		if resp.StatusCode >= 200 {
 			break
 		}
 		log.Warn("HTTP server returned with error", zap.Int("status", resp.StatusCode))
@@ -455,11 +466,24 @@ func httpRetry(
 	checkCtx:
 		select {
 		case <-ctx.Done():
-			return nil, errors.New("HTTP retry cancelled")
+			return nil, errors.WrapError(errors.ErrAvroSchemaAPIError, ctx.Err())
 		default:
 		}
 
-		time.Sleep(expBackoff.NextBackOff())
+		sleepTime := expBackoff.NextBackOff()
+		if sleepTime == backoff.Stop {
+			if err != nil {
+				return nil, errors.WrapError(errors.ErrAvroSchemaAPIError, err)
+			}
+			return nil, errors.ErrAvroSchemaAPIError.GenWithStackByArgs("HTTP retry stopped")
+		}
+		timer := time.NewTimer(sleepTime)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, errors.WrapError(errors.ErrAvroSchemaAPIError, ctx.Err())
+		case <-timer.C:
+		}
 	}
 
 	return resp, nil

--- a/pkg/sink/codec/avro/confluent_schema_registry_test.go
+++ b/pkg/sink/codec/avro/confluent_schema_registry_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,6 +113,32 @@ func TestSchemaRegistryBad(t *testing.T) {
 
 	_, err = NewConfluentSchemaManager(ctx, "https://127.0.0.1:8080", nil)
 	require.Error(t, err)
+}
+
+func TestRegisterReturnsServerError(t *testing.T) {
+	startHTTPInterceptForTestingRegistry()
+	defer stopHTTPInterceptForTestingRegistry()
+
+	ctx := getTestingContext()
+	manager, err := NewConfluentSchemaManager(ctx, "http://127.0.0.1:8081", nil)
+	require.NoError(t, err)
+
+	codec, err := GenCodec(`{
+       "type": "record",
+       "name": "test",
+       "fields":
+         [
+           {
+             "type": "string",
+             "name": "field1"
+           }
+          ]
+     }`)
+	require.NoError(t, err)
+
+	schemaID, err := manager.Register(ctx, "server-error", codec.Schema())
+	require.ErrorIs(t, err, errors.ErrAvroSchemaAPIError)
+	require.Zero(t, schemaID.confluentSchemaID)
 }
 
 func TestSchemaRegistryIdempotent(t *testing.T) {
@@ -258,11 +285,11 @@ func TestGetCachedOrRegister(t *testing.T) {
 	wg.Wait()
 }
 
-func TestHTTPRetry(t *testing.T) {
+func TestHTTPRetryReturnsServerError(t *testing.T) {
 	startHTTPInterceptForTestingRegistry()
 	defer stopHTTPInterceptForTestingRegistry()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	defer cancel()
 
 	payload := []byte("test")
@@ -272,6 +299,6 @@ func TestHTTPRetry(t *testing.T) {
 
 	resp, err := httpRetry(ctx, nil, req)
 	require.NoError(t, err)
-	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 	_ = resp.Body.Close()
 }

--- a/pkg/sink/codec/avro/mock_schema_registry.go
+++ b/pkg/sink/codec/avro/mock_schema_registry.go
@@ -54,6 +54,9 @@ func startHTTPInterceptForTestingRegistry() {
 			if err != nil {
 				return nil, err
 			}
+			if subject == "server-error" {
+				return httpmock.NewStringResponse(http.StatusInternalServerError, "Internal Server Error"), nil
+			}
 			reqBody, err := io.ReadAll(req.Body)
 			if err != nil {
 				return nil, err

--- a/tests/integration_tests/avro_schema_registry_error/run.sh
+++ b/tests/integration_tests/avro_schema_registry_error/run.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -eu
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$CUR/../_utils/test_prepare"
+WORK_DIR="$OUT_DIR/$TEST_NAME"
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+MAX_RETRIES=20
+MOCK_SCHEMA_REGISTRY_PORT=${MOCK_SCHEMA_REGISTRY_PORT:-18088}
+MOCK_SCHEMA_REGISTRY_PID=""
+
+function start_mock_schema_registry() {
+	python3 -u - "$MOCK_SCHEMA_REGISTRY_PORT" >"$WORK_DIR/mock_schema_registry.log" 2>&1 <<'PY' &
+import http.server
+import socketserver
+import sys
+
+port = int(sys.argv[1])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/":
+            body = b"{}"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_error(404)
+
+    def do_POST(self):
+        if self.path.startswith("/subjects/") and self.path.endswith("/versions"):
+            body = b"Internal Server Error"
+            self.send_response(500)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_error(404)
+
+    def log_message(self, format, *args):
+        sys.stderr.write("%s - - [%s] %s\n" %
+                         (self.address_string(), self.log_date_time_string(), format % args))
+
+class TCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+with TCPServer(("127.0.0.1", port), Handler) as httpd:
+    httpd.serve_forever()
+PY
+	MOCK_SCHEMA_REGISTRY_PID=$!
+
+	local i=0
+	while ! curl -o /dev/null -fsS "http://127.0.0.1:${MOCK_SCHEMA_REGISTRY_PORT}"; do
+		i=$((i + 1))
+		if [ "$i" -gt 30 ]; then
+			echo "failed to start mock schema registry"
+			exit 1
+		fi
+		sleep 1
+	done
+}
+
+function stop_mock_schema_registry() {
+	if [ -n "$MOCK_SCHEMA_REGISTRY_PID" ]; then
+		kill "$MOCK_SCHEMA_REGISTRY_PID" 2>/dev/null || true
+		wait "$MOCK_SCHEMA_REGISTRY_PID" 2>/dev/null || true
+	fi
+}
+
+function cleanup() {
+	stop_mock_schema_registry
+	stop_test "$WORK_DIR"
+}
+
+function create_changefeed() {
+	local protocol=$1
+	local changefeed_id=$2
+	local topic_name=$3
+	local start_ts=$4
+	local sink_uri
+
+	case "$protocol" in
+	avro)
+		sink_uri="kafka://127.0.0.1:9092/${topic_name}?protocol=avro&enable-tidb-extension=true&avro-enable-watermark=true&partition-num=1&kafka-version=${KAFKA_VERSION}&max-message-bytes=10485760&avro-decimal-handling-mode=string&avro-bigint-unsigned-handling-mode=string"
+		;;
+	debezium-avro)
+		sink_uri="kafka://127.0.0.1:9092/${topic_name}?protocol=debezium-avro&enable-tidb-extension=true&avro-enable-watermark=true&partition-num=1&kafka-version=${KAFKA_VERSION}&max-message-bytes=10485760&avro-decimal-handling-mode=precise&avro-bigint-unsigned-handling-mode=string"
+		;;
+	*)
+		echo "unsupported protocol: $protocol"
+		exit 1
+		;;
+	esac
+
+	cdc_cli_changefeed create \
+		--start-ts="$start_ts" \
+		--sink-uri="$sink_uri" \
+		-c "$changefeed_id" \
+		--schema-registry="http://127.0.0.1:${MOCK_SCHEMA_REGISTRY_PORT}"
+	ensure "$MAX_RETRIES" "check_changefeed_status '127.0.0.1:8300' '$changefeed_id' 'normal'"
+}
+
+function run() {
+	if [ "$SINK_TYPE" != "kafka" ]; then
+		return
+	fi
+
+	rm -rf "$WORK_DIR" && mkdir -p "$WORK_DIR"
+	start_mock_schema_registry
+	start_tidb_cluster --workdir "$WORK_DIR"
+
+	run_sql "CREATE DATABASE avro_schema_registry_error;" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	run_sql "CREATE TABLE avro_schema_registry_error.t1(id INT PRIMARY KEY, v VARCHAR(32));" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	start_ts=$(run_cdc_cli_tso_query "$UP_PD_HOST_1" "$UP_PD_PORT_1")
+
+	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY"
+
+	avro_changefeed_id="avro-schema-registry-error-$RANDOM"
+	debezium_changefeed_id="debezium-avro-schema-registry-error-$RANDOM"
+	create_changefeed "avro" "$avro_changefeed_id" "ticdc-avro-schema-registry-error-$RANDOM" "$start_ts"
+	create_changefeed "debezium-avro" "$debezium_changefeed_id" "ticdc-debezium-avro-schema-registry-error-$RANDOM" "$start_ts"
+
+	run_sql "INSERT INTO avro_schema_registry_error.t1 VALUES (1, 'trigger schema register');" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+
+	ensure "$MAX_RETRIES" "check_changefeed_status '127.0.0.1:8300' '$avro_changefeed_id' 'warning' 'last_warning' 'register schema failed with status 500'"
+	ensure "$MAX_RETRIES" "check_changefeed_status '127.0.0.1:8300' '$debezium_changefeed_id' 'warning' 'last_warning' 'register schema failed with status 500'"
+
+	cleanup_process "$CDC_BINARY"
+}
+
+trap cleanup EXIT
+run "$@"
+check_logs "$WORK_DIR"
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -99,7 +99,7 @@ kafka_groups=(
 	# G13
 	'cli_with_auth fail_over_ddl_N maintainer_failover_when_operator'
 	# G14
-	'kafka_simple_basic avro_basic fail_over_ddl_O update_changefeed_check_config'
+	'kafka_simple_basic avro_basic avro_schema_registry_error fail_over_ddl_O update_changefeed_check_config'
 	# G15
 	'kafka_simple_basic_avro split_region autorandom gc_safepoint kafka_log_info'
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5653

### What is changed and how it works?
  Before this change, when Schema Registry returned 500, TiCDC could keep retrying inside the Avro schema registry helper and the changefeed could remain healthy-looking.

  Now, when schema registration gets a 500, TiCDC returns the error immediately. The encoder error flows to the dispatcher manager, then to the maintainer/coordinator error path. The changefeed is reported as warning, with the registry error visible in last_warning.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
With this pr, changefeed will be in warning status
<img width="2326" height="648" alt="img_v3_0213t_ca43cc89-661c-4d5a-9020-b82e0310dcdg" src="https://github.com/user-attachments/assets/ccbc27e4-1cec-44b8-b881-b5ffacd5a404" />

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Schema Registry connection timeouts and interrupted retries.
  * Schema registration errors now include the HTTP status code, making failures clearer.
  * Prevented retries from continuing after an HTTP response is received.

* **Tests**
  * Added coverage for server-side Schema Registry errors.
  * Added integration testing to verify affected changefeeds enter a warning state with relevant error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->