### PR TITLE
schemastore: skip filtered LIKE source tables in create-table barrier

### DIFF
--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -2098,7 +2098,7 @@ func buildDDLEventForNewTableDDL(rawEvent *PersistedDDLEvent, tableFilter filter
 		InfluenceType: commonEvent.InfluenceTypeNormal,
 		TableIDs:      []int64{common.DDLSpanTableID},
 	}
-	if rawEvent.ExtraTableID != 0 {
+	if shouldBlockCreateTableLikeReferTable(rawEvent, tableFilter) {
 		if len(rawEvent.ReferTablePartitionIDs) > 0 {
 			ddlEvent.BlockedTables.TableIDs = append(ddlEvent.BlockedTables.TableIDs, rawEvent.ReferTablePartitionIDs...)
 		} else {
@@ -2163,6 +2163,37 @@ func buildDDLEventForNewTableDDL(rawEvent *PersistedDDLEvent, tableFilter filter
 
 	}
 	return ddlEvent, true, err
+}
+
+func shouldBlockCreateTableLikeReferTable(rawEvent *PersistedDDLEvent, tableFilter filter.Filter) bool {
+	if rawEvent.ExtraTableID == 0 {
+		return false
+	}
+	if tableFilter == nil || rawEvent.Query == "" {
+		return true
+	}
+
+	stmt, err := parser.New().ParseOneStmt(rawEvent.Query, "", "")
+	if err != nil {
+		log.Warn("parse create table ddl failed when checking create table like reference filter",
+			zap.String("query", rawEvent.Query),
+			zap.Error(err))
+		return true
+	}
+	createStmt, ok := stmt.(*ast.CreateTableStmt)
+	if !ok || createStmt.ReferTable == nil {
+		return true
+	}
+
+	referSchema := createStmt.ReferTable.Schema.O
+	if referSchema == "" {
+		referSchema = rawEvent.SchemaName
+	}
+	referTable := createStmt.ReferTable.Name.O
+	if referTable == "" {
+		return true
+	}
+	return !tableFilter.ShouldIgnoreTable(referSchema, referTable)
 }
 
 func buildDDLEventForDropTable(rawEvent *PersistedDDLEvent, tableFilter filter.Filter, tableID int64) (commonEvent.DDLEvent, bool, error) {

--- a/logservice/schemastore/persist_storage_test.go
+++ b/logservice/schemastore/persist_storage_test.go
@@ -4002,6 +4002,35 @@ func TestBuildDDLEventForNewTableDDL_CreateTableLikeBlockedTables(t *testing.T) 
 	require.ElementsMatch(t, []int64{common.DDLSpanTableID, 111, 112}, ddlEvent.BlockedTables.TableIDs)
 }
 
+func TestBuildDDLEventForNewTableDDL_CreateTableLikeBlockedTablesRespectFilter(t *testing.T) {
+	rawEvent := &PersistedDDLEvent{
+		Type:         byte(model.ActionCreateTable),
+		SchemaID:     1,
+		TableID:      2,
+		SchemaName:   "test",
+		TableName:    "t_new",
+		Query:        "CREATE TABLE `t_new` LIKE `t_ref`",
+		TableInfo:    newEligibleTableInfoForTest(2, "t_new"),
+		ExtraTableID: 101,
+	}
+
+	ddlEvent, ok, err := buildDDLEventForNewTableDDL(rawEvent, buildTableFilterByNameForTest("test", "t_new"), 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.ElementsMatch(t, []int64{common.DDLSpanTableID}, ddlEvent.BlockedTables.TableIDs)
+
+	rawEvent.ReferTablePartitionIDs = []int64{111, 112}
+	ddlEvent, ok, err = buildDDLEventForNewTableDDL(rawEvent, buildTableFilterByNameForTest("test", "t_new"), 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.ElementsMatch(t, []int64{common.DDLSpanTableID}, ddlEvent.BlockedTables.TableIDs)
+
+	ddlEvent, ok, err = buildDDLEventForNewTableDDL(rawEvent, buildTableFilterByNameForTest("test", "t_ref"), 0)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, ddlEvent.BlockedTables)
+}
+
 func TestUpdateDDLHistoryForAddDropTable_CreateTableLikeAddsReferTable(t *testing.T) {
 	args := updateDDLHistoryFuncArgs{
 		ddlEvent: &PersistedDDLEvent{

--- a/tests/integration_tests/event_filter/conf/diff_config.toml
+++ b/tests/integration_tests/event_filter/conf/diff_config.toml
@@ -13,7 +13,7 @@ source-instances = ["tidb0"]
 
 target-instance = "mysql1"
 
-target-check-tables = ["event_filter.t_normal", "event_filter.t_truncate", "event_filter.t_alter", "event_filter.t_name*", "event_filter.t_rename*", "event_filter.t_create"]
+target-check-tables = ["event_filter.t_normal", "event_filter.t_truncate", "event_filter.t_alter", "event_filter.t_name*", "event_filter.t_rename*", "event_filter.t_create", "event_filter.t_like_from_filtered"]
 
 [data-sources]
 [data-sources.tidb0]

--- a/tests/integration_tests/event_filter/data/test.sql
+++ b/tests/integration_tests/event_filter/data/test.sql
@@ -143,3 +143,13 @@ CREATE TABLE t_rename4 (
 );
 
 CREATE TABLE t_create (id INT PRIMARY KEY, val INT);
+
+CREATE DATABASE filtered_like_src;
+CREATE TABLE filtered_like_src.t_src_like (
+  id INT PRIMARY KEY,
+  val INT
+);
+INSERT INTO filtered_like_src.t_src_like VALUES (1, 100);
+
+CREATE TABLE event_filter.t_like_from_filtered LIKE filtered_like_src.t_src_like;
+INSERT INTO event_filter.t_like_from_filtered VALUES (1, 200);

--- a/tests/integration_tests/event_filter/run.sh
+++ b/tests/integration_tests/event_filter/run.sh
@@ -35,6 +35,11 @@ function run() {
 	pulsar) run_pulsar_consumer --upstream-uri $SINK_URI --config "$CUR/conf/cf.toml" ;;
 	esac
 
+	# CDC forwards CREATE TABLE ... LIKE ... as-is, so the downstream must have the
+	# referenced table available for the DDL to succeed.
+	run_sql "CREATE DATABASE IF NOT EXISTS filtered_like_src;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	run_sql "CREATE TABLE IF NOT EXISTS filtered_like_src.t_src_like (id INT PRIMARY KEY, val INT);" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+
 	run_sql_file $CUR/data/test.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
 	# make suer table t1 is deleted in upstream and exists in downstream
@@ -49,7 +54,6 @@ function run() {
 	check_table_exists "event_filter.t_name3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists "event_filter.t_virtual" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists "event_filter.t_like_from_filtered" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-	check_table_not_exists "filtered_like_src.t_src_like" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	sleep 20
 
 	# check those rows that are not filtered are synced to downstream

--- a/tests/integration_tests/event_filter/run.sh
+++ b/tests/integration_tests/event_filter/run.sh
@@ -48,6 +48,8 @@ function run() {
 	check_table_exists "event_filter.t_name2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists "event_filter.t_name3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists "event_filter.t_virtual" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_table_exists "event_filter.t_like_from_filtered" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_table_not_exists "filtered_like_src.t_src_like" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	sleep 20
 
 	# check those rows that are not filtered are synced to downstream
@@ -91,6 +93,12 @@ function run() {
 	# Verify that rows with is_discounted=true are filtered
 	run_sql "select count(1) from event_filter.t_virtual where quantity > 10;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_contains "count(1): 0" # All discounted items should be filtered
+
+	run_sql "select count(1) from event_filter.t_like_from_filtered;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_contains "count(1): 1"
+
+	run_sql "select count(1) from event_filter.t_like_from_filtered where id=1 and val=200;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_contains "count(1): 1"
 
 	run_sql "TRUNCATE TABLE event_filter.t_truncate;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	run_sql_file $CUR/data/test_truncate.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5150 

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event filtering for tables created with `CREATE TABLE ... LIKE`.
  * Prevents referenced source tables from being replicated when excluded by filtering.
  * Preserves correct blocking behavior for invalid or incomplete `CREATE TABLE ... LIKE` statements.
  * Ensures filtered source tables do not affect replication of newly created tables.

* **Tests**
  * Added coverage confirming the new table and expected data are replicated correctly while excluded source tables remain absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->