### PR TITLE
logpuller: remove unnecessary event buffering

### DIFF
--- a/logservice/logpuller/region_event_sink.go
+++ b/logservice/logpuller/region_event_sink.go
@@ -39,9 +39,6 @@ func newRegionEventSink(
 	option := dynstream.NewOption()
 	// Note: it is max batch size of the kv sent from tikv(not committed rows)
 	option.BatchCount = 1024
-	// TODO: Set `UseBuffer` to true until we refactor the `regionEventHandler.Handle` method so that it doesn't call any method of the dynamic stream. Currently, if `UseBuffer` is set to false, there will be a deadlock:
-	// 	ds.handleLoop fetch events from `ch` -> regionEventHandler.Handle -> ds.RemovePath -> send event to `ch`
-	option.UseBuffer = true
 	ds := dynstream.NewParallelDynamicStream(
 		"log-puller",
 		&regionEventHandler{eventSink: sink, failureHandler: failureHandler},

--- a/logservice/logpuller/region_failure_handler.go
+++ b/logservice/logpuller/region_failure_handler.go
@@ -216,7 +216,8 @@ func (r *regionFailureHandler) Report(errInfo regionErrorInfo) {
 	if errInfo.subscribedSpan.rangeLock.UnlockRange(
 		errInfo.span.StartKey, errInfo.span.EndKey,
 		errInfo.verID.GetID(), errInfo.verID.GetVer(), errInfo.resolvedTs()) {
-		r.onTableDrained(errInfo.subscribedSpan)
+		// Defer span cleanup to Run so Report never calls back into dynstream.
+		r.cache.addDrainedSpan(errInfo.subscribedSpan)
 		return
 	}
 	r.cache.add(errInfo)
@@ -228,6 +229,9 @@ func (r *regionFailureHandler) Run(ctx context.Context) error {
 	defer r.cancelRecoveries()
 
 	handleCachedErrors := func() error {
+		for _, span := range r.cache.popDrainedSpans() {
+			r.onTableDrained(span)
+		}
 		for {
 			batch := r.cache.popBatch(errCacheBatchSize)
 			for _, errInfo := range batch {
@@ -405,8 +409,9 @@ func (r *regionFailureHandler) handleError(ctx context.Context, errInfo regionEr
 
 type errCache struct {
 	sync.Mutex
-	cache  []regionErrorInfo
-	notify chan struct{}
+	cache        []regionErrorInfo
+	drainedSpans []*subscribedSpan
+	notify       chan struct{}
 }
 
 const errCacheBatchSize = 1024
@@ -422,10 +427,29 @@ func (e *errCache) add(errInfo regionErrorInfo) {
 	e.Lock()
 	defer e.Unlock()
 	e.cache = append(e.cache, errInfo)
+	e.signal()
+}
+
+func (e *errCache) addDrainedSpan(span *subscribedSpan) {
+	e.Lock()
+	defer e.Unlock()
+	e.drainedSpans = append(e.drainedSpans, span)
+	e.signal()
+}
+
+func (e *errCache) signal() {
 	select {
 	case e.notify <- struct{}{}:
 	default:
 	}
+}
+
+func (e *errCache) popDrainedSpans() []*subscribedSpan {
+	e.Lock()
+	defer e.Unlock()
+	drainedSpans := e.drainedSpans
+	e.drainedSpans = nil
+	return drainedSpans
 }
 
 func (e *errCache) popBatch(limit int) []regionErrorInfo {

--- a/logservice/logpuller/region_request_scheduler_test.go
+++ b/logservice/logpuller/region_request_scheduler_test.go
@@ -211,6 +211,10 @@ func TestRegionRequestSchedulerSkipsStoppedSubscriptionBeforeCreatingStore(t *te
 	handler := newRegionFailureHandler(nil, func(rt *subscribedSpan) {
 		drainedCh <- rt
 	}, nil, nil)
+	handlerErrCh := make(chan error, 1)
+	go func() {
+		handlerErrCh <- handler.Run(ctx)
+	}()
 	scheduler := &regionRequestScheduler{
 		upstream: &upstreamHandle{
 			pd:          pdClient,
@@ -248,4 +252,5 @@ func TestRegionRequestSchedulerSkipsStoppedSubscriptionBeforeCreatingStore(t *te
 
 	cancel()
 	require.ErrorIs(t, <-errCh, context.Canceled)
+	require.ErrorIs(t, <-handlerErrCh, context.Canceled)
 }

--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -393,7 +393,25 @@ func TestRegionFailureHandlerQueuesCanceledError(t *testing.T) {
 	}, &requestCancelledErr{}))
 
 	require.Len(t, client.failureHandler.cache.cache, 1)
-	require.Nil(t, client.spanRegistry.Get(span.subID))
+	require.Same(t, span, client.spanRegistry.Get(span.subID))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- client.failureHandler.Run(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return client.spanRegistry.Get(span.subID) == nil
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+	select {
+	case err := <-runDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("failure handler did not exit after context cancellation")
+	}
 }
 
 type mockDynamicStream struct{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6021

### What is changed and how it works?

Removes unnecessary buffering in the log puller. Span cleanup is moved from the dynamic-stream event handler to the failure handler’s run loop, avoiding re-entrant calls and potential deadlocks. Tests are updated for the asynchronous cleanup flow.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

1000K table scenario, the optimized version achieved:

  - 3.5% lower CPU usage: 33.69 → 32.52 cores
  - 2.5% lower RSS memory: 56.66 → 55.24 GiB
  - 4.4% lower Go heap: 43.91 → 42.00 GiB
  - 10.9% lower allocation rate: 2.13 → 1.90 GiB/s
  - 9.1% lower GC CPU: 5.62 → 5.10 cores

master verion
<img width="1230" height="223" alt="image" src="https://github.com/user-attachments/assets/194cba18-7829-413d-b29b-6f1ef7820f7a" />
<img width="1231" height="324" alt="image" src="https://github.com/user-attachments/assets/977654c2-330c-47fa-a37c-5ab2c57ea5d6" />
<img width="1223" height="331" alt="image" src="https://github.com/user-attachments/assets/451fb3c1-1e2f-4397-9143-9d35c16cb86c" />


this pr:
<img width="1233" height="217" alt="image" src="https://github.com/user-attachments/assets/f8164d62-8a0f-4946-89bb-9117f82a9016" />
<img width="1230" height="339" alt="image" src="https://github.com/user-attachments/assets/b63465db-33da-4683-9719-c18799339f28" />
<img width="1233" height="342" alt="image" src="https://github.com/user-attachments/assets/423035a4-7b8b-4c56-8dfd-d0ce362eeafb" />


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region failure handling by queuing drain callbacks for safe asynchronous processing.
  * Ensured failed spans are removed reliably after error reporting.
  * Maintained stable stream behavior with default buffering.

* **Tests**
  * Added coverage for asynchronous failure handling and graceful shutdown.
  * Updated scheduler tests to verify clean termination when canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->