### PR TITLE
tests: isolate TiDB slow-query logs in next-gen tests

### DIFF
--- a/tests/integration_tests/_utils/start_tidb_cluster_nextgen
+++ b/tests/integration_tests/_utils/start_tidb_cluster_nextgen
@@ -612,6 +612,7 @@ tidb-server \
 	--path "${UP_PD_HOST_1}:${UP_PD_PORT_1}" \
 	--status "${UP_TIDB_SYSTEM_STATUS}" \
 	--log-file "$OUT_DIR/log/upstream/tidb-system/tidb.log" \
+	--log-slow-query "$OUT_DIR/log/upstream/tidb-system/tidb-slow.log" \
 	>"$OUT_DIR/log/upstream/tidb-system/tidb-stdout.log" \
 	2>"$OUT_DIR/log/upstream/tidb-system/tidb-stderr.log" &
 
@@ -629,6 +630,7 @@ tidb-server \
 	--path "${UP_PD_HOST_1}:${UP_PD_PORT_1}" \
 	--status "${UP_TIDB_STATUS}" \
 	--log-file "$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME/tidb.log" \
+	--log-slow-query "$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME/tidb-slow.log" \
 	>"$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME/tidb-stdout.log" \
 	2>"$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME/tidb-stderr.log" &
 
@@ -641,6 +643,7 @@ tidb-server \
 	--path "${UP_PD_HOST_1}:${UP_PD_PORT_1}" \
 	--status "${UP_TIDB_OTHER_STATUS}" \
 	--log-file "$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME-other/tidb.log" \
+	--log-slow-query "$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME-other/tidb-slow.log" \
 	>"$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME-other/tidb-stdout.log" \
 	2>"$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME-other/tidb-stderr.log" &
 
@@ -655,6 +658,7 @@ tidb-server \
 	--path "${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
 	--status "${DOWN_TIDB_SYSTEM_STATUS}" \
 	--log-file "$OUT_DIR/log/downstream/tidb-system/tidb.log" \
+	--log-slow-query "$OUT_DIR/log/downstream/tidb-system/tidb-slow.log" \
 	>"$OUT_DIR/log/downstream/tidb-system/tidb-stdout.log" \
 	2>"$OUT_DIR/log/downstream/tidb-system/tidb-stderr.log" &
 
@@ -672,6 +676,7 @@ tidb-server \
 	--path "${DOWN_PD_HOST}:${DOWN_PD_PORT}" \
 	--status "${DOWN_TIDB_STATUS}" \
 	--log-file "$OUT_DIR/log/downstream/tidb-$KEYSPACE_NAME/tidb.log" \
+	--log-slow-query "$OUT_DIR/log/downstream/tidb-$KEYSPACE_NAME/tidb-slow.log" \
 	>"$OUT_DIR/log/downstream/tidb-$KEYSPACE_NAME/tidb-stdout.log" \
 	2>"$OUT_DIR/log/downstream/tidb-$KEYSPACE_NAME/tidb-stderr.log" &
 

--- a/tests/integration_tests/_utils/start_tidb_cluster_nextgen_test.go
+++ b/tests/integration_tests/_utils/start_tidb_cluster_nextgen_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTiDBServersUseUniqueSlowQueryLogs(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	scriptPath := filepath.Join(filepath.Dir(currentFile), "start_tidb_cluster_nextgen")
+	content, err := os.ReadFile(scriptPath)
+	require.NoError(t, err)
+
+	lines := strings.Split(string(content), "\n")
+	commands := make([]string, 0, 5)
+	for i := 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != `tidb-server \` {
+			continue
+		}
+
+		var command strings.Builder
+		for ; i < len(lines); i++ {
+			command.WriteString(lines[i])
+			command.WriteByte('\n')
+			if strings.HasSuffix(strings.TrimSpace(lines[i]), "&") {
+				break
+			}
+		}
+		commands = append(commands, command.String())
+	}
+	require.Len(t, commands, 5)
+
+	slowQueryLogPattern := regexp.MustCompile(`--log-slow-query\s+"([^"]+)"`)
+	slowQueryLogs := make(map[string]struct{}, len(commands))
+	for _, command := range commands {
+		matches := slowQueryLogPattern.FindStringSubmatch(command)
+		require.Len(t, matches, 2, "TiDB command must configure a slow-query log:\n%s", command)
+		slowQueryLogs[matches[1]] = struct{}{}
+	}
+	require.Len(t, slowQueryLogs, len(commands), "each TiDB server must use a unique slow-query log")
+	require.Equal(t, map[string]struct{}{
+		"$OUT_DIR/log/upstream/tidb-system/tidb-slow.log":               {},
+		"$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME/tidb-slow.log":       {},
+		"$OUT_DIR/log/upstream/tidb-$KEYSPACE_NAME-other/tidb-slow.log": {},
+		"$OUT_DIR/log/downstream/tidb-system/tidb-slow.log":             {},
+		"$OUT_DIR/log/downstream/tidb-$KEYSPACE_NAME/tidb-slow.log":     {},
+	}, slowQueryLogs)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5814

The next-gen storage integration pipeline starts five TiDB processes in
parallel. Without explicit slow-query log paths, they all initialize the
default `tidb-slow.log`, which can make one process exit before TiCDC starts.

### What is changed and how it works?

- Configure every next-gen TiDB process with a slow-query log in its own log
  directory.
- Add a regression test that verifies all five startup commands use the
  expected distinct paths.

### Check List

#### Tests

- Unit test
- Manual test:
  - `go test ./tests/integration_tests/_utils -count=1`
  - `bash -n tests/integration_tests/_utils/start_tidb_cluster_nextgen`
  - `make check`

#### Questions

##### Will it cause performance regression or break compatibility?

No. The change only isolates TiDB slow-query log files in the integration test
environment.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * TiDB instances now record slow queries in dedicated log files, making performance troubleshooting easier.
  * Separate logs are maintained for upstream and downstream instances, including their different keyspaces.

* **Tests**
  * Added coverage to verify that all TiDB instances use configured and unique slow-query log paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->