### PR TITLE
schemastore: skip views during physical table bootstrap

### DIFF
--- a/logservice/schemastore/disk_format.go
+++ b/logservice/schemastore/disk_format.go
@@ -1059,6 +1059,12 @@ func loadAllPhysicalTablesAtTs(
 		if !ok {
 			log.Panic("table info not found", zap.Int64("tableID", tableID))
 		}
+		// Views have no physical KV events. Their DDLs are replicated by the
+		// table-trigger dispatcher, so creating a table dispatcher for a view can
+		// only leave an orphan after the view is dropped.
+		if fullTableInfo.View != nil {
+			continue
+		}
 		if tableFilter != nil {
 			if tableFilter.ShouldIgnoreTable(schemaName, tableInfo.Name) {
 				continue

--- a/logservice/schemastore/disk_format_test.go
+++ b/logservice/schemastore/disk_format_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -279,6 +280,53 @@ func TestPersistSchemaSnapshotEncryptionRoundTrip(t *testing.T) {
 	require.Equal(t, int64(200), tables[0].TableID)
 	require.Equal(t, "test", tables[0].SchemaName)
 	require.Equal(t, "t1", tables[0].TableName)
+}
+
+func TestGetAllPhysicalTablesSkipsViews(t *testing.T) {
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	const snapshotTs = uint64(100)
+	dbInfo := &model.DBInfo{ID: 100, Name: ast.NewCIStr("test")}
+	tableInfo := newEligibleTableInfoForTest(200, "t1")
+	viewInfo := &model.TableInfo{
+		ID:   201,
+		Name: ast.NewCIStr("v1"),
+		View: &model.ViewInfo{},
+	}
+	batch := db.NewBatch()
+	defer func() {
+		require.NoError(t, batch.Close())
+	}()
+	addSchemaInfoToBatch(batch, snapshotTs, dbInfo)
+	for _, info := range []*model.TableInfo{tableInfo, viewInfo} {
+		value, err := json.Marshal(info)
+		require.NoError(t, err)
+		addTableInfoToBatch(batch, snapshotTs, dbInfo, value)
+	}
+	require.NoError(t, batch.Commit(pebble.NoSync))
+
+	snapshot := db.NewSnapshot()
+	defer func() {
+		require.NoError(t, snapshot.Close())
+	}()
+
+	tables, err := loadAllPhysicalTablesAtTs(snapshot, snapshotTs, snapshotTs, nil, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, []commonEvent.Table{
+		{
+			SchemaID:  100,
+			TableID:   200,
+			Splitable: true,
+			SchemaTableName: &commonEvent.SchemaTableName{
+				SchemaName: "test",
+				TableName:  "t1",
+			},
+		},
+	}, tables)
 }
 
 type snapshotLostByGCError struct{}

--- a/tests/integration_tests/capture_session_done_during_task/run.sh
+++ b/tests/integration_tests/capture_session_done_during_task/run.sh
@@ -8,6 +8,21 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
+function view_is_not_scheduled() {
+	local changefeed_id=$1
+	local table_id=$2
+	local view_table_id=$3
+
+	curl -sS --fail --connect-timeout 2 --max-time 5 \
+		"http://${CDC_HOST}:${CDC_PORT}/api/v2/changefeeds/${changefeed_id}/tables?keyspace=${KEYSPACE_NAME}" |
+		jq -e --argjson table_id "$table_id" --argjson view_table_id "$view_table_id" '
+			[.items[].table_ids[]?] as $table_ids |
+			(($table_ids | index($table_id)) != null) and
+			(($table_ids | index($view_table_id)) == null)
+		' >/dev/null
+}
+export -f view_is_not_scheduled
+
 function run() {
 	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 	start_tidb_cluster --workdir $WORK_DIR
@@ -31,11 +46,22 @@ function run() {
 	run_sql "CREATE table capture_session_done_during_task.t (id int primary key auto_increment, a int)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "CREATE DATABASE capture_session_done_during_task;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	run_sql "CREATE table capture_session_done_during_task.t (id int primary key auto_increment, a int)" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	if [ "$SINK_TYPE" = "mysql" ]; then
+		run_sql "CREATE VIEW capture_session_done_during_task.v AS SELECT id, a FROM capture_session_done_during_task.t" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+		run_sql "CREATE VIEW capture_session_done_during_task.v AS SELECT id, a FROM capture_session_done_during_task.t" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+		table_id=$(get_table_id "capture_session_done_during_task" "t")
+		view_table_id=$(get_table_id "capture_session_done_during_task" "v")
+	fi
 	start_ts=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
 	run_sql "INSERT INTO capture_session_done_during_task.t values (),(),(),(),(),(),()" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	export GO_FAILPOINTS='github.com/pingcap/ticdc/downstreamadapter/dispatchermanager/NewDispatcherManagerDelay=sleep(4000)'
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
 	changefeed_id=$(cdc_cli_changefeed create --pd=$pd_addr --start-ts=$start_ts --sink-uri="$SINK_URI" | grep '^ID:' | head -n1 | awk '{print $2}')
+	if [ "$SINK_TYPE" = "mysql" ]; then
+		ensure 30 view_is_not_scheduled "$changefeed_id" "$table_id" "$view_table_id"
+		run_sql "DROP VIEW capture_session_done_during_task.v" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+		check_table_not_exists "capture_session_done_during_task.v" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 30
+	fi
 	# wait task is dispatched
 	cdc_pid=$(get_cdc_pid "$CDC_HOST" "$CDC_PORT")
 	echo "cdc pid: $cdc_pid"


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #5710

A schema snapshot can include views in the physical-table bootstrap list. Because views have no KV row stream, the resulting normal dispatcher does no useful work and can become an orphan after `DROP VIEW`. A later capture replacement can then fail to reset that orphan and permanently pin the changefeed checkpoint.

### What is changed and how it works?

- Exclude views when SchemaStore builds the physical-table bootstrap result.
- Add a Pebble snapshot unit test that verifies a normal table is returned while a view is skipped.
- Extend `capture_session_done_during_task` with a pre-existing view, assert that only the normal table is scheduled, replicate `DROP VIEW`, restart the capture, and reuse the existing consistency checks.

Incremental `CREATE VIEW` and `DROP VIEW` DDLs are unchanged and continue through the table-trigger dispatcher.

### Check List

#### Tests
- Unit test
- Integration test

#### Questions

##### Will it cause performance regression or break compatibility?

No. Physical tables are unchanged, while an unnecessary dispatcher is no longer created for views. View DDL replication remains on the existing table-trigger path.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This is an internal correctness fix and does not change user-facing configuration or APIs.

### Release note
```release-note
Fix a changefeed checkpoint stall after capture replacement caused by an orphan dispatcher for a dropped view.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Views are now excluded from physical table processing and scheduling.
  * Prevents views from appearing as scheduled tables in changefeed workflows.

* **Tests**
  * Added coverage confirming physical tables are returned while views are excluded.
  * Added MySQL integration coverage for view scheduling and downstream lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->