### PR TITLE
*: cherry-pick event collector batch-by-bytes support to release-8.5

### DIFF
--- a/api/v2/model.go
+++ b/api/v2/model.go
@@ -296,6 +296,9 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 		if c.Consistent.MetaFlushIntervalInMs != nil {
 			res.Consistent.MetaFlushIntervalInMs = c.Consistent.MetaFlushIntervalInMs
 		}
+		if c.Consistent.EventCollectorBatchCount != nil {
+			res.Consistent.EventCollectorBatchCount = c.Consistent.EventCollectorBatchCount
+		}
 		if c.Consistent.EncodingWorkerNum != nil {
 			res.Consistent.EncodingWorkerNum = c.Consistent.EncodingWorkerNum
 		}
@@ -936,6 +939,9 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 		if cloned.Consistent.MetaFlushIntervalInMs != nil {
 			res.Consistent.MetaFlushIntervalInMs = cloned.Consistent.MetaFlushIntervalInMs
 		}
+		if cloned.Consistent.EventCollectorBatchCount != nil {
+			res.Consistent.EventCollectorBatchCount = cloned.Consistent.EventCollectorBatchCount
+		}
 		if cloned.Consistent.EncodingWorkerNum != nil {
 			res.Consistent.EncodingWorkerNum = cloned.Consistent.EncodingWorkerNum
 		}
