### PR TITLE
maintainer: honor balance check interval

### DIFF
--- a/coordinator/scheduler/balance.go
+++ b/coordinator/scheduler/balance.go
@@ -72,17 +72,18 @@ func NewBalanceScheduler(
 
 func (s *balanceScheduler) Execute() time.Time {
 	now := time.Now()
+	nextCheckTime := now.Add(s.checkBalanceInterval)
 	if hasDrainingOrStoppingNode(s.liveness) {
 		// Pause regular balance scheduling while any node is observed draining or
 		// stopping. Each observation extends the block window by one balance
 		// interval so regular rebalance does not race with evacuation progress.
 		s.drainBalanceBlockedUntil = now.Add(s.drainCooldown())
-		return now.Add(s.checkBalanceInterval)
+		return nextCheckTime
 	}
 	if now.Before(s.drainBalanceBlockedUntil) {
 		// If drain disappears before the previously extended block window expires,
 		// keep skipping regular rebalance until that window elapses.
-		return now.Add(s.checkBalanceInterval)
+		return nextCheckTime
 	}
 	if !s.forceBalance && time.Since(s.lastRebalanceTime) < s.checkBalanceInterval {
 		return s.lastRebalanceTime.Add(s.checkBalanceInterval)
@@ -90,7 +91,7 @@ func (s *balanceScheduler) Execute() time.Time {
 
 	if s.operatorController.OperatorSize() > 0 || s.changefeedDB.GetAbsentSize() > 0 {
 		// not in stable schedule state, skip balance
-		return now.Add(s.checkBalanceInterval)
+		return nextCheckTime
 	}
 
 	// check the balance status
@@ -99,7 +100,7 @@ func (s *balanceScheduler) Execute() time.Time {
 	moveSize := pkgScheduler.CheckBalanceStatus(s.changefeedDB.GetTaskSizePerNode(), activeNodes)
 	if moveSize <= 0 {
 		// fast check the balance status, no need to do the balance,skip
-		return now.Add(s.checkBalanceInterval)
+		return nextCheckTime
 	}
 	// balance changefeeds among the active nodes
 	movedSize := pkgScheduler.Balance(s.batchSize, s.random, activeNodes, s.changefeedDB.GetReplicating(),
@@ -109,7 +110,7 @@ func (s *balanceScheduler) Execute() time.Time {
 	s.forceBalance = movedSize >= s.batchSize
 	s.lastRebalanceTime = time.Now()
 
-	return now.Add(s.checkBalanceInterval)
+	return nextCheckTime
 }
 
 func (s *balanceScheduler) drainCooldown() time.Duration {

--- a/maintainer/scheduler/balance.go
+++ b/maintainer/scheduler/balance.go
@@ -67,7 +67,7 @@ func NewBalanceScheduler(
 	return &balanceScheduler{
 		changefeedID:         changefeedID,
 		batchSize:            moveBatchSize,
-		random:               rand.New(rand.NewSource(time.Now().UnixNano())),
+		random:               rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404
 		operatorController:   oc,
 		spanController:       sc,
 		nodeManager:          appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName),

--- a/maintainer/scheduler/balance.go
+++ b/maintainer/scheduler/balance.go
@@ -43,7 +43,8 @@ type balanceScheduler struct {
 	spanController     *span.Controller
 	nodeManager        *watcher.NodeManager
 
-	splitter *split.Splitter
+	splitter             *split.Splitter
+	checkBalanceInterval time.Duration
 
 	random *rand.Rand
 	mode   int64
@@ -58,40 +59,42 @@ func NewBalanceScheduler(
 	splitter *split.Splitter,
 	oc *operator.Controller,
 	sc *span.Controller,
-	_ time.Duration,
+	checkBalanceInterval time.Duration,
 	mode int64,
 	drainState *DrainState,
 	moveBatchSize int,
 ) *balanceScheduler {
 	return &balanceScheduler{
-		changefeedID:       changefeedID,
-		batchSize:          moveBatchSize,
-		random:             rand.New(rand.NewSource(time.Now().UnixNano())),
-		operatorController: oc,
-		spanController:     sc,
-		nodeManager:        appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName),
-		splitter:           splitter,
-		mode:               mode,
-		drainState:         drainState,
+		changefeedID:         changefeedID,
+		batchSize:            moveBatchSize,
+		random:               rand.New(rand.NewSource(time.Now().UnixNano())),
+		operatorController:   oc,
+		spanController:       sc,
+		nodeManager:          appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName),
+		splitter:             splitter,
+		checkBalanceInterval: checkBalanceInterval,
+		mode:                 mode,
+		drainState:           drainState,
 	}
 }
 
 func (s *balanceScheduler) Execute() time.Time {
-	failpoint.Inject("StopBalanceScheduler", func() {
-		failpoint.Return(time.Now().Add(time.Second * 5))
-	})
 	now := time.Now()
+	nextCheckTime := now.Add(s.checkBalanceInterval)
+	failpoint.Inject("StopBalanceScheduler", func() {
+		failpoint.Return(nextCheckTime)
+	})
 	state := s.drainState.snapshot()
 	if shouldPauseBalanceForDrain(state, now, &s.drainBalanceBlockedUntil) {
 		// Pause regular balance scheduling while dispatcher drain is active
 		// and keep a cooldown window after drain completion to avoid churn.
-		return time.Now().Add(time.Second * 5)
+		return nextCheckTime
 	}
 
 	// TODO: consider to ignore split tables' dispatcher basic schedule operator to decide whether we can make balance schedule
 	if s.operatorController.OperatorSize() > 0 || s.spanController.GetAbsentSize() > 0 {
 		// not in stable schedule state, skip balance
-		return time.Now().Add(time.Second * 5)
+		return nextCheckTime
 	}
 
 	// 1. check whether we have spans in defaultGroupID need to be splitted.
@@ -101,7 +104,7 @@ func (s *balanceScheduler) Execute() time.Time {
 
 	// to many split operators, do move operator later
 	if count >= s.batchSize {
-		return time.Now().Add(time.Second * 5)
+		return nextCheckTime
 	}
 
 	moveBudget := s.batchSize - count
@@ -109,7 +112,7 @@ func (s *balanceScheduler) Execute() time.Time {
 	// 2. do balance for the spans in defaultGroupID
 	s.schedulerDefaultGroup(moveBudget, state)
 
-	return time.Now().Add(time.Second * 5)
+	return nextCheckTime
 }
 
 func (s *balanceScheduler) Name() string {

--- a/maintainer/scheduler/balance_test.go
+++ b/maintainer/scheduler/balance_test.go
@@ -24,6 +24,40 @@ import (
 
 const testDefaultBalanceMoveBatchSize = 1024
 
+func TestBalanceSchedulerUsesCheckBalanceInterval(t *testing.T) {
+	cfID, _, oc, sc, drainState, _ := newDrainSchedulerTestHarness(t)
+	checkBalanceInterval := time.Minute
+	testCases := []struct {
+		name string
+		mode int64
+	}{
+		{name: "default", mode: common.DefaultMode},
+		{name: "redo", mode: common.RedoMode},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewBalanceScheduler(
+				cfID,
+				nil,
+				oc,
+				sc,
+				checkBalanceInterval,
+				tc.mode,
+				drainState,
+				testDefaultBalanceMoveBatchSize,
+			)
+
+			beforeExecute := time.Now()
+			nextCheckTime := s.Execute()
+			afterExecute := time.Now()
+
+			require.False(t, nextCheckTime.Before(beforeExecute.Add(checkBalanceInterval)))
+			require.False(t, nextCheckTime.After(afterExecute.Add(checkBalanceInterval)))
+		})
+	}
+}
+
 func TestBalanceSchedulerSkipsWhenDrainActive(t *testing.T) {
 	cfID, nodeManager, oc, sc, drainState, self := newDrainSchedulerTestHarness(t)
 	target := node.ID("target")


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5974

### What is changed and how it works?
  The maintainer balance schedulers receive the configured `check-balance-interval`, but discard it and always schedule the next balance check after five seconds.
This affects both the default and redo dispatcher balance schedulers.
Use the configured next check time for every `Execute` exit path, including drain handling, pending scheduling work, split batching, failpoints, and normal completion.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix the maintainer balance schedulers to honor the configured check-balance-interval.
```
