### PR TITLE
consumer: improve performance of EventsGroup 

### DIFF
--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -29,6 +29,7 @@ type EventsGroup struct {
 	tableID   int64
 
 	messages      []*codeccommon.DMLMessage
+	outOfOrder    bool
 	HighWatermark uint64
 }
 
@@ -44,6 +45,9 @@ func NewEventsGroup(partition int32, tableID int64) *EventsGroup {
 // AppendMessage appends a message to event groups.
 func (g *EventsGroup) AppendMessage(message *codeccommon.DMLMessage) {
 	commitTs := message.GetCommitTs()
+	if len(g.messages) > 0 && commitTs < g.messages[len(g.messages)-1].GetCommitTs() {
+		g.outOfOrder = true
+	}
 	if commitTs > g.HighWatermark {
 		g.HighWatermark = commitTs
 	}
@@ -58,55 +62,37 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 		return dst
 	}
 
-	original := g.messages
-	remaining := g.messages[:0]
-	resolved := make([]*codeccommon.DMLMessage, 0, len(g.messages))
-
-	var (
-		lastCommitTs       uint64
-		outOfOrder         bool
-		outOfOrderLastTs   uint64
-		outOfOrderCommitTs uint64
-	)
-	for _, message := range g.messages {
-		commitTs := message.GetCommitTs()
-		if commitTs > resolve {
-			remaining = append(remaining, message)
-			continue
-		}
-		if len(resolved) > 0 && commitTs < lastCommitTs && !outOfOrder {
-			outOfOrder = true
-			outOfOrderLastTs = lastCommitTs
-			outOfOrderCommitTs = commitTs
-		}
-		lastCommitTs = commitTs
-		resolved = append(resolved, message)
-	}
-	if len(resolved) == 0 {
-		return dst
+	if g.outOfOrder {
+		sort.SliceStable(g.messages, func(i, j int) bool {
+			return g.messages[i].GetCommitTs() < g.messages[j].GetCommitTs()
+		})
 	}
 
-	if outOfOrder {
+	resolvedCount := sort.Search(len(g.messages), func(i int) bool {
+		return g.messages[i].GetCommitTs() > resolve
+	})
+	if g.outOfOrder {
 		log.Warn("DML events are out of order before flush, sort them",
 			zap.Int32("partition", g.Partition),
 			zap.Int64("tableID", g.tableID),
 			zap.Uint64("resolveTs", resolve),
-			zap.Int("resolved", len(resolved)),
-			zap.Uint64("lastCommitTs", outOfOrderLastTs),
-			zap.Uint64("commitTs", outOfOrderCommitTs))
-		sort.SliceStable(resolved, func(i, j int) bool {
-			return resolved[i].GetCommitTs() < resolved[j].GetCommitTs()
-		})
+			zap.Int("resolved", resolvedCount))
+		g.outOfOrder = false
+	}
+	if resolvedCount == 0 {
+		return dst
 	}
 
-	dst = append(dst, resolved...)
-	clear(original[len(remaining):])
-	g.messages = remaining
+	dst = append(dst, g.messages[:resolvedCount]...)
+	remainingCount := len(g.messages) - resolvedCount
+	copy(g.messages, g.messages[resolvedCount:])
+	clear(g.messages[remainingCount:])
+	g.messages = g.messages[:remainingCount]
 	if len(g.messages) != 0 {
 		firstCommitTs := g.messages[0].GetCommitTs()
 		log.Debug("not all events resolved",
 			zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID),
-			zap.Int("resolved", len(resolved)), zap.Int("remained", len(g.messages)),
+			zap.Int("resolved", resolvedCount), zap.Int("remained", len(g.messages)),
 			zap.Uint64("resolveTs", resolve), zap.Uint64("firstCommitTs", firstCommitTs))
 	}
 	return dst

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -16,11 +16,13 @@ package util
 import (
 	"testing"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 func newTestDMLMessage(commitTs uint64) *codeccommon.DMLMessage {
@@ -180,6 +182,54 @@ func TestEventsGroupGetAllMessagesSortsOutOfOrderMessages(t *testing.T) {
 	require.Same(t, m1, messages[1])
 	require.Same(t, m3, messages[2])
 	require.Empty(t, group.messages)
+}
+
+func BenchmarkEventsGroupResolveInto(b *testing.B) {
+	const messageCount = 16 * 1024
+
+	messages := make([]*codeccommon.DMLMessage, messageCount)
+	for i := range messages {
+		messages[i] = newTestDMLMessage(uint64(i + 1))
+	}
+
+	benchmarks := []struct {
+		name       string
+		resolveTs  uint64
+		outOfOrder bool
+	}{
+		{name: "ordered/noop", resolveTs: 0},
+		{name: "ordered/half", resolveTs: messageCount / 2},
+		{name: "ordered/all", resolveTs: messageCount},
+		{name: "out-of-order/all", resolveTs: messageCount, outOfOrder: true},
+	}
+
+	oldLogLevel := log.GetLevel()
+	log.SetLevel(zapcore.FatalLevel)
+	b.Cleanup(func() { log.SetLevel(oldLogLevel) })
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			source := messages
+			if benchmark.outOfOrder {
+				source = append([]*codeccommon.DMLMessage(nil), messages...)
+				lastIndex := len(source) - 1
+				source[lastIndex-1], source[lastIndex] = source[lastIndex], source[lastIndex-1]
+			}
+			group := NewEventsGroup(0, 1)
+			group.messages = make([]*codeccommon.DMLMessage, 0, messageCount)
+			dst := make([]*codeccommon.DMLMessage, 0, messageCount)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if len(group.messages) != messageCount {
+					group.messages = append(group.messages[:0], source...)
+					group.outOfOrder = benchmark.outOfOrder
+				}
+				dst = group.ResolveInto(benchmark.resolveTs, dst[:0])
+			}
+		})
+	}
 }
 
 func TestAppendOrMergeDMLEventMergesSameCommitTs(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5937

### What is changed and how it works?
- AppendMessage records whether the message is out of order or not, with the overhead of comparing neighboring CommitTs just once.
- In normal order, ResolveInto uses sort. Search to find message boundaries with CommitTs <= resolveTs directly, instead of traversing all the search, instead of traversing all messages at once and allocating temporary resolved slices.
 
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
   |Scenario, 16K messages |   Before    |   After   |    Improvement |
   |--|--|--|--|
   |No messages resolved   |   139.9 µs/op  |  14.6 ns/op  |  roughly 9,500× |
   | Half resolved   |        161.4 µs/op  |  7.16 µs/op   |  roughly 22.5× |
   | All resolved      |        175.6 µs/op  |  8.06 µs/op   |  roughly 21.8× |

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved event resolution when messages arrive out of timestamp order.
  * Optimized processing of buffered events, including partial and complete resolution scenarios.

* **Tests**
  * Added benchmark coverage for ordered, out-of-order, partial, and full event resolution across large message sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->