### PR TITLE
eventstore: isolate tableStats by keyspace

### DIFF
--- a/heartbeatpb/table_span.go
+++ b/heartbeatpb/table_span.go
@@ -17,13 +17,16 @@ import "bytes"
 
 // Less compares two Spans, defines the order between spans.
 func (s *TableSpan) Less(other *TableSpan) bool {
-	if s.TableID < other.TableID {
-		return true
+	if s.KeyspaceID != other.KeyspaceID {
+		return s.KeyspaceID < other.KeyspaceID
 	}
-	if bytes.Compare(s.StartKey, other.StartKey) < 0 {
-		return true
+	if s.TableID != other.TableID {
+		return s.TableID < other.TableID
 	}
-	return false
+	if cmp := bytes.Compare(s.StartKey, other.StartKey); cmp != 0 {
+		return cmp < 0
+	}
+	return bytes.Compare(s.EndKey, other.EndKey) < 0
 }
 
 func (s *TableSpan) Equal(other *TableSpan) bool {

--- a/heartbeatpb/table_span_test.go
+++ b/heartbeatpb/table_span_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heartbeatpb
+
+import "testing"
+
+import "github.com/stretchr/testify/require"
+
+func TestTableSpanLess(t *testing.T) {
+	t.Parallel()
+
+	base := &TableSpan{
+		KeyspaceID: 1,
+		TableID:    10,
+		StartKey:   []byte("a"),
+		EndKey:     []byte("b"),
+	}
+
+	require.True(t, (&TableSpan{KeyspaceID: 0, TableID: 10, StartKey: []byte("a"), EndKey: []byte("b")}).Less(base))
+	require.True(t, (&TableSpan{KeyspaceID: 1, TableID: 9, StartKey: []byte("a"), EndKey: []byte("b")}).Less(base))
+	require.True(t, (&TableSpan{KeyspaceID: 1, TableID: 10, StartKey: []byte("a"), EndKey: []byte("a")}).Less(base))
+	require.True(t, (&TableSpan{KeyspaceID: 1, TableID: 10, StartKey: []byte("0"), EndKey: []byte("z")}).Less(base))
+
+	require.False(t, base.Less(&TableSpan{
+		KeyspaceID: 1,
+		TableID:    10,
+		StartKey:   []byte("a"),
+		EndKey:     []byte("b"),
+	}))
+	require.False(t, base.Less(&TableSpan{
+		KeyspaceID: 0,
+		TableID:    10,
+		StartKey:   []byte("a"),
+		EndKey:     []byte("b"),
+	}))
+	require.False(t, base.Less(&TableSpan{
+		KeyspaceID: 1,
+		TableID:    10,
+		StartKey:   []byte("a"),
+		EndKey:     []byte("a"),
+	}))
+}

--- a/heartbeatpb/table_span_test.go
+++ b/heartbeatpb/table_span_test.go
@@ -13,9 +13,11 @@
 
 package heartbeatpb
 
-import "testing"
+import (
+	"testing"
 
-import "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
+)
 
 func TestTableSpanLess(t *testing.T) {
 	t.Parallel()

--- a/logservice/coordinator/coordinator.go
+++ b/logservice/coordinator/coordinator.go
@@ -381,10 +381,14 @@ func (c *logCoordinator) getCandidateNodes(requestNodeID node.ID, span *heartbea
 		found := false
 		for _, subsState := range subStates.GetSubscriptions() {
 			// Only consider subscriptions which meet the following conditions:
-			// 1. subscription's span covers the requested span
-			// 2. subscription's checkpointTs <= request startTs
-			// 3. subscription's checkpointTs < resolvedTs (meaning the subscription has finished incremental scan)
-			if bytes.Compare(subsState.Span.StartKey, span.StartKey) <= 0 &&
+			// 1. subscription belongs to the requested keyspace
+			// 2. subscription's span covers the requested span
+			// 3. subscription's checkpointTs <= request startTs
+			// 4. subscription's checkpointTs < resolvedTs (meaning the subscription has finished incremental scan)
+			// Spans from different keyspaces normally have different encoded key ranges. Check KeyspaceID
+			// explicitly because TableStates is grouped only by TableID and isolation should not rely on key encoding.
+			if subsState.Span.KeyspaceID == span.KeyspaceID &&
+				bytes.Compare(subsState.Span.StartKey, span.StartKey) <= 0 &&
 				bytes.Compare(span.EndKey, subsState.Span.EndKey) <= 0 &&
 				subsState.CheckpointTs <= startTs &&
 				subsState.CheckpointTs < subsState.ResolvedTs {

--- a/logservice/coordinator/coordinator_test.go
+++ b/logservice/coordinator/coordinator_test.go
@@ -204,6 +204,40 @@ func TestGetCandidateNodes(t *testing.T) {
 	}
 }
 
+func TestGetCandidateNodesIgnoreDifferentKeyspace(t *testing.T) {
+	coordinator := newLogCoordinatorForTest()
+
+	requestNodeID := node.ID("request-node")
+	candidateNodeID := node.ID("candidate-node")
+	coordinator.nodes.m[requestNodeID] = &node.Info{ID: requestNodeID}
+	coordinator.nodes.m[candidateNodeID] = &node.Info{ID: candidateNodeID}
+
+	// Different keyspaces normally produce different encoded keys. Keep the key range identical here
+	// to verify that candidate selection explicitly isolates subscriptions by KeyspaceID.
+	requestedSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, 100)
+	requestedSpan.KeyspaceID = 1
+	otherKeyspaceSpan := requestedSpan
+	otherKeyspaceSpan.KeyspaceID = 2
+
+	coordinator.updateEventStoreState(candidateNodeID, &logservicepb.EventStoreState{
+		TableStates: map[int64]*logservicepb.TableState{
+			requestedSpan.TableID: {
+				Subscriptions: []*logservicepb.SubscriptionState{
+					{
+						SubID:        1,
+						Span:         &otherKeyspaceSpan,
+						CheckpointTs: 100,
+						ResolvedTs:   200,
+					},
+				},
+			},
+		},
+	})
+
+	nodes := coordinator.getCandidateNodes(requestNodeID, &requestedSpan, 100)
+	require.Empty(t, nodes)
+}
+
 func TestGetCandidateNodesIgnoreResolvedEqCheckpoint(t *testing.T) {
 	coordinator := newLogCoordinatorForTest()
 

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -198,6 +198,18 @@ type subscriptionStat struct {
 
 type subscriptionStats map[logpuller.SubscriptionID]*subscriptionStat
 
+type tableStatsKey struct {
+	keyspaceID uint32
+	tableID    int64
+}
+
+func newTableStatsKey(span *heartbeatpb.TableSpan) tableStatsKey {
+	return tableStatsKey{
+		keyspaceID: span.KeyspaceID,
+		tableID:    span.TableID,
+	}
+}
+
 type eventWithCallback struct {
 	subID      logpuller.SubscriptionID
 	tableID    int64
@@ -245,8 +257,8 @@ type eventStore struct {
 		sync.RWMutex
 		// dispatcher id -> dispatcher stat
 		dispatcherStats map[common.DispatcherID]*dispatcherStat
-		// table id -> subscription stats
-		tableStats map[int64]subscriptionStats
+		// (keyspace id, table id) -> subscription stats
+		tableStats map[tableStatsKey]subscriptionStats
 	}
 
 	decoderPool *sync.Pool
@@ -317,7 +329,7 @@ func New(
 		store.writeTaskPools = append(store.writeTaskPools, newWriteTaskPool(store, store.dbs[i], i, store.chs[i], writeWorkerNumPerDB))
 	}
 	store.dispatcherMeta.dispatcherStats = make(map[common.DispatcherID]*dispatcherStat)
-	store.dispatcherMeta.tableStats = make(map[int64]subscriptionStats)
+	store.dispatcherMeta.tableStats = make(map[tableStatsKey]subscriptionStats)
 
 	store.messageCenter.RegisterHandler(messaging.EventStoreTopic, store.handleMessage)
 	return store
@@ -534,7 +546,8 @@ func (e *eventStore) RegisterDispatcher(
 	if enableDataSharing {
 		e.dispatcherMeta.Lock()
 		var bestMatch *subscriptionStat
-		if subStats, ok := e.dispatcherMeta.tableStats[dispatcherSpan.TableID]; ok {
+		tableKey := newTableStatsKey(dispatcherSpan)
+		if subStats, ok := e.dispatcherMeta.tableStats[tableKey]; ok {
 			for _, subStat := range subStats {
 				// Check if this subStat's span contains the dispatcherSpan
 				if bytes.Compare(subStat.tableSpan.StartKey, dispatcherSpan.StartKey) <= 0 &&
@@ -628,11 +641,12 @@ func (e *eventStore) RegisterDispatcher(
 	}
 
 	e.dispatcherMeta.Lock()
+	tableKey := newTableStatsKey(dispatcherSpan)
 	e.dispatcherMeta.dispatcherStats[dispatcherID] = stat
-	if len(e.dispatcherMeta.tableStats[dispatcherSpan.TableID]) == 0 {
-		e.dispatcherMeta.tableStats[dispatcherSpan.TableID] = make(subscriptionStats)
+	if len(e.dispatcherMeta.tableStats[tableKey]) == 0 {
+		e.dispatcherMeta.tableStats[tableKey] = make(subscriptionStats)
 	}
-	e.dispatcherMeta.tableStats[dispatcherSpan.TableID][subStat.subID] = subStat
+	e.dispatcherMeta.tableStats[tableKey][subStat.subID] = subStat
 	e.dispatcherMeta.Unlock()
 
 	consumeKVEvents := func(kvs []common.RawKVEntry, finishCallback func()) bool {
@@ -1110,7 +1124,6 @@ func (e *eventStore) cleanObsoleteSubscriptions(ctx context.Context) error {
 func (e *eventStore) cleanObsoleteSubscriptionsOnce(deltaMs int64) {
 	type obsoleteSubscription struct {
 		subID   logpuller.SubscriptionID
-		tableID int64
 		dbIndex int
 		span    *heartbeatpb.TableSpan
 		idleAt  time.Time
@@ -1119,7 +1132,7 @@ func (e *eventStore) cleanObsoleteSubscriptionsOnce(deltaMs int64) {
 	obsoleteSubs := make([]obsoleteSubscription, 0)
 
 	e.dispatcherMeta.Lock()
-	for tableID, subStats := range e.dispatcherMeta.tableStats {
+	for tableKey, subStats := range e.dispatcherMeta.tableStats {
 		for subID, subStat := range subStats {
 			subData := subStat.subscribers.Load()
 			if subData == nil || len(subData.subscribers) != 0 || subData.idleTime <= 0 {
@@ -1140,7 +1153,6 @@ func (e *eventStore) cleanObsoleteSubscriptionsOnce(deltaMs int64) {
 
 			obsoleteSubs = append(obsoleteSubs, obsoleteSubscription{
 				subID:   subID,
-				tableID: tableID,
 				dbIndex: subStat.dbIndex,
 				span:    subStat.tableSpan,
 				idleAt:  time.UnixMilli(subData.idleTime).In(time.Local),
@@ -1148,7 +1160,7 @@ func (e *eventStore) cleanObsoleteSubscriptionsOnce(deltaMs int64) {
 			delete(subStats, subID)
 		}
 		if len(subStats) == 0 {
-			delete(e.dispatcherMeta.tableStats, tableID)
+			delete(e.dispatcherMeta.tableStats, tableKey)
 		}
 	}
 	e.dispatcherMeta.Unlock()
@@ -1157,11 +1169,11 @@ func (e *eventStore) cleanObsoleteSubscriptionsOnce(deltaMs int64) {
 		log.Info("clean obsolete subscription",
 			zap.Uint64("subscriptionID", uint64(sub.subID)),
 			zap.Int("dbIndex", sub.dbIndex),
-			zap.Int64("tableID", sub.tableID),
+			zap.Int64("tableID", sub.span.TableID),
 			zap.Time("idleAt", sub.idleAt))
 		e.subClient.Unsubscribe(sub.subID)
 		db := e.dbs[sub.dbIndex]
-		if err := deleteDataRange(db, uint64(sub.subID), sub.tableID, 0, math.MaxUint64); err != nil {
+		if err := deleteDataRange(db, uint64(sub.subID), sub.span.TableID, 0, math.MaxUint64); err != nil {
 			log.Warn("fail to delete events", zap.Error(err))
 		}
 		e.subscriptionChangeCh.In() <- SubscriptionChange{

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -183,6 +183,13 @@ func setZstdCompressionForTest(t *testing.T, enable bool) func() {
 	}
 }
 
+func getTableStatsForTest(es *eventStore, keyspaceID uint32, tableID int64) subscriptionStats {
+	return es.dispatcherMeta.tableStats[tableStatsKey{
+		keyspaceID: keyspaceID,
+		tableID:    tableID,
+	}]
+}
+
 func TestEventStoreInteractionWithSubClient(t *testing.T) {
 	restoreCfg := setDataSharingForTest(t, true)
 	defer restoreCfg()
@@ -423,10 +430,61 @@ func TestEventStoreHandlesUnencryptedValuesFromEncryptionLayer(t *testing.T) {
 
 func markSubStatsInitializedForTest(store EventStore, tableID int64) {
 	es := store.(*eventStore)
-	subStats := es.dispatcherMeta.tableStats[tableID]
+	subStats := getTableStatsForTest(es, 0, tableID)
 	for _, subStat := range subStats {
 		subStat.initialized.Store(true)
 	}
+}
+
+func TestEventStoreTableStatsAreKeyspaceAware(t *testing.T) {
+	restoreCfg := setDataSharingForTest(t, true)
+	defer restoreCfg()
+
+	subClient, store := newEventStoreForTest(t.TempDir())
+	es := store.(*eventStore)
+
+	dispatcherID1 := common.NewDispatcherID()
+	dispatcherID2 := common.NewDispatcherID()
+	tableID := int64(1)
+	cfID := common.NewChangefeedID4Test("default", "test-cf")
+
+	span1 := &heartbeatpb.TableSpan{
+		TableID:    tableID,
+		StartKey:   []byte("a"),
+		EndKey:     []byte("z"),
+		KeyspaceID: 1,
+	}
+	span2 := &heartbeatpb.TableSpan{
+		TableID:    tableID,
+		StartKey:   []byte("a"),
+		EndKey:     []byte("z"),
+		KeyspaceID: 2,
+	}
+
+	require.True(t, store.RegisterDispatcher(cfID, dispatcherID1, span1, 100, func(uint64, uint64) {}, false, false))
+	require.True(t, store.RegisterDispatcher(cfID, dispatcherID2, span2, 100, func(uint64, uint64) {}, false, false))
+
+	mockSubClient := subClient.(*mockSubscriptionClient)
+	mockSubClient.mu.Lock()
+	require.Len(t, mockSubClient.subscriptions, 2)
+	mockSubClient.mu.Unlock()
+
+	es.dispatcherMeta.RLock()
+	subStats1 := getTableStatsForTest(es, span1.KeyspaceID, tableID)
+	subStats2 := getTableStatsForTest(es, span2.KeyspaceID, tableID)
+	require.Len(t, subStats1, 1)
+	require.Len(t, subStats2, 1)
+
+	dispatcherStat1 := es.dispatcherMeta.dispatcherStats[dispatcherID1]
+	dispatcherStat2 := es.dispatcherMeta.dispatcherStats[dispatcherID2]
+	require.NotNil(t, dispatcherStat1.subStat)
+	require.NotNil(t, dispatcherStat2.subStat)
+	require.Nil(t, dispatcherStat1.pendingSubStat)
+	require.Nil(t, dispatcherStat2.pendingSubStat)
+	require.Equal(t, span1.KeyspaceID, dispatcherStat1.subStat.tableSpan.KeyspaceID)
+	require.Equal(t, span2.KeyspaceID, dispatcherStat2.subStat.tableSpan.KeyspaceID)
+	require.NotEqual(t, dispatcherStat1.subStat.subID, dispatcherStat2.subStat.subID)
+	es.dispatcherMeta.RUnlock()
 }
 
 func TestEventStoreOnlyReuseDispatcher(t *testing.T) {
@@ -484,7 +542,7 @@ func TestEventStoreOnlyReuseDispatcher(t *testing.T) {
 	}
 	{
 		store.UnregisterDispatcher(cfID, dispatcherID1)
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		require.Equal(t, 1, len(subStats))
 		// because there is only one subStat, we know its subID is 1
 		subStat := subStats[logpuller.SubscriptionID(1)]
@@ -585,7 +643,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 	}
 	// do some check
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		// 2 = 1 dispatcher for dispatcherID1 + 1 dispatcher for dispatcherID2
 		require.Equal(t, 2, len(subStats))
 	}
@@ -601,7 +659,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 	}
 	// do some check
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		// 3 = 1 dispatcher for dispatcherID1 + 1 dispatcher for dispatcherID2 + 1 dispatcher for dispatcherID3
 		require.Equal(t, 3, len(subStats))
 		// subStat with subID 1 should have two dispatchers
@@ -620,7 +678,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 		}
 		ok := store.RegisterDispatcher(cfID, dispatcherID4, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		require.Equal(t, 3, len(subStats))
 		// subStat with subID 1 should have three dispatchers
 		subStat := subStats[logpuller.SubscriptionID(1)]
@@ -632,7 +690,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 	// test unregister dispatcherID3 can remove its dependency on two subscriptions
 	{
 		store.UnregisterDispatcher(cfID, dispatcherID3)
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		require.Equal(t, 3, len(subStats))
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
@@ -687,7 +745,7 @@ func TestEventStoreRegisterDispatcherWithoutDataSharing(t *testing.T) {
 	mockSubClient.mu.Unlock()
 
 	es.dispatcherMeta.RLock()
-	subStats := es.dispatcherMeta.tableStats[tableID]
+	subStats := getTableStatsForTest(es, 0, tableID)
 	require.Equal(t, 3, len(subStats))
 	require.Nil(t, es.dispatcherMeta.dispatcherStats[dispatcherID2].pendingSubStat)
 	require.Nil(t, es.dispatcherMeta.dispatcherStats[dispatcherID3].pendingSubStat)
@@ -779,7 +837,7 @@ func TestEventStoreUnregisterDispatcherWithoutDataSharingRemovesSubscription(t *
 	es.dispatcherMeta.RLock()
 	_, ok := es.dispatcherMeta.dispatcherStats[dispatcherID]
 	require.False(t, ok)
-	_, ok = es.dispatcherMeta.tableStats[tableID]
+	_, ok = es.dispatcherMeta.tableStats[tableStatsKey{tableID: tableID}]
 	require.False(t, ok)
 	es.dispatcherMeta.RUnlock()
 }
@@ -815,7 +873,7 @@ func TestEventStoreUnregisterDispatcherWithDataSharingKeepsSubscriptionForTTL(t 
 	mockSubClient.mu.Unlock()
 
 	es.dispatcherMeta.RLock()
-	subStats, ok := es.dispatcherMeta.tableStats[tableID]
+	subStats, ok := es.dispatcherMeta.tableStats[tableStatsKey{tableID: tableID}]
 	require.True(t, ok)
 	require.Equal(t, 1, len(subStats))
 	var subStat *subscriptionStat
@@ -862,7 +920,7 @@ func TestEventStoreUpdateCheckpointTs(t *testing.T) {
 	{
 		store.UpdateDispatcherCheckpointTs(dispatcherID1, 110)
 		store.UpdateDispatcherCheckpointTs(dispatcherID2, 120)
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
@@ -876,7 +934,7 @@ func TestEventStoreUpdateCheckpointTs(t *testing.T) {
 	}
 	// update subStat resolvedTs
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
@@ -890,7 +948,7 @@ func TestEventStoreUpdateCheckpointTs(t *testing.T) {
 	}
 	// check subStat checkpointTs can advance normally
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		store.UpdateDispatcherCheckpointTs(dispatcherID1, 130)
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
@@ -982,7 +1040,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 	cfID := common.NewChangefeedID4Test("default", "test-cf")
 
 	updateSubStatResolvedTs := func(subID logpuller.SubscriptionID, ts uint64) {
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		subStat := subStats[subID]
 		require.NotNil(t, subStat)
 		subStat.resolvedTs.Store(ts)
@@ -1030,7 +1088,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 
 	// =========== check two subscriptions are created ============
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		require.Equal(t, 2, len(subStats))
 	}
 
@@ -1057,7 +1115,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 	}
 	// check dispatcher 2 is no longer receive event from subStat 1
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
@@ -1089,7 +1147,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		}
 	}
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)
@@ -1128,7 +1186,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 		}
 	}
 	{
-		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
+		subStats := getTableStatsForTest(store.(*eventStore), 0, tableID)
 		{
 			subStat := subStats[logpuller.SubscriptionID(1)]
 			require.NotNil(t, subStat)

--- a/pkg/spanz/btree_map_test.go
+++ b/pkg/spanz/btree_map_test.go
@@ -40,29 +40,34 @@ func TestSpanMap(t *testing.T) {
 	require.Equal(t, v, 2)
 	require.True(t, ok)
 
-	// Overwrite then get.
+	// Insert a span with the same start key but different end key.
 	old, ok := m.ReplaceOrInsert(
 		heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}, EndKey: []byte{1}}, 3)
-	require.Equal(t, old, 2)
-	require.True(t, ok)
-	require.Equal(t, 2, m.Len())
+	require.Zero(t, old)
+	require.False(t, ok)
+	require.Equal(t, 3, m.Len())
 	require.True(t, m.Has(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}}))
+	require.True(t, m.Has(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}, EndKey: []byte{1}}))
 	v, ok = m.Get(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
+	require.Equal(t, v, 2)
+	require.True(t, ok)
+	v, ok = m.Get(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}, EndKey: []byte{1}})
 	require.Equal(t, v, 3)
 	require.True(t, ok)
 
 	// get value
 	v = m.GetV(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
-	require.Equal(t, v, 3)
+	require.Equal(t, v, 2)
 
 	// Delete than get value
-	v, ok = m.Delete(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
+	v, ok = m.Delete(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}, EndKey: []byte{1}})
 	require.Equal(t, v, 3)
 	require.True(t, ok)
-	require.Equal(t, 1, m.Len())
-	require.False(t, m.Has(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}}))
+	require.Equal(t, 2, m.Len())
+	require.True(t, m.Has(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}}))
+	require.False(t, m.Has(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}, EndKey: []byte{1}}))
 	v = m.GetV(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
-	require.Equal(t, v, 0)
+	require.Equal(t, v, 2)
 
 	// Pointer value
 	mp := NewBtreeMap[*int]()
@@ -71,7 +76,31 @@ func TestSpanMap(t *testing.T) {
 	vp1, ok := mp.Get(heartbeatpb.TableSpan{TableID: 1})
 	require.Equal(t, vp, vp1)
 	require.True(t, ok)
-	require.Equal(t, 1, m.Len())
+	require.Equal(t, 1, mp.Len())
+}
+
+func TestSpanMapDistinguishesKeyspaceID(t *testing.T) {
+	t.Parallel()
+
+	m := NewBtreeMap[int]()
+	span1 := heartbeatpb.TableSpan{KeyspaceID: 1, TableID: 1, StartKey: []byte("a"), EndKey: []byte("b")}
+	span2 := heartbeatpb.TableSpan{KeyspaceID: 2, TableID: 1, StartKey: []byte("a"), EndKey: []byte("b")}
+
+	old, ok := m.ReplaceOrInsert(span1, 1)
+	require.Zero(t, old)
+	require.False(t, ok)
+
+	old, ok = m.ReplaceOrInsert(span2, 2)
+	require.Zero(t, old)
+	require.False(t, ok)
+
+	require.Equal(t, 2, m.Len())
+	v, ok := m.Get(span1)
+	require.True(t, ok)
+	require.Equal(t, 1, v)
+	v, ok = m.Get(span2)
+	require.True(t, ok)
+	require.Equal(t, 2, v)
 }
 
 func TestMapAscend(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4998 

### What is changed and how it works?

- Isolate event-store subscription statistics by keyspace and table ID.
- Make TableSpan ordering keyspace-aware and distinguish complete span ranges.
- Filter reusable event-service candidates by keyspace.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected span ordering to account for keyspace, table, start key, and end key.
  * Prevented subscriptions from different keyspaces from being conflated.
  * Ensured spans with different end keys are tracked and removed independently.

* **Tests**
  * Added coverage for keyspace-aware ordering, subscription isolation, and distinct span handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->