### PR TITLE
canal: avoid hard-coded table IDs in TestRowKey

### DIFF
--- a/pkg/sink/codec/canal/canal_json_test.go
+++ b/pkg/sink/codec/canal/canal_json_test.go
@@ -15,6 +15,7 @@ package canal
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -22,10 +23,11 @@ import (
 	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
-	"github.com/pingcap/ticdc/pkg/config/kerneltype"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/sink/kafka/claimcheck"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
@@ -1410,9 +1412,7 @@ func TestRowKey(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEqual(t, tidb_ext.CommitTs, 0)
-	expected := "dIAAAAAAAAB0X3KAAAAAAAAAAQ=="
-	if kerneltype.IsNextGen() {
-		expected = "dIAAAAAAAAAHX3KAAAAAAAAAAQ=="
-	}
+	expectedRowKey := tablecodec.EncodeRowKeyWithHandle(tableInfo.TableName.TableID, kv.IntHandle(1))
+	expected := base64.StdEncoding.EncodeToString(expectedRowKey)
 	require.Equal(t, expected, tidb_ext.Rowkey)
 }


### PR DESCRIPTION
### What problem does this PR solve?

`TestRowKey` compares Canal JSON row keys against Base64 fixtures that contain hard-coded TiDB table IDs. TiDB bootstrap changes can consume additional global IDs and shift the table ID allocated by the test, causing CI failures even though row-key encoding remains correct.

Issue Number: close #5981

### What is changed and how it works?

Build the expected row key with `tablecodec.EncodeRowKeyWithHandle` using the table ID returned by the test DDL job and the inserted integer handle. This removes the allocation-dependent Classic and Next Gen fixtures and their kernel-specific branch.

### Check List

#### Tests

- Unit test

The focused test passes in Classic and Next Gen modes on both upstream master and the newer TiDB dependency that exposed the failure. The full Canal codec unit target also passes:

```console
make unit_test_pkg PKG=./pkg/sink/codec/canal
```

#### Questions

##### Will it cause performance regression or break compatibility?

No. This is a test-only change and does not alter production behavior.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation for Canal JSON output to derive expected row keys dynamically.
  * Improved test portability by removing reliance on implementation-specific values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->