### PR TITLE
eventservice: keep transaction cursor inside scan window

### DIFF
--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -522,13 +522,14 @@ func (c *eventBroker) getScanTaskRequestResult(task scanTask) scanTaskRequestRes
 		}
 	}
 
-	hasRowResume := len(request.Cursor.Position) != 0
-	// A published row cursor at C came from an earlier scan whose DDL and received
+	hasResumeCursor := request.Cursor.TxnStartTs != 0 || len(request.Cursor.Position) != 0
+	// A published cursor at C came from an earlier scan whose DDL and received
 	// resolved-ts bounds had already reached C. Since those bounds do not regress,
 	// only the adaptive scan window can move CommitTsEnd behind C. For example, if
 	// C=100 and the window caps the end at 80, restore the effective range to
-	// [100, 100] so scanning resumes after Position inside that transaction.
-	if hasRowResume && dataRange.CommitTsEnd < dataRange.CommitTsStart {
+	// [100, 100] so Position can resume rows inside a transaction, or TxnStartTs
+	// can resume later transactions sharing commit-ts C.
+	if hasResumeCursor && dataRange.CommitTsEnd < dataRange.CommitTsStart {
 		dataRange.CommitTsEnd = dataRange.CommitTsStart
 	}
 
@@ -536,7 +537,7 @@ func (c *eventBroker) getScanTaskRequestResult(task scanTask) scanTaskRequestRes
 		// A cursor makes [C, C] meaningful: Position resumes rows inside a
 		// transaction, while TxnStartTs resumes later transactions at the same C.
 		canResumeAtStart := dataRange.CommitTsEnd == dataRange.CommitTsStart &&
-			(hasRowResume || request.Cursor.TxnStartTs != 0)
+			hasResumeCursor
 		if canResumeAtStart || task.hasPendingLargeTxnState() {
 			result := scanTaskRequestResult{needScan: true, request: request}
 			if task.changefeedStat.lowLatencyMode {

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -760,7 +760,7 @@ func TestScanRangeCappedByScanWindow(t *testing.T) {
 	require.Equal(t, oracle.GoTimeToTS(baseTime.Add(defaultScanInterval)), result.request.Range.CommitTsEnd)
 }
 
-func TestGetScanTaskDataRangeEmptyAfterCappingDoesNotResetScanRange(t *testing.T) {
+func TestGetScanTaskRequestKeepsTxnCursorInsideShrunkWindow(t *testing.T) {
 	broker, _, _, _ := newEventBrokerForTest()
 	// Close the broker, so we can catch all message in the test.
 	broker.close()
@@ -785,8 +785,12 @@ func TestGetScanTaskDataRangeEmptyAfterCappingDoesNotResetScanRange(t *testing.T
 	changefeedStatus.minSentTs.Store(baseTs)
 	changefeedStatus.scanInterval.Store(int64(defaultScanInterval))
 
-	needScan, _ := broker.getScanTaskRequest(disp)
-	require.False(t, needScan)
+	needScan, request := broker.getScanTaskRequest(disp)
+	require.True(t, needScan)
+	require.Equal(t, commitStart, request.Range.CommitTsStart)
+	require.Equal(t, commitStart, request.Range.CommitTsEnd)
+	require.Equal(t, lastStartTs, request.Cursor.TxnStartTs)
+	require.Empty(t, request.Cursor.Position)
 	require.Equal(t, commitStart, disp.loadScanProgress().txnCommitTs)
 	require.Equal(t, lastStartTs, disp.loadScanProgress().txnStartTs)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6022

An interrupted EventService scan can publish a transaction cursor `(commitTs=C, startTs=S)`. If the adaptive scan window later shrinks below `C`, the existing code skips the now-empty range even though a nonzero `TxnStartTs` also prevents signal resolved-ts, so the dispatcher must wait for the window to reach `C` again.

This is a narrow liveness corner case. It is not intended to attribute the previously observed low-CPU periodic throughput issue to this path.

### What is changed and how it works?

Treat either a row position or transaction start-ts as a resume cursor. When scan-window capping moves the end below the cursor commit-ts, normalize the effective range to `[C,C]`.

For `TxnStartTs=S`, EventStore scans from `(C,S+1)` to the end of commit-ts `C`, so only later transactions sharing `C` are resumed. Ordinary empty ranges without a cursor, DDL/syncpoint handling, and large-transaction behavior are unchanged.

A focused unit test covers the transaction-cursor case after the scan window shrinks behind `C`.

### Check List

#### Tests

- Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No compatibility change. An extra scan is possible only for a valid resume cursor that the old path skipped; the scan is required to make progress.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix a corner case where a shrinking scan window can stall a dispatcher with a transaction resume cursor.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan-range resume handling for transaction-start and row-position cursors.
  * Preserved valid scan requests when adaptive window limits shrink the range.
  * Ensured collapsed ranges retain matching start and end positions instead of being discarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->