### PR TITLE
dynstream: notify handler when removing queued events

### DIFF
--- a/utils/dynstream/event_queue.go
+++ b/utils/dynstream/event_queue.go
@@ -68,16 +68,24 @@ func (q *eventQueue[A, P, T, D, H]) appendEvent(event eventWrap[A, P, T, D, H]) 
 		q.totalPendingLength.Add(1)
 	}
 
-	if path.appendEvent(event, q.handler) {
-		addSignal()
+	if !path.appendEvent(event, q.handler) {
+		q.handler.OnDrop(event.event)
+		return
 	}
+	addSignal()
 }
 
-func (q *eventQueue[A, P, T, D, H]) releasePath(path *pathInfo[A, P, T, D, H]) {
+func (q *eventQueue[A, P, T, D, H]) releasePath(
+	path *pathInfo[A, P, T, D, H],
+	notifyDrop bool,
+) {
 	for {
-		_, ok := path.pendingQueue.PopFront()
+		event, ok := path.pendingQueue.PopFront()
 		if !ok {
 			break
+		}
+		if notifyDrop {
+			q.handler.OnDrop(event.event)
 		}
 	}
 
@@ -119,7 +127,7 @@ func (q *eventQueue[A, P, T, D, H]) popEvents(b *batcher[T]) ([]T, *pathInfo[A, 
 		if path.removed.Load() {
 			// A removed path can still receive stale in-flight signals/events.
 			// Clear the path queue and reconcile memory before dropping the signal.
-			q.releasePath(path)
+			q.releasePath(path, true)
 			q.totalPendingLength.Add(-int64(signal.eventCount))
 			q.signalQueue.PopFront()
 			continue

--- a/utils/dynstream/event_queue_test.go
+++ b/utils/dynstream/event_queue_test.go
@@ -239,6 +239,7 @@ func TestRemovePath(t *testing.T) {
 	events, _, _, _ := eq.popEvents(b)
 	require.Equal(t, 0, len(events))
 	require.Equal(t, int64(0), eq.totalPendingLength.Load())
+	require.Equal(t, []*mockEvent{{value: 1}}, handler.drainDroppedEvents())
 }
 
 func TestAreaBatchCount(t *testing.T) {

--- a/utils/dynstream/interfaces.go
+++ b/utils/dynstream/interfaces.go
@@ -137,7 +137,7 @@ type Handler[A Area, P Path, T Event, D Dest] interface {
 	// Only the events with the same type are processed in a group.
 	GetType(event T) EventType
 
-	// OnDrop is called when an event is dropped. Could be caused by the memory control or cannot find the path.
+	// OnDrop is called when an event is dropped. Could be caused by memory control, a missing path, or path removal.
 	// Do nothing by default implementation.
 	OnDrop(event T) any
 }

--- a/utils/dynstream/memory_control_test.go
+++ b/utils/dynstream/memory_control_test.go
@@ -94,6 +94,7 @@ func TestRemovePathLateAppendDoesNotPolluteAreaPendingSize(t *testing.T) {
 
 	// Simulate a stale in-flight append that races with RemovePath.
 	appendEvent(2, 7)
+	require.Equal(t, []*mockEvent{{id: 2, path: path.path}}, handler.drainDroppedEvents())
 
 	events, _, _, _ := eq.popEvents(b)
 	require.Len(t, events, 0)

--- a/utils/dynstream/parallel_dynamic_stream.go
+++ b/utils/dynstream/parallel_dynamic_stream.go
@@ -247,7 +247,7 @@ func (s *parallelDynamicStream[A, P, T, D, H]) RemovePath(path P) error {
 	s.batchConfigRegistry.onRemovePath(pi.area)
 	delete(s.pathMap.m, path)
 	s.pathMap.Unlock()
-	pi.stream.addEvent(eventWrap[A, P, T, D, H]{pathInfo: pi})
+	pi.stream.addEvent(eventWrap[A, P, T, D, H]{pathInfo: pi, removePath: true})
 	s._statRemovePathCount.Add(1)
 	return nil
 }

--- a/utils/dynstream/parallel_dynamic_stream_test.go
+++ b/utils/dynstream/parallel_dynamic_stream_test.go
@@ -72,6 +72,36 @@ func TestParallelDynamicStreamPush(t *testing.T) {
 	require.Equal(t, 0, len(handler.droppedEvents))
 }
 
+func TestParallelDynamicStreamRemovePathDropsBufferedEvent(t *testing.T) {
+	handler := &mockHandler{}
+	var handleWait sync.WaitGroup
+	handleWait.Add(1)
+	stream := newParallelDynamicStream("test", handler, Option{
+		StreamCount: 1,
+		UseBuffer:   true,
+		handleWait:  &handleWait,
+	})
+	stream.Start()
+	defer stream.Close()
+
+	const path = "test/path"
+	require.NoError(t, stream.AddPath(path, "dest"))
+	event := &mockEvent{id: 1, path: path}
+	stream.Push(path, event)
+	require.NoError(t, stream.RemovePath(path))
+	handleWait.Done()
+
+	require.Eventually(t, func() bool {
+		if stream.GetMetrics().PendingQueueLen != 0 {
+			return false
+		}
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+		return len(handler.droppedEvents) == 1 && handler.droppedEvents[0] == event
+	}, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, []*mockEvent{event}, handler.drainDroppedEvents())
+}
+
 func TestParallelDynamicStreamMetrics(t *testing.T) {
 	handler := &mockHandler{}
 	option := Option{StreamCount: 4}

--- a/utils/dynstream/stream.go
+++ b/utils/dynstream/stream.go
@@ -253,10 +253,11 @@ func (s *stream[A, P, T, D, H]) handleLoop() {
 		case e.newPath:
 			s.eventQueue.initPath(e.pathInfo)
 		case e.release:
-			s.eventQueue.releasePath(e.pathInfo)
+			s.eventQueue.releasePath(e.pathInfo, false)
+		case e.removePath:
+			s.eventQueue.releasePath(e.pathInfo, true)
 		case e.pathInfo.removed.Load():
-			// The path is removed, so we don't need to handle its events.
-			return
+			s.handler.OnDrop(e.event)
 		default:
 			s.eventQueue.appendEvent(e)
 		}
@@ -333,7 +334,7 @@ Loop:
 					eventQueueEmpty = true
 					continue Loop
 				}
-				if path.removed.Load() {
+				if s.dropBatchIfPathRemoved(path, eventBuf) {
 					cleanUpEventBuf()
 					continue Loop
 				}
@@ -354,6 +355,19 @@ Loop:
 			}
 		}
 	}
+}
+
+func (s *stream[A, P, T, D, H]) dropBatchIfPathRemoved(
+	path *pathInfo[A, P, T, D, H],
+	events []T,
+) bool {
+	if !path.removed.Load() {
+		return false
+	}
+	for _, event := range events {
+		s.handler.OnDrop(event)
+	}
+	return true
 }
 
 // ====== internal types ======
@@ -459,13 +473,13 @@ func (pi *pathInfo[A, P, T, D, H]) updatePendingSize(delta int64) {
 	}
 }
 
-// eventWrap contains the event and the path info.
-// It can be a event or a wake signal.
+// eventWrap contains either a data event or a control signal and its path info.
 type eventWrap[A Area, P Path, T Event, D Dest, H Handler[A, P, T, D]] struct {
-	event   T
-	wake    bool
-	newPath bool
-	release bool
+	event      T
+	wake       bool
+	newPath    bool
+	release    bool
+	removePath bool
 
 	pathInfo *pathInfo[A, P, T, D, H]
 

--- a/utils/dynstream/stream_test.go
+++ b/utils/dynstream/stream_test.go
@@ -208,6 +208,20 @@ func TestPathInfo(t *testing.T) {
 	require.Equal(t, int64(0), pi.pendingSize.Load())
 }
 
+func TestDropPoppedBatchAfterRemovePath(t *testing.T) {
+	handler := mockHandler{}
+	stream := newStream(1, "test", &handler, Option{}, newTestBatchConfigRegistry())
+	path := newPathInfo[int, string, *mockEvent, any, *mockHandler](1, "test", "test/path", nil)
+	events := []*mockEvent{{id: 1}, {id: 2}}
+
+	require.False(t, stream.dropBatchIfPathRemoved(path, events))
+	require.Empty(t, handler.drainDroppedEvents())
+
+	path.removed.Store(true)
+	require.True(t, stream.dropBatchIfPathRemoved(path, events))
+	require.Equal(t, events, handler.drainDroppedEvents())
+}
+
 func TestStreamEvictsOldestBatchMetricCacheEntry(t *testing.T) {
 	handler := mockHandler{}
 	stream := newStream(1, "test-batch-metric-cache-limit", &handler, Option{}, newTestBatchConfigRegistry())


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5971

### What is changed and how it works?

- Notify `Handler.OnDrop` for data events discarded after `RemovePath`, instead of silently dropping them.
- Cover all removed-path event locations, including stream buffers, pending queues, late appends, and batches popped before removal is observed.
- Add an explicit `removePath` control marker so path-removal signals are not mistaken for data events and passed to `OnDrop`.
- Preserve the existing `Release` behavior by only enabling drop notifications when draining a removed path.
- Add unit tests covering buffered events, pending events, late appends, and already-popped batches.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Events buffered for a removed stream path are now reported as dropped instead of being silently discarded.
  * Events rejected during processing consistently trigger dropped-event handling.
  * Pending event batches are correctly drained when paths are removed.

* **Tests**
  * Added coverage for buffered events, pending batches, and in-flight events dropped after path removal.

* **Documentation**
  * Clarified when dropped-event notifications may occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->