### PR TITLE
test: fix simple-handle-key-only-avro test

### DIFF
--- a/tests/integration_tests/kafka_simple_handle_key_only_avro/run.sh
+++ b/tests/integration_tests/kafka_simple_handle_key_only_avro/run.sh
@@ -32,7 +32,22 @@ function run() {
 	cdc_cli_changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c ${changefeed_id} --config="$CUR/conf/changefeed.toml"
 	run_sql_file $CUR/data/ddl.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
-	sleep 5
+	# Ensure the DDL is sent before lowering max-message-bytes. Handle-key-only only applies to DML.
+	ddl_done_tso=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
+	retry=60
+	cnt=0
+	while [[ $cnt -lt $retry ]]; do
+		checkpoint=$(cdc_cli_changefeed query -c ${changefeed_id} | grep -v "Command to ticdc" | jq -r '.checkpoint_tso')
+		if [[ "$checkpoint" != "null" && "$checkpoint" -gt "$ddl_done_tso" ]]; then
+			break
+		fi
+		sleep 2
+		cnt=$((cnt + 1))
+	done
+	if [[ $cnt -ge $retry ]]; then
+		echo "checkpoint tso did not exceed DDL completion tso in time: checkpoint=$checkpoint, ddl_done_tso=$ddl_done_tso"
+		exit 1
+	fi
 
 	cdc_cli_changefeed pause -c ${changefeed_id}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6006

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by waiting for the changefeed checkpoint to confirm DDL completion.
  * Added timeout handling when the checkpoint does not advance within the expected period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->