### PR TITLE
event: account for raw rows in batch DML event size

### DIFF
--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -344,7 +344,12 @@ func (b *BatchDMLEvent) GetStartTs() common.Ts {
 	return b.DMLEvents[0].GetStartTs()
 }
 
+// GetSize returns the in-memory size of the row payload.
+// Remote events keep their encoded rows in RawRows until AssembleRows decodes them.
 func (b *BatchDMLEvent) GetSize() int64 {
+	if b.Rows == nil {
+		return int64(len(b.RawRows))
+	}
 	return b.Rows.MemoryUsage()
 }
 

--- a/pkg/common/event/dml_event_test.go
+++ b/pkg/common/event/dml_event_test.go
@@ -216,6 +216,8 @@ func TestBatchDMLEventAssembleRowsKeepsOriginalTableInfoForLocalRowsWithoutRouti
 	require.Equal(t, "t", batchDMLEvent.TableInfo.GetTargetTableName())
 }
 
+// TestBatchDMLEventAssembleRowsDecodesRemoteRawRows verifies size accounting
+// before and after a remotely received batch decodes its raw row payload.
 func TestBatchDMLEventAssembleRowsDecodesRemoteRawRows(t *testing.T) {
 	helper := NewEventTestHelper(t)
 	defer helper.Close()
@@ -233,6 +235,9 @@ func TestBatchDMLEventAssembleRowsDecodesRemoteRawRows(t *testing.T) {
 		Rows:          dmlEvent.Rows,
 		TableInfo:     dmlEvent.TableInfo,
 	}
+	require.Equal(t, batchDMLEvent.Rows.MemoryUsage(), batchDMLEvent.GetSize())
+	require.Positive(t, batchDMLEvent.GetSize())
+
 	data, err := batchDMLEvent.Marshal()
 	require.NoError(t, err)
 
@@ -241,10 +246,13 @@ func TestBatchDMLEventAssembleRowsDecodesRemoteRawRows(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, reverseEvents.Rows)
 	require.NotEmpty(t, reverseEvents.RawRows)
+	require.Equal(t, int64(len(reverseEvents.RawRows)), reverseEvents.GetSize())
 
 	reverseEvents.AssembleRows(batchDMLEvent.TableInfo)
 
 	require.Nil(t, reverseEvents.RawRows)
+	require.Equal(t, reverseEvents.Rows.MemoryUsage(), reverseEvents.GetSize())
+	require.Positive(t, reverseEvents.GetSize())
 	require.Same(t, batchDMLEvent.TableInfo, reverseEvents.TableInfo)
 	require.Equal(t, batchDMLEvent.Rows.ToString(batchDMLEvent.TableInfo.GetFieldSlice()), reverseEvents.Rows.ToString(batchDMLEvent.TableInfo.GetFieldSlice()))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5959

Remote `BatchDMLEvent` instances keep their encoded row payload in `RawRows`
until the event collector calls `AssembleRows`. `GetSize` only accounted for
`Rows`, so dynamic stream memory control and byte-based batching treated the
remote row payload as zero bytes.

### What is changed and how it works?

Make `BatchDMLEvent.GetSize` return the encoded `RawRows` length before rows
are assembled. After assembly, it continues to return the decoded chunk's
memory usage.

Extend the existing remote-row assembly unit test to verify size accounting
before serialization, after remote deserialization, and after row assembly.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No compatibility impact. Remote batches may be split earlier when their actual
payload reaches the configured byte threshold, which is the intended behavior.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix dynamic stream memory and byte-batch accounting for remotely received DML batches.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch event size reporting when row data is stored in its encoded form.
  * Preserved accurate in-memory size reporting after row data is decoded and assembled.
* **Tests**
  * Added coverage for size accounting before and after row data decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->