### PR TITLE
kafka: add throttle time metrics and grafana

### DIFF
--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -19250,7 +19250,7 @@
           "yaxes": [
             {
               "decimals": 1,
-              "format": "ms",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -19166,6 +19166,110 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Average and p99 throttle time reported by each broker.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "hiddenSeries": false,
+          "id": 62108,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(ticdc_sink_kafka_producer_throttle_time{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", namespace=~\"$namespace\",changefeed=~\"$changefeed\", instance=~\"$ticdc_instance\"}) by (namespace,changefeed, instance, broker, type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{namespace}}-{{changefeed}}-{{instance}}-{{broker}}-{{type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Throttle Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 1,
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Sink - MQ Sink",
@@ -28342,5 +28446,5 @@
   "timezone": "browser",
   "title": "${DS_TEST-CLUSTER}-TiCDC-New-Arch",
   "uid": "YiGL8hBZ0aac",
-  "version": 41
+  "version": 42
 }

--- a/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
@@ -19166,6 +19166,110 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Average and p99 throttle time reported by each broker.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "hiddenSeries": false,
+          "id": 62108,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(ticdc_sink_kafka_producer_throttle_time{k8s_cluster=\"$k8s_cluster\", sharedpool_id=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\",changefeed=~\"$changefeed\", instance=~\"$ticdc_instance\"}) by (keyspace_name,changefeed, instance, broker, type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{keyspace_name}}-{{changefeed}}-{{instance}}-{{broker}}-{{type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Throttle Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 1,
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Sink - MQ Sink",
@@ -28342,5 +28446,5 @@
   "timezone": "browser",
   "title": "${DS_TEST-CLUSTER}-TiCDC-New-Arch",
   "uid": "YiGL8hBZ0aac",
-  "version": 41
+  "version": 42
 }

--- a/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
@@ -19250,7 +19250,7 @@
           "yaxes": [
             {
               "decimals": 1,
-              "format": "ms",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
@@ -7691,6 +7691,110 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Average and p99 throttle time reported by each broker.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "hiddenSeries": false,
+          "id": 62108,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(ticdc_sink_kafka_producer_throttle_time{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\",changefeed=~\"$changefeed\", instance=~\"$ticdc_instance\"}) by (keyspace_name,changefeed, instance, broker, type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{keyspace_name}}-{{changefeed}}-{{instance}}-{{broker}}-{{type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Throttle Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 1,
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Sink - MQ Sink",
@@ -11749,5 +11853,5 @@
   "timezone": "browser",
   "title": "${DS_TEST-CLUSTER}-TiCDC-New-Arch-KeyspaceName",
   "uid": "lGT5hED6vqTn",
-  "version": 41
+  "version": 42
 }

--- a/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
@@ -7775,7 +7775,7 @@
           "yaxes": [
             {
               "decimals": 1,
-              "format": "ms",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/pkg/sink/kafka/metrics.go
+++ b/pkg/sink/kafka/metrics.go
@@ -74,7 +74,7 @@ var (
 			Namespace: "ticdc",
 			Subsystem: "sink",
 			Name:      "kafka_producer_throttle_time",
-			Help:      "Kafka broker throttle time in milliseconds.",
+			Help:      "Kafka broker throttle time in seconds.",
 		}, []string{"namespace", "changefeed", "broker", "type"})
 
 	// Meter mark by 1 once a response received.

--- a/pkg/sink/kafka/metrics.go
+++ b/pkg/sink/kafka/metrics.go
@@ -69,6 +69,13 @@ var (
 			Name:      "kafka_producer_records_per_request",
 			Help:      "The number of records per request for all topics.",
 		}, []string{"namespace", "changefeed", "type"})
+	throttleTimeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "kafka_producer_throttle_time",
+			Help:      "Kafka broker throttle time in milliseconds.",
+		}, []string{"namespace", "changefeed", "broker", "type"})
 
 	// Meter mark by 1 once a response received.
 	responseRateGauge = prometheus.NewGaugeVec(
@@ -84,6 +91,7 @@ var (
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(compressionRatioGauge)
 	registry.MustRegister(recordsPerRequestGauge)
+	registry.MustRegister(throttleTimeGauge)
 	registry.MustRegister(OutgoingByteRateGauge)
 	registry.MustRegister(RequestRateGauge)
 	registry.MustRegister(RequestLatencyGauge)

--- a/pkg/sink/kafka/metrics_collector.go
+++ b/pkg/sink/kafka/metrics_collector.go
@@ -50,6 +50,7 @@ const (
 	requestLatencyInMsMetricNamePrefix = "request-latency-in-ms-for-broker-"
 	requestsInFlightMetricNamePrefix   = "requests-in-flight-for-broker-"
 	responseRateMetricNamePrefix       = "response-rate-for-broker-"
+	throttleTimeMetricNamePrefix       = "throttle-time-in-ms-for-broker-"
 
 	p99 = "p99"
 	avg = "avg"
@@ -168,6 +169,18 @@ func (m *saramaMetricsCollector) collectBrokerMetrics() {
 				WithLabelValues(keyspace, changefeedID, brokerID).
 				Set(meter.Snapshot().Rate1())
 		}
+
+		throttleTimeMetric := m.registry.Get(getBrokerMetricName(
+			throttleTimeMetricNamePrefix, brokerID))
+		if histogram, ok := throttleTimeMetric.(metrics.Histogram); ok {
+			snapshot := histogram.Snapshot()
+			throttleTimeGauge.
+				WithLabelValues(keyspace, changefeedID, brokerID, avg).
+				Set(snapshot.Mean())
+			throttleTimeGauge.
+				WithLabelValues(keyspace, changefeedID, brokerID, p99).
+				Set(snapshot.Percentile(0.99))
+		}
 	}
 }
 
@@ -204,6 +217,10 @@ func (m *saramaMetricsCollector) cleanupBrokerMetrics() {
 			DeleteLabelValues(keyspace, changefeedID, brokerID)
 		responseRateGauge.
 			DeleteLabelValues(keyspace, changefeedID, brokerID)
+		throttleTimeGauge.
+			DeleteLabelValues(keyspace, changefeedID, brokerID, avg)
+		throttleTimeGauge.
+			DeleteLabelValues(keyspace, changefeedID, brokerID, p99)
 
 	}
 }

--- a/pkg/sink/kafka/metrics_collector.go
+++ b/pkg/sink/kafka/metrics_collector.go
@@ -176,10 +176,10 @@ func (m *saramaMetricsCollector) collectBrokerMetrics() {
 			snapshot := histogram.Snapshot()
 			throttleTimeGauge.
 				WithLabelValues(keyspace, changefeedID, brokerID, avg).
-				Set(snapshot.Mean())
+				Set(snapshot.Mean() / 1000)
 			throttleTimeGauge.
 				WithLabelValues(keyspace, changefeedID, brokerID, p99).
-				Set(snapshot.Percentile(0.99))
+				Set(snapshot.Percentile(0.99) / 1000)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6013

<img width="1264" height="287" alt="image" src="https://github.com/user-attachments/assets/eb8bb10e-4752-4b7a-863e-31c2807ced09" />


### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kafka broker throttle-time monitoring with average and p99 measurements.
  * Added dashboard panels displaying throttle time by namespace, changefeed, instance, broker, keyspace, and throttle type.
  * Metrics are reported in seconds for clearer performance analysis.

* **Improvements**
  * Added automatic cleanup of broker throttle-time metrics when no longer active.
  * Updated monitoring dashboards to include the new Kafka throttle-time visualizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->