### PR TITLE
coordinator: handle errors from regressed checkpoint status

### DIFF
--- a/coordinator/changefeed/changefeed.go
+++ b/coordinator/changefeed/changefeed.go
@@ -161,12 +161,25 @@ func (c *Changefeed) ShouldRun() bool {
 // It returns false if the status is not changed
 // It returns the new state and error if the status is changed
 func (c *Changefeed) UpdateStatus(newStatus *heartbeatpb.MaintainerStatus) (bool, config.FeedState, *heartbeatpb.RunningError) {
+	if newStatus == nil {
+		return false, config.StateNormal, nil
+	}
+
 	old := c.status.Load()
 	failpoint.Inject("CoordinatorDontUpdateChangefeedCheckpoint", func() {
 		newStatus.CheckpointTs = old.CheckpointTs
 	})
 
-	if newStatus != nil && newStatus.CheckpointTs >= old.CheckpointTs {
+	if newStatus.CheckpointTs < old.CheckpointTs {
+		if len(newStatus.Err) == 0 {
+			return false, config.StateNormal, nil
+		}
+		statusWithMonotonicCheckpoint := *newStatus
+		statusWithMonotonicCheckpoint.CheckpointTs = old.CheckpointTs
+		newStatus = &statusWithMonotonicCheckpoint
+	}
+
+	if newStatus.CheckpointTs >= old.CheckpointTs {
 		c.status.Store(newStatus)
 
 		changed, state, err := c.backoff.checkFailedStatus(newStatus)

--- a/coordinator/changefeed/changefeed_test.go
+++ b/coordinator/changefeed/changefeed_test.go
@@ -110,6 +110,45 @@ func TestChangefeed_UpdateStatus(t *testing.T) {
 	require.Equal(t, newStatus, cf.GetStatus())
 }
 
+func TestChangefeed_UpdateStatusProcessesErrorsWhenCheckpointRegresses(t *testing.T) {
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+	info := &config.ChangeFeedInfo{
+		SinkURI: "kafka://127.0.0.1:9092",
+		State:   config.StateNormal,
+		Config:  config.GetDefaultReplicaConfig(),
+	}
+	cf := NewChangefeed(cfID, info, 200, true)
+
+	regressedStatus := &heartbeatpb.MaintainerStatus{CheckpointTs: 150}
+	updated, state, err := cf.UpdateStatus(regressedStatus)
+	require.False(t, updated)
+	require.Equal(t, config.StateNormal, state)
+	require.Nil(t, err)
+	require.Equal(t, uint64(200), cf.GetStatus().CheckpointTs)
+
+	retryableErr := &heartbeatpb.RunningError{
+		Node:    "node-1",
+		Code:    "CDC:ErrChangefeedRetryable",
+		Message: "retryable error",
+	}
+	regressedStatus = &heartbeatpb.MaintainerStatus{
+		CheckpointTs: 150,
+		Err:          []*heartbeatpb.RunningError{retryableErr},
+	}
+	updated, state, err = cf.UpdateStatus(regressedStatus)
+	require.True(t, updated)
+	require.Equal(t, config.StateWarning, state)
+	require.Same(t, retryableErr, err)
+	require.Equal(t, uint64(150), regressedStatus.CheckpointTs)
+	status := cf.GetStatus()
+	require.Equal(t, uint64(200), status.CheckpointTs)
+	require.Len(t, status.Err, 1)
+	require.Same(t, retryableErr, status.Err[0])
+	require.False(t, cf.ShouldRun())
+	require.True(t, cf.backoff.retrying.Load())
+	require.True(t, cf.backoff.isRestarting.Load())
+}
+
 func TestChangefeed_UpdateStatusFastFailWhenBootstrapDoneChanges(t *testing.T) {
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	info := &config.ChangeFeedInfo{


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5709

### What is changed and how it works?
  Before this change, `Changefeed.UpdateStatus` ignored maintainer status reports whose `CheckpointTs` was lower than the checkpoint already stored in the coordinator. This kept checkpoint updates monotonic, but it also dropped `MaintainerStatus.Err` carried by those reports. As a result, retryable maintainer errors could be missed and the changefeed would not enter warning/backoff as expected.

  This change keeps the monotonic checkpoint rule while still processing reported errors. If a maintainer reports a lower checkpoint without errors, the status is ignored as before. If it reports a lower checkpoint with errors, TiCDC copies the status, replaces the copied `CheckpointTs` with the coordinator's current checkpoint, and sends the copied status through the existing fast-fail and backoff checks.

  With this behavior, maintainer errors can update the changefeed state and trigger retry/backoff, while the stored checkpoint never decreases and the original maintainer status object is not mutated.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 Fix an issue where TiCDC could ignore maintainer errors when the reported checkpoint regressed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changefeed status handling when no new status is provided.
  * Ensured retryable errors are processed correctly even when status checkpoints move backward.
  * Preserved accurate warning state, error details, and retry behavior during checkpoint regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->