### PR TITLE
*: bump Go version to 1.25.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,16 @@ TiCDC can be built on the following operating systems:
 * Linux
 * MacOS
 
-Install GoLang 1.25.8
+Install GoLang 1.25.12
 
 ```bash
 # Linux
-wget https://go.dev/dl/go1.25.8.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.25.8.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.25.12.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.25.12.linux-amd64.tar.gz
 
 # MacOS
-curl -O https://go.dev/dl/go1.25.8.darwin-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.25.8.darwin-amd64.tar.gz
+curl -O https://go.dev/dl/go1.25.12.darwin-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.25.12.darwin-amd64.tar.gz
 
 
 export PATH=$PATH:/usr/local/go/bin

--- a/deployments/integration-test.Dockerfile
+++ b/deployments/integration-test.Dockerfile
@@ -29,7 +29,7 @@ RUN ./download-integration-test-binaries.sh $BRANCH $COMMUNITY $VERSION $OS $ARC
 RUN ls ./bin
 
 # Download go into /usr/local dir.
-ENV GOLANG_VERSION 1.25.8
+ENV GOLANG_VERSION 1.25.12
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \

--- a/deployments/next-gen-local-integration-test.Dockerfile
+++ b/deployments/next-gen-local-integration-test.Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /root/download
 #RUN ls ./bin
 
 # Download go into /usr/local dir.
-ENV GOLANG_VERSION 1.25.8
+ENV GOLANG_VERSION 1.25.12
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/ticdc
 
-go 1.25.10
+go 1.25.12
 
 require (
 	cloud.google.com/go/kms v1.21.0

--- a/tests/integration_tests/debezium01/go.mod
+++ b/tests/integration_tests/debezium01/go.mod
@@ -1,6 +1,6 @@
 module github.com/breezewish/checker
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/tools/check/go.mod
+++ b/tools/check/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-cdc/_tools
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0

--- a/tools/workload/go.mod
+++ b/tools/workload/go.mod
@@ -1,6 +1,6 @@
 module workload
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5799

TiCDC's Go patch-version declarations are split between 1.25.8 and 1.25.10. They need to use the latest Go 1.25 patch release consistently.

### What is changed and how it works?

Update the root and auxiliary module `go` directives, integration-test Docker download versions, and README installation commands to Go 1.25.12.

Patchless Go 1.25 base-image tags and application dependencies are unchanged.

### Check List

#### Tests

- No code
  - `go mod tidy -diff` in every changed module
  - `make cdc`

#### Questions

##### Will it cause performance regression or break compatibility?

No performance regression is expected. The minimum Go patch version used to build TiCDC becomes 1.25.12.

##### Do you need to update user documentation, design documentation or monitoring documentation?

The README installation commands are updated. No design or monitoring documentation changes are needed.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated source-build instructions to use Go 1.25.12 on Linux and macOS.

* **Chores**
  * Updated project and tooling environments to use Go 1.25.12.
  * Integration-test container builds now install Go 1.25.12 for improved toolchain consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->