@@ -1215,18 +1221,19 @@ type ColumnSelector struct {
 // ConsistentConfig represents replication consistency config for a changefeed
 // This is a duplicate of config.ConsistentConfig
 type ConsistentConfig struct {
-	Level                 *string `json:"level,omitempty"`
-	MaxLogSize            *int64  `json:"max_log_size,omitempty"`
-	FlushIntervalInMs     *int64  `json:"flush_interval,omitempty"`
-	MetaFlushIntervalInMs *int64  `json:"meta_flush_interval,omitempty"`
-	EncodingWorkerNum     *int    `json:"encoding_worker_num,omitempty"`
-	FlushWorkerNum        *int    `json:"flush_worker_num,omitempty"`
-	Storage               *string `json:"storage,omitempty"`
-	UseFileBackend        *bool   `json:"use_file_backend,omitempty"`
-	Compression           *string `json:"compression,omitempty"`
-	FlushConcurrency      *int    `json:"flush_concurrency,omitempty"`
+	Level                 *string                `json:"level,omitempty"`
+	MaxLogSize            *int64                 `json:"max_log_size,omitempty"`
+	FlushIntervalInMs     *int64                 `json:"flush_interval,omitempty"`
+	MetaFlushIntervalInMs *int64                 `json:"meta_flush_interval,omitempty"`
+	EncodingWorkerNum     *int                   `json:"encoding_worker_num,omitempty"`
+	FlushWorkerNum        *int                   `json:"flush_worker_num,omitempty"`
+	Storage               *string                `json:"storage,omitempty"`
+	UseFileBackend        *bool                  `json:"use_file_backend,omitempty"`
+	Compression           *string                `json:"compression,omitempty"`
+	FlushConcurrency      *int                   `json:"flush_concurrency,omitempty"`
+	MemoryUsage           *ConsistentMemoryUsage `json:"memory_usage,omitempty"`
 
-	MemoryUsage *ConsistentMemoryUsage `json:"memory_usage,omitempty"`
+	EventCollectorBatchCount *int `json:"event_collector_batch_count,omitempty"`
 }
 
 // ConsistentMemoryUsage represents memory usage of Consistent module.

--- a/api/v2/model.go
+++ b/api/v2/model.go
@@ -199,14 +199,16 @@ func (d *JSONDuration) UnmarshalJSON(b []byte) error {
 
 // ReplicaConfig is a duplicate of  config.ReplicaConfig
 type ReplicaConfig struct {
-	MemoryQuota           *uint64 `json:"memory_quota,omitempty"`
-	CaseSensitive         *bool   `json:"case_sensitive,omitempty"`
-	ForceReplicate        *bool   `json:"force_replicate,omitempty"`
-	IgnoreIneligibleTable *bool   `json:"ignore_ineligible_table,omitempty"`
-	CheckGCSafePoint      *bool   `json:"check_gc_safe_point,omitempty"`
-	EnableSyncPoint       *bool   `json:"enable_sync_point,omitempty"`
-	EnableTableMonitor    *bool   `json:"enable_table_monitor,omitempty"`
-	BDRMode               *bool   `json:"bdr_mode,omitempty"`
+	MemoryQuota              *uint64 `json:"memory_quota,omitempty"`
+	EventCollectorBatchCount *int    `json:"event_collector_batch_count,omitempty"`
+	EventCollectorBatchBytes *int    `json:"event_collector_batch_bytes,omitempty"`
+	CaseSensitive            *bool   `json:"case_sensitive,omitempty"`
+	ForceReplicate           *bool   `json:"force_replicate,omitempty"`
+	IgnoreIneligibleTable    *bool   `json:"ignore_ineligible_table,omitempty"`
+	CheckGCSafePoint         *bool   `json:"check_gc_safe_point,omitempty"`
+	EnableSyncPoint          *bool   `json:"enable_sync_point,omitempty"`
+	EnableTableMonitor       *bool   `json:"enable_table_monitor,omitempty"`
+	BDRMode                  *bool   `json:"bdr_mode,omitempty"`
 
 	SyncPointInterval  *JSONDuration `json:"sync_point_interval,omitempty"`
 	SyncPointRetention *JSONDuration `json:"sync_point_retention,omitempty"`
@@ -235,6 +237,12 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 ) *config.ReplicaConfig {
 	if c.MemoryQuota != nil {
 		res.MemoryQuota = c.MemoryQuota
+	}
+	if c.EventCollectorBatchCount != nil {
+		res.EventCollectorBatchCount = c.EventCollectorBatchCount
+	}
+	if c.EventCollectorBatchBytes != nil {
+		res.EventCollectorBatchBytes = c.EventCollectorBatchBytes
 	}
 	if c.CaseSensitive != nil {
 		res.CaseSensitive = c.CaseSensitive
@@ -639,14 +647,16 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 	cloned := c.Clone()
 
 	res := &ReplicaConfig{
-		MemoryQuota:           cloned.MemoryQuota,
-		CaseSensitive:         cloned.CaseSensitive,
-		ForceReplicate:        cloned.ForceReplicate,
-		IgnoreIneligibleTable: cloned.IgnoreIneligibleTable,
-		CheckGCSafePoint:      cloned.CheckGCSafePoint,
-		EnableSyncPoint:       cloned.EnableSyncPoint,
-		EnableTableMonitor:    cloned.EnableTableMonitor,
-		BDRMode:               cloned.BDRMode,
+		MemoryQuota:              cloned.MemoryQuota,
+		EventCollectorBatchCount: cloned.EventCollectorBatchCount,
+		EventCollectorBatchBytes: cloned.EventCollectorBatchBytes,
+		CaseSensitive:            cloned.CaseSensitive,
+		ForceReplicate:           cloned.ForceReplicate,
+		IgnoreIneligibleTable:    cloned.IgnoreIneligibleTable,
+		CheckGCSafePoint:         cloned.CheckGCSafePoint,
+		EnableSyncPoint:          cloned.EnableSyncPoint,
+		EnableTableMonitor:       cloned.EnableTableMonitor,
+		BDRMode:                  cloned.BDRMode,
 	}
 
 	if cloned.SyncPointInterval != nil {

--- a/api/v2/model_test.go
+++ b/api/v2/model_test.go
@@ -149,3 +149,61 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.Nil(t, apiNoBatch.EventCollectorBatchCount)
 	require.Nil(t, apiNoBatch.EventCollectorBatchBytes)
 }
+
+func TestReplicaConfigConversionBatchFields(t *testing.T) {
+	t.Parallel()
+
+	apiCfg := &ReplicaConfig{
+		EventCollectorBatchCount: util.AddressOf(4096),
+		EventCollectorBatchBytes: util.AddressOf(2048),
+	}
+	internalCfg := apiCfg.ToInternalReplicaConfig()
+	require.Equal(t, 4096, util.GetOrZero(internalCfg.EventCollectorBatchCount))
+	require.Equal(t, 2048, util.GetOrZero(internalCfg.EventCollectorBatchBytes))
+
+	apiCfgBack := ToAPIReplicaConfig(internalCfg)
+	require.NotNil(t, apiCfgBack.EventCollectorBatchCount)
+	require.NotNil(t, apiCfgBack.EventCollectorBatchBytes)
+	require.Equal(t, 4096, *apiCfgBack.EventCollectorBatchCount)
+	require.Equal(t, 2048, *apiCfgBack.EventCollectorBatchBytes)
+
+	apiCfgNil := &ReplicaConfig{}
+	internalCfgNil := apiCfgNil.ToInternalReplicaConfig()
+	defaultCfg := config.GetDefaultReplicaConfig()
+	require.Equal(
+		t,
+		util.GetOrZero(defaultCfg.EventCollectorBatchCount),
+		util.GetOrZero(internalCfgNil.EventCollectorBatchCount),
+	)
+	require.Equal(
+		t,
+		util.GetOrZero(defaultCfg.EventCollectorBatchBytes),
+		util.GetOrZero(internalCfgNil.EventCollectorBatchBytes),
+	)
+
+	internalCfgNoBatch := config.GetDefaultReplicaConfig()
+	internalCfgNoBatch.EventCollectorBatchCount = nil
+	internalCfgNoBatch.EventCollectorBatchBytes = nil
+	apiNoBatch := ToAPIReplicaConfig(internalCfgNoBatch)
+	require.Nil(t, apiNoBatch.EventCollectorBatchCount)
+	require.Nil(t, apiNoBatch.EventCollectorBatchBytes)
+}
+
+func TestReplicaConfigConversionRedoBatchField(t *testing.T) {
+	t.Parallel()
+
+	apiCfg := &ReplicaConfig{
+		Consistent: &ConsistentConfig{
+			EventCollectorBatchCount: util.AddressOf(4096),
+		},
+	}
+
+	internalCfg := apiCfg.ToInternalReplicaConfig()
+	require.NotNil(t, internalCfg.Consistent)
+	require.Equal(t, 4096, util.GetOrZero(internalCfg.Consistent.EventCollectorBatchCount))
+
+	apiCfgBack := ToAPIReplicaConfig(internalCfg)
+	require.NotNil(t, apiCfgBack.Consistent)
+	require.NotNil(t, apiCfgBack.Consistent.EventCollectorBatchCount)
+	require.Equal(t, 4096, *apiCfgBack.Consistent.EventCollectorBatchCount)
+}

--- a/api/v2/model_test.go
+++ b/api/v2/model_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestReplicaConfigConversion verifies API/internal replica config conversion,
+// including round-tripping the optional event collector batch overrides.
 func TestReplicaConfigConversion(t *testing.T) {
 	t.Parallel()
 
@@ -102,4 +104,48 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.True(t, *apiCfgBack.Scheduler.EnableTableAcrossNodes)
 	require.Equal(t, "correctness", *apiCfgBack.Integrity.IntegrityCheckLevel)
 	require.Equal(t, "eventual", *apiCfgBack.Consistent.Level)
+
+	// Test case 4: batch fields round trip and nil preservation
+	apiBatchCfg := &ReplicaConfig{
+		EventCollectorBatchCount: util.AddressOf(4096),
+		EventCollectorBatchBytes: util.AddressOf(2048),
+	}
+	internalBatchCfg := apiBatchCfg.ToInternalReplicaConfig()
+	require.NotNil(t, internalBatchCfg.EventCollectorBatchCount)
+	require.NotNil(t, internalBatchCfg.EventCollectorBatchBytes)
+	require.Equal(t, 4096, *internalBatchCfg.EventCollectorBatchCount)
+	require.Equal(t, 2048, *internalBatchCfg.EventCollectorBatchBytes)
+
+	apiBatchCfgBack := ToAPIReplicaConfig(internalBatchCfg)
+	require.NotNil(t, apiBatchCfgBack.EventCollectorBatchCount)
+	require.NotNil(t, apiBatchCfgBack.EventCollectorBatchBytes)
+	require.Equal(t, 4096, *apiBatchCfgBack.EventCollectorBatchCount)
+	require.Equal(t, 2048, *apiBatchCfgBack.EventCollectorBatchBytes)
+
+	apiBatchZeroCfg := &ReplicaConfig{
+		EventCollectorBatchCount: util.AddressOf(0),
+		EventCollectorBatchBytes: util.AddressOf(0),
+	}
+	internalBatchZeroCfg := apiBatchZeroCfg.ToInternalReplicaConfig()
+	require.NotNil(t, internalBatchZeroCfg.EventCollectorBatchCount)
+	require.NotNil(t, internalBatchZeroCfg.EventCollectorBatchBytes)
+	require.Equal(t, 0, *internalBatchZeroCfg.EventCollectorBatchCount)
+	require.Equal(t, 0, *internalBatchZeroCfg.EventCollectorBatchBytes)
+
+	apiBatchZeroCfgBack := ToAPIReplicaConfig(internalBatchZeroCfg)
+	require.NotNil(t, apiBatchZeroCfgBack.EventCollectorBatchCount)
+	require.NotNil(t, apiBatchZeroCfgBack.EventCollectorBatchBytes)
+	require.Equal(t, 0, *apiBatchZeroCfgBack.EventCollectorBatchCount)
+	require.Equal(t, 0, *apiBatchZeroCfgBack.EventCollectorBatchBytes)
+
+	internalCfgNoBatch := (&ReplicaConfig{}).ToInternalReplicaConfig()
+	require.Nil(t, internalCfgNoBatch.EventCollectorBatchCount)
+	require.Nil(t, internalCfgNoBatch.EventCollectorBatchBytes)
+
+	internalCfgNoBatchBack := config.GetDefaultReplicaConfig()
+	internalCfgNoBatchBack.EventCollectorBatchCount = nil
+	internalCfgNoBatchBack.EventCollectorBatchBytes = nil
+	apiNoBatch := ToAPIReplicaConfig(internalCfgNoBatchBack)
+	require.Nil(t, apiNoBatch.EventCollectorBatchCount)
+	require.Nil(t, apiNoBatch.EventCollectorBatchBytes)
 }

--- a/downstreamadapter/dispatcher/basic_dispatcher.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher.go
@@ -42,6 +42,7 @@ type DispatcherService interface {
 	GetStartTs() uint64
 	GetBDRMode() bool
 	GetChangefeedID() common.ChangeFeedID
+	GetEventCollectorBatchConfig() (batchCount int, batchBytes int)
 	GetTableSpan() *heartbeatpb.TableSpan
 	GetRouter() routing.Router
 	GetTimezone() string

--- a/downstreamadapter/dispatcher/basic_dispatcher.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher.go
@@ -165,6 +165,11 @@ type BasicDispatcher struct {
 	// Shared info containing all common configuration and resources
 	sharedInfo *SharedInfo
 
+	// normal event dispatchers set them by the shared defaults.
+	// redo dispatchers set them by the redo specific defaults.
+	eventCollectorBatchCount int
+	eventCollectorBatchBytes int
+
 	// sink is the sink for this dispatcher
 	sink sink.Sink
 
@@ -235,31 +240,35 @@ func NewBasicDispatcher(
 	schemaIDToDispatchers *SchemaIDToDispatchers,
 	skipSyncpointAtStartTs bool,
 	skipDMLAsStartTs bool,
+	eventCollectorBatchCount int,
+	eventCollectorBatchBytes int,
 	currentPDTs uint64,
 	mode int64,
 	sink sink.Sink,
 	sharedInfo *SharedInfo,
 ) *BasicDispatcher {
 	dispatcher := &BasicDispatcher{
-		id:                     id,
-		tableSpan:              tableSpan,
-		isCompleteTable:        common.IsCompleteSpan(tableSpan),
-		startTs:                startTs,
-		skipSyncpointAtStartTs: skipSyncpointAtStartTs,
-		skipDMLAsStartTs:       skipDMLAsStartTs,
-		sharedInfo:             sharedInfo,
-		sink:                   sink,
-		componentStatus:        newComponentStateWithMutex(heartbeatpb.ComponentState_Initializing),
-		isRemoving:             atomic.Bool{},
-		duringHandleEvents:     atomic.Bool{},
-		blockEventStatus:       BlockEventStatus{blockPendingEvent: nil},
-		tableProgress:          NewTableProgress(),
-		schemaID:               schemaID,
-		schemaIDToDispatchers:  schemaIDToDispatchers,
-		resendTaskMap:          newResendTaskMap(),
-		creationPDTs:           currentPDTs,
-		mode:                   mode,
-		BootstrapState:         BootstrapFinished,
+		id:                       id,
+		tableSpan:                tableSpan,
+		isCompleteTable:          common.IsCompleteSpan(tableSpan),
+		startTs:                  startTs,
+		skipSyncpointAtStartTs:   skipSyncpointAtStartTs,
+		skipDMLAsStartTs:         skipDMLAsStartTs,
+		sharedInfo:               sharedInfo,
+		eventCollectorBatchCount: eventCollectorBatchCount,
+		eventCollectorBatchBytes: eventCollectorBatchBytes,
+		sink:                     sink,
+		componentStatus:          newComponentStateWithMutex(heartbeatpb.ComponentState_Initializing),
+		isRemoving:               atomic.Bool{},
+		duringHandleEvents:       atomic.Bool{},
+		blockEventStatus:         BlockEventStatus{blockPendingEvent: nil},
+		tableProgress:            NewTableProgress(),
+		schemaID:                 schemaID,
+		schemaIDToDispatchers:    schemaIDToDispatchers,
+		resendTaskMap:            newResendTaskMap(),
+		creationPDTs:             currentPDTs,
+		mode:                     mode,
+		BootstrapState:           BootstrapFinished,
 	}
 	if dispatcher.IsTableTriggerDispatcher() {
 		dispatcher.addTableCheckpointBlocker = newCheckpointBlocker()

--- a/downstreamadapter/dispatcher/basic_dispatcher_info.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher_info.go
@@ -55,6 +55,9 @@ type SharedInfo struct {
 	// will break the splittability of this table.
 	enableSplittableCheck bool
 
+	eventCollectorBatchCount int
+	eventCollectorBatchBytes int
+
 	// router is used to route source schema/table names to target schema/table names.
 	// It is used to apply routing to TableInfo before storing it.
 	router routing.Router
@@ -90,26 +93,30 @@ func NewSharedInfo(
 	syncPointConfig *syncpoint.SyncPointConfig,
 	txnAtomicity *config.AtomicityLevel,
 	enableSplittableCheck bool,
+	eventCollectorBatchCount int,
+	eventCollectorBatchBytes int,
 	router routing.Router,
 	statusesChan chan TableSpanStatusWithSeq,
 	blockStatusBufferSize int,
 	errCh chan error,
 ) *SharedInfo {
 	sharedInfo := &SharedInfo{
-		changefeedID:          changefeedID,
-		timezone:              timezone,
-		bdrMode:               bdrMode,
-		outputRawChangeEvent:  outputRawChangeEvent,
-		integrityConfig:       integrityConfig,
-		filterConfig:          filterConfig,
-		syncPointConfig:       syncPointConfig,
-		enableSplittableCheck: enableSplittableCheck,
-		router:                router,
-		statusesChan:          statusesChan,
-		blockStatusBuffer:     NewBlockStatusBuffer(blockStatusBufferSize),
-		blockExecutor:         newBlockEventExecutor(),
-		errCh:                 errCh,
-		metricHandleDDLHis:    metrics.HandleDDLHistogram.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name()),
+		changefeedID:             changefeedID,
+		timezone:                 timezone,
+		bdrMode:                  bdrMode,
+		outputRawChangeEvent:     outputRawChangeEvent,
+		integrityConfig:          integrityConfig,
+		filterConfig:             filterConfig,
+		syncPointConfig:          syncPointConfig,
+		enableSplittableCheck:    enableSplittableCheck,
+		eventCollectorBatchCount: eventCollectorBatchCount,
+		eventCollectorBatchBytes: eventCollectorBatchBytes,
+		router:                   router,
+		statusesChan:             statusesChan,
+		blockStatusBuffer:        NewBlockStatusBuffer(blockStatusBufferSize),
+		blockExecutor:            newBlockEventExecutor(),
+		errCh:                    errCh,
+		metricHandleDDLHis:       metrics.HandleDDLHistogram.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name()),
 	}
 
 	if txnAtomicity != nil {
@@ -134,6 +141,10 @@ func (d *BasicDispatcher) GetMode() int64 {
 
 func (d *BasicDispatcher) GetChangefeedID() common.ChangeFeedID {
 	return d.sharedInfo.changefeedID
+}
+
+func (d *BasicDispatcher) GetEventCollectorBatchConfig() (batchCount int, batchBytes int) {
+	return d.sharedInfo.eventCollectorBatchCount, d.sharedInfo.eventCollectorBatchBytes
 }
 
 func (d *BasicDispatcher) GetComponentStatus() heartbeatpb.ComponentState {

--- a/downstreamadapter/dispatcher/basic_dispatcher_info.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher_info.go
@@ -55,6 +55,7 @@ type SharedInfo struct {
 	// will break the splittability of this table.
 	enableSplittableCheck bool
 
+	// Normal event dispatchers inherit these shared batch defaults.
 	eventCollectorBatchCount int
 	eventCollectorBatchBytes int
 
@@ -144,7 +145,7 @@ func (d *BasicDispatcher) GetChangefeedID() common.ChangeFeedID {
 }
 
 func (d *BasicDispatcher) GetEventCollectorBatchConfig() (batchCount int, batchBytes int) {
-	return d.sharedInfo.eventCollectorBatchCount, d.sharedInfo.eventCollectorBatchBytes
+	return d.eventCollectorBatchCount, d.eventCollectorBatchBytes
 }
 
 func (d *BasicDispatcher) GetComponentStatus() heartbeatpb.ComponentState {

--- a/downstreamadapter/dispatcher/event_dispatcher.go
+++ b/downstreamadapter/dispatcher/event_dispatcher.go
@@ -73,6 +73,8 @@ func NewEventDispatcher(
 		schemaIDToDispatchers,
 		skipSyncpointAtStartTs,
 		skipDMLAsStartTs,
+		sharedInfo.eventCollectorBatchCount,
+		sharedInfo.eventCollectorBatchBytes,
 		currentPdTs,
 		common.DefaultMode,
 		sink,

--- a/downstreamadapter/dispatcher/event_dispatcher_test.go
+++ b/downstreamadapter/dispatcher/event_dispatcher_test.go
@@ -158,6 +158,8 @@ func newTestSharedInfo(
 		syncPointConfig,
 		&defaultAtomicity,
 		enableSplittableCheck,
+		0,
+		0,
 		routing.Router{},
 		make(chan TableSpanStatusWithSeq, 128),
 		128,
@@ -199,24 +201,7 @@ func getUncompleteTableSpan() *heartbeatpb.TableSpan {
 func newDispatcherForTest(sink sink.Sink, tableSpan *heartbeatpb.TableSpan) *EventDispatcher {
 	var redoTs atomic.Uint64
 	redoTs.Store(math.MaxUint64)
-	sharedInfo := NewSharedInfo(
-		common.NewChangefeedID(common.DefaultKeyspaceName),
-		"system",
-		false,
-		false,
-		nil,
-		nil,
-		&syncpoint.SyncPointConfig{
-			SyncPointInterval:  time.Duration(5 * time.Second),
-			SyncPointRetention: time.Duration(10 * time.Minute),
-		}, // syncPointConfig
-		&defaultAtomicity,
-		false, // enableSplittableCheck
-		routing.Router{},
-		make(chan TableSpanStatusWithSeq, 128),
-		128,
-		make(chan error, 1),
-	)
+	sharedInfo := newTestSharedInfo(false, newTestSyncPointConfig())
 	return NewEventDispatcher(
 		common.NewDispatcherID(),
 		tableSpan,
@@ -1179,24 +1164,7 @@ func TestDispatcherSplittableCheck(t *testing.T) {
 	tableSpan := getUncompleteTableSpan()
 
 	// Create shared info with enableSplittableCheck=true
-	sharedInfo := NewSharedInfo(
-		common.NewChangefeedID(common.DefaultKeyspaceName),
-		"system",
-		false,
-		false,
-		nil,
-		nil,
-		&syncpoint.SyncPointConfig{
-			SyncPointInterval:  time.Duration(5 * time.Second),
-			SyncPointRetention: time.Duration(10 * time.Minute),
-		},
-		&defaultAtomicity,
-		true, // enableSplittableCheck = true
-		routing.Router{},
-		make(chan TableSpanStatusWithSeq, 128),
-		128,
-		make(chan error, 1),
-	)
+	sharedInfo := newTestSharedInfo(true, newTestSyncPointConfig())
 
 	// Create dispatcher with the split table span
 	var redoTs atomic.Uint64
@@ -1289,24 +1257,7 @@ func TestDispatcher_SkipDMLAsStartTs_FilterCorrectly(t *testing.T) {
 	// - Need to skip DML at commitTs = 100 (already written before crash)
 	var redoTs atomic.Uint64
 	redoTs.Store(math.MaxUint64)
-	sharedInfo := NewSharedInfo(
-		common.NewChangefeedID(common.DefaultKeyspaceName),
-		"system",
-		false,
-		false,
-		nil,
-		nil,
-		&syncpoint.SyncPointConfig{
-			SyncPointInterval:  time.Duration(5 * time.Second),
-			SyncPointRetention: time.Duration(10 * time.Minute),
-		},
-		&defaultAtomicity,
-		false,
-		routing.Router{},
-		make(chan TableSpanStatusWithSeq, 128),
-		128,
-		make(chan error, 1),
-	)
+	sharedInfo := newTestSharedInfo(false, newTestSyncPointConfig())
 
 	dispatcher := NewEventDispatcher(
 		common.NewDispatcherID(),
@@ -1369,24 +1320,7 @@ func TestDispatcher_SkipDMLAsStartTs_Disabled(t *testing.T) {
 	// Create dispatcher with skipDMLAsStartTs=false
 	var redoTs atomic.Uint64
 	redoTs.Store(math.MaxUint64)
-	sharedInfo := NewSharedInfo(
-		common.NewChangefeedID(common.DefaultKeyspaceName),
-		"system",
-		false,
-		false,
-		nil,
-		nil,
-		&syncpoint.SyncPointConfig{
-			SyncPointInterval:  time.Duration(5 * time.Second),
-			SyncPointRetention: time.Duration(10 * time.Minute),
-		},
-		&defaultAtomicity,
-		false,
-		routing.Router{},
-		make(chan TableSpanStatusWithSeq, 128),
-		128,
-		make(chan error, 1),
-	)
+	sharedInfo := newTestSharedInfo(false, newTestSyncPointConfig())
 
 	dispatcher := NewEventDispatcher(
 		common.NewDispatcherID(),

--- a/downstreamadapter/dispatcher/redo_dispatcher.go
+++ b/downstreamadapter/dispatcher/redo_dispatcher.go
@@ -45,6 +45,8 @@ func NewRedoDispatcher(
 	schemaIDToDispatchers *SchemaIDToDispatchers,
 	skipSyncpointAtStartTs bool,
 	skipDMLAsStartTs bool,
+	eventCollectorBatchCount int,
+	eventCollectorBatchBytes int,
 	sink sink.Sink,
 	sharedInfo *SharedInfo,
 ) *RedoDispatcher {
@@ -56,6 +58,8 @@ func NewRedoDispatcher(
 		schemaIDToDispatchers,
 		skipSyncpointAtStartTs,
 		skipDMLAsStartTs,
+		eventCollectorBatchCount,
+		eventCollectorBatchBytes,
 		0,
 		common.RedoMode,
 		sink,

--- a/downstreamadapter/dispatcher/redo_dispatcher_test.go
+++ b/downstreamadapter/dispatcher/redo_dispatcher_test.go
@@ -23,9 +23,7 @@ import (
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
-	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/node"
-	"github.com/pingcap/ticdc/pkg/routing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,22 +34,7 @@ func redoCallback() {
 }
 
 func newRedoDispatcherForTest(sink sink.Sink, tableSpan *heartbeatpb.TableSpan) *RedoDispatcher {
-	defaultAtomicity := config.DefaultAtomicityLevel()
-	sharedInfo := NewSharedInfo(
-		common.NewChangefeedID(common.DefaultKeyspaceName),
-		"system",
-		false,
-		false,
-		nil,
-		nil,
-		nil, // redo dispatcher doesn't need syncPointConfig
-		&defaultAtomicity,
-		false, // enableSplittableCheck
-		routing.Router{},
-		make(chan TableSpanStatusWithSeq, 128),
-		128,
-		make(chan error, 1),
-	)
+	sharedInfo := newTestSharedInfo(false, nil)
 	return NewRedoDispatcher(
 		common.NewDispatcherID(),
 		tableSpan,

--- a/downstreamadapter/dispatcher/redo_dispatcher_test.go
+++ b/downstreamadapter/dispatcher/redo_dispatcher_test.go
@@ -33,7 +33,12 @@ func redoCallback() {
 	redoCount.Add(1)
 }
 
-func newRedoDispatcherForTest(sink sink.Sink, tableSpan *heartbeatpb.TableSpan) *RedoDispatcher {
+func newRedoDispatcherForTest(
+	sink sink.Sink,
+	tableSpan *heartbeatpb.TableSpan,
+	batchCount int,
+	batchBytes int,
+) *RedoDispatcher {
 	sharedInfo := newTestSharedInfo(false, nil)
 	return NewRedoDispatcher(
 		common.NewDispatcherID(),
@@ -43,6 +48,8 @@ func newRedoDispatcherForTest(sink sink.Sink, tableSpan *heartbeatpb.TableSpan) 
 		NewSchemaIDToDispatchers(),
 		false, // skipSyncpointAtStartTs
 		false, // skipDMLAsStartTs
+		batchCount,
+		batchBytes,
 		sink,
 		sharedInfo,
 	)
@@ -67,7 +74,7 @@ func TestRedoDispatcherHandleEvents(t *testing.T) {
 	testSink := newDispatcherTestSink(t, common.MysqlSinkType)
 	tableSpan, err := getCompleteTableSpan(getTestingKeyspaceID())
 	require.NoError(t, err)
-	dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan)
+	dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan, 0, 0)
 	require.Equal(t, uint64(0), dispatcher.GetCheckpointTs())
 	require.Equal(t, uint64(0), dispatcher.GetResolvedTs())
 	tableProgress := dispatcher.tableProgress
@@ -296,6 +303,18 @@ func TestRedoDispatcherHandleEvents(t *testing.T) {
 	require.Equal(t, uint64(7), checkpointTs)
 }
 
+func TestRedoDispatcherUsesOwnBatchConfig(t *testing.T) {
+	tableSpan, err := getCompleteTableSpan(getTestingKeyspaceID())
+	require.NoError(t, err)
+
+	testSink := newDispatcherTestSink(t, common.MysqlSinkType)
+	dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan, 4096, 32<<20)
+
+	batchCount, batchBytes := dispatcher.GetEventCollectorBatchConfig()
+	require.Equal(t, 4096, batchCount)
+	require.Equal(t, 32<<20, batchBytes)
+}
+
 func TestRedoUncompeleteTableSpanDispatcherHandleEvents(t *testing.T) {
 	redoCount.Store(0)
 	helper := commonEvent.NewEventTestHelper(t)
@@ -307,7 +326,7 @@ func TestRedoUncompeleteTableSpanDispatcherHandleEvents(t *testing.T) {
 
 	testSink := newDispatcherTestSink(t, common.MysqlSinkType)
 	tableSpan := getUncompleteTableSpan()
-	dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan)
+	dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan, 0, 0)
 
 	dmlEvent := helper.DML2Event("test", "t", "insert into t values(1, 1)")
 	require.NotNil(t, dmlEvent)
@@ -376,7 +395,7 @@ func TestTableTriggerRedoDispatcherInMysql(t *testing.T) {
 
 	ddlTableSpan := common.KeyspaceDDLSpan(common.DefaultKeyspaceID)
 	testSink := newDispatcherTestSink(t, common.MysqlSinkType)
-	tableTriggerEventDispatcher := newRedoDispatcherForTest(testSink.Sink(), ddlTableSpan)
+	tableTriggerEventDispatcher := newRedoDispatcherForTest(testSink.Sink(), ddlTableSpan, 0, 0)
 
 	helper := commonEvent.NewEventTestHelper(t)
 	defer helper.Close()
@@ -446,7 +465,7 @@ func TestTableTriggerRedoDispatcherInKafka(t *testing.T) {
 
 	ddlTableSpan := common.KeyspaceDDLSpan(common.DefaultKeyspaceID)
 	testSink := newDispatcherTestSink(t, common.KafkaSinkType)
-	tableTriggerEventDispatcher := newRedoDispatcherForTest(testSink.Sink(), ddlTableSpan)
+	tableTriggerEventDispatcher := newRedoDispatcherForTest(testSink.Sink(), ddlTableSpan, 0, 0)
 
 	helper := commonEvent.NewEventTestHelper(t)
 	defer helper.Close()
@@ -528,7 +547,7 @@ func TestRedoDispatcherClose(t *testing.T) {
 		testSink := newDispatcherTestSink(t, common.MysqlSinkType)
 		tableSpan, err := getCompleteTableSpan(getTestingKeyspaceID())
 		require.NoError(t, err)
-		dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan)
+		dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan, 0, 0)
 
 		// ===== dml event =====
 		nodeID := node.NewID()
@@ -551,7 +570,7 @@ func TestRedoDispatcherClose(t *testing.T) {
 		testSink := newDispatcherTestSink(t, common.MysqlSinkType)
 		tableSpan, err := getCompleteTableSpan(getTestingKeyspaceID())
 		require.NoError(t, err)
-		dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan)
+		dispatcher := newRedoDispatcherForTest(testSink.Sink(), tableSpan, 0, 0)
 
 		// ===== dml event =====
 		nodeID := node.NewID()
@@ -596,7 +615,7 @@ func TestRedoBatchDMLEventsPartialFlush(t *testing.T) {
 	mockSink := newDispatcherTestSink(t, common.MysqlSinkType)
 	tableSpan, err := getCompleteTableSpan(getTestingKeyspaceID())
 	require.NoError(t, err)
-	dispatcher := newRedoDispatcherForTest(mockSink.Sink(), tableSpan)
+	dispatcher := newRedoDispatcherForTest(mockSink.Sink(), tableSpan, 0, 0)
 
 	// Create a redoCallback that records when it's called
 	var redoCallbackCalled atomic.Bool

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -326,6 +326,7 @@ func NewDispatcherManager(
 	if err != nil {
 		return nil, err
 	}
+	batchCounts, batchBytes := manager.getEventCollectorBatchCountAndBytes(manager.sink)
 	// Create shared info for all dispatchers
 	sharedInfo := dispatcher.NewSharedInfo(
 		manager.changefeedID,
@@ -337,6 +338,8 @@ func NewDispatcherManager(
 		syncPointConfig,
 		manager.config.SinkConfig.TxnAtomicity,
 		manager.config.EnableSplittableCheck,
+		batchCounts,
+		batchBytes,
 		router,
 		make(chan dispatcher.TableSpanStatusWithSeq, 8192),
 		blockStatusBufferSize,
@@ -428,6 +431,20 @@ func countIgnoreUpdateOnlyColumnsRules(filter *config.FilterConfig) int {
 		}
 	}
 	return count
+}
+
+func (e *DispatcherManager) getEventCollectorBatchCountAndBytes(s sink.Sink) (int, int) {
+	var (
+		batchCount = s.BatchCount()
+		batchBytes = s.BatchBytes()
+	)
+	if e.config.EventCollectorBatchCount != nil {
+		batchCount = *e.config.EventCollectorBatchCount
+	}
+	if e.config.EventCollectorBatchBytes != nil {
+		batchBytes = *e.config.EventCollectorBatchBytes
+	}
+	return batchCount, batchBytes
 }
 
 func (e *DispatcherManager) NewTableTriggerEventDispatcher(id *heartbeatpb.DispatcherID, startTs uint64, newChangefeed bool) error {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_batch_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_batch_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatchermanager
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	sinkmock "github.com/pingcap/ticdc/downstreamadapter/sink/mock"
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func newBatchConfigSink(t *testing.T, batchCount int, batchBytes int) *sinkmock.MockSink {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	s := sinkmock.NewMockSink(ctrl)
+	s.EXPECT().SinkType().Return(common.MysqlSinkType).AnyTimes()
+	s.EXPECT().BatchCount().Return(batchCount).AnyTimes()
+	s.EXPECT().BatchBytes().Return(batchBytes).AnyTimes()
+	return s
+}
+
+// TestDispatcherManagerBatchConfig ensures changefeed overrides take precedence
+// over sink-derived defaults while preserving explicit zero values.
+func TestDispatcherManagerBatchConfig(t *testing.T) {
+	assertBatchConfig := func(
+		sinkBatchCount int,
+		sinkBatchBytes int,
+		cfg *config.ChangefeedConfig,
+		wantCount int,
+		wantBytes int,
+	) {
+		sink := newBatchConfigSink(t, sinkBatchCount, sinkBatchBytes)
+		m := &DispatcherManager{
+			config: cfg,
+		}
+		gotCount, gotBytes := m.getEventCollectorBatchCountAndBytes(sink)
+		require.Equal(t, wantCount, gotCount)
+		require.Equal(t, wantBytes, gotBytes)
+	}
+
+	assertBatchConfig(2048, 8192, &config.ChangefeedConfig{}, 2048, 8192)
+	assertBatchConfig(2048, 8192, &config.ChangefeedConfig{
+		EventCollectorBatchCount: util.AddressOf(0),
+		EventCollectorBatchBytes: util.AddressOf(0),
+	}, 0, 0)
+	assertBatchConfig(2048, 8192, &config.ChangefeedConfig{
+		EventCollectorBatchBytes: util.AddressOf(0),
+	}, 2048, 0)
+	assertBatchConfig(2048, 8192, &config.ChangefeedConfig{
+		EventCollectorBatchCount: util.AddressOf(0),
+	}, 0, 8192)
+	assertBatchConfig(2048, 8192, &config.ChangefeedConfig{
+		EventCollectorBatchCount: util.AddressOf(123),
+	}, 123, 8192)
+	assertBatchConfig(2048, 8192, &config.ChangefeedConfig{
+		EventCollectorBatchBytes: util.AddressOf(456),
+	}, 2048, 456)
+	assertBatchConfig(2048, 8192, &config.ChangefeedConfig{
+		EventCollectorBatchCount: util.AddressOf(123),
+		EventCollectorBatchBytes: util.AddressOf(456),
+	}, 123, 456)
+}

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_batch_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_batch_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	sinkmock "github.com/pingcap/ticdc/downstreamadapter/sink/mock"
+	redosink "github.com/pingcap/ticdc/downstreamadapter/sink/redo"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/util"
@@ -74,4 +75,26 @@ func TestDispatcherManagerBatchConfig(t *testing.T) {
 		EventCollectorBatchCount: util.AddressOf(123),
 		EventCollectorBatchBytes: util.AddressOf(456),
 	}, 123, 456)
+}
+
+func TestDispatcherManagerRedoBatchConfig(t *testing.T) {
+	assertBatchConfig := func(cfg *config.ChangefeedConfig, wantCount int, wantBytes int) {
+		m := &DispatcherManager{
+			config: cfg,
+		}
+		gotCount, gotBytes := m.getRedoEventCollectorBatchCountAndBytes(&redosink.Sink{})
+		require.Equal(t, wantCount, gotCount)
+		require.Equal(t, wantBytes, gotBytes)
+	}
+
+	assertBatchConfig(&config.ChangefeedConfig{}, 4096, 0)
+	assertBatchConfig(&config.ChangefeedConfig{
+		EventCollectorBatchCount: util.AddressOf(123),
+		EventCollectorBatchBytes: util.AddressOf(456),
+	}, 4096, 0)
+	assertBatchConfig(&config.ChangefeedConfig{
+		Consistent: &config.ConsistentConfig{
+			EventCollectorBatchCount: util.AddressOf(321),
+		},
+	}, 321, 0)
 }

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -159,11 +159,23 @@ func (e *DispatcherManager) NewTableTriggerRedoDispatcher(id *heartbeatpb.Dispat
 	return nil
 }
 
+func (e *DispatcherManager) getRedoEventCollectorBatchCountAndBytes(redoSink *redo.Sink) (int, int) {
+	var (
+		batchCount = redoSink.BatchCount()
+		batchBytes = redoSink.BatchBytes()
+	)
+	if e.config.Consistent != nil && e.config.Consistent.EventCollectorBatchCount != nil {
+		batchCount = *e.config.Consistent.EventCollectorBatchCount
+	}
+	return batchCount, batchBytes
+}
+
 func (e *DispatcherManager) newRedoDispatchers(infos map[common.DispatcherID]dispatcherCreateInfo, removeDDLTs bool) error {
 	if e.writePathClosed.Load() {
 		return newWritePathClosedError()
 	}
 	start := time.Now()
+	batchCount, batchBytes := e.getRedoEventCollectorBatchCountAndBytes(e.redoSink)
 
 	dispatcherIds, _, startTsList, tableSpans, schemaIds, scheduleSkipDMLAsStartTsList := prepareCreateDispatcher(infos, e.redoDispatcherMap)
 	if len(dispatcherIds) == 0 {
@@ -193,6 +205,8 @@ func (e *DispatcherManager) newRedoDispatchers(infos map[common.DispatcherID]dis
 			e.redoSchemaIDToDispatchers,
 			false, // skipSyncpointAtStartTs
 			scheduleSkipDMLAsStartTsList[idx],
+			batchCount,
+			batchBytes,
 			e.redoSink,
 			e.sharedInfo,
 		)
@@ -255,6 +269,7 @@ func (e *DispatcherManager) mergeRedoDispatcher(dispatcherIDs []common.Dispatche
 	if mergedSpan == nil {
 		return nil
 	}
+	batchCount, batchBytes := e.getRedoEventCollectorBatchCountAndBytes(e.redoSink)
 
 	mergedDispatcher := dispatcher.NewRedoDispatcher(
 		mergedDispatcherID,
@@ -264,6 +279,8 @@ func (e *DispatcherManager) mergeRedoDispatcher(dispatcherIDs []common.Dispatche
 		e.redoSchemaIDToDispatchers,
 		false, // skipSyncpointAtStartTs
 		false, // skipDMLAsStartTs
+		batchCount,
+		batchBytes,
 		e.redoSink,
 		e.sharedInfo,
 	)

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -130,6 +130,8 @@ func createTestManager(t *testing.T) *DispatcherManager {
 		nil,   // syncPointConfig
 		&defaultAtomicity,
 		false,
+		0,
+		0,
 		routing.Router{},
 		make(chan dispatcher.TableSpanStatusWithSeq, 8192),
 		blockStatusBufferSize,

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -792,6 +792,8 @@ func TestValidateBootstrapNilRedoTriggerRejectsExistingRedoTrigger(t *testing.T)
 		dispatcher.NewSchemaIDToDispatchers(),
 		false,
 		false,
+		0,
+		0,
 		nil,
 		nil,
 	)

--- a/downstreamadapter/eventcollector/event_collector.go
+++ b/downstreamadapter/eventcollector/event_collector.go
@@ -273,7 +273,15 @@ func (c *EventCollector) PrepareAddDispatcher(
 	cfStat.dispatcherCount.Add(1)
 
 	ds := c.getDynamicStream(target.GetMode())
-	areaSetting := dynstream.NewAreaSettingsWithMaxPendingSize(memoryQuota, dynstream.MemoryControlForEventCollector, "eventCollector")
+
+	batchCount, batchBytes := target.GetEventCollectorBatchConfig()
+	areaSetting := dynstream.NewAreaSettingsWithMaxPendingSizeAndBatchConfig(
+		memoryQuota,
+		dynstream.MemoryControlForEventCollector,
+		"eventCollector",
+		batchCount,
+		batchBytes,
+	)
 	err := ds.AddPath(target.GetId(), stat, areaSetting)
 	if err != nil {
 		log.Warn("add dispatcher to dynamic stream failed", zap.Error(err))

--- a/downstreamadapter/eventcollector/event_collector_test.go
+++ b/downstreamadapter/eventcollector/event_collector_test.go
@@ -15,6 +15,7 @@ package eventcollector
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -36,11 +37,20 @@ import (
 var _ dispatcher.DispatcherService = (*mockEventDispatcher)(nil)
 
 type mockEventDispatcher struct {
-	id           common.DispatcherID
-	tableSpan    *heartbeatpb.TableSpan
-	handle       func(commonEvent.Event)
-	changefeedID common.ChangeFeedID
-	checkpointTs uint64
+	id                       common.DispatcherID
+	tableSpan                *heartbeatpb.TableSpan
+	handle                   func(commonEvent.Event)
+	handleEvents             func([]dispatcher.DispatcherEvent, func()) bool
+	changefeedID             common.ChangeFeedID
+	checkpointTs             uint64
+	eventCollectorBatchCount int
+	eventCollectorBatchBytes int
+	batchRecords             chan batchRecord
+}
+
+type batchRecord struct {
+	size      int
+	eventType int
 }
 
 func (m *mockEventDispatcher) GetId() common.DispatcherID {
@@ -61,6 +71,10 @@ func (m *mockEventDispatcher) GetBDRMode() bool {
 
 func (m *mockEventDispatcher) GetChangefeedID() common.ChangeFeedID {
 	return m.changefeedID
+}
+
+func (d *mockEventDispatcher) GetEventCollectorBatchConfig() (batchCount int, batchBytes int) {
+	return d.eventCollectorBatchCount, d.eventCollectorBatchBytes
 }
 
 func (m *mockEventDispatcher) GetTableSpan() *heartbeatpb.TableSpan {
@@ -104,6 +118,15 @@ func (m *mockEventDispatcher) GetCheckpointTs() uint64 {
 }
 
 func (m *mockEventDispatcher) HandleEvents(dispatcherEvents []dispatcher.DispatcherEvent, wakeCallback func()) (block bool) {
+	if m.batchRecords != nil && len(dispatcherEvents) > 0 {
+		m.batchRecords <- batchRecord{
+			size:      len(dispatcherEvents),
+			eventType: dispatcherEvents[0].GetType(),
+		}
+	}
+	if m.handleEvents != nil {
+		return m.handleEvents(dispatcherEvents, wakeCallback)
+	}
 	for _, dispatcherEvent := range dispatcherEvents {
 		m.handle(dispatcherEvent.Event)
 	}
@@ -178,7 +201,10 @@ func TestProcessMessage(t *testing.T) {
 
 	seq.Store(1)
 	done := make(chan struct{})
-	d := &mockEventDispatcher{id: did, tableSpan: &heartbeatpb.TableSpan{TableID: 1}}
+	d := &mockEventDispatcher{
+		id:        did,
+		tableSpan: &heartbeatpb.TableSpan{TableID: 1},
+	}
 	d.handle = func(e commonEvent.Event) {
 		require.Equal(t, e.GetSeq(), seq.Add(1))
 		require.Equal(t, events[e.GetSeq()], e)
@@ -216,9 +242,21 @@ func TestRemoveLastDispatcher(t *testing.T) {
 	cfID1 := common.NewChangefeedID(common.DefaultKeyspaceName)
 	cfID2 := common.NewChangefeedID(common.DefaultKeyspaceName)
 
-	d1 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: &heartbeatpb.TableSpan{TableID: 1}, changefeedID: cfID1}
-	d2 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: &heartbeatpb.TableSpan{TableID: 2}, changefeedID: cfID1}
-	d3 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: &heartbeatpb.TableSpan{TableID: 3}, changefeedID: cfID2}
+	d1 := &mockEventDispatcher{
+		id:           common.NewDispatcherID(),
+		tableSpan:    &heartbeatpb.TableSpan{TableID: 1},
+		changefeedID: cfID1,
+	}
+	d2 := &mockEventDispatcher{
+		id:           common.NewDispatcherID(),
+		tableSpan:    &heartbeatpb.TableSpan{TableID: 2},
+		changefeedID: cfID1,
+	}
+	d3 := &mockEventDispatcher{
+		id:           common.NewDispatcherID(),
+		tableSpan:    &heartbeatpb.TableSpan{TableID: 3},
+		changefeedID: cfID2,
+	}
 
 	// Add dispatchers
 	c.AddDispatcher(d1, 1024)
@@ -437,4 +475,197 @@ func TestGroupHeartbeatResetThenHandshake(t *testing.T) {
 	require.Equal(t, uint8(commonEvent.DispatcherProgressVersion1), heartbeat.DispatcherProgresses[0].Version)
 	require.Equal(t, uint64(210), heartbeat.DispatcherProgresses[0].CheckpointTs)
 	require.Equal(t, uint64(1), heartbeat.DispatcherProgresses[0].Epoch)
+}
+
+// TestEventCollectorBatchByCount blocks the first wake-up so pending DMLs
+// accumulate and the dynamic stream must honor the configured batch count.
+func TestEventCollectorBatchByCount(t *testing.T) {
+	ctx := context.Background()
+	localServerID := node.NewID()
+	c := newTestEventCollector(localServerID)
+	defer c.ds.Close()
+	defer c.redoDs.Close()
+
+	const batchCount = 3
+	const totalDML = 10
+
+	did := common.NewDispatcherID()
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+	helper.Tk().MustExec("use test")
+	ddl := helper.DDL2Event("create table t(id int primary key, v int)")
+	require.NotNil(t, ddl)
+
+	batchRecords := make(chan batchRecord, totalDML+8)
+	done := make(chan struct{})
+	release := make(chan struct{})
+	var seenDML atomic.Int64
+	var blocked atomic.Bool
+
+	d := &mockEventDispatcher{
+		id:                       did,
+		tableSpan:                &heartbeatpb.TableSpan{TableID: 1},
+		changefeedID:             common.NewChangefeedID(common.DefaultKeyspaceName),
+		eventCollectorBatchCount: batchCount,
+		eventCollectorBatchBytes: 0,
+		batchRecords:             batchRecords,
+	}
+	d.handle = func(e commonEvent.Event) {
+		if e.GetType() != commonEvent.TypeDMLEvent {
+			return
+		}
+		if seenDML.Add(1) == totalDML {
+			close(done)
+		}
+	}
+	d.handleEvents = func(events []dispatcher.DispatcherEvent, wakeCallback func()) bool {
+		for _, event := range events {
+			d.handle(event.Event)
+		}
+		if blocked.CompareAndSwap(false, true) {
+			go func() {
+				<-release
+				wakeCallback()
+			}()
+			return true
+		}
+		return false
+	}
+	c.AddDispatcher(d, util.GetOrZero(config.GetDefaultReplicaConfig().MemoryQuota))
+
+	from := localServerID
+	readyEvent := commonEvent.NewReadyEvent(did)
+	c.ds.Push(did, dispatcher.NewDispatcherEvent(&from, &readyEvent))
+
+	handshakeEvent := commonEvent.NewHandshakeEvent(did, ddl.GetStartTs()-1, 1, ddl.TableInfo)
+	c.ds.Push(did, dispatcher.NewDispatcherEvent(&from, &handshakeEvent))
+
+	var seq atomic.Uint64
+	seq.Store(1) // handshake event has seq 1
+	for i := 1; i <= totalDML; i++ {
+		dml := helper.DML2Event("test", "t", fmt.Sprintf("insert into t values(%d, %d)", i, i))
+		require.NotNil(t, dml)
+		dml.DispatcherID = did
+		dml.Seq = seq.Add(1)
+		dml.Epoch = 1
+		dml.CommitTs = ddl.FinishedTs + uint64(i)
+		c.ds.Push(did, dispatcher.NewDispatcherEvent(&from, dml))
+	}
+	close(release)
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		require.FailNow(t, "timeout waiting for dml events")
+	}
+
+	sumDML := 0
+	maxBatch := 0
+	for sumDML < totalDML {
+		select {
+		case r := <-batchRecords:
+			if r.eventType != commonEvent.TypeDMLEvent {
+				continue
+			}
+			sumDML += r.size
+			if r.size > maxBatch {
+				maxBatch = r.size
+			}
+		case <-ctx.Done():
+			require.FailNow(t, "timeout collecting dml batch records")
+		}
+	}
+
+	require.Equal(t, batchCount, maxBatch)
+	require.Equal(t, totalDML, sumDML)
+}
+
+// TestEventCollectorBatchByBytes uses a tiny byte budget so each DML must be
+// delivered alone once the per-dispatcher batch bytes wiring is applied.
+func TestEventCollectorBatchByBytes(t *testing.T) {
+	ctx := context.Background()
+	localServerID := node.NewID()
+	c := newTestEventCollector(localServerID)
+	defer c.ds.Close()
+	defer c.redoDs.Close()
+
+	const totalDML = 12
+
+	did := common.NewDispatcherID()
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+	helper.Tk().MustExec("use test")
+	ddl := helper.DDL2Event("create table t(id int primary key, v int)")
+	require.NotNil(t, ddl)
+
+	batchRecords := make(chan batchRecord, totalDML+8)
+	done := make(chan struct{})
+	var seenDML atomic.Int64
+
+	d := &mockEventDispatcher{
+		id:                       did,
+		tableSpan:                &heartbeatpb.TableSpan{TableID: 1},
+		changefeedID:             common.NewChangefeedID(common.DefaultKeyspaceName),
+		eventCollectorBatchCount: 1024,
+		eventCollectorBatchBytes: 1,
+		batchRecords:             batchRecords,
+	}
+	d.handle = func(e commonEvent.Event) {
+		if e.GetType() != commonEvent.TypeDMLEvent {
+			return
+		}
+		if seenDML.Add(1) == totalDML {
+			close(done)
+		}
+	}
+	c.AddDispatcher(d, util.GetOrZero(config.GetDefaultReplicaConfig().MemoryQuota))
+
+	from := localServerID
+	readyEvent := commonEvent.NewReadyEvent(did)
+	c.ds.Push(did, dispatcher.NewDispatcherEvent(&from, &readyEvent))
+
+	handshakeEvent := commonEvent.NewHandshakeEvent(did, ddl.GetStartTs()-1, 1, ddl.TableInfo)
+	c.ds.Push(did, dispatcher.NewDispatcherEvent(&from, &handshakeEvent))
+
+	var seq atomic.Uint64
+	seq.Store(1) // handshake event has seq 1
+	for i := 1; i <= totalDML; i++ {
+		dml := helper.DML2Event("test", "t", fmt.Sprintf("insert into t values(%d, %d)", i, i))
+		require.NotNil(t, dml)
+		dml.DispatcherID = did
+		dml.Seq = seq.Add(1)
+		dml.Epoch = 1
+		dml.CommitTs = ddl.FinishedTs + uint64(i)
+		c.ds.Push(did, dispatcher.NewDispatcherEvent(&from, dml))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		require.FailNow(t, "timeout waiting for dml events")
+	}
+
+	sumDML := 0
+	maxBatch := 0
+	for sumDML < totalDML {
+		select {
+		case r := <-batchRecords:
+			if r.eventType != commonEvent.TypeDMLEvent {
+				continue
+			}
+			sumDML += r.size
+			if r.size > maxBatch {
+				maxBatch = r.size
+			}
+		case <-ctx.Done():
+			require.FailNow(t, "timeout collecting dml batch records")
+		}
+	}
+
+	require.Equal(t, totalDML, sumDML)
+	require.Equal(t, 1, maxBatch)
 }

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -501,3 +501,11 @@ func (s *sink) Close() {
 		s.storage.Close()
 	}
 }
+
+func (s *sink) BatchCount() int {
+	return 4096
+}
+
+func (s *sink) BatchBytes() int {
+	return s.cfg.FileSize
+}

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -217,6 +217,16 @@ func TestIgnoreCallsAfterRunError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCloudStorageSinkBatchConfig(t *testing.T) {
+	sink := &sink{
+		cfg: &cloudstorage.Config{
+			FileSize: 2048,
+		},
+	}
+	require.Equal(t, 4096, sink.BatchCount())
+	require.Equal(t, 2048, sink.BatchBytes())
+}
+
 func TestWriteDDLEvent(t *testing.T) {
 	parentDir := t.TempDir()
 	uri := fmt.Sprintf("file:///%s?protocol=csv", parentDir)

--- a/downstreamadapter/sink/mock/sink_mock.go
+++ b/downstreamadapter/sink/mock/sink_mock.go
@@ -60,6 +60,34 @@ func (mr *MockSinkMockRecorder) AddDMLEvent(event interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDMLEvent", reflect.TypeOf((*MockSink)(nil).AddDMLEvent), event)
 }
 
+// BatchBytes mocks base method.
+func (m *MockSink) BatchBytes() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchBytes")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// BatchBytes indicates an expected call of BatchBytes.
+func (mr *MockSinkMockRecorder) BatchBytes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchBytes", reflect.TypeOf((*MockSink)(nil).BatchBytes))
+}
+
+// BatchCount mocks base method.
+func (m *MockSink) BatchCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// BatchCount indicates an expected call of BatchCount.
+func (mr *MockSinkMockRecorder) BatchCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchCount", reflect.TypeOf((*MockSink)(nil).BatchCount))
+}
+
 // Close mocks base method.
 func (m *MockSink) Close() {
 	m.ctrl.T.Helper()

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -420,3 +420,11 @@ func (s *Sink) BatchCount() int {
 func (s *Sink) BatchBytes() int {
 	return int(s.cfg.MaxAllowedPacket)
 }
+
+func (s *Sink) BatchCount() int {
+	return s.maxTxnRows * len(s.dmlWriter)
+}
+
+func (s *Sink) BatchBytes() int {
+	return int(s.cfg.MaxAllowedPacket)
+}

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -420,11 +420,3 @@ func (s *Sink) BatchCount() int {
 func (s *Sink) BatchBytes() int {
 	return int(s.cfg.MaxAllowedPacket)
 }
-
-func (s *Sink) BatchCount() int {
-	return s.maxTxnRows * len(s.dmlWriter)
-}
-
-func (s *Sink) BatchBytes() int {
-	return int(s.cfg.MaxAllowedPacket)
-}

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -128,6 +128,21 @@ func expectCreateTableDDLFlow(mock sqlmock.Sqlmock) {
 	mock.ExpectCommit()
 }
 
+func TestMysqlSinkBatchConfig(t *testing.T) {
+	cfg := mysql.New()
+	cfg.MaxTxnRow = 128
+	cfg.MaxAllowedPacket = 4096
+
+	sink := &Sink{
+		cfg:        cfg,
+		maxTxnRows: cfg.MaxTxnRow,
+		dmlWriter:  make([]*mysql.Writer, 3),
+	}
+
+	require.Equal(t, 384, sink.BatchCount())
+	require.Equal(t, 4096, sink.BatchBytes())
+}
+
 // Test callback and tableProgress works as expected after AddDMLEvent
 func TestMysqlSinkBasicFunctionality(t *testing.T) {
 	sink, mock := MysqlSinkForTest()

--- a/downstreamadapter/sink/pulsar/sink_test.go
+++ b/downstreamadapter/sink/pulsar/sink_test.go
@@ -139,7 +139,6 @@ func TestPulsarSinkBatchConfig(t *testing.T) {
 	require.Equal(t, 4096, sink.BatchCount())
 	require.Zero(t, sink.BatchBytes())
 }
-
 func TestPulsarSinkNewWithComponentReturnsDMLProducerError(t *testing.T) {
 	changefeedID := common.NewChangefeedID4Test("test", "test")
 	expectedErr := cerror.ErrPulsarNewProducer.GenWithStackByArgs()

--- a/downstreamadapter/sink/pulsar/sink_test.go
+++ b/downstreamadapter/sink/pulsar/sink_test.go
@@ -139,6 +139,7 @@ func TestPulsarSinkBatchConfig(t *testing.T) {
 	require.Equal(t, 4096, sink.BatchCount())
 	require.Zero(t, sink.BatchBytes())
 }
+
 func TestPulsarSinkNewWithComponentReturnsDMLProducerError(t *testing.T) {
 	changefeedID := common.NewChangefeedID4Test("test", "test")
 	expectedErr := cerror.ErrPulsarNewProducer.GenWithStackByArgs()

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -46,6 +46,8 @@ type Sink interface {
 	SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStore)
 	Close()
 	Run(ctx context.Context) error
+	BatchCount() int
+	BatchBytes() int
 }
 
 func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) (Sink, error) {

--- a/pkg/config/changefeed.go
+++ b/pkg/config/changefeed.go
@@ -198,9 +198,11 @@ type ChangefeedConfig struct {
 	TimeZone      string `json:"timezone" default:"system"`
 	CaseSensitive bool   `json:"case_sensitive" default:"false"`
 	// if true, force to replicate some ineligible tables
-	ForceReplicate bool          `json:"force_replicate" default:"false"`
-	Filter         *FilterConfig `toml:"filter" json:"filter"`
-	MemoryQuota    uint64        `toml:"memory-quota" json:"memory-quota"`
+	ForceReplicate           bool          `json:"force_replicate" default:"false"`
+	Filter                   *FilterConfig `toml:"filter" json:"filter"`
+	MemoryQuota              uint64        `toml:"memory-quota" json:"memory-quota"`
+	EventCollectorBatchCount *int          `json:"event_collector_batch_count"`
+	EventCollectorBatchBytes *int          `json:"event_collector_batch_bytes"`
 	// sync point related
 	// TODO: Is syncPointRetention|default can be removed?
 	EnableSyncPoint       bool          `json:"enable_sync_point" default:"false"`
@@ -272,24 +274,26 @@ type ChangeFeedInfo struct {
 
 func (info *ChangeFeedInfo) ToChangefeedConfig() *ChangefeedConfig {
 	return &ChangefeedConfig{
-		ChangefeedID:           info.ChangefeedID,
-		StartTS:                info.StartTs,
-		TargetTS:               info.TargetTs,
-		SinkURI:                info.SinkURI,
-		CaseSensitive:          util.GetOrZero(info.Config.CaseSensitive),
-		ForceReplicate:         util.GetOrZero(info.Config.ForceReplicate),
-		SinkConfig:             info.Config.Sink,
-		Filter:                 info.Config.Filter,
-		EnableSyncPoint:        util.GetOrZero(info.Config.EnableSyncPoint),
-		SyncPointInterval:      util.GetOrZero(info.Config.SyncPointInterval),
-		SyncPointRetention:     util.GetOrZero(info.Config.SyncPointRetention),
-		EnableSplittableCheck:  util.GetOrZero(info.Config.Scheduler.EnableSplittableCheck),
-		MemoryQuota:            util.GetOrZero(info.Config.MemoryQuota),
-		Epoch:                  info.Epoch,
-		BDRMode:                util.GetOrZero(info.Config.BDRMode),
-		TimeZone:               GetGlobalServerConfig().TZ,
-		Consistent:             info.Config.Consistent,
-		EnableTableAcrossNodes: util.GetOrZero(info.Config.Scheduler.EnableTableAcrossNodes),
+		ChangefeedID:             info.ChangefeedID,
+		StartTS:                  info.StartTs,
+		TargetTS:                 info.TargetTs,
+		SinkURI:                  info.SinkURI,
+		CaseSensitive:            util.GetOrZero(info.Config.CaseSensitive),
+		ForceReplicate:           util.GetOrZero(info.Config.ForceReplicate),
+		SinkConfig:               info.Config.Sink,
+		Filter:                   info.Config.Filter,
+		EnableSyncPoint:          util.GetOrZero(info.Config.EnableSyncPoint),
+		SyncPointInterval:        util.GetOrZero(info.Config.SyncPointInterval),
+		SyncPointRetention:       util.GetOrZero(info.Config.SyncPointRetention),
+		EnableSplittableCheck:    util.GetOrZero(info.Config.Scheduler.EnableSplittableCheck),
+		MemoryQuota:              util.GetOrZero(info.Config.MemoryQuota),
+		EventCollectorBatchCount: info.Config.EventCollectorBatchCount,
+		EventCollectorBatchBytes: info.Config.EventCollectorBatchBytes,
+		Epoch:                    info.Epoch,
+		BDRMode:                  util.GetOrZero(info.Config.BDRMode),
+		TimeZone:                 GetGlobalServerConfig().TZ,
+		Consistent:               info.Config.Consistent,
+		EnableTableAcrossNodes:   util.GetOrZero(info.Config.Scheduler.EnableTableAcrossNodes),
 		// other fields are not necessary for dispatcherManager
 	}
 }

--- a/pkg/config/changefeed_test.go
+++ b/pkg/config/changefeed_test.go
@@ -16,6 +16,8 @@ package config
 import (
 	"testing"
 
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +41,27 @@ func TestFeedStateIsResumable(t *testing.T) {
 	for _, tt := range tests {
 		require.Equal(t, tt.resumable, tt.state.IsResumable())
 	}
+}
+
+// TestChangeFeedInfoToChangefeedConfigBatchFields ensures the maintainer-facing
+// changefeed config keeps the optional event collector batch overrides.
+func TestChangeFeedInfoToChangefeedConfigBatchFields(t *testing.T) {
+	assertBatchFields := func(batchCount *int, batchBytes *int) {
+		replicaConfig := GetDefaultReplicaConfig()
+		replicaConfig.EventCollectorBatchCount = batchCount
+		replicaConfig.EventCollectorBatchBytes = batchBytes
+
+		info := &ChangeFeedInfo{
+			ChangefeedID: common.NewChangefeedID4Test("test", "test"),
+			Config:       replicaConfig,
+		}
+
+		changefeedConfig := info.ToChangefeedConfig()
+		require.Equal(t, batchCount, changefeedConfig.EventCollectorBatchCount)
+		require.Equal(t, batchBytes, changefeedConfig.EventCollectorBatchBytes)
+	}
+
+	assertBatchFields(nil, nil)
+	assertBatchFields(util.AddressOf(0), util.AddressOf(0))
+	assertBatchFields(util.AddressOf(123), util.AddressOf(456))
 }

--- a/pkg/config/consistent.go
+++ b/pkg/config/consistent.go
@@ -32,6 +32,7 @@ type ConsistentConfig struct {
 	Level *string `toml:"level" json:"level,omitempty"`
 	// MaxLogSize is the max size(MiB) of a log file written by redo log.
 	// Default is 64MiB.
+	// It also controls the redo default event collector batch bytes.
 	MaxLogSize *int64 `toml:"max-log-size" json:"max-log-size,omitempty"`
 	// FlushIntervalInMs is the flush interval(ms) of redo log to flush log to storage.
 	// Default is 2000ms.
@@ -40,6 +41,9 @@ type ConsistentConfig struct {
 	// flush meta(resolvedTs and checkpointTs) to storage.
 	// Default is 200ms.
 	MetaFlushIntervalInMs *int64 `toml:"meta-flush-interval" json:"meta-flush-interval,omitempty"`
+	// EventCollectorBatchCount overrides redo event collector batch count.
+	// If unset, redo uses the sink-derived default.
+	EventCollectorBatchCount *int `toml:"event-collector-batch-count" json:"event-collector-batch-count,omitempty"`
 	// EncodingWorkerNum is the number of workers to encode `RowChangeEvent`` to redo log.
 	// Default is 16.
 	EncodingWorkerNum *int `toml:"encoding-worker-num" json:"encoding-worker-num,omitempty"`
@@ -105,6 +109,15 @@ func (c *ConsistentConfig) validateAndAdjust(enableIOCheck bool) error {
 		return errors.ErrInvalidReplicaConfig.FastGenByArgs(
 			fmt.Sprintf("The consistent.meta-flush-interval:%d must be equal or greater than %d",
 				util.GetOrZero(c.MetaFlushIntervalInMs), redo.MinFlushIntervalInMs))
+	}
+
+	if c.EventCollectorBatchCount != nil {
+		if *c.EventCollectorBatchCount < 0 {
+			return errors.ErrInvalidReplicaConfig.FastGenByArgs("consistent.event-collector-batch-count must be set not smaller than 0")
+		}
+		if *c.EventCollectorBatchCount > MaxEventCollectorBatchCount {
+			return errors.ErrInvalidReplicaConfig.FastGenByArgs("consistent.event-collector-batch-count must be set not larger than %d", MaxEventCollectorBatchCount)
+		}
 	}
 
 	compressionType := util.GetOrZero(c.Compression)

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -39,6 +39,8 @@ const (
 	minChangeFeedErrorStuckDuration = time.Minute * 30
 	// DefaultTiDBSourceID is the default source ID of TiDB cluster.
 	DefaultTiDBSourceID = 1
+
+	MaxEventCollectorBatchCount = 8192
 )
 
 var defaultReplicaConfig = &ReplicaConfig{
@@ -171,6 +173,12 @@ type replicaConfig struct {
 	Integrity                    *integrity.Config   `toml:"integrity" json:"integrity"`
 	ChangefeedErrorStuckDuration *time.Duration      `toml:"changefeed-error-stuck-duration" json:"changefeed-error-stuck-duration,omitempty"`
 	SyncedStatus                 *SyncedStatusConfig `toml:"synced-status" json:"synced-status,omitempty"`
+
+	// these fields are used by the event collector dynamic stream to achieve better batch performance.
+	// it's not initialized in the defaultReplicaConfig by the purpose.
+	// if it's set, will override the default value which derived from the internal sink.
+	EventCollectorBatchCount *int `toml:"event-collector-batch-count" json:"event-collector-batch-count,omitempty"`
+	EventCollectorBatchBytes *int `toml:"event-collector-batch-bytes" json:"event-collector-batch-bytes,omitempty"`
 
 	// Deprecated: we don't use this field since v8.0.0.
 	SQLMode string `toml:"sql-mode" json:"sql-mode"`
@@ -342,6 +350,18 @@ func (c *ReplicaConfig) ValidateAndAdjust(sinkURI *url.URL) error { // check sin
 					minChangeFeedErrorStuckDuration.Seconds()))
 	}
 
+	// allow the batch count and batch bytes set to 0, to disable the batch mechanism
+	if c.EventCollectorBatchCount != nil && *c.EventCollectorBatchCount < 0 {
+		return cerror.ErrInvalidReplicaConfig.FastGenByArgs("event-collector-batch-count must be set not smaller than 0")
+	}
+	if c.EventCollectorBatchCount != nil && *c.EventCollectorBatchCount > MaxEventCollectorBatchCount {
+		return cerror.ErrInvalidReplicaConfig.FastGenByArgs(
+			"event-collector-batch-count must be set not larger than %d", MaxEventCollectorBatchCount,
+		)
+	}
+	if c.EventCollectorBatchBytes != nil && *c.EventCollectorBatchBytes < 0 {
+		return cerror.ErrInvalidReplicaConfig.FastGenByArgs("event-collector-batch-bytes must be set not smaller than 0")
+	}
 	return nil
 }
 

--- a/pkg/config/replica_config_test.go
+++ b/pkg/config/replica_config_test.go
@@ -194,6 +194,34 @@ func TestReplicaConfig_EnableSplittableCheck_DefaultValue(t *testing.T) {
 	require.False(t, util.GetOrZero(config.Scheduler.EnableSplittableCheck))
 }
 
+// TestReplicaConfigValidateBatchConfig verifies validation accepts zero as an
+// explicit override and rejects values outside the supported range.
+func TestReplicaConfigValidateBatchConfig(t *testing.T) {
+	sinkURI, err := url.Parse("mysql://localhost:3306/test")
+	require.NoError(t, err)
+
+	assertBatchConfig := func(batchCount *int, batchBytes *int, wantErr string) {
+		cfg := GetDefaultReplicaConfig()
+		cfg.EventCollectorBatchCount = batchCount
+		cfg.EventCollectorBatchBytes = batchBytes
+
+		err := cfg.ValidateAndAdjust(sinkURI)
+		if wantErr != "" {
+			require.ErrorContains(t, err, wantErr)
+			return
+		}
+		require.NoError(t, err)
+	}
+
+	assertBatchConfig(util.AddressOf(0), nil, "")
+	assertBatchConfig(nil, util.AddressOf(0), "")
+	assertBatchConfig(util.AddressOf(1), util.AddressOf(1), "")
+	assertBatchConfig(util.AddressOf(MaxEventCollectorBatchCount), nil, "")
+	assertBatchConfig(util.AddressOf(MaxEventCollectorBatchCount+1), nil, "event-collector-batch-count")
+	assertBatchConfig(util.AddressOf(-1), nil, "event-collector-batch-count")
+	assertBatchConfig(nil, util.AddressOf(-1), "event-collector-batch-bytes")
+}
+
 func TestReplicaConfig_EnableRedoIOCheck_DefaultValue(t *testing.T) {
 	config := GetDefaultReplicaConfig()
 	require.True(t, util.GetOrZero(config.EnableRedoIOCheck))

--- a/pkg/metrics/dynamic_stream.go
+++ b/pkg/metrics/dynamic_stream.go
@@ -55,7 +55,7 @@ var (
 			Subsystem: "dynamic_stream",
 			Name:      "batch_count",
 			Help:      "The number of events in each batch processed by dynamic stream",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 15), // 1 ~ 16384
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 16), // 1 ~ 32768
 		}, []string{"module", "area"})
 	DynamicStreamBatchBytes = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -63,7 +63,7 @@ var (
 			Subsystem: "dynamic_stream",
 			Name:      "batch_bytes",
 			Help:      "The total bytes in each batch processed by dynamic stream",
-			Buckets:   prometheus.ExponentialBuckets(1024, 2, 18), // 1KB ~ 128MB
+			Buckets:   prometheus.ExponentialBuckets(1024, 2, 20), // 1KiB ~ 512MiB
 		}, []string{"module", "area"})
 	DynamicStreamBatchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/utils/dynstream/area_batch_config_registry.go
+++ b/utils/dynstream/area_batch_config_registry.go
@@ -1,0 +1,110 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynstream
+
+import "sync/atomic"
+
+type areaBatchConfigRegistry[A Area] struct {
+	defaultConfig batchConfig
+
+	// The configs are stored as an immutable map in atomic.Value
+	// getBatchConfig can stay lock-free on the hot path (popEvents).
+	// The tradeoff is copy-on-write on updates.
+	configs atomic.Value // map[A]batchConfig
+
+	// areaRefCount is not thread safe by itself.
+	// Callers must serialize updates externally
+	areaRefCount map[A]int
+}
+
+func newAreaBatchConfigRegistry[A Area](defaultConfig batchConfig) *areaBatchConfigRegistry[A] {
+	s := &areaBatchConfigRegistry[A]{
+		defaultConfig: defaultConfig,
+		areaRefCount:  make(map[A]int),
+	}
+	s.configs.Store(make(map[A]batchConfig))
+	return s
+}
+
+func (s *areaBatchConfigRegistry[A]) getBatchConfig(area A) batchConfig {
+	configs := s.configs.Load().(map[A]batchConfig)
+	if config, ok := configs[area]; ok {
+		return config
+	}
+	return s.defaultConfig
+}
+
+// onAddPath is not thread safe.
+func (s *areaBatchConfigRegistry[A]) onAddPath(area A, cfg batchConfig) {
+	oldCount := s.areaRefCount[area]
+	s.areaRefCount[area] = oldCount + 1
+	if oldCount > 0 {
+		// First-add semantics: once an area already has paths, later AddPath calls
+		// should not overwrite its batch config.
+		return
+	}
+
+	// Zero config means no explicit area batch config was provided.
+	if cfg.softCount <= 0 && cfg.hardBytes <= 0 {
+		return
+	}
+
+	cfg = newBatchConfig(cfg.softCount, cfg.hardBytes)
+	if cfg == s.defaultConfig {
+		return
+	}
+
+	s.setOverrideLocked(area, cfg)
+}
+
+// onRemovePath is not thread safe.
+func (s *areaBatchConfigRegistry[A]) onRemovePath(area A) {
+	oldCount := s.areaRefCount[area]
+	if oldCount <= 1 {
+		delete(s.areaRefCount, area)
+		s.removeOverrideLocked(area)
+		return
+	}
+	s.areaRefCount[area] = oldCount - 1
+}
+
+func (s *areaBatchConfigRegistry[A]) setOverrideLocked(area A, config batchConfig) {
+	// Copy-on-write update:
+	// - Read path is lock-free and wait-free (single atomic load + map lookup).
+	// - Write path is O(n) in override-count, but writes are expected to be infrequent
+	//   compared to reads, and n is usually small because only overridden areas are stored.
+	oldConfigs := s.configs.Load().(map[A]batchConfig)
+	newConfigs := make(map[A]batchConfig, len(oldConfigs)+1)
+	for k, v := range oldConfigs {
+		newConfigs[k] = v
+	}
+	newConfigs[area] = config
+	s.configs.Store(newConfigs)
+}
+
+func (s *areaBatchConfigRegistry[A]) removeOverrideLocked(area A) {
+	// Same copy-on-write rationale as setOverrideLocked.
+	oldConfigs := s.configs.Load().(map[A]batchConfig)
+	if _, ok := oldConfigs[area]; !ok {
+		return
+	}
+	newConfigs := make(map[A]batchConfig, len(oldConfigs)-1)
+	for k, v := range oldConfigs {
+		if k == area {
+			continue
+		}
+		newConfigs[k] = v
+	}
+	s.configs.Store(newConfigs)
+}

--- a/utils/dynstream/area_batch_config_registry.go
+++ b/utils/dynstream/area_batch_config_registry.go
@@ -46,6 +46,7 @@ func (s *areaBatchConfigRegistry[A]) getBatchConfig(area A) batchConfig {
 }
 
 // onAddPath is not thread safe.
+// it's called by the AddPath, which is protected by the caller's lock.
 func (s *areaBatchConfigRegistry[A]) onAddPath(area A, cfg batchConfig) {
 	oldCount := s.areaRefCount[area]
 	s.areaRefCount[area] = oldCount + 1
@@ -69,6 +70,7 @@ func (s *areaBatchConfigRegistry[A]) onAddPath(area A, cfg batchConfig) {
 }
 
 // onRemovePath is not thread safe.
+// it's called by the RemovePath, which is protected by the caller's lock.
 func (s *areaBatchConfigRegistry[A]) onRemovePath(area A) {
 	oldCount := s.areaRefCount[area]
 	if oldCount <= 1 {

--- a/utils/dynstream/area_batch_config_registry_test.go
+++ b/utils/dynstream/area_batch_config_registry_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynstream
+
+// Tests for per-area batch config registry.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAreaConfigNoOverrideOnZeroConfig(t *testing.T) {
+	defaultConfig := newBatchConfig(4, 0)
+	registry := newAreaBatchConfigRegistry[int](defaultConfig)
+
+	registry.onAddPath(1, batchConfig{})
+	require.Equal(t, defaultConfig, registry.getBatchConfig(1))
+}
+
+func TestAreaConfigApplyOnFirstAdd(t *testing.T) {
+	defaultConfig := newBatchConfig(4, 0)
+	registry := newAreaBatchConfigRegistry[int](defaultConfig)
+
+	registry.onAddPath(1, newBatchConfig(2, 0))
+	require.Equal(t, newBatchConfig(2, 0), registry.getBatchConfig(1))
+}
+
+func TestAreaConfigFirstAddWins(t *testing.T) {
+	defaultConfig := newBatchConfig(4, 0)
+	registry := newAreaBatchConfigRegistry[int](defaultConfig)
+
+	registry.onAddPath(1, newBatchConfig(2, 0))
+	registry.onAddPath(1, newBatchConfig(3, 0))
+	require.Equal(t, newBatchConfig(2, 0), registry.getBatchConfig(1))
+}
+
+func TestAreaConfigReapplyAfterCleanup(t *testing.T) {
+	defaultConfig := newBatchConfig(4, 0)
+	registry := newAreaBatchConfigRegistry[int](defaultConfig)
+
+	registry.onAddPath(1, newBatchConfig(2, 0))
+	require.Equal(t, newBatchConfig(2, 0), registry.getBatchConfig(1))
+
+	registry.onRemovePath(1)
+	require.Equal(t, defaultConfig, registry.getBatchConfig(1))
+
+	registry.onAddPath(1, newBatchConfig(3, 0))
+	require.Equal(t, newBatchConfig(3, 0), registry.getBatchConfig(1))
+}
+
+func TestAreaSettingsBatchConfigNormalized(t *testing.T) {
+	settings := NewAreaSettingsWithMaxPendingSizeAndBatchConfig(
+		64*1024*1024, 0, "test", 0, -1,
+	)
+	require.Equal(t, newBatchConfig(0, -1), settings.batchConfig)
+}

--- a/utils/dynstream/area_batch_config_registry_test.go
+++ b/utils/dynstream/area_batch_config_registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,11 +58,4 @@ func TestAreaConfigReapplyAfterCleanup(t *testing.T) {
 
 	registry.onAddPath(1, newBatchConfig(3, 0))
 	require.Equal(t, newBatchConfig(3, 0), registry.getBatchConfig(1))
-}
-
-func TestAreaSettingsBatchConfigNormalized(t *testing.T) {
-	settings := NewAreaSettingsWithMaxPendingSizeAndBatchConfig(
-		64*1024*1024, 0, "test", 0, -1,
-	)
-	require.Equal(t, newBatchConfig(0, -1), settings.batchConfig)
 }

--- a/utils/dynstream/batcher.go
+++ b/utils/dynstream/batcher.go
@@ -1,0 +1,119 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynstream
+
+import (
+	"time"
+)
+
+type batchConfig struct {
+	// if the bytes == 0, softCount is the hard count limit.
+	// if the bytes > 0, softCount is the soft count limit, means it can be exceed.
+	softCount int
+
+	// hardCount take effect only if the bytes > 0, it becomes the hard count limit.
+	hardCount int
+
+	// hardBytes controls size based flushing. 0 disables byte based limit.
+	// The current batch can exceed bytes by at most one event.
+	hardBytes int
+}
+
+const countCapMultiple = 8
+
+func newDefaultBatchConfig() batchConfig {
+	// Keep the default behavior consistent with the legacy Option.BatchCount=1:
+	// no batching unless explicitly configured by the caller.
+	return newBatchConfig(1, 0)
+}
+
+func newBatchConfig(count, bytes int) batchConfig {
+	if count <= 0 {
+		count = 1
+	}
+	if bytes < 0 {
+		bytes = 0
+	}
+	return batchConfig{
+		softCount: count,
+		hardCount: count * countCapMultiple,
+		hardBytes: bytes,
+	}
+}
+
+type batcher[T Event] struct {
+	config batchConfig
+	nBytes int
+	buf    []T
+
+	start time.Time
+}
+
+func newDefaultBatcher[T Event]() *batcher[T] {
+	return newBatcher[T](newDefaultBatchConfig())
+}
+
+func newBatcher[T Event](cfg batchConfig) *batcher[T] {
+	b := &batcher[T]{}
+	b.setLimit(cfg)
+	return b
+}
+
+// setLimit must be called after the previous flushed data is fully consumed
+func (b *batcher[T]) setLimit(cfg batchConfig) {
+	b.config = cfg
+	if cap(b.buf) < cfg.softCount {
+		b.buf = make([]T, 0, cfg.softCount)
+	} else {
+		b.buf = b.buf[:0]
+	}
+	b.nBytes = 0
+	b.start = time.Now()
+}
+
+func (b *batcher[T]) addEvent(event T, size int) {
+	b.buf = append(b.buf, event)
+	b.nBytes += size
+}
+
+// isFull returns true if the batcher should flush and stop appending more events.
+func (b *batcher[T]) isFull() bool {
+	n := len(b.buf)
+	if n == 0 {
+		return false
+	}
+
+	if b.config.hardBytes <= 0 {
+		return n >= b.config.softCount
+	}
+
+	if n >= b.config.hardCount {
+		return true
+	}
+
+	return b.nBytes >= b.config.hardBytes
+}
+
+// flush returned events must be processed before adding more events to the batcher.
+func (b *batcher[T]) flush() ([]T, int, time.Duration) {
+	if len(b.buf) == 0 {
+		return nil, 0, 0
+	}
+	// note: the returned events share the underlying slice with the batcher
+	events := b.buf
+	b.buf = b.buf[:0]
+	nBytes := b.nBytes
+	b.nBytes = 0
+	return events, nBytes, time.Since(b.start)
+}

--- a/utils/dynstream/batcher.go
+++ b/utils/dynstream/batcher.go
@@ -15,6 +15,8 @@ package dynstream
 
 import (
 	"time"
+
+	"github.com/pingcap/ticdc/pkg/config"
 )
 
 type batchConfig struct {
@@ -30,7 +32,7 @@ type batchConfig struct {
 	hardBytes int
 }
 
-const countCapMultiple = 8
+const countCapMultiple = 4
 
 func newDefaultBatchConfig() batchConfig {
 	// Keep the default behavior consistent with the legacy Option.BatchCount=1:
@@ -41,6 +43,9 @@ func newDefaultBatchConfig() batchConfig {
 func newBatchConfig(count, bytes int) batchConfig {
 	if count <= 0 {
 		count = 1
+	}
+	if count > config.MaxEventCollectorBatchCount {
+		count = config.MaxEventCollectorBatchCount
 	}
 	if bytes < 0 {
 		bytes = 0

--- a/utils/dynstream/batcher_test.go
+++ b/utils/dynstream/batcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@ package dynstream
 import (
 	"testing"
 
+	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/stretchr/testify/require"
 )
 
+// TestBatcherSetLimit verifies switching area batch config clears buffered
+// state before the batcher is reused.
 func TestBatcherSetLimit(t *testing.T) {
 	b := newBatcher[*mockEvent](newBatchConfig(4, 0))
 	b.addEvent(&mockEvent{value: 1}, 16)
@@ -32,6 +35,27 @@ func TestBatcherSetLimit(t *testing.T) {
 	require.Equal(t, 64, b.config.hardBytes)
 }
 
+// TestNewAreaSettingsWithMaxPendingSizeAndBatchConfigNormalizesBatchConfig
+// verifies the public constructor keeps the same normalization rules as the
+// internal batch config helper.
+func TestNewAreaSettingsWithMaxPendingSizeAndBatchConfigNormalizesBatchConfig(t *testing.T) {
+	settings := NewAreaSettingsWithMaxPendingSizeAndBatchConfig(
+		64*1024*1024, 0, "test", 0, -1,
+	)
+	require.Equal(t, newBatchConfig(0, -1), settings.batchConfig)
+}
+
+// TestNewBatchConfigClampsSoftCount keeps user overrides within the supported
+// upper bound before dynstream starts batching.
+func TestNewBatchConfigClampsSoftCount(t *testing.T) {
+	cfg := newBatchConfig(config.MaxEventCollectorBatchCount+1, 0)
+	require.Equal(t, config.MaxEventCollectorBatchCount, cfg.softCount)
+	require.Equal(t, config.MaxEventCollectorBatchCount*countCapMultiple, cfg.hardCount)
+	require.Equal(t, 0, cfg.hardBytes)
+}
+
+// TestBatchByBytes verifies byte-based batching flushes at the first event that
+// would push the accumulated batch size over the configured threshold.
 func TestBatchByBytes(t *testing.T) {
 	handler := mockHandler{}
 	registry := newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
@@ -91,6 +115,8 @@ func TestBatchByBytes(t *testing.T) {
 	require.Equal(t, int64(0), eq.totalPendingLength.Load())
 }
 
+// TestBatchByHardCount verifies byte-based batching still has a hard event cap
+// to prevent unbounded growth when individual events are tiny.
 func TestBatchByHardCount(t *testing.T) {
 	handler := mockHandler{}
 	registry := newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
@@ -114,14 +140,20 @@ func TestBatchByHardCount(t *testing.T) {
 	}
 
 	events, _, _, _ := eq.popEvents(b)
-	require.Len(t, events, 8)
-	require.Equal(t, int64(1), eq.totalPendingLength.Load())
+	require.Len(t, events, countCapMultiple)
+	require.Equal(t, int64(9-countCapMultiple), eq.totalPendingLength.Load())
+
+	events, _, _, _ = eq.popEvents(b)
+	require.Len(t, events, countCapMultiple)
+	require.Equal(t, int64(9-2*countCapMultiple), eq.totalPendingLength.Load())
 
 	events, _, _, _ = eq.popEvents(b)
 	require.Len(t, events, 1)
 	require.Equal(t, int64(0), eq.totalPendingLength.Load())
 }
 
+// TestBatchByBytesLargeFirstEvent verifies an oversized first event still gets
+// delivered and does not consume the following event in the same batch.
 func TestBatchByBytesLargeFirstEvent(t *testing.T) {
 	handler := mockHandler{}
 	registry := newAreaBatchConfigRegistry[int](newDefaultBatchConfig())

--- a/utils/dynstream/event_queue.go
+++ b/utils/dynstream/event_queue.go
@@ -27,26 +27,28 @@ type eventSignal[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]] struct 
 }
 
 type eventQueue[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]] struct {
-	option  Option
 	handler H
-	// Used to reduce the block allocation in the paths' pending queue.
+	// Used to reduce the block allocation in the paths pending queue.
 	eventBlockAlloc *deque.BlockAllocator[eventWrap[A, P, T, D, H]]
 
-	// Signal queue is used to decide which path's events should be popped.
+	batchConfigRegistry *areaBatchConfigRegistry[A]
+
+	// Signal queue is used to decide which paths events should be popped.
 	signalQueue        *deque.Deque[eventSignal[A, P, T, D, H]]
 	totalPendingLength *atomic.Int64 // The total signal count in the queue.
 }
 
-func newEventQueue[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](option Option, handler H) eventQueue[A, P, T, D, H] {
-	eq := eventQueue[A, P, T, D, H]{
-		option:             option,
-		handler:            handler,
-		eventBlockAlloc:    deque.NewBlockAllocator[eventWrap[A, P, T, D, H]](32, 1024),
-		signalQueue:        deque.NewDeque(1024, deque.NewBlockAllocator[eventSignal[A, P, T, D, H]](1024, 32)),
-		totalPendingLength: &atomic.Int64{},
+func newEventQueue[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](
+	handler H,
+	batchConfigRegistry *areaBatchConfigRegistry[A],
+) eventQueue[A, P, T, D, H] {
+	return eventQueue[A, P, T, D, H]{
+		handler:             handler,
+		eventBlockAlloc:     deque.NewBlockAllocator[eventWrap[A, P, T, D, H]](32, 1024),
+		batchConfigRegistry: batchConfigRegistry,
+		signalQueue:         deque.NewDeque(1024, deque.NewBlockAllocator[eventSignal[A, P, T, D, H]](1024, 32)),
+		totalPendingLength:  &atomic.Int64{},
 	}
-
-	return eq
 }
 
 func (q *eventQueue[A, P, T, D, H]) initPath(path *pathInfo[A, P, T, D, H]) {
@@ -100,28 +102,20 @@ func (q *eventQueue[A, P, T, D, H]) wakePath(path *pathInfo[A, P, T, D, H]) {
 	}
 }
 
-func (q *eventQueue[A, P, T, D, H]) popEvents(buf []T) ([]T, *pathInfo[A, P, T, D, H], int) {
-	// Append the event to the buffer
-	var totalBytes int
-	appendToBuf := func(event *eventWrap[A, P, T, D, H], path *pathInfo[A, P, T, D, H]) {
-		buf = append(buf, event.event)
-		totalBytes += event.eventSize
-		path.popEvent()
-	}
-
+func (q *eventQueue[A, P, T, D, H]) popEvents(b *batcher[T]) ([]T, *pathInfo[A, P, T, D, H], int, time.Duration) {
 	for {
 		// We are going to update the signal directly, so we need the reference.
 		signal, ok := q.signalQueue.FrontRef()
 		if !ok {
-			return buf, nil, totalBytes
+			return nil, nil, 0, 0
 		}
-
-		path := signal.pathInfo
-		pendingQueue := path.pendingQueue
 
 		if signal.eventCount == 0 {
 			log.Panic("signal event count is zero")
 		}
+
+		path := signal.pathInfo
+		pendingQueue := path.pendingQueue
 		if path.removed.Load() {
 			// A removed path can still receive stale in-flight signals/events.
 			// Clear the path queue and reconcile memory before dropping the signal.
@@ -138,8 +132,6 @@ func (q *eventQueue[A, P, T, D, H]) popEvents(buf []T) ([]T, *pathInfo[A, P, T, 
 			continue
 		}
 
-		batchSize := min(signal.eventCount, q.option.BatchCount)
-
 		firstEvent, ok := pendingQueue.FrontRef()
 		if !ok {
 			// The signal could contain more events than the pendingQueue,
@@ -152,11 +144,17 @@ func (q *eventQueue[A, P, T, D, H]) popEvents(buf []T) ([]T, *pathInfo[A, P, T, 
 		firstGroup := firstEvent.eventType.DataGroup
 		firstProperty := firstEvent.eventType.Property
 
-		appendToBuf(firstEvent, path)
+		batchConfig := q.batchConfigRegistry.getBatchConfig(path.area)
+		b.setLimit(batchConfig)
+
+		var count int
+		b.addEvent(firstEvent.event, firstEvent.eventSize)
+		path.popEvent()
+		count++
 
 		// Try to batch events with the same data group.
-		count := 1
-		for ; count < batchSize; count++ {
+		// We check isFull before append, so batch-by-bytes can exceed the limit by at most one event.
+		for count < signal.eventCount && !b.isFull() {
 			// Get the reference of the front event of the path.
 			// We don't use PopFront here because we need to keep the event in the path.
 			// Otherwise, the event may lost when the loop is break below.
@@ -168,7 +166,9 @@ func (q *eventQueue[A, P, T, D, H]) popEvents(buf []T) ([]T, *pathInfo[A, P, T, 
 				front.eventType.Property == NonBatchable {
 				break
 			}
-			appendToBuf(front, path)
+			b.addEvent(front.event, front.eventSize)
+			path.popEvent()
+			count++
 		}
 
 		signal.eventCount -= count
@@ -176,7 +176,7 @@ func (q *eventQueue[A, P, T, D, H]) popEvents(buf []T) ([]T, *pathInfo[A, P, T, 
 			q.signalQueue.PopFront()
 		}
 		q.totalPendingLength.Add(-int64(count))
-
-		return buf, path, totalBytes
+		events, nBytes, duration := b.flush()
+		return events, path, nBytes, duration
 	}
 }

--- a/utils/dynstream/event_queue_batcher_test.go
+++ b/utils/dynstream/event_queue_batcher_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatcherSetLimit(t *testing.T) {
+	b := newBatcher[*mockEvent](newBatchConfig(4, 0))
+	b.addEvent(&mockEvent{value: 1}, 16)
+	require.Equal(t, 1, len(b.buf))
+	require.Equal(t, 16, b.nBytes)
+
+	b.setLimit(newBatchConfig(8, 64))
+	require.Equal(t, 0, len(b.buf))
+	require.Equal(t, 0, b.nBytes)
+	require.Equal(t, 8, b.config.softCount)
+	require.Equal(t, 64, b.config.hardBytes)
+}
+
+func TestBatchByBytes(t *testing.T) {
+	handler := mockHandler{}
+	registry := newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
+	registry.onAddPath(0, newBatchConfig(10, 12))
+	eq := newEventQueue(&handler, registry)
+	b := newDefaultBatcher[*mockEvent]()
+
+	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
+	eq.initPath(path)
+
+	for i := 1; i <= 4; i++ {
+		eq.appendEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+			pathInfo:  path,
+			event:     &mockEvent{value: i},
+			eventSize: 4,
+			eventType: EventType{
+				DataGroup: 1,
+				Property:  BatchableData,
+			},
+		})
+	}
+
+	events, _, _, _ := eq.popEvents(b)
+	require.Len(t, events, 3)
+	require.Equal(t, 1, events[0].value)
+	require.Equal(t, 2, events[1].value)
+	require.Equal(t, 3, events[2].value)
+	require.Equal(t, int64(1), eq.totalPendingLength.Load())
+
+	events, _, _, _ = eq.popEvents(b)
+	require.Len(t, events, 1)
+	require.Equal(t, 4, events[0].value)
+	require.Equal(t, int64(0), eq.totalPendingLength.Load())
+
+	registry = newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
+	registry.onAddPath(0, newBatchConfig(10, 12))
+	eq = newEventQueue(&handler, registry)
+	path = newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
+	eq.initPath(path)
+	for i := 1; i <= 4; i++ {
+		eq.appendEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+			pathInfo:  path,
+			event:     &mockEvent{value: i},
+			eventSize: 5,
+			eventType: EventType{
+				DataGroup: 1,
+				Property:  BatchableData,
+			},
+		})
+	}
+	events, _, _, _ = eq.popEvents(b)
+	require.Len(t, events, 3)
+	require.Equal(t, int64(1), eq.totalPendingLength.Load())
+
+	events, _, _, _ = eq.popEvents(b)
+	require.Len(t, events, 1)
+	require.Equal(t, int64(0), eq.totalPendingLength.Load())
+}
+
+func TestBatchByHardCount(t *testing.T) {
+	handler := mockHandler{}
+	registry := newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
+	registry.onAddPath(0, newBatchConfig(1, 1000))
+	eq := newEventQueue(&handler, registry)
+	b := newDefaultBatcher[*mockEvent]()
+
+	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
+	eq.initPath(path)
+
+	for i := 1; i <= 9; i++ {
+		eq.appendEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+			pathInfo:  path,
+			event:     &mockEvent{value: i},
+			eventSize: 10,
+			eventType: EventType{
+				DataGroup: 1,
+				Property:  BatchableData,
+			},
+		})
+	}
+
+	events, _, _, _ := eq.popEvents(b)
+	require.Len(t, events, 8)
+	require.Equal(t, int64(1), eq.totalPendingLength.Load())
+
+	events, _, _, _ = eq.popEvents(b)
+	require.Len(t, events, 1)
+	require.Equal(t, int64(0), eq.totalPendingLength.Load())
+}
+
+func TestBatchByBytesLargeFirstEvent(t *testing.T) {
+	handler := mockHandler{}
+	registry := newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
+	registry.onAddPath(0, newBatchConfig(10, 50))
+	eq := newEventQueue(&handler, registry)
+	b := newDefaultBatcher[*mockEvent]()
+
+	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
+	eq.initPath(path)
+
+	eq.appendEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+		pathInfo:  path,
+		event:     &mockEvent{value: 1},
+		eventSize: 100,
+		eventType: EventType{
+			DataGroup: 1,
+			Property:  BatchableData,
+		},
+	})
+	eq.appendEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+		pathInfo:  path,
+		event:     &mockEvent{value: 2},
+		eventSize: 10,
+		eventType: EventType{
+			DataGroup: 1,
+			Property:  BatchableData,
+		},
+	})
+
+	events, _, _, _ := eq.popEvents(b)
+	require.Len(t, events, 1)
+	require.Equal(t, 1, events[0].value)
+	require.Equal(t, int64(1), eq.totalPendingLength.Load())
+
+	events, _, _, _ = eq.popEvents(b)
+	require.Len(t, events, 1)
+	require.Equal(t, 2, events[0].value)
+	require.Equal(t, int64(0), eq.totalPendingLength.Load())
+}

--- a/utils/dynstream/event_queue_test.go
+++ b/utils/dynstream/event_queue_test.go
@@ -19,29 +19,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newTestBatchConfigRegistry() *areaBatchConfigRegistry[int] {
+	return newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
+}
+
+func newTestBatchConfigRegistryWithDefault(cfg batchConfig) *areaBatchConfigRegistry[int] {
+	return newAreaBatchConfigRegistry[int](cfg)
+}
+
 func TestNewEventQueue(t *testing.T) {
 	handler := mockHandler{}
-	option := Option{BatchCount: 10}
-
-	eq := newEventQueue(option, &handler)
+	eq := newEventQueue(&handler, newTestBatchConfigRegistry())
 
 	require.NotNil(t, eq.eventBlockAlloc)
 	require.NotNil(t, eq.signalQueue)
 	require.NotNil(t, eq.totalPendingLength)
-	require.Equal(t, option, eq.option)
 	require.Equal(t, &handler, eq.handler)
 	require.Equal(t, int64(0), eq.totalPendingLength.Load())
 }
 
 func TestAppendAndPopSingleEvent(t *testing.T) {
 	handler := mockHandler{}
-	eq := newEventQueue(Option{BatchCount: 10}, &handler)
+	eq := newEventQueue(&handler, newTestBatchConfigRegistry())
+	b := newDefaultBatcher[*mockEvent]()
 
-	// create a path
 	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
 	eq.initPath(path)
 
-	// append an event
 	event := eventWrap[int, string, *mockEvent, any, *mockHandler]{
 		pathInfo: path,
 		event:    &mockEvent{value: 1},
@@ -50,16 +54,11 @@ func TestAppendAndPopSingleEvent(t *testing.T) {
 			Property:  BatchableData,
 		},
 	}
-
 	eq.appendEvent(event)
 
-	// verify the event is appended
 	require.Equal(t, int64(1), eq.totalPendingLength.Load())
 
-	// pop the event
-	buf := make([]*mockEvent, 0)
-	events, popPath, _ := eq.popEvents(buf)
-
+	events, popPath, _, _ := eq.popEvents(b)
 	require.Equal(t, 1, len(events))
 	require.Equal(t, mockEvent{value: 1}, *events[0])
 	require.Equal(t, path, popPath)
@@ -68,12 +67,12 @@ func TestAppendAndPopSingleEvent(t *testing.T) {
 
 func TestBlockAndWakePath(t *testing.T) {
 	handler := mockHandler{}
-	eq := newEventQueue(Option{BatchCount: 10}, &handler)
+	eq := newEventQueue(&handler, newTestBatchConfigRegistry())
+	b := newDefaultBatcher[*mockEvent]()
 
 	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
 	eq.initPath(path)
 
-	// append an event
 	event := eventWrap[int, string, *mockEvent, any, *mockHandler]{
 		pathInfo: path,
 		event:    &mockEvent{value: 1},
@@ -84,21 +83,16 @@ func TestBlockAndWakePath(t *testing.T) {
 	}
 	eq.appendEvent(event)
 
-	// block the path
 	eq.blockPath(path)
 
-	// try to pop the event (should not pop)
-	buf := make([]*mockEvent, 0)
-	events, _, _ := eq.popEvents(buf)
+	events, _, _, _ := eq.popEvents(b)
 	require.Equal(t, 0, len(events))
 	require.Equal(t, int64(0), eq.totalPendingLength.Load())
 
-	// wake the path
 	eq.wakePath(path)
 	require.Equal(t, int64(1), eq.totalPendingLength.Load())
 
-	// try to pop the event (should pop)
-	events, popPath, _ := eq.popEvents(buf)
+	events, popPath, _, _ := eq.popEvents(b)
 	require.Equal(t, 1, len(events))
 	require.Equal(t, &mockEvent{value: 1}, events[0])
 	require.Equal(t, path, popPath)
@@ -107,12 +101,12 @@ func TestBlockAndWakePath(t *testing.T) {
 
 func TestBatchEvents(t *testing.T) {
 	handler := mockHandler{}
-	eq := newEventQueue(Option{BatchCount: 3}, &handler)
+	eq := newEventQueue(&handler, newTestBatchConfigRegistryWithDefault(newBatchConfig(3, 0)))
+	b := newDefaultBatcher[*mockEvent]()
 
 	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
 	eq.initPath(path)
 
-	// append multiple events with the same DataGroup
 	for i := 1; i <= 5; i++ {
 		event := eventWrap[int, string, *mockEvent, any, *mockHandler]{
 			pathInfo: path,
@@ -125,28 +119,22 @@ func TestBatchEvents(t *testing.T) {
 		eq.appendEvent(event)
 	}
 
-	// verify the batch pop
-	buf := make([]*mockEvent, 0)
-	events, _, _ := eq.popEvents(buf)
-
-	// since BatchCount = 3, only the first 3 events should be popped
+	events, _, _, _ := eq.popEvents(b)
 	require.Equal(t, 3, len(events))
 	require.Equal(t, &mockEvent{value: 1}, events[0])
 	require.Equal(t, &mockEvent{value: 2}, events[1])
 	require.Equal(t, &mockEvent{value: 3}, events[2])
-
-	// verify the remaining event count
 	require.Equal(t, int64(2), eq.totalPendingLength.Load())
 }
 
 func TestBatchableAndNonBatchableEvents(t *testing.T) {
 	handler := mockHandler{}
-	eq := newEventQueue(Option{BatchCount: 3}, &handler)
+	eq := newEventQueue(&handler, newTestBatchConfigRegistryWithDefault(newBatchConfig(3, 0)))
+	b := newDefaultBatcher[*mockEvent]()
 
 	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
 	eq.initPath(path)
 
-	// append a non-batchable event
 	event1 := eventWrap[int, string, *mockEvent, any, *mockHandler]{
 		pathInfo: path,
 		event:    &mockEvent{value: 1},
@@ -157,7 +145,6 @@ func TestBatchableAndNonBatchableEvents(t *testing.T) {
 	}
 	eq.appendEvent(event1)
 
-	// append 2 batchable events
 	for i := 1; i <= 2; i++ {
 		e := eventWrap[int, string, *mockEvent, any, *mockHandler]{
 			pathInfo: path,
@@ -170,7 +157,6 @@ func TestBatchableAndNonBatchableEvents(t *testing.T) {
 		eq.appendEvent(e)
 	}
 
-	// add 2 non-batchable events
 	for i := 1; i <= 2; i++ {
 		e := eventWrap[int, string, *mockEvent, any, *mockHandler]{
 			pathInfo: path,
@@ -183,7 +169,6 @@ func TestBatchableAndNonBatchableEvents(t *testing.T) {
 		eq.appendEvent(e)
 	}
 
-	// append 5 batchable events
 	for i := 1; i <= 5; i++ {
 		e := eventWrap[int, string, *mockEvent, any, *mockHandler]{
 			pathInfo: path,
@@ -196,47 +181,35 @@ func TestBatchableAndNonBatchableEvents(t *testing.T) {
 		eq.appendEvent(e)
 	}
 
-	// case 1: pop the first non-batchable event
-	buf := make([]*mockEvent, 0)
-	events, _, _ := eq.popEvents(buf)
+	events, _, _, _ := eq.popEvents(b)
 	require.Equal(t, 1, len(events))
 	require.Equal(t, &mockEvent{value: 1}, events[0])
 	require.Equal(t, int64(9), eq.totalPendingLength.Load())
 
-	// case 2: pop the first 2 batchable event
-	buf = make([]*mockEvent, 0)
-	events, _, _ = eq.popEvents(buf)
+	events, _, _, _ = eq.popEvents(b)
 	require.Equal(t, 2, len(events))
 	require.Equal(t, &mockEvent{value: 1}, events[0])
 	require.Equal(t, &mockEvent{value: 2}, events[1])
 	require.Equal(t, int64(7), eq.totalPendingLength.Load())
 
-	// case 3: pop a non-batchable event
-	buf = make([]*mockEvent, 0)
-	events, _, _ = eq.popEvents(buf)
+	events, _, _, _ = eq.popEvents(b)
 	require.Equal(t, 1, len(events))
 	require.Equal(t, &mockEvent{value: 1}, events[0])
 	require.Equal(t, int64(6), eq.totalPendingLength.Load())
 
-	// case 4: pop the second non-batchable event
-	buf = make([]*mockEvent, 0)
-	events, _, _ = eq.popEvents(buf)
+	events, _, _, _ = eq.popEvents(b)
 	require.Equal(t, 1, len(events))
 	require.Equal(t, &mockEvent{value: 2}, events[0])
 	require.Equal(t, int64(5), eq.totalPendingLength.Load())
 
-	// case 5: pop the first 3 batchable events
-	buf = make([]*mockEvent, 0)
-	events, _, _ = eq.popEvents(buf)
+	events, _, _, _ = eq.popEvents(b)
 	require.Equal(t, 3, len(events))
 	require.Equal(t, &mockEvent{value: 1}, events[0])
 	require.Equal(t, &mockEvent{value: 2}, events[1])
 	require.Equal(t, &mockEvent{value: 3}, events[2])
 	require.Equal(t, int64(2), eq.totalPendingLength.Load())
 
-	// case 6: pop the remaining 2 batchable events
-	buf = make([]*mockEvent, 0)
-	events, _, _ = eq.popEvents(buf)
+	events, _, _, _ = eq.popEvents(b)
 	require.Equal(t, 2, len(events))
 	require.Equal(t, &mockEvent{value: 4}, events[0])
 	require.Equal(t, &mockEvent{value: 5}, events[1])
@@ -245,7 +218,8 @@ func TestBatchableAndNonBatchableEvents(t *testing.T) {
 
 func TestRemovePath(t *testing.T) {
 	handler := mockHandler{}
-	eq := newEventQueue(Option{BatchCount: 3}, &handler)
+	eq := newEventQueue(&handler, newTestBatchConfigRegistry())
+	b := newDefaultBatcher[*mockEvent]()
 
 	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](0, "test", "test", nil)
 	eq.initPath(path)
@@ -262,8 +236,51 @@ func TestRemovePath(t *testing.T) {
 	require.Equal(t, int64(1), eq.totalPendingLength.Load())
 
 	path.removed.Store(true)
-	buf := make([]*mockEvent, 0)
-	events, _, _ := eq.popEvents(buf)
+	events, _, _, _ := eq.popEvents(b)
 	require.Equal(t, 0, len(events))
 	require.Equal(t, int64(0), eq.totalPendingLength.Load())
+}
+
+func TestAreaBatchCount(t *testing.T) {
+	handler := mockHandler{}
+	registry := newAreaBatchConfigRegistry[int](newBatchConfig(10, 0))
+	eq := newEventQueue(&handler, registry)
+
+	path1 := newPathInfo[int, string, *mockEvent, any, *mockHandler](1, "test", "path1", nil)
+	path2 := newPathInfo[int, string, *mockEvent, any, *mockHandler](2, "test", "path2", nil)
+	eq.initPath(path1)
+	eq.initPath(path2)
+
+	registry.onAddPath(1, newBatchConfig(1, 0))
+	registry.onAddPath(2, batchConfig{})
+
+	appendEvent := func(path *pathInfo[int, string, *mockEvent, any, *mockHandler], value int) {
+		eq.appendEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+			pathInfo: path,
+			event:    &mockEvent{value: value},
+			eventType: EventType{
+				DataGroup: 1,
+				Property:  BatchableData,
+			},
+		})
+	}
+
+	appendEvent(path1, 1)
+	appendEvent(path1, 2)
+	appendEvent(path2, 3)
+	appendEvent(path2, 4)
+
+	b := newDefaultBatcher[*mockEvent]()
+
+	events, path, _, _ := eq.popEvents(b)
+	require.Equal(t, path1, path)
+	require.Len(t, events, 1)
+
+	events, path, _, _ = eq.popEvents(b)
+	require.Equal(t, path1, path)
+	require.Len(t, events, 1)
+
+	events, path, _, _ = eq.popEvents(b)
+	require.Equal(t, path2, path)
+	require.Len(t, events, 2)
 }

--- a/utils/dynstream/interfaces.go
+++ b/utils/dynstream/interfaces.go
@@ -139,7 +139,7 @@ type Handler[A Area, P Path, T Event, D Dest] interface {
 
 	// OnDrop is called when an event is dropped. Could be caused by the memory control or cannot find the path.
 	// Do nothing by default implementation.
-	OnDrop(event T) interface{}
+	OnDrop(event T) any
 }
 
 type PathAndDest[P Path, D Dest] struct {
@@ -211,8 +211,8 @@ type Option struct {
 	ReportInterval    time.Duration // The interval of reporting the status of stream, the status is used by the scheduler.
 
 	StreamCount int // The count of streams. I.e. the count of goroutines to handle events. By default 0, means runtime.NumCPU().
-	BatchCount  int // The batch count of handling events. <= 1 means no batch. By default 1.
-	BatchBytes  int // The max bytes of the batch. <= 1 means no limit. By default 0.
+	BatchCount  int // The batch count limit of handling events. <= 0 means 1.
+	BatchBytes  int // The batch bytes limit of handling events. < 0 means 0.
 
 	EnableMemoryControl bool // Enable the memory control. By default false.
 
@@ -227,6 +227,7 @@ func NewOption() Option {
 		ReportInterval:    DefaultReportInterval,
 		StreamCount:       0,
 		BatchCount:        1,
+		BatchBytes:        0,
 		UseBuffer:         false,
 	}
 }
@@ -241,6 +242,9 @@ func (o *Option) fix() {
 	if o.BatchCount <= 0 {
 		o.BatchCount = 1
 	}
+	if o.BatchBytes < 0 {
+		o.BatchBytes = 0
+	}
 }
 
 type AreaSettings struct {
@@ -248,8 +252,13 @@ type AreaSettings struct {
 	maxPendingSize     uint64        // The max memory usage of the pending events of the area. Must be larger than 0. By default 1GB.
 	pathMaxPendingSize uint64        // The max memory usage of the pending events of the path. Must be larger than 0. By default 10% of the area max pending size.
 	feedbackInterval   time.Duration // The interval of the feedback. By default 1000ms.
+
 	// Remove it when we determine the v2 is working well.
-	algorithm int // The algorithm of the memory control.
+	// The algorithm of the memory control.
+	algorithm int
+
+	// control how to batch events
+	batchConfig batchConfig
 }
 
 func (s *AreaSettings) fix() {
@@ -262,17 +271,27 @@ func (s *AreaSettings) fix() {
 	}
 }
 
-func NewAreaSettingsWithMaxPendingSize(size uint64, memoryControlAlgorithm int, component string) AreaSettings {
+func NewAreaSettingsWithMaxPendingSize(
+	quota uint64, algorithm int, component string,
+) AreaSettings {
 	// The path max pending size is at least 1MB.
-	pathMaxPendingSize := max(size/10, 1*1024*1024)
-
+	pathMaxPendingSize := max(quota/10, 1*1024*1024)
 	return AreaSettings{
 		component:          component,
 		feedbackInterval:   DefaultFeedbackInterval,
-		maxPendingSize:     size,
+		maxPendingSize:     quota,
 		pathMaxPendingSize: pathMaxPendingSize,
-		algorithm:          memoryControlAlgorithm,
+		algorithm:          algorithm,
+		batchConfig:        batchConfig{},
 	}
+}
+
+func NewAreaSettingsWithMaxPendingSizeAndBatchConfig(
+	quota uint64, algorithm int, component string, batchCount int, batchBytes int,
+) AreaSettings {
+	s := NewAreaSettingsWithMaxPendingSize(quota, algorithm, component)
+	s.batchConfig = newBatchConfig(batchCount, batchBytes)
+	return s
 }
 
 type FeedbackType int

--- a/utils/dynstream/memory_control.go
+++ b/utils/dynstream/memory_control.go
@@ -366,7 +366,7 @@ func (m *memControl[A, P, T, D, H]) getMetrics() MemoryMetric[A, P] {
 			MaxMemoryValue:      int64(area.settings.Load().maxPendingSize),
 			PathMaxMemoryValue:  int64(area.settings.Load().pathMaxPendingSize),
 		}
-		area.pathMap.Range(func(k, v interface{}) bool {
+		area.pathMap.Range(func(k, v any) bool {
 			usedMemory := v.(*pathInfo[A, P, T, D, H]).pendingSize.Load()
 			availableMemory := max(0, areaMetric.PathMaxMemoryValue-usedMemory)
 			areaMetric.PathAvailableMemory[k.(P)] = availableMemory

--- a/utils/dynstream/memory_control_test.go
+++ b/utils/dynstream/memory_control_test.go
@@ -68,7 +68,8 @@ func TestRemovePathLateAppendDoesNotPolluteAreaPendingSize(t *testing.T) {
 	mc.addPathToArea(path, settings, feedbackChan)
 
 	handler := &mockHandler{}
-	eq := newEventQueue(Option{BatchCount: 4}, handler)
+	eq := newEventQueue(handler, newTestBatchConfigRegistryWithDefault(newBatchConfig(4, 0)))
+	b := newDefaultBatcher[*mockEvent]()
 	eq.initPath(path)
 
 	appendEvent := func(id int, size int) {
@@ -94,8 +95,7 @@ func TestRemovePathLateAppendDoesNotPolluteAreaPendingSize(t *testing.T) {
 	// Simulate a stale in-flight append that races with RemovePath.
 	appendEvent(2, 7)
 
-	buf := make([]*mockEvent, 0)
-	events, _, _ := eq.popEvents(buf)
+	events, _, _, _ := eq.popEvents(b)
 	require.Len(t, events, 0)
 
 	// Removed-path events must not leave stale memory accounting behind.

--- a/utils/dynstream/parallel_dynamic_stream.go
+++ b/utils/dynstream/parallel_dynamic_stream.go
@@ -35,8 +35,9 @@ type parallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D
 		m map[P]*pathInfo[A, P, T, D, H]
 	}
 
-	eventExtraSize int
-	memControl     *memControl[A, P, T, D, H]
+	eventExtraSize      int
+	memControl          *memControl[A, P, T, D, H]
+	batchConfigRegistry *areaBatchConfigRegistry[A]
 
 	feedbackChan chan Feedback[A, P, D]
 
@@ -68,6 +69,7 @@ func newParallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T
 	}
 
 	s.pathMap.m = make(map[P]*pathInfo[A, P, T, D, H])
+	s.batchConfigRegistry = newAreaBatchConfigRegistry[A](newBatchConfig(option.BatchCount, option.BatchBytes))
 
 	if option.EnableMemoryControl {
 		log.Info("Dynamic stream enable memory control")
@@ -75,7 +77,7 @@ func newParallelDynamicStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T
 		s.memControl = newMemControl[A, P, T, D, H]()
 	}
 	for i := range option.StreamCount {
-		s.streams = append(s.streams, newStream(i, component, handler, option))
+		s.streams = append(s.streams, newStream(i, component, handler, option, s.batchConfigRegistry))
 	}
 	return s
 }
@@ -204,6 +206,11 @@ func (s *parallelDynamicStream[A, P, T, D, H]) AddPath(path P, dest D, as ...Are
 
 	area := s.handler.GetArea(path, dest)
 	metricLabel := s.handler.GetMetricLabel(dest)
+	areaBatchConfig := batchConfig{}
+	if len(as) > 0 {
+		areaBatchConfig = as[0].batchConfig
+	}
+	s.batchConfigRegistry.onAddPath(area, areaBatchConfig)
 	pi := newPathInfo[A, P, T, D, H](area, metricLabel, path, dest)
 
 	streamID := s._statAddPathCount.Load() % int64(len(s.streams))
@@ -237,6 +244,7 @@ func (s *parallelDynamicStream[A, P, T, D, H]) RemovePath(path P) error {
 	if s.memControl != nil {
 		s.memControl.removePathFromArea(pi)
 	}
+	s.batchConfigRegistry.onRemovePath(pi.area)
 	delete(s.pathMap.m, path)
 	s.pathMap.Unlock()
 	pi.stream.addEvent(eventWrap[A, P, T, D, H]{pathInfo: pi})

--- a/utils/dynstream/parallel_dynamic_stream_test.go
+++ b/utils/dynstream/parallel_dynamic_stream_test.go
@@ -95,6 +95,49 @@ func TestParallelDynamicStreamMetrics(t *testing.T) {
 	require.Equal(t, 1, metrics.RemovePath)
 }
 
+func TestAddPathKeepsDefaultBatchConfig(t *testing.T) {
+	t.Run("no area settings", func(t *testing.T) {
+		handler := &mockHandler{}
+		stream := newParallelDynamicStream("test", handler, Option{
+			StreamCount: 1,
+			BatchCount:  4,
+		})
+		defer stream.Close()
+
+		require.NoError(t, stream.AddPath("path1", "dest1"))
+		require.Equal(t, newBatchConfig(4, 0), stream.batchConfigRegistry.getBatchConfig(0))
+	})
+
+	t.Run("area settings without batch override", func(t *testing.T) {
+		handler := &mockHandler{}
+		stream := newParallelDynamicStream("test", handler, Option{
+			StreamCount: 1,
+			BatchCount:  4,
+		})
+		defer stream.Close()
+
+		settings := NewAreaSettingsWithMaxPendingSize(64*1024*1024, 0, "test")
+		require.NoError(t, stream.AddPath("path1", "dest1", settings))
+		require.Equal(t, newBatchConfig(4, 0), stream.batchConfigRegistry.getBatchConfig(0))
+	})
+
+	t.Run("first add wins over later override", func(t *testing.T) {
+		handler := &mockHandler{}
+		stream := newParallelDynamicStream("test", handler, Option{
+			StreamCount: 1,
+			BatchCount:  4,
+		})
+		defer stream.Close()
+
+		require.NoError(t, stream.AddPath("path1", "dest1"))
+		require.Equal(t, newBatchConfig(4, 0), stream.batchConfigRegistry.getBatchConfig(0))
+
+		settings := NewAreaSettingsWithMaxPendingSizeAndBatchConfig(64*1024*1024, 0, "test", 1, 0)
+		require.NoError(t, stream.AddPath("path2", "dest2", settings))
+		require.Equal(t, newBatchConfig(4, 0), stream.batchConfigRegistry.getBatchConfig(0))
+	})
+}
+
 func TestParallelDynamicStreamMemoryControl(t *testing.T) {
 	handler := &mockHandler{}
 	option := Option{

--- a/utils/dynstream/stream.go
+++ b/utils/dynstream/stream.go
@@ -52,6 +52,7 @@ type stream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]] struct {
 
 	// The queue to store the pending events of this stream.
 	eventQueue            eventQueue[A, P, T, D, H]
+	batcher               *batcher[T]
 	batchMetricCache      map[string]batchMetricObservers
 	batchMetricCacheOrder []string
 	batchMetricCacheNext  int
@@ -72,12 +73,14 @@ func newStream[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]](
 	component string,
 	handler H,
 	option Option,
+	batchConfigRegistry *areaBatchConfigRegistry[A],
 ) *stream[A, P, T, D, H] {
 	s := &stream[A, P, T, D, H]{
 		module:           component,
 		id:               id,
 		handler:          handler,
-		eventQueue:       newEventQueue(option, handler),
+		eventQueue:       newEventQueue(handler, batchConfigRegistry),
+		batcher:          newDefaultBatcher[T](),
 		batchMetricCache: make(map[string]batchMetricObservers),
 		option:           option,
 		startTime:        time.Now(),
@@ -151,7 +154,6 @@ func (s *stream[A, P, T, D, H]) addEvent(event eventWrap[A, P, T, D, H]) {
 	// Fast path: try direct send without blocking to avoid context check
 	select {
 	case eventChan <- event:
-		return
 	default:
 		// Slow path: with close check while waiting
 		select {
@@ -203,10 +205,10 @@ func (s *stream[A, P, T, D, H]) receiver() {
 	}()
 
 	for {
-		event, ok := buffer.FrontRef()
 		if s.closed.Load() {
 			return
 		}
+		event, ok := buffer.FrontRef()
 		if !ok {
 			select {
 			case <-s.ctx.Done():
@@ -273,16 +275,17 @@ func (s *stream[A, P, T, D, H]) handleLoop() {
 	// Declared here to avoid repeated allocation.
 	var (
 		eventQueueEmpty = false
-		eventBuf        = make([]T, 0, s.option.BatchCount)
+		eventBuf        []T
 		zeroT           T
 		cleanUpEventBuf = func() {
 			for i := range eventBuf {
 				eventBuf[i] = zeroT
 			}
-			eventBuf = eventBuf[:0]
+			eventBuf = nil
 		}
-		path   *pathInfo[A, P, T, D, H]
-		nBytes int
+		path     *pathInfo[A, P, T, D, H]
+		nBytes   int
+		duration time.Duration
 	)
 
 	// For testing. Don't handle events until this wait group is done.
@@ -325,8 +328,7 @@ Loop:
 				handleEvent(e)
 				eventQueueEmpty = false
 			default:
-				start := time.Now()
-				eventBuf, path, nBytes = s.eventQueue.popEvents(eventBuf)
+				eventBuf, path, nBytes, duration = s.eventQueue.popEvents(s.batcher)
 				if len(eventBuf) == 0 {
 					eventQueueEmpty = true
 					continue Loop
@@ -336,15 +338,13 @@ Loop:
 					continue Loop
 				}
 
-				path.lastHandleEventTs.Store(uint64(s.handler.GetTimestamp(eventBuf[0])))
-
-				path.blocking.Store(s.handler.Handle(path.dest, eventBuf...))
-
-				duration := time.Since(start)
 				batchMetrics := s.getBatchMetricObservers(path.metricLabel)
 				batchMetrics.duration.Observe(duration.Seconds())
 				batchMetrics.count.Observe(float64(len(eventBuf)))
 				batchMetrics.bytes.Observe(float64(nBytes))
+
+				path.lastHandleEventTs.Store(uint64(s.handler.GetTimestamp(eventBuf[0])))
+				path.blocking.Store(s.handler.Handle(path.dest, eventBuf...))
 
 				if path.blocking.Load() {
 					s.eventQueue.blockPath(path)

--- a/utils/dynstream/stream_bench_test.go
+++ b/utils/dynstream/stream_bench_test.go
@@ -60,7 +60,8 @@ func runStream(eventCount int, times int) {
 	handler := &incHandler{}
 
 	pi := newPathInfo[int, string, *inc, D, *incHandler](0, "test", "p1", D{})
-	stream := newStream[int, string, *inc, D](1 /*id*/, "test", handler, NewOption())
+	registry := newAreaBatchConfigRegistry[int](newDefaultBatchConfig())
+	stream := newStream[int, string, *inc, D](1 /*id*/, "test", handler, NewOption(), registry)
 	stream.start()
 
 	total := &atomic.Int64{}

--- a/utils/dynstream/stream_test.go
+++ b/utils/dynstream/stream_test.go
@@ -124,7 +124,7 @@ func newInc(num int64, inc *atomic.Int64, notify ...*sync.WaitGroup) *Inc {
 
 func TestStreamBasic(t *testing.T) {
 	handler := mockHandler{}
-	stream := newStream(1, "test", &handler, Option{UseBuffer: false})
+	stream := newStream(1, "test", &handler, Option{UseBuffer: false}, newTestBatchConfigRegistry())
 	require.Equal(t, 0, stream.getPendingSize())
 
 	stream.start()
@@ -163,7 +163,7 @@ func TestStreamBasic(t *testing.T) {
 
 func TestStreamBasicWithBuffer(t *testing.T) {
 	handler := mockHandler{}
-	stream := newStream(1, "test", &handler, Option{UseBuffer: true})
+	stream := newStream(1, "test", &handler, Option{UseBuffer: true}, newTestBatchConfigRegistry())
 	require.Equal(t, 0, stream.getPendingSize())
 
 	stream.start()
@@ -210,7 +210,7 @@ func TestPathInfo(t *testing.T) {
 
 func TestStreamEvictsOldestBatchMetricCacheEntry(t *testing.T) {
 	handler := mockHandler{}
-	stream := newStream(1, "test-batch-metric-cache-limit", &handler, Option{})
+	stream := newStream(1, "test-batch-metric-cache-limit", &handler, Option{}, newTestBatchConfigRegistry())
 
 	for i := range maxBatchMetricCacheEntries {
 		stream.getBatchMetricObservers(fmt.Sprintf("label-%d", i))
@@ -222,4 +222,31 @@ func TestStreamEvictsOldestBatchMetricCacheEntry(t *testing.T) {
 	require.Len(t, stream.batchMetricCache, maxBatchMetricCacheEntries)
 	require.NotContains(t, stream.batchMetricCache, "label-0")
 	require.Contains(t, stream.batchMetricCache, "new-label")
+}
+
+func TestStreamCleansBatcherBufferAfterHandle(t *testing.T) {
+	handler := mockHandler{}
+	stream := newStream(1, "test", &handler, Option{UseBuffer: false}, newTestBatchConfigRegistry())
+
+	stream.start()
+
+	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](1, "test", "test/path", nil)
+	stream.addPath(path)
+
+	var wg sync.WaitGroup
+	stream.addEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+		pathInfo: path,
+		event:    newMockEvent(1, path.path, 0, nil, nil, &wg),
+	})
+
+	wg.Wait()
+	stream.close()
+
+	if cap(stream.batcher.buf) == 0 {
+		return
+	}
+	backing := stream.batcher.buf[:cap(stream.batcher.buf)]
+	for _, event := range backing {
+		require.Nil(t, event)
+	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5950, ref #3237

This PR backports the event collector batch-by-bytes support from `master` to `release-8.5`.

Previously, the event collector batched events mainly by event count. Because event sizes can vary significantly, batches with the same event count may have very different memory footprints. The old behavior also lacked a unified way for different sinks and changefeeds to select suitable batch limits.

### What is changed and how it works?

This PR cherry-picks #4656, #4674, #4663, and #4662.

After this backport:

- Dynamic stream supports per-area batching based on both event count and total bytes.
- When byte-based batching is enabled, a batch is flushed after reaching the byte limit, with a hard event-count cap to prevent an excessively large batch.
- Each sink provides its default event collector batch count and byte limit.
- Changefeeds can override the sink defaults through `event_collector_batch_count` and `event_collector_batch_bytes`.
- Redo event collectors use redo-specific batch settings. Their batch count can be configured through `consistent.event-collector-batch-count`, while the default byte limit follows the redo log size.
- Dynamic stream exposes batch count, batch bytes, and batch duration metrics for observing the resulting batching behavior.

### Check List

#### Tests

- Unit test
- Integration test

#### Questions

##### Will it cause performance regression or break compatibility?

Existing configurations remain valid. When the new fields are unset, the event collector uses the defaults provided by the corresponding sink. Explicitly configured values override those defaults.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No additional documentation update is required for this backport.

### Release note

```release-note
None
```