### PR TITLE
sink: Increase defaultAsyncDDLTimeout to 2 minutes

### DIFF
--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -68,7 +68,7 @@ const (
 	defaultReadTimeout     = "2m"
 	defaultWriteTimeout    = "2m"
 	defaultDialTimeout     = "2m"
-	defaultAsyncDDLTimeout = "10s"
+	defaultAsyncDDLTimeout = "2m"
 	defaultSafeMode        = false
 	defaultTxnIsolationRC  = "READ-COMMITTED"
 	defaultCharacterSet    = "utf8mb4"


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5711

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the default timeout for asynchronous database schema changes from 10 seconds to 2 minutes, allowing longer-running operations to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->