### PR TITLE
consumer: spill event group messages to disk

### DIFF
--- a/cmd/kafka-consumer/consumer.go
+++ b/cmd/kafka-consumer/consumer.go
@@ -151,7 +151,10 @@ func (c *consumer) readMessage(ctx context.Context) error {
 			log.Error("read message failed, just continue to retry", zap.Error(err))
 			continue
 		}
-		needCommit := c.writer.WriteMessage(ctx, msg)
+		needCommit, err := c.writer.WriteMessage(ctx, msg)
+		if err != nil {
+			return err
+		}
 		if !needCommit {
 			continue
 		}
@@ -169,8 +172,12 @@ func (c *consumer) readMessage(ctx context.Context) error {
 }
 
 // Run the consumer, read data and write to the downstream target.
-func (c *consumer) Run(ctx context.Context) error {
-	defer c.writer.cleanupEventsGroups()
+func (c *consumer) Run(ctx context.Context) (err error) {
+	defer func() {
+		if cleanupErr := c.writer.cleanupEventsGroups(); err == nil && cleanupErr != nil {
+			err = cleanupErr
+		}
+	}()
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {

--- a/cmd/kafka-consumer/consumer.go
+++ b/cmd/kafka-consumer/consumer.go
@@ -170,6 +170,8 @@ func (c *consumer) readMessage(ctx context.Context) error {
 
 // Run the consumer, read data and write to the downstream target.
 func (c *consumer) Run(ctx context.Context) error {
+	defer c.writer.cleanupEventsGroups()
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return c.writer.run(ctx)

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -38,7 +38,7 @@ var (
 )
 
 func main() {
-	debug.SetMemoryLimit(14 * 1024 * 1024 * 1024)
+	debug.SetMemoryLimit(8 * 1024 * 1024 * 1024)
 	var (
 		upstreamURIStr  string
 		configFile      string

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -183,11 +183,14 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *event.DDLEvent) error {
 			if err != nil {
 				return err
 			}
-			events := make([]*event.DMLEvent, 0, len(messages))
+			// A commit-ts is only a timestamp in a multi-source stream. It does
+			// not identify one transaction, so events from different upstreams can
+			// legitimately have the same value while carrying different schema
+			// snapshots. Keep restored events separate instead of merging their
+			// chunks by commit-ts.
 			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
+				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
 			}
-			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 
@@ -298,11 +301,11 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			events := make([]*event.DMLEvent, 0, len(messages))
+			// See flushDDLEvent: events with an identical commit-ts can belong to
+			// different upstream transactions in a multi-source stream.
 			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
+				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
 			}
-			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 	total := len(resolvedEvents)

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -183,10 +183,7 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *event.DDLEvent) error {
 			if err != nil {
 				return err
 			}
-			events := make([]*event.DMLEvent, 0, len(messages))
-			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
-			}
+			events := util.DMLMessagesToEvents(messages)
 			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
@@ -298,10 +295,7 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			events := make([]*event.DMLEvent, 0, len(messages))
-			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
-			}
+			events := util.DMLMessagesToEvents(messages)
 			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
@@ -377,7 +371,9 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool
 				log.Info("simple protocol cached event resolved, append to the group",
 					zap.Int64("tableID", dmlMessage.TableID), zap.Uint64("commitTs", dmlMessage.GetCommitTs()),
 					zap.Int32("partition", partition), zap.Any("offset", offset))
-				if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
+				if err := w.appendMessage2Group(dmlMessage, progress, offset, util.DMLMessageSpillData{
+					Restore: func([]byte) (*common.DMLMessage, error) { return dmlMessage, nil },
+				}); err != nil {
 					return false, err
 				}
 			}
@@ -413,7 +409,8 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool
 			break
 		}
 
-		if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
+		if err := w.appendMessage2Group(dmlMessage, progress, offset,
+			util.NewDMLMessageSpillData(progress.decoder, message.Key, message.Value, uint64(counter))); err != nil {
 			return false, err
 		}
 		counter++
@@ -431,7 +428,8 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool
 				log.Debug("DML message is nil, it's cached", zap.Int32("partition", partition), zap.Any("offset", offset))
 				break
 			}
-			if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
+			if err := w.appendMessage2Group(dmlMessage, progress, offset,
+				util.NewDMLMessageSpillData(progress.decoder, message.Key, message.Value, uint64(counter))); err != nil {
 				return false, err
 			}
 			counter++
@@ -627,7 +625,12 @@ func (w *writer) messageWithPartitionCheck(message *common.DMLMessage, partition
 	})
 }
 
-func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *partitionProgress, offset kafka.Offset) error {
+func (w *writer) appendMessage2Group(
+	message *common.DMLMessage,
+	progress *partitionProgress,
+	offset kafka.Offset,
+	spillDataArgs ...util.DMLMessageSpillData,
+) error {
 	// if the kafka cluster is normal, this should not hit.
 	// else if the cluster is abnormal, the consumer may consume old message, then cause the watermark fallback.
 	var (
@@ -655,9 +658,16 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	if err := group.AppendMessageWithPostRestore(message, func(message *common.DMLMessage) *common.DMLMessage {
+	spillData := util.DMLMessageSpillData{
+		Restore: func([]byte) (*common.DMLMessage, error) { return message, nil },
+	}
+	if len(spillDataArgs) > 0 {
+		spillData = spillDataArgs[0]
+	}
+	spillData.PostRestore = func(message *common.DMLMessage) *common.DMLMessage {
 		return w.messageWithPartitionCheck(message, progress.partition, offset)
-	}); err != nil {
+	}
+	if err := group.AppendSpillMessage(message, spillData); err != nil {
 		return err
 	}
 	if commitTs < progress.watermark {

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -147,6 +147,17 @@ func (w *writer) run(ctx context.Context) error {
 	return w.mysqlSink.Run(ctx)
 }
 
+func (w *writer) cleanupEventsGroups() {
+	for _, progress := range w.progresses {
+		for _, group := range progress.eventsGroup {
+			if err := group.Cleanup(); err != nil {
+				log.Warn("cleanup events group spill file failed",
+					zap.Int32("partition", progress.partition), zap.Error(err))
+			}
+		}
+	}
+}
+
 func (w *writer) flushDDLEvent(ctx context.Context, ddl *event.DDLEvent) error {
 	var (
 		done = make(chan struct{}, 1)
@@ -628,8 +639,9 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	message = w.messageWithPartitionCheck(message, progress.partition, offset)
-	group.AppendMessage(message)
+	group.AppendMessageWithPostRestore(message, func(message *common.DMLMessage) *common.DMLMessage {
+		return w.messageWithPartitionCheck(message, progress.partition, offset)
+	})
 	if commitTs < progress.watermark {
 		log.Warn("DML event fallback row, since less than the partition watermark, append it and sort before flush",
 			zap.Int64("tableID", tableID), zap.Int32("partition", group.Partition),

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -147,15 +147,20 @@ func (w *writer) run(ctx context.Context) error {
 	return w.mysqlSink.Run(ctx)
 }
 
-func (w *writer) cleanupEventsGroups() {
+func (w *writer) cleanupEventsGroups() error {
+	var cleanupErr error
 	for _, progress := range w.progresses {
 		for _, group := range progress.eventsGroup {
 			if err := group.Cleanup(); err != nil {
 				log.Warn("cleanup events group spill file failed",
 					zap.Int32("partition", progress.partition), zap.Error(err))
+				if cleanupErr == nil {
+					cleanupErr = err
+				}
 			}
 		}
 	}
+	return cleanupErr
 }
 
 func (w *writer) flushDDLEvent(ctx context.Context, ddl *event.DDLEvent) error {
@@ -174,7 +179,10 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *event.DDLEvent) error {
 			if !ok {
 				continue
 			}
-			messages := g.ResolveInto(commitTs, nil)
+			messages, err := g.ResolveInto(commitTs, nil)
+			if err != nil {
+				return err
+			}
 			events := make([]*event.DMLEvent, 0, len(messages))
 			for _, message := range messages {
 				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
@@ -286,7 +294,10 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 	resolvedEvents := make([]*event.DMLEvent, 0)
 	for _, p := range w.progresses {
 		for _, group := range p.eventsGroup {
-			messages := group.ResolveInto(watermark, nil)
+			messages, err := group.ResolveInto(watermark, nil)
+			if err != nil {
+				return err
+			}
 			events := make([]*event.DMLEvent, 0, len(messages))
 			for _, message := range messages {
 				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
@@ -331,7 +342,7 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 // WriteMessage is to decode kafka message to event.
 // return true if the message is flushed to the downstream.
 // return error if flush messages failed.
-func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool {
+func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool, error) {
 	var (
 		partition = message.TopicPartition.Partition
 		offset    = message.TopicPartition.Offset
@@ -366,19 +377,21 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool 
 				log.Info("simple protocol cached event resolved, append to the group",
 					zap.Int64("tableID", dmlMessage.TableID), zap.Uint64("commitTs", dmlMessage.GetCommitTs()),
 					zap.Int32("partition", partition), zap.Any("offset", offset))
-				w.appendMessage2Group(dmlMessage, progress, offset)
+				if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
+					return false, err
+				}
 			}
 		}
 
 		w.onDDL(ddl)
 		// DDL is broadcast to all partitions, but only handle the DDL from partition-0.
 		if partition != 0 {
-			return false
+			return false, nil
 		}
 
 		// the Query maybe empty if using simple protocol, it's comes from `bootstrap` event, no need to handle it.
 		if ddl.Query == "" {
-			return false
+			return false, nil
 		}
 		w.appendDDL(ddl)
 		log.Info("DDL event received",
@@ -400,7 +413,9 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool 
 			break
 		}
 
-		w.appendMessage2Group(dmlMessage, progress, offset)
+		if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
+			return false, err
+		}
 		counter++
 		for {
 			_, hasNext = progress.decoder.HasNext()
@@ -416,7 +431,9 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool 
 				log.Debug("DML message is nil, it's cached", zap.Int32("partition", partition), zap.Any("offset", offset))
 				break
 			}
-			w.appendMessage2Group(dmlMessage, progress, offset)
+			if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
+				return false, err
+			}
 			counter++
 		}
 		// If the message containing only one event exceeds the length limit, CDC will allow it and issue a warning.
@@ -438,11 +455,11 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool 
 	if needFlush {
 		return w.Write(ctx, messageType)
 	}
-	return false
+	return false, nil
 }
 
 // Write will synchronously write data downstream
-func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool {
+func (w *writer) Write(ctx context.Context, messageType common.MessageType) (bool, error) {
 	// DDL events can be received out of commit-ts order (e.g. due to protocol-level broadcasting and
 	// buffering differences between DDL kinds). We must execute DDLs in commit-ts order; otherwise a
 	// "future" DDL that is not yet eligible (commitTs > watermark) can block executing earlier DDLs
@@ -490,8 +507,7 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 			break
 		}
 		if err := w.flushDDLEvent(ctx, todoDDL); err != nil {
-			log.Panic("write DDL event failed", zap.Error(err),
-				zap.String("DDL", todoDDL.Query), zap.Uint64("commitTs", todoDDL.GetCommitTs()))
+			return false, err
 		}
 	}
 
@@ -499,7 +515,7 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 		// since watermark is broadcast to all partitions, so that each partition can flush events individually.
 		err := w.flushDMLEventsByWatermark(ctx)
 		if err != nil {
-			log.Panic("flush dml events by the watermark failed", zap.Error(err))
+			return false, err
 		}
 	}
 
@@ -509,9 +525,9 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 		log.Info("some DDL events will be flushed in the future",
 			zap.Uint64("watermark", watermark),
 			zap.Int("length", len(w.ddlList)))
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (w *writer) onDDL(ddl *event.DDLEvent) {
@@ -611,7 +627,7 @@ func (w *writer) messageWithPartitionCheck(message *common.DMLMessage, partition
 	})
 }
 
-func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *partitionProgress, offset kafka.Offset) {
+func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *partitionProgress, offset kafka.Offset) error {
 	// if the kafka cluster is normal, this should not hit.
 	// else if the cluster is abnormal, the consumer may consume old message, then cause the watermark fallback.
 	var (
@@ -631,7 +647,7 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 			zap.String("schema", schema), zap.String("table", table),
 			zap.Stringer("eventType", message.RowType),
 			zap.Any("protocol", w.protocol), zap.Bool("enableTableAcrossNodes", w.enableTableAcrossNodes))
-		return
+		return nil
 	}
 
 	group := progress.eventsGroup[tableID]
@@ -639,9 +655,11 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	group.AppendMessageWithPostRestore(message, func(message *common.DMLMessage) *common.DMLMessage {
+	if err := group.AppendMessageWithPostRestore(message, func(message *common.DMLMessage) *common.DMLMessage {
 		return w.messageWithPartitionCheck(message, progress.partition, offset)
-	})
+	}); err != nil {
+		return err
+	}
 	if commitTs < progress.watermark {
 		log.Warn("DML event fallback row, since less than the partition watermark, append it and sort before flush",
 			zap.Int64("tableID", tableID), zap.Int32("partition", group.Partition),
@@ -651,7 +669,7 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 			zap.String("schema", schema), zap.String("table", table),
 			zap.Stringer("eventType", message.RowType),
 			zap.Any("protocol", w.protocol), zap.Bool("enableTableAcrossNodes", w.enableTableAcrossNodes))
-		return
+		return nil
 	}
 	if commitTs >= group.HighWatermark {
 		log.Debug("DML event append to the group",
@@ -659,7 +677,7 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 			zap.Uint64("commitTs", commitTs), zap.Uint64("HighWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", message.RowType))
-		return
+		return nil
 	}
 	log.Warn("DML event commit ts fallback, append it and sort before flush",
 		zap.Int32("partition", progress.partition), zap.Any("offset", offset),
@@ -668,6 +686,7 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 		zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 		zap.Stringer("eventType", message.RowType),
 		zap.Any("protocol", w.protocol), zap.Bool("enableTableAcrossNodes", w.enableTableAcrossNodes))
+	return nil
 }
 
 func openDB(ctx context.Context, dsn string) (*sql.DB, error) {

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -45,14 +45,14 @@ type partitionProgress struct {
 	watermarkOffset kafka.Offset
 
 	eventsGroup map[int64]*util.EventsGroup
-	decoder     common.Decoder
+	decoder     *util.DMLMessageDecoder
 }
 
 func newPartitionProgress(partition int32, decoder common.Decoder) *partitionProgress {
 	return &partitionProgress{
 		partition:   partition,
 		eventsGroup: make(map[int64]*util.EventsGroup),
-		decoder:     decoder,
+		decoder:     util.NewDMLMessageDecoder(decoder),
 	}
 }
 
@@ -343,6 +343,9 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool
 	)
 
 	progress := w.progresses[partition]
+	progress.decoder.SetDMLMessageRestorer(func(message *common.DMLMessage) *common.DMLMessage {
+		return w.messageWithPartitionCheck(message, progress.partition, offset)
+	})
 	progress.decoder.AddKeyValue(message.Key, message.Value)
 
 	messageType, hasNext := progress.decoder.HasNext()
@@ -365,15 +368,14 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool
 		// but all DDL event messages should be consumed.
 		ddl := progress.decoder.NextDDLEvent()
 
-		if dec, ok := progress.decoder.(*simple.Decoder); ok {
+		if dec, ok := progress.decoder.Unwrap().(*simple.Decoder); ok {
 			cachedMessages := dec.GetCachedMessages()
 			for _, dmlMessage := range cachedMessages {
 				log.Info("simple protocol cached event resolved, append to the group",
 					zap.Int64("tableID", dmlMessage.TableID), zap.Uint64("commitTs", dmlMessage.GetCommitTs()),
 					zap.Int32("partition", partition), zap.Any("offset", offset))
-				if err := w.appendMessage2Group(dmlMessage, progress, offset, util.DMLMessageSpillData{
-					Restore: func([]byte) (*common.DMLMessage, error) { return dmlMessage, nil },
-				}); err != nil {
+				progress.decoder.AttachCachedDMLMessage(dmlMessage)
+				if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
 					return false, err
 				}
 			}
@@ -409,8 +411,7 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool
 			break
 		}
 
-		if err := w.appendMessage2Group(dmlMessage, progress, offset,
-			util.NewDMLMessageSpillData(progress.decoder, message.Key, message.Value, uint64(counter))); err != nil {
+		if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
 			return false, err
 		}
 		counter++
@@ -428,8 +429,7 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) (bool
 				log.Debug("DML message is nil, it's cached", zap.Int32("partition", partition), zap.Any("offset", offset))
 				break
 			}
-			if err := w.appendMessage2Group(dmlMessage, progress, offset,
-				util.NewDMLMessageSpillData(progress.decoder, message.Key, message.Value, uint64(counter))); err != nil {
+			if err := w.appendMessage2Group(dmlMessage, progress, offset); err != nil {
 				return false, err
 			}
 			counter++
@@ -629,7 +629,6 @@ func (w *writer) appendMessage2Group(
 	message *common.DMLMessage,
 	progress *partitionProgress,
 	offset kafka.Offset,
-	spillDataArgs ...util.DMLMessageSpillData,
 ) error {
 	// if the kafka cluster is normal, this should not hit.
 	// else if the cluster is abnormal, the consumer may consume old message, then cause the watermark fallback.
@@ -658,16 +657,7 @@ func (w *writer) appendMessage2Group(
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	spillData := util.DMLMessageSpillData{
-		Restore: func([]byte) (*common.DMLMessage, error) { return message, nil },
-	}
-	if len(spillDataArgs) > 0 {
-		spillData = spillDataArgs[0]
-	}
-	spillData.PostRestore = func(message *common.DMLMessage) *common.DMLMessage {
-		return w.messageWithPartitionCheck(message, progress.partition, offset)
-	}
-	if err := group.AppendSpillMessage(message, spillData); err != nil {
+	if err := group.AppendMessage(message); err != nil {
 		return err
 	}
 	if commitTs < progress.watermark {

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -183,14 +183,11 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *event.DDLEvent) error {
 			if err != nil {
 				return err
 			}
-			// A commit-ts is only a timestamp in a multi-source stream. It does
-			// not identify one transaction, so events from different upstreams can
-			// legitimately have the same value while carrying different schema
-			// snapshots. Keep restored events separate instead of merging their
-			// chunks by commit-ts.
+			events := make([]*event.DMLEvent, 0, len(messages))
 			for _, message := range messages {
-				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
+				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
 			}
+			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 
@@ -301,11 +298,11 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			// See flushDDLEvent: events with an identical commit-ts can belong to
-			// different upstream transactions in a multi-source stream.
+			events := make([]*event.DMLEvent, 0, len(messages))
 			for _, message := range messages {
-				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
+				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
 			}
+			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 	total := len(resolvedEvents)

--- a/cmd/kafka-consumer/writer_test.go
+++ b/cmd/kafka-consumer/writer_test.go
@@ -299,7 +299,9 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	w.appendMessage2Group(newDMLMessageForWriterTest(20), p, kafka.Offset(3))
 
 	p.watermark = 20
-	require.True(t, w.Write(ctx, codeccommon.MessageTypeResolved))
+	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
+	require.NoError(t, err)
+	require.True(t, needCommit)
 	require.Equal(t, []uint64{10, 20}, flushedCommitTs)
 }
 
@@ -323,9 +325,10 @@ func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {
 		maxMessageBytes: 1,
 	}
 
-	needCommit := w.WriteMessage(ctx, &kafka.Message{
+	needCommit, err := w.WriteMessage(ctx, &kafka.Message{
 		TopicPartition: kafka.TopicPartition{Partition: 0, Offset: kafka.Offset(10)},
 	})
+	require.NoError(t, err)
 
 	require.False(t, needCommit)
 	require.Nil(t, progress.eventsGroup[1])
@@ -353,7 +356,8 @@ func TestAppendMessageKeepsFallbackDMLAboveGlobalWatermark(t *testing.T) {
 	w.appendMessage2Group(newDMLMessageForWriterTest(10), progress, kafka.Offset(10))
 
 	require.NotNil(t, progress.eventsGroup[1])
-	resolved := progress.eventsGroup[1].ResolveInto(20, nil)
+	resolved, err := progress.eventsGroup[1].ResolveInto(20, nil)
+	require.NoError(t, err)
 	require.Len(t, resolved, 1)
 	require.Equal(t, uint64(10), resolved[0].GetCommitTs())
 }
@@ -404,7 +408,8 @@ func TestOnDDLMarksRoutedCreateTableLikePartitionTableForAvro(t *testing.T) {
 	w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(200)), progress, kafka.Offset(10))
 	w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(100)), progress, kafka.Offset(11))
 
-	resolved := progress.eventsGroup[1].ResolveInto(150, nil)
+	resolved, err := progress.eventsGroup[1].ResolveInto(150, nil)
+	require.NoError(t, err)
 	require.Len(t, resolved, 1)
 	require.Equal(t, uint64(100), resolved[0].GetCommitTs())
 }
@@ -452,7 +457,8 @@ func TestAppendRow2GroupKeepsDebeziumPartitionTableFallback(t *testing.T) {
 			w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(200)), progress, kafka.Offset(10))
 			w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(100)), progress, kafka.Offset(11))
 
-			resolved := progress.eventsGroup[1].ResolveInto(150, nil)
+			resolved, err := progress.eventsGroup[1].ResolveInto(150, nil)
+			require.NoError(t, err)
 			require.Len(t, resolved, 1)
 			require.Equal(t, uint64(100), resolved[0].GetCommitTs())
 		})

--- a/cmd/kafka-consumer/writer_test.go
+++ b/cmd/kafka-consumer/writer_test.go
@@ -273,10 +273,12 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := sinkmock.NewMockSink(ctrl)
 	flushedCommitTs := make([]uint64, 0)
+	flushedRowTypeCounts := make([]int, 0)
 	s.EXPECT().AddDMLEvent(gomock.Any()).Do(func(event *commonEvent.DMLEvent) {
 		flushedCommitTs = append(flushedCommitTs, event.GetCommitTs())
+		flushedRowTypeCounts = append(flushedRowTypeCounts, len(event.RowTypes))
 		event.PostFlush()
-	}).Times(3)
+	}).Times(2)
 
 	replicaCfg := config.GetDefaultReplicaConfig()
 	eventRouter, err := eventrouter.NewEventRouter(replicaCfg.Sink, "test-topic", false, false)
@@ -302,7 +304,8 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
 	require.NoError(t, err)
 	require.True(t, needCommit)
-	require.Equal(t, []uint64{10, 20, 20}, flushedCommitTs)
+	require.Equal(t, []uint64{10, 20}, flushedCommitTs)
+	require.Equal(t, []int{1, 2}, flushedRowTypeCounts)
 }
 
 func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {

--- a/cmd/kafka-consumer/writer_test.go
+++ b/cmd/kafka-consumer/writer_test.go
@@ -296,9 +296,16 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 		protocol:    config.ProtocolOpen,
 	}
 
-	w.appendMessage2Group(newDMLMessageForWriterTest(20), p, kafka.Offset(1))
-	w.appendMessage2Group(newDMLMessageForWriterTest(10), p, kafka.Offset(2))
-	w.appendMessage2Group(newDMLMessageForWriterTest(20), p, kafka.Offset(3))
+	for _, item := range []struct {
+		message *codeccommon.DMLMessage
+		offset  kafka.Offset
+	}{
+		{newDMLMessageForWriterTest(20), kafka.Offset(1)},
+		{newDMLMessageForWriterTest(10), kafka.Offset(2)},
+		{newDMLMessageForWriterTest(20), kafka.Offset(3)},
+	} {
+		require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(item.message), p, item.offset))
+	}
 
 	p.watermark = 20
 	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
@@ -318,7 +325,7 @@ func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {
 		partition:   0,
 		eventsGroup: make(map[int64]*util.EventsGroup),
 		watermark:   20,
-		decoder:     &singleDMLDecoder{message: newDMLMessageForWriterTest(10)},
+		decoder:     util.NewDMLMessageDecoder(&singleDMLDecoder{message: newDMLMessageForWriterTest(10)}),
 	}
 	w := &writer{
 		progresses:      []*partitionProgress{progress},
@@ -356,7 +363,8 @@ func TestAppendMessageKeepsFallbackDMLAboveGlobalWatermark(t *testing.T) {
 		protocol:    config.ProtocolOpen,
 	}
 
-	w.appendMessage2Group(newDMLMessageForWriterTest(10), progress, kafka.Offset(10))
+	message := newDMLMessageForWriterTest(10)
+	require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(message), progress, kafka.Offset(10)))
 
 	require.NotNil(t, progress.eventsGroup[1])
 	resolved, err := progress.eventsGroup[1].ResolveInto(20, nil)
@@ -408,8 +416,10 @@ func TestOnDDLMarksRoutedCreateTableLikePartitionTableForAvro(t *testing.T) {
 	}
 
 	progress := w.progresses[0]
-	w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(200)), progress, kafka.Offset(10))
-	w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(100)), progress, kafka.Offset(11))
+	first := codeccommon.NewDMLMessageFromEvent(newDMLEvent(200))
+	second := codeccommon.NewDMLMessageFromEvent(newDMLEvent(100))
+	require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(first), progress, kafka.Offset(10)))
+	require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(second), progress, kafka.Offset(11)))
 
 	resolved, err := progress.eventsGroup[1].ResolveInto(150, nil)
 	require.NoError(t, err)
@@ -457,8 +467,10 @@ func TestAppendRow2GroupKeepsDebeziumPartitionTableFallback(t *testing.T) {
 			}
 
 			progress := w.progresses[0]
-			w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(200)), progress, kafka.Offset(10))
-			w.appendMessage2Group(codeccommon.NewDMLMessageFromEvent(newDMLEvent(100)), progress, kafka.Offset(11))
+			first := codeccommon.NewDMLMessageFromEvent(newDMLEvent(200))
+			second := codeccommon.NewDMLMessageFromEvent(newDMLEvent(100))
+			require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(first), progress, kafka.Offset(10)))
+			require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(second), progress, kafka.Offset(11)))
 
 			resolved, err := progress.eventsGroup[1].ResolveInto(150, nil)
 			require.NoError(t, err)
@@ -481,6 +493,16 @@ func newDMLMessageForWriterTest(commitTs uint64) *codeccommon.DMLMessage {
 			},
 		}
 	})
+}
+
+func attachDMLMessageDataForWriterTest(message *codeccommon.DMLMessage) *codeccommon.DMLMessage {
+	messageData := codeccommon.NewDMLMessageData(nil, nil,
+		func([]byte, uint64) (*codeccommon.DMLMessage, error) {
+			return message, nil
+		},
+	)
+	messageData.AttachDMLMessage(message)
+	return message
 }
 
 type singleDMLDecoder struct {

--- a/cmd/kafka-consumer/writer_test.go
+++ b/cmd/kafka-consumer/writer_test.go
@@ -472,6 +472,7 @@ func newDMLMessageForWriterTest(commitTs uint64) *codeccommon.DMLMessage {
 	return codeccommon.NewDMLMessage(1, "test", "t", commitTs, common.RowTypeUpdate, func() *commonEvent.DMLEvent {
 		return &commonEvent.DMLEvent{
 			PhysicalTableID: 1,
+			StartTs:         commitTs - 1,
 			CommitTs:        commitTs,
 			RowTypes:        []common.RowType{common.RowTypeUpdate},
 			Rows:            chunk.NewChunkWithCapacity(nil, 0),

--- a/cmd/kafka-consumer/writer_test.go
+++ b/cmd/kafka-consumer/writer_test.go
@@ -276,7 +276,7 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	s.EXPECT().AddDMLEvent(gomock.Any()).Do(func(event *commonEvent.DMLEvent) {
 		flushedCommitTs = append(flushedCommitTs, event.GetCommitTs())
 		event.PostFlush()
-	}).Times(2)
+	}).Times(3)
 
 	replicaCfg := config.GetDefaultReplicaConfig()
 	eventRouter, err := eventrouter.NewEventRouter(replicaCfg.Sink, "test-topic", false, false)
@@ -302,7 +302,7 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
 	require.NoError(t, err)
 	require.True(t, needCommit)
-	require.Equal(t, []uint64{10, 20}, flushedCommitTs)
+	require.Equal(t, []uint64{10, 20, 20}, flushedCommitTs)
 }
 
 func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {

--- a/cmd/pulsar-consumer/consumer.go
+++ b/cmd/pulsar-consumer/consumer.go
@@ -124,6 +124,8 @@ func (c *consumer) readMessage(ctx context.Context) error {
 
 // Run the consumer, read data and write to the downstream target.
 func (c *consumer) Run(ctx context.Context) error {
+	defer c.writer.cleanupEventsGroups()
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return c.writer.run(ctx)

--- a/cmd/pulsar-consumer/consumer.go
+++ b/cmd/pulsar-consumer/consumer.go
@@ -110,7 +110,10 @@ func (c *consumer) readMessage(ctx context.Context) error {
 			return errors.Trace(ctx.Err())
 		case consumerMsg := <-msgChan:
 			log.Debug("Received message", zap.Stringer("msgId", consumerMsg.ID()), zap.ByteString("content", consumerMsg.Payload()))
-			needCommit := c.writer.WriteMessage(ctx, consumerMsg)
+			needCommit, writeErr := c.writer.WriteMessage(ctx, consumerMsg)
+			if writeErr != nil {
+				return writeErr
+			}
 			if !needCommit {
 				continue
 			}
@@ -123,8 +126,12 @@ func (c *consumer) readMessage(ctx context.Context) error {
 }
 
 // Run the consumer, read data and write to the downstream target.
-func (c *consumer) Run(ctx context.Context) error {
-	defer c.writer.cleanupEventsGroups()
+func (c *consumer) Run(ctx context.Context) (err error) {
+	defer func() {
+		if cleanupErr := c.writer.cleanupEventsGroups(); err == nil && cleanupErr != nil {
+			err = cleanupErr
+		}
+	}()
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {

--- a/cmd/pulsar-consumer/main.go
+++ b/cmd/pulsar-consumer/main.go
@@ -39,7 +39,7 @@ var (
 )
 
 func main() {
-	debug.SetMemoryLimit(14 * 1024 * 1024 * 1024)
+	debug.SetMemoryLimit(8 * 1024 * 1024 * 1024)
 	cmd := &cobra.Command{
 		Use: "pulsar consumer",
 		Run: run,

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -139,15 +139,20 @@ func (w *writer) run(ctx context.Context) error {
 	return w.mysqlSink.Run(ctx)
 }
 
-func (w *writer) cleanupEventsGroups() {
+func (w *writer) cleanupEventsGroups() error {
+	var cleanupErr error
 	for _, progress := range w.progresses {
 		for _, group := range progress.eventsGroup {
 			if err := group.Cleanup(); err != nil {
 				log.Warn("cleanup events group spill file failed",
 					zap.Int32("partition", progress.partition), zap.Error(err))
+				if cleanupErr == nil {
+					cleanupErr = err
+				}
 			}
 		}
 	}
+	return cleanupErr
 }
 
 func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) error {
@@ -166,7 +171,10 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 			if !ok {
 				continue
 			}
-			messages := g.ResolveInto(commitTs, nil)
+			messages, err := g.ResolveInto(commitTs, nil)
+			if err != nil {
+				return err
+			}
 			events := make([]*commonEvent.DMLEvent, 0, len(messages))
 			for _, message := range messages {
 				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
@@ -278,7 +286,10 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 	resolvedEvents := make([]*commonEvent.DMLEvent, 0)
 	for _, p := range w.progresses {
 		for _, group := range p.eventsGroup {
-			messages := group.ResolveInto(watermark, nil)
+			messages, err := group.ResolveInto(watermark, nil)
+			if err != nil {
+				return err
+			}
 			events := make([]*commonEvent.DMLEvent, 0, len(messages))
 			for _, message := range messages {
 				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
@@ -321,7 +332,7 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 // WriteMessage is to decode pulsar message to event.
 // return true if the message is flushed to the downstream.
 // return error if flush messages failed.
-func (w *writer) WriteMessage(ctx context.Context, message pulsar.Message) bool {
+func (w *writer) WriteMessage(ctx context.Context, message pulsar.Message) (bool, error) {
 	progress := w.progresses[0]
 	progress.decoder.AddKeyValue([]byte(message.Key()), message.Payload())
 
@@ -349,7 +360,7 @@ func (w *writer) WriteMessage(ctx context.Context, message pulsar.Message) bool 
 
 		// the Query maybe empty if using simple protocol, it's comes from `bootstrap` event, no need to handle it.
 		if ddl.Query == "" {
-			return false
+			return false, nil
 		}
 		w.appendDDL(ddl)
 		log.Info("DDL event received",
@@ -362,18 +373,20 @@ func (w *writer) WriteMessage(ctx context.Context, message pulsar.Message) bool 
 		if dmlMessage == nil {
 			log.Panic("DML message is nil, it's not expected")
 		}
-		w.appendMessage2Group(dmlMessage, progress)
+		if err := w.appendMessage2Group(dmlMessage, progress); err != nil {
+			return false, err
+		}
 	default:
 		log.Panic("unknown message type", zap.Any("messageType", messageType))
 	}
 	if needFlush {
 		return w.Write(ctx, messageType)
 	}
-	return false
+	return false, nil
 }
 
 // Write will synchronously write data downstream
-func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool {
+func (w *writer) Write(ctx context.Context, messageType common.MessageType) (bool, error) {
 	// DDL events can be received out of commit-ts order (e.g. due to protocol-level broadcasting and
 	// buffering differences between DDL kinds). We must execute DDLs in commit-ts order; otherwise a
 	// "future" DDL that is not yet eligible (commitTs > watermark) can block executing earlier DDLs
@@ -420,8 +433,7 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 			break
 		}
 		if err := w.flushDDLEvent(ctx, todoDDL); err != nil {
-			log.Panic("write DDL event failed", zap.Error(err),
-				zap.String("DDL", todoDDL.Query), zap.Uint64("commitTs", todoDDL.GetCommitTs()))
+			return false, err
 		}
 	}
 
@@ -429,7 +441,7 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 		// since watermark is broadcast to all partitions, so that each partition can flush events individually.
 		err := w.flushDMLEventsByWatermark(ctx)
 		if err != nil {
-			log.Panic("flush dml events by the watermark failed", zap.Error(err))
+			return false, err
 		}
 	}
 
@@ -439,9 +451,9 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 		log.Info("some DDL events will be flushed in the future",
 			zap.Uint64("watermark", watermark),
 			zap.Int("length", len(w.ddlList)))
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (w *writer) onDDL(ddl *commonEvent.DDLEvent) {
@@ -502,7 +514,7 @@ func (w *writer) addPartitionTable(schema, table string) {
 	w.partitionTableAccessor.Add(schema, table)
 }
 
-func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *partitionProgress) {
+func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *partitionProgress) error {
 	var (
 		tableID  = message.TableID
 		schema   = message.Schema
@@ -519,7 +531,7 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 			zap.String("schema", schema), zap.String("table", table),
 			zap.Stringer("eventType", message.RowType),
 			zap.Any("protocol", w.protocol), zap.Bool("enableTableAcrossNodes", w.enableTableAcrossNodes))
-		return
+		return nil
 	}
 
 	group := progress.eventsGroup[tableID]
@@ -527,7 +539,9 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	group.AppendMessage(message)
+	if err := group.AppendMessage(message); err != nil {
+		return err
+	}
 	if commitTs < progress.watermark {
 		log.Warn("DML event fallback row, since less than the partition watermark, append it and sort before flush",
 			zap.Int64("tableID", tableID), zap.Int32("partition", group.Partition),
@@ -536,14 +550,14 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 			zap.String("schema", schema), zap.String("table", table),
 			zap.Stringer("eventType", message.RowType),
 			zap.Any("protocol", w.protocol), zap.Bool("enableTableAcrossNodes", w.enableTableAcrossNodes))
-		return
+		return nil
 	}
 	if commitTs >= group.HighWatermark {
 		log.Debug("DML event append to the group",
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", message.RowType))
-		return
+		return nil
 	}
 	log.Warn("DML event commit ts fallback, append it and sort before flush",
 		zap.Int32("partition", progress.partition),
@@ -552,4 +566,5 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 		zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 		zap.Stringer("eventType", message.RowType),
 		zap.Any("protocol", w.protocol), zap.Bool("enableTableAcrossNodes", w.enableTableAcrossNodes))
+	return nil
 }

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -42,14 +42,14 @@ type partitionProgress struct {
 	partition   int32
 	watermark   uint64
 	eventsGroup map[int64]*util.EventsGroup
-	decoder     common.Decoder
+	decoder     *util.DMLMessageDecoder
 }
 
 func newPartitionProgress(partition int32, decoder common.Decoder) *partitionProgress {
 	return &partitionProgress{
 		partition:   partition,
 		eventsGroup: make(map[int64]*util.EventsGroup),
-		decoder:     decoder,
+		decoder:     util.NewDMLMessageDecoder(decoder),
 	}
 }
 
@@ -367,8 +367,7 @@ func (w *writer) WriteMessage(ctx context.Context, message pulsar.Message) (bool
 		if dmlMessage == nil {
 			log.Panic("DML message is nil, it's not expected")
 		}
-		if err := w.appendMessage2Group(dmlMessage, progress,
-			util.NewDMLMessageSpillData(progress.decoder, []byte(message.Key()), message.Payload(), 0)); err != nil {
+		if err := w.appendMessage2Group(dmlMessage, progress); err != nil {
 			return false, err
 		}
 	default:
@@ -512,7 +511,6 @@ func (w *writer) addPartitionTable(schema, table string) {
 func (w *writer) appendMessage2Group(
 	message *common.DMLMessage,
 	progress *partitionProgress,
-	spillDataArgs ...util.DMLMessageSpillData,
 ) error {
 	var (
 		tableID  = message.TableID
@@ -538,13 +536,7 @@ func (w *writer) appendMessage2Group(
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	spillData := util.DMLMessageSpillData{
-		Restore: func([]byte) (*common.DMLMessage, error) { return message, nil },
-	}
-	if len(spillDataArgs) > 0 {
-		spillData = spillDataArgs[0]
-	}
-	if err := group.AppendSpillMessage(message, spillData); err != nil {
+	if err := group.AppendMessage(message); err != nil {
 		return err
 	}
 	if commitTs < progress.watermark {

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -175,10 +175,7 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 			if err != nil {
 				return err
 			}
-			events := make([]*commonEvent.DMLEvent, 0, len(messages))
-			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
-			}
+			events := util.DMLMessagesToEvents(messages)
 			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
@@ -290,10 +287,7 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			events := make([]*commonEvent.DMLEvent, 0, len(messages))
-			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
-			}
+			events := util.DMLMessagesToEvents(messages)
 			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
@@ -373,7 +367,8 @@ func (w *writer) WriteMessage(ctx context.Context, message pulsar.Message) (bool
 		if dmlMessage == nil {
 			log.Panic("DML message is nil, it's not expected")
 		}
-		if err := w.appendMessage2Group(dmlMessage, progress); err != nil {
+		if err := w.appendMessage2Group(dmlMessage, progress,
+			util.NewDMLMessageSpillData(progress.decoder, []byte(message.Key()), message.Payload(), 0)); err != nil {
 			return false, err
 		}
 	default:
@@ -514,7 +509,11 @@ func (w *writer) addPartitionTable(schema, table string) {
 	w.partitionTableAccessor.Add(schema, table)
 }
 
-func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *partitionProgress) error {
+func (w *writer) appendMessage2Group(
+	message *common.DMLMessage,
+	progress *partitionProgress,
+	spillDataArgs ...util.DMLMessageSpillData,
+) error {
 	var (
 		tableID  = message.TableID
 		schema   = message.Schema
@@ -539,7 +538,13 @@ func (w *writer) appendMessage2Group(message *common.DMLMessage, progress *parti
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	if err := group.AppendMessage(message); err != nil {
+	spillData := util.DMLMessageSpillData{
+		Restore: func([]byte) (*common.DMLMessage, error) { return message, nil },
+	}
+	if len(spillDataArgs) > 0 {
+		spillData = spillDataArgs[0]
+	}
+	if err := group.AppendSpillMessage(message, spillData); err != nil {
 		return err
 	}
 	if commitTs < progress.watermark {

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -175,11 +175,14 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 			if err != nil {
 				return err
 			}
-			events := make([]*commonEvent.DMLEvent, 0, len(messages))
+			// A commit-ts is only a timestamp in a multi-source stream. It does
+			// not identify one transaction, so events from different upstreams can
+			// legitimately have the same value while carrying different schema
+			// snapshots. Keep restored events separate instead of merging their
+			// chunks by commit-ts.
 			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
+				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
 			}
-			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 
@@ -290,11 +293,11 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			events := make([]*commonEvent.DMLEvent, 0, len(messages))
+			// See flushDDLEvent: events with an identical commit-ts can belong to
+			// different upstream transactions in a multi-source stream.
 			for _, message := range messages {
-				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
+				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
 			}
-			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 	total := len(resolvedEvents)

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -139,6 +139,17 @@ func (w *writer) run(ctx context.Context) error {
 	return w.mysqlSink.Run(ctx)
 }
 
+func (w *writer) cleanupEventsGroups() {
+	for _, progress := range w.progresses {
+		for _, group := range progress.eventsGroup {
+			if err := group.Cleanup(); err != nil {
+				log.Warn("cleanup events group spill file failed",
+					zap.Int32("partition", progress.partition), zap.Error(err))
+			}
+		}
+	}
+}
+
 func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) error {
 	var (
 		done = make(chan struct{}, 1)

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -175,14 +175,11 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 			if err != nil {
 				return err
 			}
-			// A commit-ts is only a timestamp in a multi-source stream. It does
-			// not identify one transaction, so events from different upstreams can
-			// legitimately have the same value while carrying different schema
-			// snapshots. Keep restored events separate instead of merging their
-			// chunks by commit-ts.
+			events := make([]*commonEvent.DMLEvent, 0, len(messages))
 			for _, message := range messages {
-				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
+				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
 			}
+			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 
@@ -293,11 +290,11 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			// See flushDDLEvent: events with an identical commit-ts can belong to
-			// different upstream transactions in a multi-source stream.
+			events := make([]*commonEvent.DMLEvent, 0, len(messages))
 			for _, message := range messages {
-				resolvedEvents = append(resolvedEvents, message.ToDMLEvent())
+				events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
 			}
+			resolvedEvents = append(resolvedEvents, events...)
 		}
 	}
 	total := len(resolvedEvents)

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -276,7 +276,7 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	s.EXPECT().AddDMLEvent(gomock.Any()).Do(func(event *commonEvent.DMLEvent) {
 		flushedCommitTs = append(flushedCommitTs, event.GetCommitTs())
 		event.PostFlush()
-	}).Times(2)
+	}).Times(3)
 
 	p := &partitionProgress{
 		partition:   0,
@@ -297,7 +297,7 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
 	require.NoError(t, err)
 	require.True(t, needCommit)
-	require.Equal(t, []uint64{10, 20}, flushedCommitTs)
+	require.Equal(t, []uint64{10, 20, 20}, flushedCommitTs)
 }
 
 func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -291,9 +291,13 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 		protocol:   config.ProtocolCanalJSON,
 	}
 
-	w.appendMessage2Group(newDMLMessageForWriterTest(20), p)
-	w.appendMessage2Group(newDMLMessageForWriterTest(10), p)
-	w.appendMessage2Group(newDMLMessageForWriterTest(20), p)
+	for _, message := range []*codeccommon.DMLMessage{
+		newDMLMessageForWriterTest(20),
+		newDMLMessageForWriterTest(10),
+		newDMLMessageForWriterTest(20),
+	} {
+		require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(message), p))
+	}
 
 	p.watermark = 20
 	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
@@ -323,7 +327,7 @@ func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {
 		partition:   0,
 		eventsGroup: make(map[int64]*util.EventsGroup),
 		watermark:   20,
-		decoder:     decoder,
+		decoder:     util.NewDMLMessageDecoder(decoder),
 	}
 	w := &writer{
 		progresses: []*partitionProgress{progress},
@@ -352,7 +356,8 @@ func TestAppendMessageKeepsFallbackDMLAboveGlobalWatermark(t *testing.T) {
 		protocol: config.ProtocolCanalJSON,
 	}
 
-	w.appendMessage2Group(newDMLMessageForWriterTest(10), progress)
+	message := newDMLMessageForWriterTest(10)
+	require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(message), progress))
 
 	require.NotNil(t, progress.eventsGroup[1])
 	resolved, err := progress.eventsGroup[1].ResolveInto(20, nil)
@@ -389,8 +394,10 @@ func TestOnDDLMarksRoutedCreateTableLikePartitionTable(t *testing.T) {
 	require.True(t, w.partitionTableAccessor.IsPartitionTable("target", "dst"))
 
 	progress := w.progresses[0]
-	w.appendMessage2Group(newDMLMessageForWriterTest(200), progress)
-	w.appendMessage2Group(newDMLMessageForWriterTest(100), progress)
+	first := newDMLMessageForWriterTest(200)
+	second := newDMLMessageForWriterTest(100)
+	require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(first), progress))
+	require.NoError(t, w.appendMessage2Group(attachDMLMessageDataForWriterTest(second), progress))
 
 	resolved, err := progress.eventsGroup[1].ResolveInto(150, nil)
 	require.NoError(t, err)
@@ -419,7 +426,7 @@ func TestWriteMessageSpillsDMLImmediately(t *testing.T) {
 	progress := &partitionProgress{
 		partition:   0,
 		eventsGroup: make(map[int64]*util.EventsGroup),
-		decoder:     decoder,
+		decoder:     util.NewDMLMessageDecoder(decoder),
 	}
 	w := &writer{
 		progresses: []*partitionProgress{progress},
@@ -504,6 +511,16 @@ func newDMLMessageForWriterTest(commitTs uint64) *codeccommon.DMLMessage {
 			},
 		}
 	})
+}
+
+func attachDMLMessageDataForWriterTest(message *codeccommon.DMLMessage) *codeccommon.DMLMessage {
+	messageData := codeccommon.NewDMLMessageData(nil, nil,
+		func([]byte, uint64) (*codeccommon.DMLMessage, error) {
+			return message, nil
+		},
+	)
+	messageData.AttachDMLMessage(message)
+	return message
 }
 
 type fakePulsarMessage struct {

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -273,10 +273,12 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := sinkmock.NewMockSink(ctrl)
 	flushedCommitTs := make([]uint64, 0)
+	flushedRowTypeCounts := make([]int, 0)
 	s.EXPECT().AddDMLEvent(gomock.Any()).Do(func(event *commonEvent.DMLEvent) {
 		flushedCommitTs = append(flushedCommitTs, event.GetCommitTs())
+		flushedRowTypeCounts = append(flushedRowTypeCounts, len(event.RowTypes))
 		event.PostFlush()
-	}).Times(3)
+	}).Times(2)
 
 	p := &partitionProgress{
 		partition:   0,
@@ -297,7 +299,8 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
 	require.NoError(t, err)
 	require.True(t, needCommit)
-	require.Equal(t, []uint64{10, 20, 20}, flushedCommitTs)
+	require.Equal(t, []uint64{10, 20}, flushedCommitTs)
+	require.Equal(t, []int{1, 2}, flushedRowTypeCounts)
 }
 
 func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -381,20 +381,16 @@ func TestOnDDLMarksRoutedCreateTableLikePartitionTable(t *testing.T) {
 	w.onDDL(ddl)
 	require.True(t, w.partitionTableAccessor.IsPartitionTable("target", "dst"))
 
-	newDMLMessage := func(commitTs uint64) *codeccommon.DMLMessage {
-		return codeccommon.NewDMLMessage(1, "target", "dst", commitTs, common.RowTypeUpdate, nil)
-	}
-
 	progress := w.progresses[0]
-	w.appendMessage2Group(newDMLMessage(200), progress)
-	w.appendMessage2Group(newDMLMessage(100), progress)
+	w.appendMessage2Group(newDMLMessageForWriterTest(200), progress)
+	w.appendMessage2Group(newDMLMessageForWriterTest(100), progress)
 
 	resolved := progress.eventsGroup[1].ResolveInto(150, nil)
 	require.Len(t, resolved, 1)
 	require.Equal(t, uint64(100), resolved[0].GetCommitTs())
 }
 
-func TestWriteMessageDefersDMLAssemblyUntilFlush(t *testing.T) {
+func TestWriteMessageSpillsDMLImmediately(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	s := sinkmock.NewMockSink(ctrl)
@@ -428,7 +424,7 @@ func TestWriteMessageDefersDMLAssemblyUntilFlush(t *testing.T) {
 	require.Equal(t, 1, decoder.addKeyValueCount)
 	require.Equal(t, 1, decoder.hasNextCount)
 	require.Equal(t, 1, decoder.nextDMLMessageCount)
-	require.Zero(t, decoder.toDMLEventCount)
+	require.Equal(t, 1, decoder.toDMLEventCount)
 	require.Len(t, progress.eventsGroup[1].ResolveInto(99, nil), 0)
 
 	progress.watermark = 100

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -294,7 +294,9 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	w.appendMessage2Group(newDMLMessageForWriterTest(20), p)
 
 	p.watermark = 20
-	require.True(t, w.Write(ctx, codeccommon.MessageTypeResolved))
+	needCommit, err := w.Write(ctx, codeccommon.MessageTypeResolved)
+	require.NoError(t, err)
+	require.True(t, needCommit)
 	require.Equal(t, []uint64{10, 20}, flushedCommitTs)
 }
 
@@ -326,7 +328,8 @@ func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {
 		protocol:   config.ProtocolCanalJSON,
 	}
 
-	needCommit := w.WriteMessage(ctx, fakePulsarMessage{key: "k", payload: []byte(`{"fake":"row"}`)})
+	needCommit, err := w.WriteMessage(ctx, fakePulsarMessage{key: "k", payload: []byte(`{"fake":"row"}`)})
+	require.NoError(t, err)
 
 	require.False(t, needCommit)
 	require.Nil(t, progress.eventsGroup[1])
@@ -349,7 +352,8 @@ func TestAppendMessageKeepsFallbackDMLAboveGlobalWatermark(t *testing.T) {
 	w.appendMessage2Group(newDMLMessageForWriterTest(10), progress)
 
 	require.NotNil(t, progress.eventsGroup[1])
-	resolved := progress.eventsGroup[1].ResolveInto(20, nil)
+	resolved, err := progress.eventsGroup[1].ResolveInto(20, nil)
+	require.NoError(t, err)
 	require.Len(t, resolved, 1)
 	require.Equal(t, uint64(10), resolved[0].GetCommitTs())
 }
@@ -385,7 +389,8 @@ func TestOnDDLMarksRoutedCreateTableLikePartitionTable(t *testing.T) {
 	w.appendMessage2Group(newDMLMessageForWriterTest(200), progress)
 	w.appendMessage2Group(newDMLMessageForWriterTest(100), progress)
 
-	resolved := progress.eventsGroup[1].ResolveInto(150, nil)
+	resolved, err := progress.eventsGroup[1].ResolveInto(150, nil)
+	require.NoError(t, err)
 	require.Len(t, resolved, 1)
 	require.Equal(t, uint64(100), resolved[0].GetCommitTs())
 }
@@ -419,21 +424,28 @@ func TestWriteMessageSpillsDMLImmediately(t *testing.T) {
 		protocol:   config.ProtocolCanalJSON,
 	}
 
-	needCommit := w.WriteMessage(ctx, fakePulsarMessage{key: "k", payload: []byte(`{"fake":"row"}`)})
+	needCommit, err := w.WriteMessage(ctx, fakePulsarMessage{key: "k", payload: []byte(`{"fake":"row"}`)})
+	require.NoError(t, err)
 	require.False(t, needCommit)
 	require.Equal(t, 1, decoder.addKeyValueCount)
 	require.Equal(t, 1, decoder.hasNextCount)
 	require.Equal(t, 1, decoder.nextDMLMessageCount)
 	require.Equal(t, 1, decoder.toDMLEventCount)
-	require.Len(t, progress.eventsGroup[1].ResolveInto(99, nil), 0)
+	resolved, err := progress.eventsGroup[1].ResolveInto(99, nil)
+	require.NoError(t, err)
+	require.Len(t, resolved, 0)
 
 	progress.watermark = 100
-	require.True(t, w.Write(ctx, codeccommon.MessageTypeResolved))
+	needCommit, err = w.Write(ctx, codeccommon.MessageTypeResolved)
+	require.NoError(t, err)
+	require.True(t, needCommit)
 	require.Equal(t, 1, decoder.addKeyValueCount)
 	require.Equal(t, 1, decoder.hasNextCount)
 	require.Equal(t, 1, decoder.nextDMLMessageCount)
 	require.Equal(t, 1, decoder.toDMLEventCount)
-	require.Empty(t, progress.eventsGroup[1].ResolveInto(100, nil))
+	resolved, err = progress.eventsGroup[1].ResolveInto(100, nil)
+	require.NoError(t, err)
+	require.Empty(t, resolved)
 	require.Equal(t, []byte(`{"fake":"row"}`), decoder.lastValue)
 }
 

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -433,7 +433,7 @@ func TestWriteMessageSpillsDMLImmediately(t *testing.T) {
 	require.Equal(t, 1, decoder.addKeyValueCount)
 	require.Equal(t, 1, decoder.hasNextCount)
 	require.Equal(t, 1, decoder.nextDMLMessageCount)
-	require.Equal(t, 1, decoder.toDMLEventCount)
+	require.Zero(t, decoder.toDMLEventCount)
 	resolved, err := progress.eventsGroup[1].ResolveInto(99, nil)
 	require.NoError(t, err)
 	require.Len(t, resolved, 0)
@@ -442,9 +442,9 @@ func TestWriteMessageSpillsDMLImmediately(t *testing.T) {
 	needCommit, err = w.Write(ctx, codeccommon.MessageTypeResolved)
 	require.NoError(t, err)
 	require.True(t, needCommit)
-	require.Equal(t, 1, decoder.addKeyValueCount)
-	require.Equal(t, 1, decoder.hasNextCount)
-	require.Equal(t, 1, decoder.nextDMLMessageCount)
+	require.Equal(t, 2, decoder.addKeyValueCount)
+	require.Equal(t, 3, decoder.hasNextCount)
+	require.Equal(t, 2, decoder.nextDMLMessageCount)
 	require.Equal(t, 1, decoder.toDMLEventCount)
 	resolved, err = progress.eventsGroup[1].ResolveInto(100, nil)
 	require.NoError(t, err)
@@ -460,16 +460,18 @@ type deferredDMLDecoder struct {
 	nextDMLMessageCount int
 	toDMLEventCount     int
 	lastValue           []byte
+	pending             bool
 }
 
 func (d *deferredDMLDecoder) AddKeyValue(_, value []byte) {
 	d.addKeyValueCount++
 	d.lastValue = append(d.lastValue[:0], value...)
+	d.pending = true
 }
 
 func (d *deferredDMLDecoder) HasNext() (codeccommon.MessageType, bool) {
 	d.hasNextCount++
-	return codeccommon.MessageTypeRow, true
+	return codeccommon.MessageTypeRow, d.pending
 }
 
 func (d *deferredDMLDecoder) NextResolvedEvent() uint64 {
@@ -478,6 +480,7 @@ func (d *deferredDMLDecoder) NextResolvedEvent() uint64 {
 
 func (d *deferredDMLDecoder) NextDMLMessage() *codeccommon.DMLMessage {
 	d.nextDMLMessageCount++
+	d.pending = false
 	return codeccommon.NewDMLMessage(1, "test", "t", d.row.CommitTs, common.RowTypeInsert, func() *commonEvent.DMLEvent {
 		d.toDMLEventCount++
 		return d.row
@@ -492,6 +495,7 @@ func newDMLMessageForWriterTest(commitTs uint64) *codeccommon.DMLMessage {
 	return codeccommon.NewDMLMessage(1, "test", "t", commitTs, common.RowTypeUpdate, func() *commonEvent.DMLEvent {
 		return &commonEvent.DMLEvent{
 			PhysicalTableID: 1,
+			StartTs:         commitTs - 1,
 			CommitTs:        commitTs,
 			RowTypes:        []common.RowType{common.RowTypeUpdate},
 			Rows:            chunk.NewChunkWithCapacity(nil, 0),

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -309,10 +309,7 @@ func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAc
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", message.RowType))
-		if err := group.AppendMessage(message); err != nil {
-			return err
-		}
-		return nil
+		return group.AppendMessage(message)
 	}
 	log.Warn("dml event commit ts fallback, ignore",
 		zap.Uint64("commitTs", commitTs),

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -282,7 +282,7 @@ func (c *consumer) getNewFiles(
 	return tableDMLMap, err
 }
 
-func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAcrossNodes bool) {
+func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAcrossNodes bool) error {
 	var (
 		tableID  = message.TableID
 		schema   = message.Schema
@@ -295,20 +295,24 @@ func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAc
 		c.eventsGroup[tableID] = group
 	}
 	if commitTs >= group.HighWatermark {
-		group.AppendMessage(message)
+		if err := group.AppendMessage(message); err != nil {
+			return err
+		}
 		log.Debug("DML event append to the group",
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", message.RowType))
-		return
+		return nil
 	}
 	if enableTableAcrossNodes {
 		log.Warn("DML events fallback, but enableTableAcrossNodes is true, still append it",
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", message.RowType))
-		group.AppendMessage(message)
-		return
+		if err := group.AppendMessage(message); err != nil {
+			return err
+		}
+		return nil
 	}
 	log.Warn("dml event commit ts fallback, ignore",
 		zap.Uint64("commitTs", commitTs),
@@ -316,6 +320,7 @@ func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAc
 		zap.String("schema", schema),
 		zap.String("table", table),
 	)
+	return nil
 }
 
 // appendDMLEvents decodes RowChangedEvents from file content and append them to event group.
@@ -372,7 +377,9 @@ func (c *consumer) appendDMLEvents(
 			c.dmlCount.Add(1)
 
 			message := decoder.NextDMLMessage()
-			c.appendMessage2Group(messageWithPhysicalTableID(message, tableID), fileIdx.EnableTableAcrossNodes)
+			if err := c.appendMessage2Group(messageWithPhysicalTableID(message, tableID), fileIdx.EnableTableAcrossNodes); err != nil {
+				return err
+			}
 			filteredCnt++
 		}
 	}
@@ -398,7 +405,10 @@ func (c *consumer) flushDMLEvents(ctx context.Context, tableID int64) error {
 	if group == nil {
 		return nil
 	}
-	messages := group.GetAllMessages()
+	messages, err := group.GetAllMessages()
+	if err != nil {
+		return err
+	}
 	if len(messages) == 0 {
 		return nil
 	}
@@ -449,12 +459,17 @@ func (c *consumer) flushDMLEvents(ctx context.Context, tableID int64) error {
 	}
 }
 
-func (c *consumer) cleanupEventsGroups() {
+func (c *consumer) cleanupEventsGroups() error {
+	var cleanupErr error
 	for _, group := range c.eventsGroup {
 		if err := group.Cleanup(); err != nil {
 			log.Warn("cleanup events group spill file failed", zap.Error(err))
+			if cleanupErr == nil {
+				cleanupErr = err
+			}
 		}
 	}
+	return cleanupErr
 }
 
 func (c *consumer) parseDMLIndexFile(ctx context.Context, path string, dmlkey cloudstorage.DMLPathKey) {
@@ -774,8 +789,12 @@ func (c *consumer) handle(ctx context.Context) error {
 	}
 }
 
-func (c *consumer) run(ctx context.Context) error {
-	defer c.cleanupEventsGroups()
+func (c *consumer) run(ctx context.Context) (err error) {
+	defer func() {
+		if cleanupErr := c.cleanupEventsGroups(); err == nil && cleanupErr != nil {
+			err = cleanupErr
+		}
+	}()
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -409,11 +409,9 @@ func (c *consumer) flushDMLEvents(ctx context.Context, tableID int64) error {
 	if len(messages) == 0 {
 		return nil
 	}
-	// A commit-ts is only a timestamp in a multi-source stream. Keep restored
-	// events separate instead of merging chunks from independent transactions.
 	events := make([]*event.DMLEvent, 0, len(messages))
 	for _, message := range messages {
-		events = append(events, message.ToDMLEvent())
+		events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
 	}
 	total := len(events)
 	if total == 0 {

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -361,7 +361,7 @@ func (c *consumer) appendDMLEvents(
 	}
 
 	spillDecoder := util.NewDMLMessageDecoderWithDataFactory(decoder,
-		func(_ common.Decoder, key, value []byte) *common.DMLMessageData {
+		func(_ common.Decoder, _, value []byte) *common.DMLMessageData {
 			return c.newDMLMessageData(ctx, schemaFile, value, tableID)
 		})
 	spillDecoder.SetRawMessage(nil, content)

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -285,7 +285,6 @@ func (c *consumer) getNewFiles(
 func (c *consumer) appendMessage2Group(
 	message *common.DMLMessage,
 	enableTableAcrossNodes bool,
-	spillData util.DMLMessageSpillData,
 ) error {
 	var (
 		tableID  = message.TableID
@@ -299,7 +298,7 @@ func (c *consumer) appendMessage2Group(
 		c.eventsGroup[tableID] = group
 	}
 	if commitTs >= group.HighWatermark {
-		if err := group.AppendSpillMessage(message, spillData); err != nil {
+		if err := group.AppendMessage(message); err != nil {
 			return err
 		}
 		log.Debug("DML event append to the group",
@@ -313,7 +312,7 @@ func (c *consumer) appendMessage2Group(
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", message.RowType))
-		return group.AppendSpillMessage(message, spillData)
+		return group.AppendMessage(message)
 	}
 	log.Warn("dml event commit ts fallback, ignore",
 		zap.Uint64("commitTs", commitTs),
@@ -361,11 +360,15 @@ func (c *consumer) appendDMLEvents(
 		decoder.AddKeyValue(nil, content)
 	}
 
+	spillDecoder := util.NewDMLMessageDecoderWithDataFactory(decoder,
+		func(_ common.Decoder, key, value []byte) *common.DMLMessageData {
+			return c.newDMLMessageData(ctx, schemaFile, value, tableID)
+		})
+	spillDecoder.SetRawMessage(nil, content)
 	cnt := 0
-	dmlIndex := uint64(0)
 	filteredCnt := 0
 	for {
-		tp, hasNext := decoder.HasNext()
+		tp, hasNext := spillDecoder.HasNext()
 		if err != nil {
 			log.Error("failed to decode message", zap.Error(err))
 			return err
@@ -378,13 +381,8 @@ func (c *consumer) appendDMLEvents(
 		if tp == common.MessageTypeRow {
 			c.dmlCount.Add(1)
 
-			message := decoder.NextDMLMessage()
-			spillData := c.newDMLMessageSpillData(ctx, schemaFile, content, dmlIndex)
-			dmlIndex++
-			spillData.PostRestore = func(message *common.DMLMessage) *common.DMLMessage {
-				return messageWithPhysicalTableID(message, tableID)
-			}
-			if err := c.appendMessage2Group(message, fileIdx.EnableTableAcrossNodes, spillData); err != nil {
+			message := spillDecoder.NextDMLMessage()
+			if err := c.appendMessage2Group(message, fileIdx.EnableTableAcrossNodes); err != nil {
 				return err
 			}
 			filteredCnt++
@@ -399,15 +397,15 @@ func (c *consumer) appendDMLEvents(
 	return err
 }
 
-func (c *consumer) newDMLMessageSpillData(
+func (c *consumer) newDMLMessageData(
 	ctx context.Context,
 	schemaFile cloudstorage.SchemaFile,
 	content []byte,
-	dmlIndex uint64,
-) util.DMLMessageSpillData {
+	tableID int64,
+) *common.DMLMessageData {
 	tableInfo := schemaFile.TableInfo()
 	selector := c.columnSelectors.GetForTableInfo(tableInfo)
-	return util.NewDMLMessageSpillDataWithDecoderFactory(nil, content, dmlIndex,
+	messageData := util.NewDMLMessageDataWithDecoderFactory(nil, content,
 		func(_ []byte, value []byte) (common.Decoder, error) {
 			switch c.codecCfg.Protocol {
 			case config.ProtocolCsv:
@@ -419,6 +417,15 @@ func (c *consumer) newDMLMessageSpillData(
 				return nil, errors.ErrSpillFileOp.FastGenByArgs("unsupported storage DML spill protocol")
 			}
 		})
+	restore := messageData.Restore
+	messageData.Restore = func(data []byte, dmlIndex uint64) (*common.DMLMessage, error) {
+		message, err := restore(data, dmlIndex)
+		if err != nil {
+			return nil, err
+		}
+		return messageWithPhysicalTableID(message, tableID), nil
+	}
+	return messageData
 }
 
 func messageWithPhysicalTableID(message *common.DMLMessage, tableID int64) *common.DMLMessage {

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -412,9 +412,11 @@ func (c *consumer) flushDMLEvents(ctx context.Context, tableID int64) error {
 	if len(messages) == 0 {
 		return nil
 	}
+	// A commit-ts is only a timestamp in a multi-source stream. Keep restored
+	// events separate instead of merging chunks from independent transactions.
 	events := make([]*event.DMLEvent, 0, len(messages))
 	for _, message := range messages {
-		events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
+		events = append(events, message.ToDMLEvent())
 	}
 	total := len(events)
 	if total == 0 {

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -284,10 +284,10 @@ func (c *consumer) getNewFiles(
 
 func (c *consumer) appendMessage2Group(
 	message *common.DMLMessage,
+	tableID int64,
 	enableTableAcrossNodes bool,
 ) error {
 	var (
-		tableID  = message.TableID
 		schema   = message.Schema
 		table    = message.Table
 		commitTs = message.GetCommitTs()
@@ -382,7 +382,7 @@ func (c *consumer) appendDMLEvents(
 			c.dmlCount.Add(1)
 
 			message := spillDecoder.NextDMLMessage()
-			if err := c.appendMessage2Group(message, fileIdx.EnableTableAcrossNodes); err != nil {
+			if err := c.appendMessage2Group(message, tableID, fileIdx.EnableTableAcrossNodes); err != nil {
 				return err
 			}
 			filteredCnt++

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -449,6 +449,14 @@ func (c *consumer) flushDMLEvents(ctx context.Context, tableID int64) error {
 	}
 }
 
+func (c *consumer) cleanupEventsGroups() {
+	for _, group := range c.eventsGroup {
+		if err := group.Cleanup(); err != nil {
+			log.Warn("cleanup events group spill file failed", zap.Error(err))
+		}
+	}
+}
+
 func (c *consumer) parseDMLIndexFile(ctx context.Context, path string, dmlkey cloudstorage.DMLPathKey) {
 	if c.globalCheckpointTs > 0 && dmlkey.TableVersion > c.globalCheckpointTs {
 		log.Debug("skip dml index file by checkpoint",
@@ -767,6 +775,8 @@ func (c *consumer) handle(ctx context.Context) error {
 }
 
 func (c *consumer) run(ctx context.Context) error {
+	defer c.cleanupEventsGroups()
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return c.sink.Run(ctx)

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -282,7 +282,11 @@ func (c *consumer) getNewFiles(
 	return tableDMLMap, err
 }
 
-func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAcrossNodes bool) error {
+func (c *consumer) appendMessage2Group(
+	message *common.DMLMessage,
+	enableTableAcrossNodes bool,
+	spillData util.DMLMessageSpillData,
+) error {
 	var (
 		tableID  = message.TableID
 		schema   = message.Schema
@@ -295,7 +299,7 @@ func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAc
 		c.eventsGroup[tableID] = group
 	}
 	if commitTs >= group.HighWatermark {
-		if err := group.AppendMessage(message); err != nil {
+		if err := group.AppendSpillMessage(message, spillData); err != nil {
 			return err
 		}
 		log.Debug("DML event append to the group",
@@ -309,7 +313,7 @@ func (c *consumer) appendMessage2Group(message *common.DMLMessage, enableTableAc
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", message.RowType))
-		return group.AppendMessage(message)
+		return group.AppendSpillMessage(message, spillData)
 	}
 	log.Warn("dml event commit ts fallback, ignore",
 		zap.Uint64("commitTs", commitTs),
@@ -358,6 +362,7 @@ func (c *consumer) appendDMLEvents(
 	}
 
 	cnt := 0
+	dmlIndex := uint64(0)
 	filteredCnt := 0
 	for {
 		tp, hasNext := decoder.HasNext()
@@ -374,7 +379,12 @@ func (c *consumer) appendDMLEvents(
 			c.dmlCount.Add(1)
 
 			message := decoder.NextDMLMessage()
-			if err := c.appendMessage2Group(messageWithPhysicalTableID(message, tableID), fileIdx.EnableTableAcrossNodes); err != nil {
+			spillData := c.newDMLMessageSpillData(ctx, schemaFile, content, dmlIndex)
+			dmlIndex++
+			spillData.PostRestore = func(message *common.DMLMessage) *common.DMLMessage {
+				return messageWithPhysicalTableID(message, tableID)
+			}
+			if err := c.appendMessage2Group(message, fileIdx.EnableTableAcrossNodes, spillData); err != nil {
 				return err
 			}
 			filteredCnt++
@@ -387,6 +397,28 @@ func (c *consumer) appendDMLEvents(
 		zap.Int("filteredRowsCnt", filteredCnt))
 
 	return err
+}
+
+func (c *consumer) newDMLMessageSpillData(
+	ctx context.Context,
+	schemaFile cloudstorage.SchemaFile,
+	content []byte,
+	dmlIndex uint64,
+) util.DMLMessageSpillData {
+	tableInfo := schemaFile.TableInfo()
+	selector := c.columnSelectors.GetForTableInfo(tableInfo)
+	return util.NewDMLMessageSpillDataWithDecoderFactory(nil, content, dmlIndex,
+		func(_ []byte, value []byte) (common.Decoder, error) {
+			switch c.codecCfg.Protocol {
+			case config.ProtocolCsv:
+				return csv.NewDecoderWithColumnSelector(ctx, c.codecCfg, tableInfo, value, selector)
+			case config.ProtocolCanalJSON:
+				decoder := canal.NewTxnDecoder(c.codecCfg)
+				return decoder, nil
+			default:
+				return nil, errors.ErrSpillFileOp.FastGenByArgs("unsupported storage DML spill protocol")
+			}
+		})
 }
 
 func messageWithPhysicalTableID(message *common.DMLMessage, tableID int64) *common.DMLMessage {
@@ -409,10 +441,7 @@ func (c *consumer) flushDMLEvents(ctx context.Context, tableID int64) error {
 	if len(messages) == 0 {
 		return nil
 	}
-	events := make([]*event.DMLEvent, 0, len(messages))
-	for _, message := range messages {
-		events = util.AppendOrMergeDMLEvent(events, message.ToDMLEvent())
-	}
+	events := util.DMLMessagesToEvents(messages)
 	total := len(events)
 	if total == 0 {
 		return nil

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -82,6 +83,7 @@ func init() {
 }
 
 func main() {
+	debug.SetMemoryLimit(8 * 1024 * 1024 * 1024)
 	var consumer *consumer
 	var err error
 

--- a/cmd/util/dml_message_decoder.go
+++ b/cmd/util/dml_message_decoder.go
@@ -1,0 +1,112 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
+
+// DMLMessageDataFactory creates data shared by DML messages decoded from one
+// input. It is called lazily when the decoder first returns a DML message.
+type DMLMessageDataFactory func(codeccommon.Decoder, []byte, []byte) *codeccommon.DMLMessageData
+
+// DMLMessageDecoder attaches spill data to DML messages as they are decoded.
+// It keeps raw input only until EventsGroup has written it to the spill file.
+type DMLMessageDecoder struct {
+	codeccommon.Decoder
+
+	key, value []byte
+	data       *codeccommon.DMLMessageData
+	factory    DMLMessageDataFactory
+	restore    func(*codeccommon.DMLMessage) *codeccommon.DMLMessage
+}
+
+// NewDMLMessageDecoder wraps a decoder with the standard raw-message restorer.
+func NewDMLMessageDecoder(decoder codeccommon.Decoder) *DMLMessageDecoder {
+	return NewDMLMessageDecoderWithDataFactory(decoder,
+		func(decoder codeccommon.Decoder, key, value []byte) *codeccommon.DMLMessageData {
+			return NewDMLMessageData(decoder, key, value)
+		})
+}
+
+// NewDMLMessageDecoderWithDataFactory is for decoders such as CSV whose
+// restore decoder must be constructed from the input value.
+func NewDMLMessageDecoderWithDataFactory(
+	decoder codeccommon.Decoder, factory DMLMessageDataFactory,
+) *DMLMessageDecoder {
+	return &DMLMessageDecoder{Decoder: decoder, factory: factory}
+}
+
+// SetDMLMessageRestorer sets the per-input restore wrapper before AddKeyValue.
+func (d *DMLMessageDecoder) SetDMLMessageRestorer(
+	restore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
+) {
+	d.restore = restore
+}
+
+// AddKeyValue implements codeccommon.Decoder.
+func (d *DMLMessageDecoder) AddKeyValue(key, value []byte) {
+	d.Decoder.AddKeyValue(key, value)
+	d.SetRawMessage(key, value)
+}
+
+// SetRawMessage records input that was supplied while constructing a decoder,
+// such as a CSV decoder. It does not pass the input to the wrapped decoder.
+func (d *DMLMessageDecoder) SetRawMessage(key, value []byte) {
+	d.key = key
+	d.value = value
+	d.data = nil
+}
+
+// NextDMLMessage implements codeccommon.Decoder.
+func (d *DMLMessageDecoder) NextDMLMessage() *codeccommon.DMLMessage {
+	message := d.Decoder.NextDMLMessage()
+	if message != nil {
+		d.attachDMLMessage(message)
+	}
+	return message
+}
+
+func (d *DMLMessageDecoder) attachDMLMessage(message *codeccommon.DMLMessage) {
+	if d.data == nil {
+		d.data = d.wrapRestore(d.factory(d.Decoder, d.key, d.value))
+	}
+	d.data.AttachDMLMessage(message)
+}
+
+// AttachCachedDMLMessage attaches data to a materialized DML message from
+// Simple's DDL cache. It has no raw row payload to restore.
+func (d *DMLMessageDecoder) AttachCachedDMLMessage(message *codeccommon.DMLMessage) {
+	data := codeccommon.NewDMLMessageData(nil, nil,
+		func([]byte, uint64) (*codeccommon.DMLMessage, error) { return message, nil })
+	d.wrapRestore(data).AttachDMLMessage(message)
+}
+
+func (d *DMLMessageDecoder) wrapRestore(data *codeccommon.DMLMessageData) *codeccommon.DMLMessageData {
+	if d.restore == nil {
+		return data
+	}
+	restore := data.Restore
+	data.Restore = func(data []byte, dmlIndex uint64) (*codeccommon.DMLMessage, error) {
+		message, err := restore(data, dmlIndex)
+		if err != nil {
+			return nil, err
+		}
+		return d.restore(message), nil
+	}
+	return data
+}
+
+// Unwrap returns the decoder that produces protocol messages.
+func (d *DMLMessageDecoder) Unwrap() codeccommon.Decoder {
+	return d.Decoder
+}

--- a/cmd/util/dml_message_decoder_test.go
+++ b/cmd/util/dml_message_decoder_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDMLMessageDecoderAttachesSharedData(t *testing.T) {
+	first := newTestDMLMessage(10)
+	second := newTestDMLMessage(11)
+	decoder := &dmlMessageDecoderStub{messages: []*codeccommon.DMLMessage{first, second}}
+	wrapped := NewDMLMessageDecoder(decoder)
+
+	wrapped.AddKeyValue([]byte("key"), []byte("value"))
+	decodedFirst := wrapped.NextDMLMessage()
+	firstData, firstIndex := decodedFirst.SpillData()
+	require.Equal(t, []byte("key"), firstData.Key)
+	require.Equal(t, []byte("value"), firstData.Value)
+	require.Zero(t, firstIndex)
+
+	decodedSecond := wrapped.NextDMLMessage()
+	secondData, secondIndex := decodedSecond.SpillData()
+	require.Same(t, firstData, secondData)
+	require.Equal(t, uint64(1), secondIndex)
+}
+
+type dmlMessageDecoderStub struct {
+	messages []*codeccommon.DMLMessage
+}
+
+func (d *dmlMessageDecoderStub) AddKeyValue(_, _ []byte) {}
+
+func (d *dmlMessageDecoderStub) HasNext() (codeccommon.MessageType, bool) {
+	return codeccommon.MessageTypeRow, len(d.messages) > 0
+}
+
+func (d *dmlMessageDecoderStub) NextResolvedEvent() uint64 { return 0 }
+
+func (d *dmlMessageDecoderStub) NextDMLMessage() *codeccommon.DMLMessage {
+	if len(d.messages) == 0 {
+		return nil
+	}
+	message := d.messages[0]
+	d.messages = d.messages[1:]
+	return message
+}
+
+func (d *dmlMessageDecoderStub) NextDDLEvent() *commonEvent.DDLEvent { return nil }

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -62,8 +62,8 @@ func NewEventsGroup(partition int32, tableID int64) *EventsGroup {
 // AppendMessage materializes a message and appends it to a local spill file. DMLMessage carries a
 // decoder closure, so persisting its reconstructed event is necessary to release the decoder input
 // retained by that closure.
-func (g *EventsGroup) AppendMessage(message *codeccommon.DMLMessage) {
-	g.appendMessage(message, nil)
+func (g *EventsGroup) AppendMessage(message *codeccommon.DMLMessage) error {
+	return g.appendMessage(message, nil)
 }
 
 // AppendMessageWithPostRestore appends a message and applies postRestore after it is read back from
@@ -72,38 +72,39 @@ func (g *EventsGroup) AppendMessage(message *codeccommon.DMLMessage) {
 func (g *EventsGroup) AppendMessageWithPostRestore(
 	message *codeccommon.DMLMessage,
 	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
-) {
-	g.appendMessage(message, postRestore)
+) error {
+	return g.appendMessage(message, postRestore)
 }
 
 func (g *EventsGroup) appendMessage(
 	message *codeccommon.DMLMessage,
 	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
-) {
+
+) error {
+	if message == nil {
+		return errors.ErrSpillFileOp.FastGenByArgs("cannot spill nil DML message")
+	}
 	commitTs := message.GetCommitTs()
+
+	data, row, err := marshalDMLMessage(message)
+	if err != nil {
+		return err
+	}
+	if g.spillFile == nil {
+		g.spillFile, err = spill.NewRecordFile(os.TempDir(), eventsGroupSpillPattern)
+		if err != nil {
+			return err
+		}
+	}
+	handle, err := g.spillFile.Append(data)
+	if err != nil {
+		return err
+	}
 	if len(g.messages) > 0 && commitTs < g.messages[len(g.messages)-1].commitTs {
 		g.outOfOrder = true
 	}
 	if commitTs > g.HighWatermark {
 		g.HighWatermark = commitTs
-	}
-
-	data, row, err := marshalDMLMessage(message)
-	if err != nil {
-		log.Panic("marshal DML message for spill failed",
-			zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
-	}
-	if g.spillFile == nil {
-		g.spillFile, err = spill.NewRecordFile(os.TempDir(), eventsGroupSpillPattern)
-		if err != nil {
-			log.Panic("create events group spill file failed",
-				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
-		}
-	}
-	handle, err := g.spillFile.Append(data)
-	if err != nil {
-		log.Panic("write DML message to spill file failed",
-			zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
 	}
 	g.messages = append(g.messages, spilledMessage{
 		commitTs:    commitTs,
@@ -113,14 +114,15 @@ func (g *EventsGroup) appendMessage(
 	// Codec decoders use this callback to release their pooled chunks. The event is durable in the
 	// spill file now, so the original in-memory event is no longer needed.
 	row.PostFlush()
+	return nil
 }
 
 // ResolveInto appends all messages with CommitTs <= resolve into dst in commit-ts order and removes
 // them from the group. Resolved messages are restored from the spill file only when downstream needs
 // them, keeping the buffered group out of heap memory.
-func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage) []*codeccommon.DMLMessage {
+func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage) ([]*codeccommon.DMLMessage, error) {
 	if len(g.messages) == 0 {
-		return dst
+		return dst, nil
 	}
 
 	if g.outOfOrder {
@@ -141,19 +143,20 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 		g.outOfOrder = false
 	}
 	if resolvedCount == 0 {
-		return dst
+		return dst, nil
+	}
+	if g.spillFile == nil {
+		return dst, errors.ErrSpillFileOp.FastGenByArgs("events group spill file is missing")
 	}
 
 	for _, message := range g.messages[:resolvedCount] {
 		data, err := g.spillFile.Read(message.handle)
 		if err != nil {
-			log.Panic("read DML message from spill file failed",
-				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+			return dst, err
 		}
 		restored, err := unmarshalDMLMessage(data)
 		if err != nil {
-			log.Panic("unmarshal DML message from spill file failed",
-				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+			return dst, err
 		}
 		if message.postRestore != nil {
 			restored = message.postRestore(restored)
@@ -166,8 +169,7 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 	g.messages = g.messages[:remainingCount]
 	if len(g.messages) == 0 {
 		if err := g.spillFile.Cleanup(); err != nil {
-			log.Panic("cleanup events group spill file failed",
-				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+			return dst, err
 		}
 		g.spillFile = nil
 	}
@@ -178,11 +180,11 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 			zap.Int("resolved", resolvedCount), zap.Int("remained", len(g.messages)),
 			zap.Uint64("resolveTs", resolve), zap.Uint64("firstCommitTs", firstCommitTs))
 	}
-	return dst
+	return dst, nil
 }
 
 // GetAllMessages gets all messages.
-func (g *EventsGroup) GetAllMessages() []*codeccommon.DMLMessage {
+func (g *EventsGroup) GetAllMessages() ([]*codeccommon.DMLMessage, error) {
 	return g.ResolveInto(math.MaxUint64, nil)
 }
 
@@ -192,10 +194,13 @@ func (g *EventsGroup) Cleanup() error {
 		return nil
 	}
 	err := g.spillFile.Cleanup()
+	if err != nil {
+		return err
+	}
 	g.spillFile = nil
 	clear(g.messages)
 	g.messages = g.messages[:0]
-	return err
+	return nil
 }
 
 func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commonEvent.DMLEvent, err error) {
@@ -223,6 +228,8 @@ func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commo
 			if row.Rows != nil && row.Rows.NumRows() > 0 {
 				return nil, nil, err
 			}
+			log.Warn("spill DML event without table info",
+				zap.Int64("tableID", row.PhysicalTableID), zap.Uint64("commitTs", row.CommitTs), zap.Error(err))
 			tableInfoData = nil
 		} else {
 			tableInfoStored = true
@@ -236,6 +243,8 @@ func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commo
 			if row.Rows.NumRows() > 0 {
 				return nil, nil, err
 			}
+			log.Warn("spill DML event without row data",
+				zap.Int64("tableID", row.PhysicalTableID), zap.Uint64("commitTs", row.CommitTs), zap.Error(err))
 			rowsData = nil
 		}
 	}
@@ -245,7 +254,7 @@ func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commo
 		return nil, nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML checksums")
 	}
 
-	data = make([]byte, 0, 7*8+len(eventData)+len(tableInfoData)+len(rowsData)+len(checksumData))
+	data = make([]byte, 0, 10*8+len(eventData)+len(tableInfoData)+len(rowsData)+len(checksumData)+len(message.Schema)+len(message.Table))
 	data = appendUint64(data, uint64(len(eventData)))
 	data = append(data, eventData...)
 	data = appendUint64(data, uint64(len(tableInfoData)))
@@ -254,6 +263,11 @@ func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commo
 	data = append(data, rowsData...)
 	data = appendUint64(data, uint64(len(checksumData)))
 	data = append(data, checksumData...)
+	data = appendUint64(data, uint64(len(message.Schema)))
+	data = append(data, message.Schema...)
+	data = appendUint64(data, uint64(len(message.Table)))
+	data = append(data, message.Table...)
+	data = appendUint64(data, uint64(message.RowType))
 	if row.Rows != nil {
 		data = appendUint64(data, 1)
 	} else {
@@ -309,6 +323,21 @@ func unmarshalDMLMessage(data []byte) (*codeccommon.DMLMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	schemaData, data, err := readSpilledField(data)
+	if err != nil {
+		return nil, err
+	}
+	tableData, data, err := readSpilledField(data)
+	if err != nil {
+		return nil, err
+	}
+	rowType, data, err := readSpilledUint64(data)
+	if err != nil {
+		return nil, err
+	}
+	if rowType > uint64(^commonType.RowType(0)) {
+		return nil, errors.ErrSpillFileOp.FastGenByArgs("invalid DML spill row type")
+	}
 	rowsPresent, data, err := readSpilledUint64(data)
 	if err != nil {
 		return nil, err
@@ -346,26 +375,31 @@ func unmarshalDMLMessage(data []byte) (*codeccommon.DMLMessage, error) {
 		if row.TableInfo != nil {
 			fieldTypes = row.TableInfo.GetFieldSlice()
 		}
-		row.Rows, _ = chunk.NewCodec(fieldTypes).Decode(rowsData)
+		rows, err := unmarshalDMLRows(rowsData, fieldTypes)
+		if err != nil {
+			return nil, err
+		}
+		row.Rows = rows
 	}
 	row.TableInfoVersion = tableInfoVersion
 	row.ReplicatingTs = replicatingTs
 	if err := json.Unmarshal(checksumData, &row.Checksum); err != nil {
 		return nil, errors.WrapError(errors.ErrSpillFileOp, err, "unmarshal DML checksums")
 	}
-	if len(row.RowTypes) == 0 {
-		return nil, errors.ErrSpillFileOp.FastGenByArgs("spilled DML event has no row type")
-	}
+	return codeccommon.NewDMLMessage(row.PhysicalTableID, string(schemaData), string(tableData), row.CommitTs,
+		commonType.RowType(rowType), func() *commonEvent.DMLEvent {
+			return row
+		}), nil
+}
 
-	var schema, table string
-	if row.TableInfo != nil {
-		schema = row.TableInfo.GetSchemaName()
-		table = row.TableInfo.GetTableName()
-	}
-
-	return codeccommon.NewDMLMessage(row.PhysicalTableID, schema, table, row.CommitTs, row.RowTypes[0], func() *commonEvent.DMLEvent {
-		return row
-	}), nil
+func unmarshalDMLRows(data []byte, fieldTypes []*types.FieldType) (rows *chunk.Chunk, err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.ErrSpillFileOp.FastGenByArgs("decode DML spill rows")
+		}
+	}()
+	rows, _ = chunk.NewCodec(fieldTypes).Decode(data)
+	return rows, nil
 }
 
 func appendUint64(data []byte, value uint64) []byte {

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -306,7 +306,17 @@ func marshalDMLRows(row *commonEvent.DMLEvent, tableInfoStored bool) (data []byt
 	begin := row.PreviousTotalOffset
 	end := row.Rows.NumRows()
 	if len(row.RowTypes) != 0 {
-		end = begin + len(row.RowTypes)
+		end = begin
+		for _, rowType := range row.RowTypes {
+			switch rowType {
+			case commonType.RowTypeInsert, commonType.RowTypeDelete:
+				end++
+			case commonType.RowTypeUpdate:
+				end += 2
+			default:
+				return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event has invalid row type")
+			}
+		}
 	}
 	if begin < 0 || end < begin || end > row.Rows.NumRows() {
 		return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event rows are outside the shared chunk")

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -86,7 +86,7 @@ func (g *EventsGroup) appendMessage(
 	}
 	commitTs := message.GetCommitTs()
 
-	data, row, err := marshalDMLMessage(message)
+	data, _, err := marshalDMLMessage(message)
 	if err != nil {
 		return err
 	}
@@ -111,9 +111,6 @@ func (g *EventsGroup) appendMessage(
 		handle:      handle,
 		postRestore: postRestore,
 	})
-	// Codec decoders use this callback to release their pooled chunks. The event is durable in the
-	// spill file now, so the original in-memory event is no longer needed.
-	row.PostFlush()
 	return nil
 }
 

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -79,7 +79,6 @@ func (g *EventsGroup) AppendMessageWithPostRestore(
 func (g *EventsGroup) appendMessage(
 	message *codeccommon.DMLMessage,
 	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
-
 ) error {
 	if message == nil {
 		return errors.ErrSpillFileOp.FastGenByArgs("cannot spill nil DML message")

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -15,20 +15,15 @@ package util
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"math"
 	"os"
-	"reflect"
 	"sort"
 
 	"github.com/pingcap/log"
-	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/errors"
 	codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/spill"
-	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/chunk"
 	"go.uber.org/zap"
 )
 
@@ -37,7 +32,16 @@ const eventsGroupSpillPattern = "ticdc-events-group-*.spill"
 type spilledMessage struct {
 	commitTs    uint64
 	handle      spill.Handle
+	restore     func([]byte) (*codeccommon.DMLMessage, error)
 	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage
+}
+
+// DMLMessageSpillData is an opaque codec payload which can restore a lazy DML
+// message after it is read from disk. Restore must not construct a DMLEvent.
+type DMLMessageSpillData struct {
+	Data        []byte
+	Restore     func([]byte) (*codeccommon.DMLMessage, error)
+	PostRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage
 }
 
 // EventsGroup stores change event messages.
@@ -60,41 +64,44 @@ func NewEventsGroup(partition int32, tableID int64) *EventsGroup {
 	}
 }
 
-// AppendMessage materializes a message and appends it to a local spill file. DMLMessage carries a
-// decoder closure, so persisting its reconstructed event is necessary to release the decoder input
-// retained by that closure.
+// AppendMessage is kept for tests that already own a materialized event. Consumer
+// code must use AppendSpillMessage so DMLEvent construction stays at flush time.
 func (g *EventsGroup) AppendMessage(message *codeccommon.DMLMessage) error {
-	return g.appendMessage(message, nil)
+	return g.AppendSpillMessage(message, DMLMessageSpillData{
+		Restore: func([]byte) (*codeccommon.DMLMessage, error) {
+			return message, nil
+		},
+	})
 }
 
-// AppendMessageWithPostRestore appends a message and applies postRestore after it is read back from
-// disk. It keeps consumer checks that intentionally run immediately before flushing out of the
-// on-disk representation.
-func (g *EventsGroup) AppendMessageWithPostRestore(
+// AppendSpillMessage appends an opaque codec payload to the spill file. It does
+// not call DMLMessage.ToDMLEvent; the restored message remains lazy until the
+// consumer flushes it against a watermark or DDL barrier.
+func (g *EventsGroup) AppendSpillMessage(
 	message *codeccommon.DMLMessage,
-	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
-) error {
-	return g.appendMessage(message, postRestore)
-}
-
-func (g *EventsGroup) appendMessage(
-	message *codeccommon.DMLMessage,
-	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
+	spillData DMLMessageSpillData,
 ) error {
 	if message == nil {
 		return errors.ErrSpillFileOp.FastGenByArgs("cannot spill nil DML message")
 	}
+	if spillData.Restore == nil {
+		return errors.ErrSpillFileOp.FastGenByArgs("cannot spill DML message without restore function")
+	}
 	commitTs := message.GetCommitTs()
 
-	data, _, err := marshalDMLMessage(message)
-	if err != nil {
-		return err
-	}
 	if g.spillFile == nil {
+		var err error
 		g.spillFile, err = spill.NewRecordFile(os.TempDir(), eventsGroupSpillPattern)
 		if err != nil {
 			return err
 		}
+	}
+	data := spillData.Data
+	if len(data) == 0 {
+		// A lazy message may not need an input payload (for example, a Simple
+		// decoder message released from its table-info cache). RecordFile rejects
+		// empty records, so retain a marker while keeping the event lazy.
+		data = []byte{0}
 	}
 	handle, err := g.spillFile.Append(data)
 	if err != nil {
@@ -109,7 +116,8 @@ func (g *EventsGroup) appendMessage(
 	g.messages = append(g.messages, spilledMessage{
 		commitTs:    commitTs,
 		handle:      handle,
-		postRestore: postRestore,
+		restore:     spillData.Restore,
+		postRestore: spillData.PostRestore,
 	})
 	return nil
 }
@@ -119,6 +127,12 @@ func (g *EventsGroup) appendMessage(
 // them, keeping the buffered group out of heap memory.
 func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage) ([]*codeccommon.DMLMessage, error) {
 	if len(g.messages) == 0 {
+		if g.spillFile != nil {
+			if err := g.spillFile.Cleanup(); err != nil {
+				return dst, err
+			}
+			g.spillFile = nil
+		}
 		return dst, nil
 	}
 
@@ -151,7 +165,7 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 		if err != nil {
 			return dst, err
 		}
-		restored, err := unmarshalDMLMessage(data)
+		restored, err := message.restore(data)
 		if err != nil {
 			return dst, err
 		}
@@ -200,12 +214,18 @@ func (g *EventsGroup) Cleanup() error {
 	return nil
 }
 
-// AppendOrMergeDMLEvent appends row to events, or merges it into the preceding
-// event when both are compatible parts of the same transaction. Events with the
-// same commit-ts from different sources can use different table schemas, so a
-// commit-ts alone is not enough to merge their chunks safely.
-func AppendOrMergeDMLEvent(events []*commonEvent.DMLEvent, row *commonEvent.DMLEvent) []*commonEvent.DMLEvent {
-	if len(events) == 0 || !canMergeDMLEvents(events[len(events)-1], row) {
+// DMLMessagesToEvents materializes messages and merges compatible adjacent
+// messages before they are handed to the downstream sink.
+func DMLMessagesToEvents(messages []*codeccommon.DMLMessage) []*commonEvent.DMLEvent {
+	events := make([]*commonEvent.DMLEvent, 0, len(messages))
+	for _, message := range messages {
+		events = appendOrMergeDMLEvent(events, message.ToDMLEvent())
+	}
+	return events
+}
+
+func appendOrMergeDMLEvent(events []*commonEvent.DMLEvent, row *commonEvent.DMLEvent) []*commonEvent.DMLEvent {
+	if len(events) == 0 || !sameDMLTransaction(events[len(events)-1], row) {
 		return append(events, row)
 	}
 
@@ -223,25 +243,21 @@ func AppendOrMergeDMLEvent(events []*commonEvent.DMLEvent, row *commonEvent.DMLE
 	return events
 }
 
-func canMergeDMLEvents(last, row *commonEvent.DMLEvent) bool {
-	if last == nil || row == nil ||
-		last.CommitTs != row.CommitTs ||
-		last.StartTs != row.StartTs ||
-		last.DispatcherID != row.DispatcherID ||
-		last.PhysicalTableID != row.PhysicalTableID ||
-		last.TableInfoVersion != row.TableInfoVersion ||
-		last.TableInfo == nil || row.TableInfo == nil ||
-		last.TableInfo.GetSchemaName() != row.TableInfo.GetSchemaName() ||
-		last.TableInfo.GetTableName() != row.TableInfo.GetTableName() ||
-		last.TableInfo.GetUpdateTS() != row.TableInfo.GetUpdateTS() ||
-		last.Rows == nil || row.Rows == nil ||
-		last.Rows.NumCols() != row.Rows.NumCols() ||
-		last.PreviousTotalOffset != 0 || row.PreviousTotalOffset != 0 ||
-		!reflect.DeepEqual(last.TableInfo.GetFieldSlice(), row.TableInfo.GetFieldSlice()) {
-		return false
-	}
-
-	return hasOptionalDMLValues(last.RowKeys, len(last.RowTypes)) &&
+func sameDMLTransaction(last, row *commonEvent.DMLEvent) bool {
+	return last != nil && row != nil &&
+		last.CommitTs == row.CommitTs &&
+		last.StartTs == row.StartTs &&
+		last.DispatcherID == row.DispatcherID &&
+		last.PhysicalTableID == row.PhysicalTableID &&
+		last.TableInfoVersion == row.TableInfoVersion &&
+		last.TableInfo != nil && row.TableInfo != nil &&
+		last.TableInfo.GetSchemaName() == row.TableInfo.GetSchemaName() &&
+		last.TableInfo.GetTableName() == row.TableInfo.GetTableName() &&
+		last.TableInfo.GetUpdateTS() == row.TableInfo.GetUpdateTS() &&
+		last.Rows != nil && row.Rows != nil &&
+		last.Rows.NumCols() == row.Rows.NumCols() &&
+		last.PreviousTotalOffset == 0 && row.PreviousTotalOffset == 0 &&
+		hasOptionalDMLValues(last.RowKeys, len(last.RowTypes)) &&
 		hasOptionalDMLValues(row.RowKeys, len(row.RowTypes)) &&
 		hasOptionalDMLValues(last.Checksum, len(last.RowTypes)) &&
 		hasOptionalDMLValues(row.Checksum, len(row.RowTypes))
@@ -260,264 +276,112 @@ func appendOptionalDMLValues[T any](last, row []T, lastRowTypeCount, rowRowTypeC
 	return append(last, row...)
 }
 
-func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commonEvent.DMLEvent, err error) {
-	if message == nil {
-		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("cannot spill nil DML message")
-	}
+// NewDMLMessageSpillData preserves the original codec input and the ordinal of
+// its DML message. The decoder is intentionally used only during ResolveInto:
+// this preserves the old behaviour where schema is selected at the DDL or
+// watermark barrier, rather than while the message is appended.
+func NewDMLMessageSpillData(
+	decoder codeccommon.Decoder, key, value []byte, dmlIndex uint64,
+) DMLMessageSpillData {
+	return NewDMLMessageSpillDataWithDecoderFactory(key, value, dmlIndex,
+		func([]byte, []byte) (codeccommon.Decoder, error) { return decoder, nil })
+}
 
-	row = message.ToDMLEvent()
-	if row == nil {
-		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("cannot spill DML message without event")
-	}
-	if row.Version == 0 {
-		row.Version = commonEvent.DMLEventVersion1
-	}
-	// Rows can be shared by several DML events. Persist only this event's rows
-	// below, so its offset must be reset in the serialized event as well.
-	event := *row
-	event.PreviousTotalOffset = 0
-	eventData, err := event.Marshal()
-	if err != nil {
-		return nil, nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML event")
-	}
-
-	var tableInfoData []byte
-	tableInfoStored := false
-	if row.TableInfo != nil {
-		tableInfoData, err = marshalDMLTableInfo(row.TableInfo)
-		if err != nil {
-			if row.Rows != nil && row.Rows.NumRows() > 0 {
-				return nil, nil, err
+// NewDMLMessageSpillDataWithDecoderFactory is for decoders such as CSV whose
+// input is supplied during construction rather than through AddKeyValue.
+func NewDMLMessageSpillDataWithDecoderFactory(
+	key, value []byte,
+	dmlIndex uint64,
+	decoderFactory func([]byte, []byte) (codeccommon.Decoder, error),
+) DMLMessageSpillData {
+	data := make([]byte, 0, 3*8+len(key)+len(value))
+	data = appendSpillUint64(data, dmlIndex)
+	data = appendSpillBytes(data, key)
+	data = appendSpillBytes(data, value)
+	return DMLMessageSpillData{
+		Data: data,
+		Restore: func(data []byte) (*codeccommon.DMLMessage, error) {
+			dmlIndex, key, value, err := unmarshalDMLMessageSpillData(data)
+			if err != nil {
+				return nil, err
 			}
-			log.Warn("spill DML event without table info",
-				zap.Int64("tableID", row.PhysicalTableID), zap.Uint64("commitTs", row.CommitTs), zap.Error(err))
-			tableInfoData = nil
-		} else {
-			tableInfoStored = true
-		}
-	}
-
-	var rowsData []byte
-	if row.Rows != nil && (row.Rows.NumRows() > 0 || tableInfoStored) {
-		rowsData, err = marshalDMLRows(row, tableInfoStored)
-		if err != nil {
-			if row.Rows.NumRows() > 0 {
-				return nil, nil, err
+			decoder, err := decoderFactory(key, value)
+			if err != nil {
+				return nil, errors.WrapError(errors.ErrSpillFileOp, err, "create DML spill decoder")
 			}
-			log.Warn("spill DML event without row data",
-				zap.Int64("tableID", row.PhysicalTableID), zap.Uint64("commitTs", row.CommitTs), zap.Error(err))
-			rowsData = nil
-		}
+			return restoreDMLMessage(decoder, key, value, dmlIndex)
+		},
 	}
-
-	checksumData, err := json.Marshal(row.Checksum)
-	if err != nil {
-		return nil, nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML checksums")
-	}
-
-	data = make([]byte, 0, 10*8+len(eventData)+len(tableInfoData)+len(rowsData)+len(checksumData)+len(message.Schema)+len(message.Table))
-	data = appendUint64(data, uint64(len(eventData)))
-	data = append(data, eventData...)
-	data = appendUint64(data, uint64(len(tableInfoData)))
-	data = append(data, tableInfoData...)
-	data = appendUint64(data, uint64(len(rowsData)))
-	data = append(data, rowsData...)
-	data = appendUint64(data, uint64(len(checksumData)))
-	data = append(data, checksumData...)
-	data = appendUint64(data, uint64(len(message.Schema)))
-	data = append(data, message.Schema...)
-	data = appendUint64(data, uint64(len(message.Table)))
-	data = append(data, message.Table...)
-	data = appendUint64(data, uint64(message.RowType))
-	if row.Rows != nil {
-		data = appendUint64(data, 1)
-	} else {
-		data = appendUint64(data, 0)
-	}
-	data = appendUint64(data, row.TableInfoVersion)
-	data = appendUint64(data, row.ReplicatingTs)
-	return data, row, nil
 }
 
-func marshalDMLTableInfo(tableInfo *commonType.TableInfo) (data []byte, err error) {
-	defer func() {
-		if recover() != nil {
-			err = errors.ErrSpillFileOp.FastGenByArgs("marshal incomplete DML table info")
-		}
-	}()
-
-	data, err = tableInfo.Marshal()
-	if err != nil {
-		return nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML table info")
-	}
-	return data, nil
-}
-
-func marshalDMLRows(row *commonEvent.DMLEvent, tableInfoStored bool) (data []byte, err error) {
-	defer func() {
-		if recover() != nil {
-			err = errors.ErrSpillFileOp.FastGenByArgs("marshal DML rows with incomplete table info")
-		}
-	}()
-
-	fieldTypes := []*types.FieldType(nil)
-	if tableInfoStored {
-		fieldTypes = row.TableInfo.GetFieldSlice()
-	}
-	begin := row.PreviousTotalOffset
-	end := row.Rows.NumRows()
-	if len(row.RowTypes) != 0 {
-		end = begin + len(row.RowTypes)
-		// Most decoders, including batched DML events, use one RowType entry per
-		// physical chunk row. An update consequently appears twice. The Avro
-		// decoder instead represents its single logical update with one entry,
-		// while retaining both rows in the chunk. Length distinguishes the two
-		// encodings: it is the number of logical row changes.
-		compactRowTypes := row.Length > 0 && len(row.RowTypes) == int(row.Length)
-		if compactRowTypes {
-			end = begin
-		}
-		for _, rowType := range row.RowTypes {
-			switch rowType {
-			case commonType.RowTypeInsert, commonType.RowTypeDelete:
-				if compactRowTypes {
-					end++
-				}
-			case commonType.RowTypeUpdate:
-				if compactRowTypes {
-					end += 2
-				}
-			default:
-				return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event has invalid row type")
+func restoreDMLMessage(
+	decoder codeccommon.Decoder, key, value []byte, dmlIndex uint64,
+) (*codeccommon.DMLMessage, error) {
+	decoder.AddKeyValue(key, value)
+	var restored *codeccommon.DMLMessage
+	for currentIndex := uint64(0); ; currentIndex++ {
+		messageType, hasNext := decoder.HasNext()
+		if !hasNext {
+			if restored == nil {
+				return nil, errors.ErrSpillFileOp.FastGenByArgs("DML spill payload has no message")
 			}
+			return restored, nil
+		}
+		if messageType != codeccommon.MessageTypeRow {
+			return nil, errors.ErrSpillFileOp.FastGenByArgs("DML spill payload contains a non-DML message")
+		}
+		message := decoder.NextDMLMessage()
+		if message == nil {
+			return nil, errors.ErrSpillFileOp.FastGenByArgs("DML spill payload cannot be restored")
+		}
+		if currentIndex == dmlIndex {
+			restored = message
 		}
 	}
-	if begin < 0 || end < begin || end > row.Rows.NumRows() {
-		return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event rows are outside the shared chunk")
-	}
-	if !tableInfoStored && begin != 0 {
-		return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event rows require table info")
-	}
-
-	rows := chunk.NewChunkWithCapacity(fieldTypes, end-begin)
-	rows.Append(row.Rows, begin, end)
-	return chunk.NewCodec(fieldTypes).Encode(rows), nil
 }
 
-func unmarshalDMLMessage(data []byte) (*codeccommon.DMLMessage, error) {
-	eventData, data, err := readSpilledField(data)
-	if err != nil {
-		return nil, err
-	}
-	tableInfoData, data, err := readSpilledField(data)
-	if err != nil {
-		return nil, err
-	}
-	rowsData, data, err := readSpilledField(data)
-	if err != nil {
-		return nil, err
-	}
-	checksumData, data, err := readSpilledField(data)
-	if err != nil {
-		return nil, err
-	}
-	schemaData, data, err := readSpilledField(data)
-	if err != nil {
-		return nil, err
-	}
-	tableData, data, err := readSpilledField(data)
-	if err != nil {
-		return nil, err
-	}
-	rowType, data, err := readSpilledUint64(data)
-	if err != nil {
-		return nil, err
-	}
-	if rowType > uint64(^commonType.RowType(0)) {
-		return nil, errors.ErrSpillFileOp.FastGenByArgs("invalid DML spill row type")
-	}
-	rowsPresent, data, err := readSpilledUint64(data)
-	if err != nil {
-		return nil, err
-	}
-	if rowsPresent > 1 {
-		return nil, errors.ErrSpillFileOp.FastGenByArgs("invalid DML spill rows flag")
-	}
-	tableInfoVersion, data, err := readSpilledUint64(data)
-	if err != nil {
-		return nil, err
-	}
-	replicatingTs, data, err := readSpilledUint64(data)
-	if err != nil {
-		return nil, err
-	}
-	if len(data) != 0 {
-		return nil, errors.ErrSpillFileOp.FastGenByArgs("unexpected trailing DML spill data")
-	}
-
-	row := &commonEvent.DMLEvent{}
-	if err := row.Unmarshal(eventData); err != nil {
-		return nil, errors.WrapError(errors.ErrSpillFileOp, err, "unmarshal DML event")
-	}
-	if len(tableInfoData) != 0 {
-		tableInfo, err := commonType.UnmarshalJSONToTableInfo(tableInfoData)
-		if err != nil {
-			return nil, errors.WrapError(errors.ErrSpillFileOp, err, "unmarshal DML table info")
-		}
-		row.TableInfo = tableInfo
-	}
-	if rowsPresent == 1 && len(rowsData) == 0 {
-		row.Rows = chunk.NewChunkWithCapacity(nil, 0)
-	} else if len(rowsData) != 0 {
-		fieldTypes := []*types.FieldType(nil)
-		if row.TableInfo != nil {
-			fieldTypes = row.TableInfo.GetFieldSlice()
-		}
-		rows, err := unmarshalDMLRows(rowsData, fieldTypes)
-		if err != nil {
-			return nil, err
-		}
-		row.Rows = rows
-	}
-	row.TableInfoVersion = tableInfoVersion
-	row.ReplicatingTs = replicatingTs
-	if err := json.Unmarshal(checksumData, &row.Checksum); err != nil {
-		return nil, errors.WrapError(errors.ErrSpillFileOp, err, "unmarshal DML checksums")
-	}
-	return codeccommon.NewDMLMessage(row.PhysicalTableID, string(schemaData), string(tableData), row.CommitTs,
-		commonType.RowType(rowType), func() *commonEvent.DMLEvent {
-			return row
-		}), nil
+func appendSpillBytes(data, value []byte) []byte {
+	data = appendSpillUint64(data, uint64(len(value)))
+	return append(data, value...)
 }
 
-func unmarshalDMLRows(data []byte, fieldTypes []*types.FieldType) (rows *chunk.Chunk, err error) {
-	defer func() {
-		if recover() != nil {
-			err = errors.ErrSpillFileOp.FastGenByArgs("decode DML spill rows")
-		}
-	}()
-	rows, _ = chunk.NewCodec(fieldTypes).Decode(data)
-	return rows, nil
-}
-
-func appendUint64(data []byte, value uint64) []byte {
+func appendSpillUint64(data []byte, value uint64) []byte {
 	var buf [8]byte
 	binary.BigEndian.PutUint64(buf[:], value)
 	return append(data, buf[:]...)
 }
 
-func readSpilledField(data []byte) ([]byte, []byte, error) {
-	length, data, err := readSpilledUint64(data)
+func unmarshalDMLMessageSpillData(data []byte) (uint64, []byte, []byte, error) {
+	dmlIndex, data, err := readSpillUint64(data)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	key, data, err := readSpillBytes(data)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	value, data, err := readSpillBytes(data)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	if len(data) != 0 {
+		return 0, nil, nil, errors.ErrSpillFileOp.FastGenByArgs("unexpected trailing DML spill data")
+	}
+	return dmlIndex, key, value, nil
+}
+
+func readSpillBytes(data []byte) ([]byte, []byte, error) {
+	length, data, err := readSpillUint64(data)
 	if err != nil {
 		return nil, nil, err
 	}
 	if length > uint64(len(data)) {
-		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("invalid DML spill field length")
+		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("invalid DML spill payload length")
 	}
 	return data[:length], data[length:], nil
 }
 
-func readSpilledUint64(data []byte) (uint64, []byte, error) {
+func readSpillUint64(data []byte) (uint64, []byte, error) {
 	if len(data) < 8 {
 		return 0, nil, errors.ErrSpillFileOp.FastGenByArgs("truncated DML spill data")
 	}

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -306,13 +306,26 @@ func marshalDMLRows(row *commonEvent.DMLEvent, tableInfoStored bool) (data []byt
 	begin := row.PreviousTotalOffset
 	end := row.Rows.NumRows()
 	if len(row.RowTypes) != 0 {
-		end = begin
+		end = begin + len(row.RowTypes)
+		// Most decoders, including batched DML events, use one RowType entry per
+		// physical chunk row. An update consequently appears twice. The Avro
+		// decoder instead represents its single logical update with one entry,
+		// while retaining both rows in the chunk. Length distinguishes the two
+		// encodings: it is the number of logical row changes.
+		compactRowTypes := row.Length > 0 && len(row.RowTypes) == int(row.Length)
+		if compactRowTypes {
+			end = begin
+		}
 		for _, rowType := range row.RowTypes {
 			switch rowType {
 			case commonType.RowTypeInsert, commonType.RowTypeDelete:
-				end++
+				if compactRowTypes {
+					end++
+				}
 			case commonType.RowTypeUpdate:
-				end += 2
+				if compactRowTypes {
+					end += 2
+				}
 			default:
 				return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event has invalid row type")
 			}

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -439,29 +439,3 @@ func readSpilledUint64(data []byte) (uint64, []byte, error) {
 	}
 	return binary.BigEndian.Uint64(data[:8]), data[8:], nil
 }
-
-// AppendOrMergeDMLEvent appends a DML event, or merges it into the previous event
-// when both events belong to the same table group and have the same commit-ts.
-func AppendOrMergeDMLEvent(events []*commonEvent.DMLEvent, row *commonEvent.DMLEvent) []*commonEvent.DMLEvent {
-	var lastDMLEvent *commonEvent.DMLEvent
-	if len(events) > 0 {
-		lastDMLEvent = events[len(events)-1]
-	}
-
-	if lastDMLEvent == nil || lastDMLEvent.GetCommitTs() < row.GetCommitTs() {
-		return append(events, row)
-	}
-
-	if lastDMLEvent.GetCommitTs() == row.GetCommitTs() {
-		lastDMLEvent.Rows.Append(row.Rows, 0, row.Rows.NumRows())
-		lastDMLEvent.RowTypes = append(lastDMLEvent.RowTypes, row.RowTypes...)
-		lastDMLEvent.Length += row.Length
-		lastDMLEvent.PostTxnFlushed = append(lastDMLEvent.PostTxnFlushed, row.PostTxnFlushed...)
-		return events
-	}
-
-	log.Panic("append event with smaller commit ts",
-		zap.Int64("tableID", row.GetTableID()),
-		zap.Uint64("lastCommitTs", lastDMLEvent.GetCommitTs()), zap.Uint64("commitTs", row.GetCommitTs()))
-	return events
-}

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -211,7 +211,11 @@ func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commo
 	if row.Version == 0 {
 		row.Version = commonEvent.DMLEventVersion1
 	}
-	eventData, err := row.Marshal()
+	// Rows can be shared by several DML events. Persist only this event's rows
+	// below, so its offset must be reset in the serialized event as well.
+	event := *row
+	event.PreviousTotalOffset = 0
+	eventData, err := event.Marshal()
 	if err != nil {
 		return nil, nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML event")
 	}
@@ -299,7 +303,21 @@ func marshalDMLRows(row *commonEvent.DMLEvent, tableInfoStored bool) (data []byt
 	if tableInfoStored {
 		fieldTypes = row.TableInfo.GetFieldSlice()
 	}
-	return chunk.NewCodec(fieldTypes).Encode(row.Rows), nil
+	begin := row.PreviousTotalOffset
+	end := row.Rows.NumRows()
+	if len(row.RowTypes) != 0 {
+		end = begin + len(row.RowTypes)
+	}
+	if begin < 0 || end < begin || end > row.Rows.NumRows() {
+		return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event rows are outside the shared chunk")
+	}
+	if !tableInfoStored && begin != 0 {
+		return nil, errors.ErrSpillFileOp.FastGenByArgs("DML event rows require table info")
+	}
+
+	rows := chunk.NewChunkWithCapacity(fieldTypes, end-begin)
+	rows.Append(row.Rows, begin, end)
+	return chunk.NewCodec(fieldTypes).Encode(rows), nil
 }
 
 func unmarshalDMLMessage(data []byte) (*codeccommon.DMLMessage, error) {

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"math"
 	"os"
+	"reflect"
 	"sort"
 
 	"github.com/pingcap/log"
@@ -197,6 +198,66 @@ func (g *EventsGroup) Cleanup() error {
 	clear(g.messages)
 	g.messages = g.messages[:0]
 	return nil
+}
+
+// AppendOrMergeDMLEvent appends row to events, or merges it into the preceding
+// event when both are compatible parts of the same transaction. Events with the
+// same commit-ts from different sources can use different table schemas, so a
+// commit-ts alone is not enough to merge their chunks safely.
+func AppendOrMergeDMLEvent(events []*commonEvent.DMLEvent, row *commonEvent.DMLEvent) []*commonEvent.DMLEvent {
+	if len(events) == 0 || !canMergeDMLEvents(events[len(events)-1], row) {
+		return append(events, row)
+	}
+
+	last := events[len(events)-1]
+	lastRowTypeCount := len(last.RowTypes)
+	rowRowTypeCount := len(row.RowTypes)
+	last.Rows.Append(row.Rows, 0, row.Rows.NumRows())
+	last.RowTypes = append(last.RowTypes, row.RowTypes...)
+	last.RowKeys = appendOptionalDMLValues(last.RowKeys, row.RowKeys, lastRowTypeCount, rowRowTypeCount)
+	last.Checksum = appendOptionalDMLValues(last.Checksum, row.Checksum, lastRowTypeCount, rowRowTypeCount)
+	last.Length += row.Length
+	last.ApproximateSize += row.ApproximateSize
+	last.PostTxnEnqueued = append(last.PostTxnEnqueued, row.PostTxnEnqueued...)
+	last.PostTxnFlushed = append(last.PostTxnFlushed, row.PostTxnFlushed...)
+	return events
+}
+
+func canMergeDMLEvents(last, row *commonEvent.DMLEvent) bool {
+	if last == nil || row == nil ||
+		last.CommitTs != row.CommitTs ||
+		last.StartTs != row.StartTs ||
+		last.DispatcherID != row.DispatcherID ||
+		last.PhysicalTableID != row.PhysicalTableID ||
+		last.TableInfoVersion != row.TableInfoVersion ||
+		last.TableInfo == nil || row.TableInfo == nil ||
+		last.TableInfo.GetSchemaName() != row.TableInfo.GetSchemaName() ||
+		last.TableInfo.GetTableName() != row.TableInfo.GetTableName() ||
+		last.TableInfo.GetUpdateTS() != row.TableInfo.GetUpdateTS() ||
+		last.Rows == nil || row.Rows == nil ||
+		last.Rows.NumCols() != row.Rows.NumCols() ||
+		last.PreviousTotalOffset != 0 || row.PreviousTotalOffset != 0 ||
+		!reflect.DeepEqual(last.TableInfo.GetFieldSlice(), row.TableInfo.GetFieldSlice()) {
+		return false
+	}
+
+	return hasOptionalDMLValues(last.RowKeys, len(last.RowTypes)) &&
+		hasOptionalDMLValues(row.RowKeys, len(row.RowTypes)) &&
+		hasOptionalDMLValues(last.Checksum, len(last.RowTypes)) &&
+		hasOptionalDMLValues(row.Checksum, len(row.RowTypes))
+}
+
+func hasOptionalDMLValues[T any](values []T, rowTypeCount int) bool {
+	return len(values) == 0 || len(values) == rowTypeCount
+}
+
+func appendOptionalDMLValues[T any](last, row []T, lastRowTypeCount, rowRowTypeCount int) []T {
+	if len(last) == 0 && len(row) != 0 {
+		last = make([]T, lastRowTypeCount)
+	} else if len(last) != 0 && len(row) == 0 {
+		row = make([]T, rowRowTypeCount)
+	}
+	return append(last, row...)
 }
 
 func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commonEvent.DMLEvent, err error) {

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -30,18 +30,10 @@ import (
 const eventsGroupSpillPattern = "ticdc-events-group-*.spill"
 
 type spilledMessage struct {
-	commitTs    uint64
-	handle      spill.Handle
-	restore     func([]byte) (*codeccommon.DMLMessage, error)
-	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage
-}
-
-// DMLMessageSpillData is an opaque codec payload which can restore a lazy DML
-// message after it is read from disk. Restore must not construct a DMLEvent.
-type DMLMessageSpillData struct {
-	Data        []byte
-	Restore     func([]byte) (*codeccommon.DMLMessage, error)
-	PostRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage
+	commitTs uint64
+	handle   spill.Handle
+	dmlIndex uint64
+	restore  func([]byte, uint64) (*codeccommon.DMLMessage, error)
 }
 
 // EventsGroup stores change event messages.
@@ -51,6 +43,7 @@ type EventsGroup struct {
 
 	messages      []spilledMessage
 	spillFile     *spill.RecordFile
+	spillHandles  map[uint64]spill.Handle
 	outOfOrder    bool
 	HighWatermark uint64
 }
@@ -64,27 +57,17 @@ func NewEventsGroup(partition int32, tableID int64) *EventsGroup {
 	}
 }
 
-// AppendMessage is kept for tests that already own a materialized event. Consumer
-// code must use AppendSpillMessage so DMLEvent construction stays at flush time.
-func (g *EventsGroup) AppendMessage(message *codeccommon.DMLMessage) error {
-	return g.AppendSpillMessage(message, DMLMessageSpillData{
-		Restore: func([]byte) (*codeccommon.DMLMessage, error) {
-			return message, nil
-		},
-	})
-}
-
-// AppendSpillMessage appends an opaque codec payload to the spill file. It does
+// AppendMessage appends an opaque codec payload to the spill file. It does
 // not call DMLMessage.ToDMLEvent; the restored message remains lazy until the
 // consumer flushes it against a watermark or DDL barrier.
-func (g *EventsGroup) AppendSpillMessage(
+func (g *EventsGroup) AppendMessage(
 	message *codeccommon.DMLMessage,
-	spillData DMLMessageSpillData,
 ) error {
 	if message == nil {
 		return errors.ErrSpillFileOp.FastGenByArgs("cannot spill nil DML message")
 	}
-	if spillData.Restore == nil {
+	messageData, dmlIndex := message.SpillData()
+	if messageData == nil || messageData.Restore == nil {
 		return errors.ErrSpillFileOp.FastGenByArgs("cannot spill DML message without restore function")
 	}
 	commitTs := message.GetCommitTs()
@@ -96,16 +79,24 @@ func (g *EventsGroup) AppendSpillMessage(
 			return err
 		}
 	}
-	data := spillData.Data
-	if len(data) == 0 {
-		// A lazy message may not need an input payload (for example, a Simple
-		// decoder message released from its table-info cache). RecordFile rejects
-		// empty records, so retain a marker while keeping the event lazy.
-		data = []byte{0}
+	if g.spillHandles == nil {
+		g.spillHandles = make(map[uint64]spill.Handle)
 	}
-	handle, err := g.spillFile.Append(data)
-	if err != nil {
-		return err
+	handle, ok := g.spillHandles[messageData.ID]
+	if !ok {
+		data := marshalDMLMessageData(messageData.Key, messageData.Value)
+		if len(data) == 0 {
+			// A lazy message may not need an input payload (for example, a Simple
+			// decoder message released from its table-info cache). RecordFile rejects
+			// empty records, so retain a marker while keeping the event lazy.
+			data = []byte{0}
+		}
+		var err error
+		handle, err = g.spillFile.Append(data)
+		if err != nil {
+			return err
+		}
+		g.spillHandles[messageData.ID] = handle
 	}
 	if len(g.messages) > 0 && commitTs < g.messages[len(g.messages)-1].commitTs {
 		g.outOfOrder = true
@@ -114,10 +105,10 @@ func (g *EventsGroup) AppendSpillMessage(
 		g.HighWatermark = commitTs
 	}
 	g.messages = append(g.messages, spilledMessage{
-		commitTs:    commitTs,
-		handle:      handle,
-		restore:     spillData.Restore,
-		postRestore: spillData.PostRestore,
+		commitTs: commitTs,
+		handle:   handle,
+		dmlIndex: dmlIndex,
+		restore:  messageData.Restore,
 	})
 	return nil
 }
@@ -132,6 +123,7 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 				return dst, err
 			}
 			g.spillFile = nil
+			clear(g.spillHandles)
 		}
 		return dst, nil
 	}
@@ -165,12 +157,9 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 		if err != nil {
 			return dst, err
 		}
-		restored, err := message.restore(data)
+		restored, err := message.restore(data, message.dmlIndex)
 		if err != nil {
 			return dst, err
-		}
-		if message.postRestore != nil {
-			restored = message.postRestore(restored)
 		}
 		dst = append(dst, restored)
 	}
@@ -183,6 +172,7 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 			return dst, err
 		}
 		g.spillFile = nil
+		clear(g.spillHandles)
 	}
 	if len(g.messages) != 0 {
 		firstCommitTs := g.messages[0].commitTs
@@ -209,6 +199,7 @@ func (g *EventsGroup) Cleanup() error {
 		return err
 	}
 	g.spillFile = nil
+	clear(g.spillHandles)
 	clear(g.messages)
 	g.messages = g.messages[:0]
 	return nil
@@ -244,27 +235,7 @@ func appendOrMergeDMLEvent(events []*commonEvent.DMLEvent, row *commonEvent.DMLE
 }
 
 func sameDMLTransaction(last, row *commonEvent.DMLEvent) bool {
-	return last != nil && row != nil &&
-		last.CommitTs == row.CommitTs &&
-		last.StartTs == row.StartTs &&
-		last.DispatcherID == row.DispatcherID &&
-		last.PhysicalTableID == row.PhysicalTableID &&
-		last.TableInfoVersion == row.TableInfoVersion &&
-		last.TableInfo != nil && row.TableInfo != nil &&
-		last.TableInfo.GetSchemaName() == row.TableInfo.GetSchemaName() &&
-		last.TableInfo.GetTableName() == row.TableInfo.GetTableName() &&
-		last.TableInfo.GetUpdateTS() == row.TableInfo.GetUpdateTS() &&
-		last.Rows != nil && row.Rows != nil &&
-		last.Rows.NumCols() == row.Rows.NumCols() &&
-		last.PreviousTotalOffset == 0 && row.PreviousTotalOffset == 0 &&
-		hasOptionalDMLValues(last.RowKeys, len(last.RowTypes)) &&
-		hasOptionalDMLValues(row.RowKeys, len(row.RowTypes)) &&
-		hasOptionalDMLValues(last.Checksum, len(last.RowTypes)) &&
-		hasOptionalDMLValues(row.Checksum, len(row.RowTypes))
-}
-
-func hasOptionalDMLValues[T any](values []T, rowTypeCount int) bool {
-	return len(values) == 0 || len(values) == rowTypeCount
+	return last != nil && row != nil && last.CommitTs == row.CommitTs
 }
 
 func appendOptionalDMLValues[T any](last, row []T, lastRowTypeCount, rowRowTypeCount int) []T {
@@ -276,32 +247,22 @@ func appendOptionalDMLValues[T any](last, row []T, lastRowTypeCount, rowRowTypeC
 	return append(last, row...)
 }
 
-// NewDMLMessageSpillData preserves the original codec input and the ordinal of
-// its DML message. The decoder is intentionally used only during ResolveInto:
-// this preserves the old behaviour where schema is selected at the DDL or
-// watermark barrier, rather than while the message is appended.
-func NewDMLMessageSpillData(
-	decoder codeccommon.Decoder, key, value []byte, dmlIndex uint64,
-) DMLMessageSpillData {
-	return NewDMLMessageSpillDataWithDecoderFactory(key, value, dmlIndex,
+// NewDMLMessageData preserves one original codec input. The decoder is used
+// only during ResolveInto, after the DDL or watermark barrier selects schema.
+func NewDMLMessageData(decoder codeccommon.Decoder, key, value []byte) *codeccommon.DMLMessageData {
+	return NewDMLMessageDataWithDecoderFactory(key, value,
 		func([]byte, []byte) (codeccommon.Decoder, error) { return decoder, nil })
 }
 
-// NewDMLMessageSpillDataWithDecoderFactory is for decoders such as CSV whose
+// NewDMLMessageDataWithDecoderFactory is for decoders such as CSV whose
 // input is supplied during construction rather than through AddKeyValue.
-func NewDMLMessageSpillDataWithDecoderFactory(
+func NewDMLMessageDataWithDecoderFactory(
 	key, value []byte,
-	dmlIndex uint64,
 	decoderFactory func([]byte, []byte) (codeccommon.Decoder, error),
-) DMLMessageSpillData {
-	data := make([]byte, 0, 3*8+len(key)+len(value))
-	data = appendSpillUint64(data, dmlIndex)
-	data = appendSpillBytes(data, key)
-	data = appendSpillBytes(data, value)
-	return DMLMessageSpillData{
-		Data: data,
-		Restore: func(data []byte) (*codeccommon.DMLMessage, error) {
-			dmlIndex, key, value, err := unmarshalDMLMessageSpillData(data)
+) *codeccommon.DMLMessageData {
+	return codeccommon.NewDMLMessageData(key, value,
+		func(data []byte, dmlIndex uint64) (*codeccommon.DMLMessage, error) {
+			key, value, err := unmarshalDMLMessageData(data)
 			if err != nil {
 				return nil, err
 			}
@@ -310,8 +271,16 @@ func NewDMLMessageSpillDataWithDecoderFactory(
 				return nil, errors.WrapError(errors.ErrSpillFileOp, err, "create DML spill decoder")
 			}
 			return restoreDMLMessage(decoder, key, value, dmlIndex)
-		},
+		})
+}
+
+func marshalDMLMessageData(key, value []byte) []byte {
+	if len(key) == 0 && len(value) == 0 {
+		return nil
 	}
+	data := make([]byte, 0, 2*8+len(key)+len(value))
+	data = appendSpillBytes(data, key)
+	return appendSpillBytes(data, value)
 }
 
 func restoreDMLMessage(
@@ -351,23 +320,19 @@ func appendSpillUint64(data []byte, value uint64) []byte {
 	return append(data, buf[:]...)
 }
 
-func unmarshalDMLMessageSpillData(data []byte) (uint64, []byte, []byte, error) {
-	dmlIndex, data, err := readSpillUint64(data)
-	if err != nil {
-		return 0, nil, nil, err
-	}
+func unmarshalDMLMessageData(data []byte) ([]byte, []byte, error) {
 	key, data, err := readSpillBytes(data)
 	if err != nil {
-		return 0, nil, nil, err
+		return nil, nil, err
 	}
 	value, data, err := readSpillBytes(data)
 	if err != nil {
-		return 0, nil, nil, err
+		return nil, nil, err
 	}
 	if len(data) != 0 {
-		return 0, nil, nil, errors.ErrSpillFileOp.FastGenByArgs("unexpected trailing DML spill data")
+		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("unexpected trailing DML spill data")
 	}
-	return dmlIndex, key, value, nil
+	return key, value, nil
 }
 
 func readSpillBytes(data []byte) ([]byte, []byte, error) {

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -14,21 +14,38 @@
 package util
 
 import (
+	"encoding/binary"
+	"encoding/json"
 	"math"
+	"os"
 	"sort"
 
 	"github.com/pingcap/log"
+	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/errors"
 	codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/pingcap/ticdc/pkg/spill"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"go.uber.org/zap"
 )
+
+const eventsGroupSpillPattern = "ticdc-events-group-*.spill"
+
+type spilledMessage struct {
+	commitTs    uint64
+	handle      spill.Handle
+	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage
+}
 
 // EventsGroup stores change event messages.
 type EventsGroup struct {
 	Partition int32
 	tableID   int64
 
-	messages      []*codeccommon.DMLMessage
+	messages      []spilledMessage
+	spillFile     *spill.RecordFile
 	outOfOrder    bool
 	HighWatermark uint64
 }
@@ -38,25 +55,69 @@ func NewEventsGroup(partition int32, tableID int64) *EventsGroup {
 	return &EventsGroup{
 		Partition: partition,
 		tableID:   tableID,
-		messages:  make([]*codeccommon.DMLMessage, 0, 1024),
+		messages:  make([]spilledMessage, 0, 1024),
 	}
 }
 
-// AppendMessage appends a message to event groups.
+// AppendMessage materializes a message and appends it to a local spill file. DMLMessage carries a
+// decoder closure, so persisting its reconstructed event is necessary to release the decoder input
+// retained by that closure.
 func (g *EventsGroup) AppendMessage(message *codeccommon.DMLMessage) {
+	g.appendMessage(message, nil)
+}
+
+// AppendMessageWithPostRestore appends a message and applies postRestore after it is read back from
+// disk. It keeps consumer checks that intentionally run immediately before flushing out of the
+// on-disk representation.
+func (g *EventsGroup) AppendMessageWithPostRestore(
+	message *codeccommon.DMLMessage,
+	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
+) {
+	g.appendMessage(message, postRestore)
+}
+
+func (g *EventsGroup) appendMessage(
+	message *codeccommon.DMLMessage,
+	postRestore func(*codeccommon.DMLMessage) *codeccommon.DMLMessage,
+) {
 	commitTs := message.GetCommitTs()
-	if len(g.messages) > 0 && commitTs < g.messages[len(g.messages)-1].GetCommitTs() {
+	if len(g.messages) > 0 && commitTs < g.messages[len(g.messages)-1].commitTs {
 		g.outOfOrder = true
 	}
 	if commitTs > g.HighWatermark {
 		g.HighWatermark = commitTs
 	}
-	g.messages = append(g.messages, message)
+
+	data, row, err := marshalDMLMessage(message)
+	if err != nil {
+		log.Panic("marshal DML message for spill failed",
+			zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+	}
+	if g.spillFile == nil {
+		g.spillFile, err = spill.NewRecordFile(os.TempDir(), eventsGroupSpillPattern)
+		if err != nil {
+			log.Panic("create events group spill file failed",
+				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+		}
+	}
+	handle, err := g.spillFile.Append(data)
+	if err != nil {
+		log.Panic("write DML message to spill file failed",
+			zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+	}
+	g.messages = append(g.messages, spilledMessage{
+		commitTs:    commitTs,
+		handle:      handle,
+		postRestore: postRestore,
+	})
+	// Codec decoders use this callback to release their pooled chunks. The event is durable in the
+	// spill file now, so the original in-memory event is no longer needed.
+	row.PostFlush()
 }
 
 // ResolveInto appends all messages with CommitTs <= resolve into dst in commit-ts order and removes
-// them from the group. ResolveInto copies pointers into dst first, then clears the resolved messages
-// so Go GC can reclaim them once downstream is done with them.
+// them from the group. Resolved messages are restored from the spill file only when downstream needs
+// them, keeping the buffered group out of heap memory.
 func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage) []*codeccommon.DMLMessage {
 	if len(g.messages) == 0 {
 		return dst
@@ -64,12 +125,12 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 
 	if g.outOfOrder {
 		sort.SliceStable(g.messages, func(i, j int) bool {
-			return g.messages[i].GetCommitTs() < g.messages[j].GetCommitTs()
+			return g.messages[i].commitTs < g.messages[j].commitTs
 		})
 	}
 
 	resolvedCount := sort.Search(len(g.messages), func(i int) bool {
-		return g.messages[i].GetCommitTs() > resolve
+		return g.messages[i].commitTs > resolve
 	})
 	if g.outOfOrder {
 		log.Warn("DML events are out of order before flush, sort them",
@@ -83,13 +144,35 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 		return dst
 	}
 
-	dst = append(dst, g.messages[:resolvedCount]...)
+	for _, message := range g.messages[:resolvedCount] {
+		data, err := g.spillFile.Read(message.handle)
+		if err != nil {
+			log.Panic("read DML message from spill file failed",
+				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+		}
+		restored, err := unmarshalDMLMessage(data)
+		if err != nil {
+			log.Panic("unmarshal DML message from spill file failed",
+				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+		}
+		if message.postRestore != nil {
+			restored = message.postRestore(restored)
+		}
+		dst = append(dst, restored)
+	}
 	remainingCount := len(g.messages) - resolvedCount
 	copy(g.messages, g.messages[resolvedCount:])
 	clear(g.messages[remainingCount:])
 	g.messages = g.messages[:remainingCount]
+	if len(g.messages) == 0 {
+		if err := g.spillFile.Cleanup(); err != nil {
+			log.Panic("cleanup events group spill file failed",
+				zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID), zap.Error(err))
+		}
+		g.spillFile = nil
+	}
 	if len(g.messages) != 0 {
-		firstCommitTs := g.messages[0].GetCommitTs()
+		firstCommitTs := g.messages[0].commitTs
 		log.Debug("not all events resolved",
 			zap.Int32("partition", g.Partition), zap.Int64("tableID", g.tableID),
 			zap.Int("resolved", resolvedCount), zap.Int("remained", len(g.messages)),
@@ -101,6 +184,212 @@ func (g *EventsGroup) ResolveInto(resolve uint64, dst []*codeccommon.DMLMessage)
 // GetAllMessages gets all messages.
 func (g *EventsGroup) GetAllMessages() []*codeccommon.DMLMessage {
 	return g.ResolveInto(math.MaxUint64, nil)
+}
+
+// Cleanup removes pending spill records when the consumer is stopping.
+func (g *EventsGroup) Cleanup() error {
+	if g.spillFile == nil {
+		return nil
+	}
+	err := g.spillFile.Cleanup()
+	g.spillFile = nil
+	clear(g.messages)
+	g.messages = g.messages[:0]
+	return err
+}
+
+func marshalDMLMessage(message *codeccommon.DMLMessage) (data []byte, row *commonEvent.DMLEvent, err error) {
+	if message == nil {
+		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("cannot spill nil DML message")
+	}
+
+	row = message.ToDMLEvent()
+	if row == nil {
+		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("cannot spill DML message without event")
+	}
+	if row.Version == 0 {
+		row.Version = commonEvent.DMLEventVersion1
+	}
+	eventData, err := row.Marshal()
+	if err != nil {
+		return nil, nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML event")
+	}
+
+	var tableInfoData []byte
+	tableInfoStored := false
+	if row.TableInfo != nil {
+		tableInfoData, err = marshalDMLTableInfo(row.TableInfo)
+		if err != nil {
+			if row.Rows != nil && row.Rows.NumRows() > 0 {
+				return nil, nil, err
+			}
+			tableInfoData = nil
+		} else {
+			tableInfoStored = true
+		}
+	}
+
+	var rowsData []byte
+	if row.Rows != nil && (row.Rows.NumRows() > 0 || tableInfoStored) {
+		rowsData, err = marshalDMLRows(row, tableInfoStored)
+		if err != nil {
+			if row.Rows.NumRows() > 0 {
+				return nil, nil, err
+			}
+			rowsData = nil
+		}
+	}
+
+	checksumData, err := json.Marshal(row.Checksum)
+	if err != nil {
+		return nil, nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML checksums")
+	}
+
+	data = make([]byte, 0, 7*8+len(eventData)+len(tableInfoData)+len(rowsData)+len(checksumData))
+	data = appendUint64(data, uint64(len(eventData)))
+	data = append(data, eventData...)
+	data = appendUint64(data, uint64(len(tableInfoData)))
+	data = append(data, tableInfoData...)
+	data = appendUint64(data, uint64(len(rowsData)))
+	data = append(data, rowsData...)
+	data = appendUint64(data, uint64(len(checksumData)))
+	data = append(data, checksumData...)
+	if row.Rows != nil {
+		data = appendUint64(data, 1)
+	} else {
+		data = appendUint64(data, 0)
+	}
+	data = appendUint64(data, row.TableInfoVersion)
+	data = appendUint64(data, row.ReplicatingTs)
+	return data, row, nil
+}
+
+func marshalDMLTableInfo(tableInfo *commonType.TableInfo) (data []byte, err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.ErrSpillFileOp.FastGenByArgs("marshal incomplete DML table info")
+		}
+	}()
+
+	data, err = tableInfo.Marshal()
+	if err != nil {
+		return nil, errors.WrapError(errors.ErrSpillFileOp, err, "marshal DML table info")
+	}
+	return data, nil
+}
+
+func marshalDMLRows(row *commonEvent.DMLEvent, tableInfoStored bool) (data []byte, err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.ErrSpillFileOp.FastGenByArgs("marshal DML rows with incomplete table info")
+		}
+	}()
+
+	fieldTypes := []*types.FieldType(nil)
+	if tableInfoStored {
+		fieldTypes = row.TableInfo.GetFieldSlice()
+	}
+	return chunk.NewCodec(fieldTypes).Encode(row.Rows), nil
+}
+
+func unmarshalDMLMessage(data []byte) (*codeccommon.DMLMessage, error) {
+	eventData, data, err := readSpilledField(data)
+	if err != nil {
+		return nil, err
+	}
+	tableInfoData, data, err := readSpilledField(data)
+	if err != nil {
+		return nil, err
+	}
+	rowsData, data, err := readSpilledField(data)
+	if err != nil {
+		return nil, err
+	}
+	checksumData, data, err := readSpilledField(data)
+	if err != nil {
+		return nil, err
+	}
+	rowsPresent, data, err := readSpilledUint64(data)
+	if err != nil {
+		return nil, err
+	}
+	if rowsPresent > 1 {
+		return nil, errors.ErrSpillFileOp.FastGenByArgs("invalid DML spill rows flag")
+	}
+	tableInfoVersion, data, err := readSpilledUint64(data)
+	if err != nil {
+		return nil, err
+	}
+	replicatingTs, data, err := readSpilledUint64(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) != 0 {
+		return nil, errors.ErrSpillFileOp.FastGenByArgs("unexpected trailing DML spill data")
+	}
+
+	row := &commonEvent.DMLEvent{}
+	if err := row.Unmarshal(eventData); err != nil {
+		return nil, errors.WrapError(errors.ErrSpillFileOp, err, "unmarshal DML event")
+	}
+	if len(tableInfoData) != 0 {
+		tableInfo, err := commonType.UnmarshalJSONToTableInfo(tableInfoData)
+		if err != nil {
+			return nil, errors.WrapError(errors.ErrSpillFileOp, err, "unmarshal DML table info")
+		}
+		row.TableInfo = tableInfo
+	}
+	if rowsPresent == 1 && len(rowsData) == 0 {
+		row.Rows = chunk.NewChunkWithCapacity(nil, 0)
+	} else if len(rowsData) != 0 {
+		fieldTypes := []*types.FieldType(nil)
+		if row.TableInfo != nil {
+			fieldTypes = row.TableInfo.GetFieldSlice()
+		}
+		row.Rows, _ = chunk.NewCodec(fieldTypes).Decode(rowsData)
+	}
+	row.TableInfoVersion = tableInfoVersion
+	row.ReplicatingTs = replicatingTs
+	if err := json.Unmarshal(checksumData, &row.Checksum); err != nil {
+		return nil, errors.WrapError(errors.ErrSpillFileOp, err, "unmarshal DML checksums")
+	}
+	if len(row.RowTypes) == 0 {
+		return nil, errors.ErrSpillFileOp.FastGenByArgs("spilled DML event has no row type")
+	}
+
+	var schema, table string
+	if row.TableInfo != nil {
+		schema = row.TableInfo.GetSchemaName()
+		table = row.TableInfo.GetTableName()
+	}
+
+	return codeccommon.NewDMLMessage(row.PhysicalTableID, schema, table, row.CommitTs, row.RowTypes[0], func() *commonEvent.DMLEvent {
+		return row
+	}), nil
+}
+
+func appendUint64(data []byte, value uint64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], value)
+	return append(data, buf[:]...)
+}
+
+func readSpilledField(data []byte) ([]byte, []byte, error) {
+	length, data, err := readSpilledUint64(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	if length > uint64(len(data)) {
+		return nil, nil, errors.ErrSpillFileOp.FastGenByArgs("invalid DML spill field length")
+	}
+	return data[:length], data[length:], nil
+}
+
+func readSpilledUint64(data []byte) (uint64, []byte, error) {
+	if len(data) < 8 {
+		return 0, nil, errors.ErrSpillFileOp.FastGenByArgs("truncated DML spill data")
+	}
+	return binary.BigEndian.Uint64(data[:8]), data[8:], nil
 }
 
 // AppendOrMergeDMLEvent appends a DML event, or merges it into the previous event

--- a/cmd/util/event_group.go
+++ b/cmd/util/event_group.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"sync"
 
 	"github.com/pingcap/log"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
@@ -260,17 +261,33 @@ func NewDMLMessageDataWithDecoderFactory(
 	key, value []byte,
 	decoderFactory func([]byte, []byte) (codeccommon.Decoder, error),
 ) *codeccommon.DMLMessageData {
+	var (
+		once     sync.Once
+		messages []*codeccommon.DMLMessage
+		err      error
+	)
 	return codeccommon.NewDMLMessageData(key, value,
 		func(data []byte, dmlIndex uint64) (*codeccommon.DMLMessage, error) {
-			key, value, err := unmarshalDMLMessageData(data)
+			once.Do(func() {
+				key, value, unmarshalErr := unmarshalDMLMessageData(data)
+				if unmarshalErr != nil {
+					err = unmarshalErr
+					return
+				}
+				decoder, decoderErr := decoderFactory(key, value)
+				if decoderErr != nil {
+					err = errors.WrapError(errors.ErrSpillFileOp, decoderErr, "create DML spill decoder")
+					return
+				}
+				messages, err = restoreDMLMessages(decoder, key, value)
+			})
 			if err != nil {
 				return nil, err
 			}
-			decoder, err := decoderFactory(key, value)
-			if err != nil {
-				return nil, errors.WrapError(errors.ErrSpillFileOp, err, "create DML spill decoder")
+			if dmlIndex >= uint64(len(messages)) {
+				return nil, errors.ErrSpillFileOp.FastGenByArgs("DML spill message index is out of range")
 			}
-			return restoreDMLMessage(decoder, key, value, dmlIndex)
+			return messages[dmlIndex], nil
 		})
 }
 
@@ -283,18 +300,18 @@ func marshalDMLMessageData(key, value []byte) []byte {
 	return appendSpillBytes(data, value)
 }
 
-func restoreDMLMessage(
-	decoder codeccommon.Decoder, key, value []byte, dmlIndex uint64,
-) (*codeccommon.DMLMessage, error) {
+func restoreDMLMessages(
+	decoder codeccommon.Decoder, key, value []byte,
+) ([]*codeccommon.DMLMessage, error) {
 	decoder.AddKeyValue(key, value)
-	var restored *codeccommon.DMLMessage
-	for currentIndex := uint64(0); ; currentIndex++ {
+	messages := make([]*codeccommon.DMLMessage, 0, 1)
+	for {
 		messageType, hasNext := decoder.HasNext()
 		if !hasNext {
-			if restored == nil {
+			if len(messages) == 0 {
 				return nil, errors.ErrSpillFileOp.FastGenByArgs("DML spill payload has no message")
 			}
-			return restored, nil
+			return messages, nil
 		}
 		if messageType != codeccommon.MessageTypeRow {
 			return nil, errors.ErrSpillFileOp.FastGenByArgs("DML spill payload contains a non-DML message")
@@ -303,9 +320,7 @@ func restoreDMLMessage(
 		if message == nil {
 			return nil, errors.ErrSpillFileOp.FastGenByArgs("DML spill payload cannot be restored")
 		}
-		if currentIndex == dmlIndex {
-			restored = message
-		}
+		messages = append(messages, message)
 	}
 }
 

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -66,7 +66,8 @@ func TestEventsGroupResolveIntoAppendsAndCleansResolvedSpillRecords(t *testing.T
 	spillPath := group.spillFile.Path()
 
 	var dst []*codeccommon.DMLMessage
-	dst = group.ResolveInto(2, dst)
+	dst, err := group.ResolveInto(2, dst)
+	require.NoError(t, err)
 
 	require.Len(t, dst, 2)
 	require.Equal(t, m1.GetCommitTs(), dst[0].GetCommitTs())
@@ -76,9 +77,10 @@ func TestEventsGroupResolveIntoAppendsAndCleansResolvedSpillRecords(t *testing.T
 	require.Equal(t, m3.GetCommitTs(), group.messages[0].commitTs)
 	require.FileExists(t, spillPath)
 
-	group.GetAllMessages()
+	_, err = group.GetAllMessages()
+	require.NoError(t, err)
 	require.Nil(t, group.spillFile)
-	_, err := os.Stat(spillPath)
+	_, err = os.Stat(spillPath)
 	require.True(t, os.IsNotExist(err))
 }
 
@@ -92,7 +94,8 @@ func TestEventsGroupResolveIntoNoopWhenNothingResolved(t *testing.T) {
 	group.AppendMessage(m2)
 
 	dst := make([]*codeccommon.DMLMessage, 0, 1)
-	dst = group.ResolveInto(5, dst)
+	dst, err := group.ResolveInto(5, dst)
+	require.NoError(t, err)
 
 	require.Len(t, dst, 0)
 	require.Len(t, group.messages, 2)
@@ -111,7 +114,8 @@ func TestEventsGroupResolveIntoClearsAllWhenFullyResolved(t *testing.T) {
 
 	spillPath := group.spillFile.Path()
 	var dst []*codeccommon.DMLMessage
-	dst = group.ResolveInto(100, dst)
+	dst, err := group.ResolveInto(100, dst)
+	require.NoError(t, err)
 
 	require.Len(t, dst, 2)
 	require.Equal(t, m1.GetCommitTs(), dst[0].GetCommitTs())
@@ -119,7 +123,7 @@ func TestEventsGroupResolveIntoClearsAllWhenFullyResolved(t *testing.T) {
 
 	require.Len(t, group.messages, 0)
 	require.Nil(t, group.spillFile)
-	_, err := os.Stat(spillPath)
+	_, err = os.Stat(spillPath)
 	require.True(t, os.IsNotExist(err))
 }
 
@@ -133,7 +137,8 @@ func TestEventsGroupResolveIntoSortsOutOfOrderResolvedMessages(t *testing.T) {
 	group.AppendMessage(m3)
 
 	var dst []*codeccommon.DMLMessage
-	dst = group.ResolveInto(25, dst)
+	dst, err := group.ResolveInto(25, dst)
+	require.NoError(t, err)
 
 	require.Len(t, dst, 2)
 	require.Equal(t, m2.GetCommitTs(), dst[0].GetCommitTs())
@@ -153,7 +158,8 @@ func TestEventsGroupResolveIntoKeepsSameCommitTsStable(t *testing.T) {
 	group.AppendMessage(m3)
 
 	var dst []*codeccommon.DMLMessage
-	dst = group.ResolveInto(20, dst)
+	dst, err := group.ResolveInto(20, dst)
+	require.NoError(t, err)
 
 	require.Len(t, dst, 3)
 	require.Equal(t, m2.GetCommitTs(), dst[0].GetCommitTs())
@@ -171,7 +177,8 @@ func TestEventsGroupGetAllMessagesSortsOutOfOrderMessages(t *testing.T) {
 	group.AppendMessage(m2)
 	group.AppendMessage(m3)
 
-	messages := group.GetAllMessages()
+	messages, err := group.GetAllMessages()
+	require.NoError(t, err)
 
 	require.Len(t, messages, 3)
 	require.Equal(t, m2.GetCommitTs(), messages[0].GetCommitTs())
@@ -205,7 +212,8 @@ func TestEventsGroupRestoresSpilledEventRowsAndTableInfo(t *testing.T) {
 	group := NewEventsGroup(0, 1)
 	group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event))
 
-	messages := group.GetAllMessages()
+	messages, err := group.GetAllMessages()
+	require.NoError(t, err)
 	require.Len(t, messages, 1)
 	restored := messages[0].ToDMLEvent()
 	require.Equal(t, uint64(100), restored.CommitTs)
@@ -252,12 +260,24 @@ func BenchmarkEventsGroupResolveInto(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+			b.StopTimer()
 			for b.Loop() {
 				group := NewEventsGroup(0, 1)
 				for _, message := range source {
-					group.AppendMessage(message)
+					if err := group.AppendMessage(message); err != nil {
+						b.Fatal(err)
+					}
 				}
-				dst = group.ResolveInto(benchmark.resolveTs, dst[:0])
+				b.StartTimer()
+				var err error
+				dst, err = group.ResolveInto(benchmark.resolveTs, dst[:0])
+				b.StopTimer()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := group.Cleanup(); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -271,17 +271,6 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 	second := messages[1].ToDMLEvent()
 	require.True(t, second.Rows.GetRow(0).IsNull(1))
 	require.Equal(t, int64(2), second.Rows.GetRow(1).GetInt64(1))
-
-	var events []*commonEvent.DMLEvent
-	for _, message := range messages {
-		events = AppendOrMergeDMLEvent(events, message.ToDMLEvent())
-	}
-	require.Len(t, events, 1)
-	require.Len(t, events[0].RowTypes, events[0].Rows.NumRows())
-	require.True(t, events[0].Rows.GetRow(0).IsNull(1))
-	require.Equal(t, int64(1), events[0].Rows.GetRow(1).GetInt64(1))
-	require.True(t, events[0].Rows.GetRow(2).IsNull(1))
-	require.Equal(t, int64(2), events[0].Rows.GetRow(3).GetInt64(1))
 }
 
 func TestEventsGroupSpillDoesNotSignalDownstreamCallbacks(t *testing.T) {
@@ -353,35 +342,4 @@ func BenchmarkEventsGroupResolveInto(b *testing.B) {
 			}
 		})
 	}
-}
-
-func TestAppendOrMergeDMLEventMergesSameCommitTs(t *testing.T) {
-	var flushed []int
-	e1 := newTestDMLEvent(10, common.RowTypeInsert)
-	e1.AddPostFlushFunc(func() { flushed = append(flushed, 1) })
-	e2 := newTestDMLEvent(10, common.RowTypeDelete)
-	e2.AddPostFlushFunc(func() { flushed = append(flushed, 2) })
-
-	events := AppendOrMergeDMLEvent(nil, e1)
-	events = AppendOrMergeDMLEvent(events, e2)
-
-	require.Len(t, events, 1)
-	require.Same(t, e1, events[0])
-	require.Equal(t, int32(2), events[0].Length)
-	require.Equal(t, []common.RowType{common.RowTypeInsert, common.RowTypeDelete}, events[0].RowTypes)
-
-	events[0].PostFlush()
-	require.Equal(t, []int{1, 2}, flushed)
-}
-
-func TestAppendOrMergeDMLEventAppendsDifferentCommitTs(t *testing.T) {
-	e1 := newTestDMLEvent(10, common.RowTypeInsert)
-	e2 := newTestDMLEvent(20, common.RowTypeDelete)
-
-	events := AppendOrMergeDMLEvent(nil, e1)
-	events = AppendOrMergeDMLEvent(events, e2)
-
-	require.Len(t, events, 2)
-	require.Same(t, e1, events[0])
-	require.Same(t, e2, events[1])
 }

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -14,19 +14,25 @@
 package util
 
 import (
+	"os"
 	"testing"
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/integrity"
 	codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 )
 
 func newTestDMLMessage(commitTs uint64) *codeccommon.DMLMessage {
-	return codeccommon.NewDMLMessage(1, "test", "t", commitTs, common.RowTypeInsert, nil)
+	return codeccommon.NewDMLMessageFromEvent(newTestDMLEvent(commitTs, common.RowTypeInsert))
 }
 
 func newTestDMLEvent(commitTs uint64, rowTypes ...common.RowType) *commonEvent.DMLEvent {
@@ -39,16 +45,16 @@ func newTestDMLEvent(commitTs uint64, rowTypes ...common.RowType) *commonEvent.D
 	}
 }
 
-func TestEventsGroupResolveIntoAppendsAndClearsResolvedMessages(t *testing.T) {
+func TestEventsGroupResolveIntoAppendsAndCleansResolvedSpillRecords(t *testing.T) {
 	// Scenario: A consumer resolves events by watermark/commit-ts and appends them into a downstream
-	// batch slice. We must clear resolved messages in the group's backing array to avoid retaining
-	// already-flushed events and causing unbounded memory growth.
+	// batch slice. Buffered messages are held only by a spill file, and the file must be cleaned once
+	// all of its records have been resolved.
 	//
 	// Steps:
 	//  1. Append 3 events with increasing CommitTs.
 	//  2. Call ResolveInto with resolve=2 and a nil dst.
 	//  3. Verify (a) returned events are correct, (b) group keeps only the remaining event,
-	//     (c) resolved messages in the original backing slice are cleared (nil'd).
+	//     (c) the file survives the partial resolve.
 	group := NewEventsGroup(0, 1)
 	m1 := newTestDMLMessage(1)
 	m2 := newTestDMLMessage(2)
@@ -57,25 +63,23 @@ func TestEventsGroupResolveIntoAppendsAndClearsResolvedMessages(t *testing.T) {
 	group.AppendMessage(m2)
 	group.AppendMessage(m3)
 
-	// Keep a reference to the original slice header so we can validate that ResolveInto clears
-	// resolved messages in-place (this is what prevents GC retention of flushed events).
-	original := group.messages
+	spillPath := group.spillFile.Path()
 
 	var dst []*codeccommon.DMLMessage
 	dst = group.ResolveInto(2, dst)
 
 	require.Len(t, dst, 2)
-	require.Same(t, m1, dst[0])
-	require.Same(t, m2, dst[1])
+	require.Equal(t, m1.GetCommitTs(), dst[0].GetCommitTs())
+	require.Equal(t, m2.GetCommitTs(), dst[1].GetCommitTs())
 
 	require.Len(t, group.messages, 1)
-	require.Same(t, m3, group.messages[0])
+	require.Equal(t, m3.GetCommitTs(), group.messages[0].commitTs)
+	require.FileExists(t, spillPath)
 
-	// The unresolved event is compacted to the front, and the tail is cleared so the group
-	// doesn't keep flushed events alive via its backing array.
-	require.Same(t, m3, original[0])
-	require.Nil(t, original[1])
-	require.Nil(t, original[2])
+	group.GetAllMessages()
+	require.Nil(t, group.spillFile)
+	_, err := os.Stat(spillPath)
+	require.True(t, os.IsNotExist(err))
 }
 
 func TestEventsGroupResolveIntoNoopWhenNothingResolved(t *testing.T) {
@@ -87,18 +91,13 @@ func TestEventsGroupResolveIntoNoopWhenNothingResolved(t *testing.T) {
 	group.AppendMessage(m1)
 	group.AppendMessage(m2)
 
-	original := group.messages
 	dst := make([]*codeccommon.DMLMessage, 0, 1)
 	dst = group.ResolveInto(5, dst)
 
 	require.Len(t, dst, 0)
 	require.Len(t, group.messages, 2)
-	require.Same(t, m1, group.messages[0])
-	require.Same(t, m2, group.messages[1])
-
-	// No prefix should be cleared because nothing was resolved.
-	require.Same(t, m1, original[0])
-	require.Same(t, m2, original[1])
+	require.Equal(t, m1.GetCommitTs(), group.messages[0].commitTs)
+	require.Equal(t, m2.GetCommitTs(), group.messages[1].commitTs)
 }
 
 func TestEventsGroupResolveIntoClearsAllWhenFullyResolved(t *testing.T) {
@@ -110,17 +109,18 @@ func TestEventsGroupResolveIntoClearsAllWhenFullyResolved(t *testing.T) {
 	group.AppendMessage(m1)
 	group.AppendMessage(m2)
 
-	original := group.messages
+	spillPath := group.spillFile.Path()
 	var dst []*codeccommon.DMLMessage
 	dst = group.ResolveInto(100, dst)
 
 	require.Len(t, dst, 2)
-	require.Same(t, m1, dst[0])
-	require.Same(t, m2, dst[1])
+	require.Equal(t, m1.GetCommitTs(), dst[0].GetCommitTs())
+	require.Equal(t, m2.GetCommitTs(), dst[1].GetCommitTs())
 
 	require.Len(t, group.messages, 0)
-	require.Nil(t, original[0])
-	require.Nil(t, original[1])
+	require.Nil(t, group.spillFile)
+	_, err := os.Stat(spillPath)
+	require.True(t, os.IsNotExist(err))
 }
 
 func TestEventsGroupResolveIntoSortsOutOfOrderResolvedMessages(t *testing.T) {
@@ -132,19 +132,15 @@ func TestEventsGroupResolveIntoSortsOutOfOrderResolvedMessages(t *testing.T) {
 	group.AppendMessage(m2)
 	group.AppendMessage(m3)
 
-	original := group.messages
 	var dst []*codeccommon.DMLMessage
 	dst = group.ResolveInto(25, dst)
 
 	require.Len(t, dst, 2)
-	require.Same(t, m2, dst[0])
-	require.Same(t, m1, dst[1])
+	require.Equal(t, m2.GetCommitTs(), dst[0].GetCommitTs())
+	require.Equal(t, m1.GetCommitTs(), dst[1].GetCommitTs())
 
 	require.Len(t, group.messages, 1)
-	require.Same(t, m3, group.messages[0])
-	require.Same(t, m3, original[0])
-	require.Nil(t, original[1])
-	require.Nil(t, original[2])
+	require.Equal(t, m3.GetCommitTs(), group.messages[0].commitTs)
 }
 
 func TestEventsGroupResolveIntoKeepsSameCommitTsStable(t *testing.T) {
@@ -160,9 +156,9 @@ func TestEventsGroupResolveIntoKeepsSameCommitTsStable(t *testing.T) {
 	dst = group.ResolveInto(20, dst)
 
 	require.Len(t, dst, 3)
-	require.Same(t, m2, dst[0])
-	require.Same(t, m1, dst[1])
-	require.Same(t, m3, dst[2])
+	require.Equal(t, m2.GetCommitTs(), dst[0].GetCommitTs())
+	require.Equal(t, m1.GetCommitTs(), dst[1].GetCommitTs())
+	require.Equal(t, m3.GetCommitTs(), dst[2].GetCommitTs())
 	require.Empty(t, group.messages)
 }
 
@@ -178,10 +174,47 @@ func TestEventsGroupGetAllMessagesSortsOutOfOrderMessages(t *testing.T) {
 	messages := group.GetAllMessages()
 
 	require.Len(t, messages, 3)
-	require.Same(t, m2, messages[0])
-	require.Same(t, m1, messages[1])
-	require.Same(t, m3, messages[2])
+	require.Equal(t, m2.GetCommitTs(), messages[0].GetCommitTs())
+	require.Equal(t, m1.GetCommitTs(), messages[1].GetCommitTs())
+	require.Equal(t, m3.GetCommitTs(), messages[2].GetCommitTs())
 	require.Empty(t, group.messages)
+}
+
+func TestEventsGroupRestoresSpilledEventRowsAndTableInfo(t *testing.T) {
+	tableInfo := common.WrapTableInfo("test", &model.TableInfo{
+		ID:   1,
+		Name: ast.NewCIStr("t"),
+		Columns: []*model.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *types.NewFieldType(mysql.TypeLonglong),
+			},
+		},
+	})
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
+	rows.AppendInt64(0, 42)
+	event := commonEvent.NewDMLEvent(common.NewDispatcherID(), 1, 90, 100, tableInfo)
+	event.Rows = rows
+	event.RowTypes = []common.RowType{common.RowTypeInsert}
+	event.Length = 1
+	event.TableInfoVersion = 88
+	event.ReplicatingTs = 99
+	event.Checksum = []*integrity.Checksum{{Current: 1, Previous: 2, Corrupted: true, Version: 3}}
+
+	group := NewEventsGroup(0, 1)
+	group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event))
+
+	messages := group.GetAllMessages()
+	require.Len(t, messages, 1)
+	restored := messages[0].ToDMLEvent()
+	require.Equal(t, uint64(100), restored.CommitTs)
+	require.Equal(t, uint64(88), restored.TableInfoVersion)
+	require.Equal(t, uint64(99), restored.ReplicatingTs)
+	require.Equal(t, event.Checksum, restored.Checksum)
+	require.Equal(t, "test", restored.TableInfo.GetSchemaName())
+	require.Equal(t, "t", restored.TableInfo.GetTableName())
+	require.Equal(t, int64(42), restored.Rows.GetRow(0).GetInt64(0))
 }
 
 func BenchmarkEventsGroupResolveInto(b *testing.B) {
@@ -215,16 +248,14 @@ func BenchmarkEventsGroupResolveInto(b *testing.B) {
 				lastIndex := len(source) - 1
 				source[lastIndex-1], source[lastIndex] = source[lastIndex], source[lastIndex-1]
 			}
-			group := NewEventsGroup(0, 1)
-			group.messages = make([]*codeccommon.DMLMessage, 0, messageCount)
 			dst := make([]*codeccommon.DMLMessage, 0, messageCount)
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				if len(group.messages) != messageCount {
-					group.messages = append(group.messages[:0], source...)
-					group.outOfOrder = benchmark.outOfOrder
+				group := NewEventsGroup(0, 1)
+				for _, message := range source {
+					group.AppendMessage(message)
 				}
 				dst = group.ResolveInto(benchmark.resolveTs, dst[:0])
 			}

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -64,9 +64,7 @@ func newMergeTestTableInfo(tableID int64, updateTS uint64, columnCount int) *com
 	})
 }
 
-func newMergeTestDMLEvent(
-	commitTs uint64, tableInfo *common.TableInfo, value int64,
-) *commonEvent.DMLEvent {
+func newMergeTestDMLEvent(commitTs uint64, tableInfo *common.TableInfo, value int64) *commonEvent.DMLEvent {
 	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
 	for column := range tableInfo.GetFieldSlice() {
 		rows.AppendInt64(column, value)
@@ -84,6 +82,11 @@ func newMergeTestDMLEvent(
 	}
 }
 
+func newMergeTestDMLMessage(event *commonEvent.DMLEvent) *codeccommon.DMLMessage {
+	return codeccommon.NewDMLMessage(event.GetTableID(), event.TableInfo.GetSchemaName(), event.TableInfo.GetTableName(),
+		event.GetCommitTs(), event.RowTypes[0], func() *commonEvent.DMLEvent { return event })
+}
+
 func TestAppendOrMergeDMLEvent(t *testing.T) {
 	t.Run("merge compatible events", func(t *testing.T) {
 		tableInfo := newMergeTestTableInfo(1, 10, 1)
@@ -97,8 +100,10 @@ func TestAppendOrMergeDMLEvent(t *testing.T) {
 		first.AddPostFlushFunc(func() { flushed = append(flushed, 1) })
 		second.AddPostFlushFunc(func() { flushed = append(flushed, 2) })
 
-		events := AppendOrMergeDMLEvent(nil, first)
-		events = AppendOrMergeDMLEvent(events, second)
+		events := DMLMessagesToEvents([]*codeccommon.DMLMessage{
+			newMergeTestDMLMessage(first),
+			newMergeTestDMLMessage(second),
+		})
 
 		require.Len(t, events, 1)
 		require.Same(t, first, events[0])
@@ -114,8 +119,10 @@ func TestAppendOrMergeDMLEvent(t *testing.T) {
 		first := newMergeTestDMLEvent(100, newMergeTestTableInfo(1, 10, 1), 1)
 		second := newMergeTestDMLEvent(100, newMergeTestTableInfo(1, 11, 2), 2)
 
-		events := AppendOrMergeDMLEvent(nil, first)
-		events = AppendOrMergeDMLEvent(events, second)
+		events := DMLMessagesToEvents([]*codeccommon.DMLMessage{
+			newMergeTestDMLMessage(first),
+			newMergeTestDMLMessage(second),
+		})
 
 		require.Len(t, events, 2)
 		require.Same(t, first, events[0])
@@ -128,8 +135,10 @@ func TestAppendOrMergeDMLEvent(t *testing.T) {
 		second := newMergeTestDMLEvent(100, tableInfo, 2)
 		second.DispatcherID = common.DispatcherID{Low: 2}
 
-		events := AppendOrMergeDMLEvent(nil, first)
-		events = AppendOrMergeDMLEvent(events, second)
+		events := DMLMessagesToEvents([]*codeccommon.DMLMessage{
+			newMergeTestDMLMessage(first),
+			newMergeTestDMLMessage(second),
+		})
 
 		require.Len(t, events, 2)
 	})
@@ -137,16 +146,15 @@ func TestAppendOrMergeDMLEvent(t *testing.T) {
 	t.Run("merge compatible events restored from spill", func(t *testing.T) {
 		tableInfo := newMergeTestTableInfo(1, 10, 1)
 		group := NewEventsGroup(0, 1)
-		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(
-			newMergeTestDMLEvent(100, tableInfo, 1))))
-		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(
-			newMergeTestDMLEvent(100, tableInfo, 2))))
+		first := newMergeTestDMLEvent(100, tableInfo, 1)
+		second := newMergeTestDMLEvent(100, tableInfo, 2)
+		require.NoError(t, group.AppendMessage(newMergeTestDMLMessage(first)))
+		require.NoError(t, group.AppendMessage(newMergeTestDMLMessage(second)))
 
 		messages, err := group.GetAllMessages()
 		require.NoError(t, err)
 		require.Len(t, messages, 2)
-		events := AppendOrMergeDMLEvent(nil, messages[0].ToDMLEvent())
-		events = AppendOrMergeDMLEvent(events, messages[1].ToDMLEvent())
+		events := DMLMessagesToEvents(messages)
 
 		require.Len(t, events, 1)
 		require.Equal(t, 2, events[0].Rows.NumRows())
@@ -361,10 +369,10 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 	messages, err := group.GetAllMessages()
 	require.NoError(t, err)
 	require.Len(t, messages, 2)
+	require.Zero(t, messages[0].ToDMLEvent().PreviousTotalOffset)
+	require.Equal(t, 2, messages[1].ToDMLEvent().PreviousTotalOffset)
 	for _, message := range messages {
-		restored := message.ToDMLEvent()
-		require.Zero(t, restored.PreviousTotalOffset)
-		require.Equal(t, 2, restored.Rows.NumRows())
+		require.Equal(t, 4, message.ToDMLEvent().Rows.NumRows())
 	}
 
 	second := messages[1].ToDMLEvent()

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -183,6 +183,39 @@ func TestEventsGroupSharesRawMessageData(t *testing.T) {
 	require.Same(t, second, messages[1])
 }
 
+func TestEventsGroupRestoresSharedSpillInputOnce(t *testing.T) {
+	// A single canal-json input can contain thousands of DML messages. Restoring
+	// each ordinal must not re-decode the complete input.
+	inputMessages := []*codeccommon.DMLMessage{
+		newTestDMLMessage(30),
+		newTestDMLMessage(10),
+		newTestDMLMessage(20),
+	}
+	var decoderCount int
+	messageData := NewDMLMessageDataWithDecoderFactory(nil, []byte("raw message"),
+		func(_, _ []byte) (codeccommon.Decoder, error) {
+			decoderCount++
+			return &dmlMessageDecoderStub{messages: []*codeccommon.DMLMessage{
+				newTestDMLMessage(30),
+				newTestDMLMessage(10),
+				newTestDMLMessage(20),
+			}}, nil
+		})
+
+	group := NewEventsGroup(0, 1)
+	for _, message := range inputMessages {
+		messageData.AttachDMLMessage(message)
+		require.NoError(t, group.AppendMessage(message))
+	}
+
+	messages, err := group.GetAllMessages()
+	require.NoError(t, err)
+	require.Equal(t, 1, decoderCount)
+	require.Equal(t, []uint64{10, 20, 30}, []uint64{
+		messages[0].GetCommitTs(), messages[1].GetCommitTs(), messages[2].GetCommitTs(),
+	})
+}
+
 func TestEventsGroupResolveIntoAppendsAndCleansResolvedSpillRecords(t *testing.T) {
 	// Scenario: A consumer resolves events by watermark/commit-ts and appends them into a downstream
 	// batch slice. Buffered messages are held only by a spill file, and the file must be cleaned once

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -225,6 +225,65 @@ func TestEventsGroupRestoresSpilledEventRowsAndTableInfo(t *testing.T) {
 	require.Equal(t, int64(42), restored.Rows.GetRow(0).GetInt64(0))
 }
 
+func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
+	tableInfo := common.WrapTableInfo("test", &model.TableInfo{
+		ID:   1,
+		Name: ast.NewCIStr("t"),
+		Columns: []*model.ColumnInfo{
+			{ID: 1, Name: ast.NewCIStr("id"), FieldType: *types.NewFieldType(mysql.TypeLonglong)},
+			{ID: 2, Name: ast.NewCIStr("v1"), FieldType: *types.NewFieldType(mysql.TypeLong)},
+		},
+	})
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 4)
+	for _, value := range []struct {
+		null  bool
+		value int64
+	}{
+		{null: true}, {value: 1}, {null: true}, {value: 2},
+	} {
+		rows.AppendInt64(0, 42)
+		if value.null {
+			rows.AppendNull(1)
+		} else {
+			rows.AppendInt64(1, value.value)
+		}
+	}
+
+	group := NewEventsGroup(0, 1)
+	for _, offset := range []int{0, 2} {
+		event := commonEvent.NewDMLEvent(common.NewDispatcherID(), 1, 90, 100, tableInfo)
+		event.Rows = rows
+		event.RowTypes = []common.RowType{common.RowTypeInsert, common.RowTypeInsert}
+		event.Length = 2
+		event.PreviousTotalOffset = offset
+		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
+	}
+
+	messages, err := group.GetAllMessages()
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	for _, message := range messages {
+		restored := message.ToDMLEvent()
+		require.Zero(t, restored.PreviousTotalOffset)
+		require.Len(t, restored.RowTypes, restored.Rows.NumRows())
+	}
+
+	second := messages[1].ToDMLEvent()
+	require.True(t, second.Rows.GetRow(0).IsNull(1))
+	require.Equal(t, int64(2), second.Rows.GetRow(1).GetInt64(1))
+
+	var events []*commonEvent.DMLEvent
+	for _, message := range messages {
+		events = AppendOrMergeDMLEvent(events, message.ToDMLEvent())
+	}
+	require.Len(t, events, 1)
+	require.Len(t, events[0].RowTypes, events[0].Rows.NumRows())
+	require.True(t, events[0].Rows.GetRow(0).IsNull(1))
+	require.Equal(t, int64(1), events[0].Rows.GetRow(1).GetInt64(1))
+	require.True(t, events[0].Rows.GetRow(2).IsNull(1))
+	require.Equal(t, int64(2), events[0].Rows.GetRow(3).GetInt64(1))
+}
+
 func TestEventsGroupSpillDoesNotSignalDownstreamCallbacks(t *testing.T) {
 	event := newTestDMLEvent(100, common.RowTypeInsert)
 	var enqueued, flushed int

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -242,7 +242,9 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 	for _, offset := range []int{0, 2} {
 		event := commonEvent.NewDMLEvent(common.NewDispatcherID(), 1, 90, 100, tableInfo)
 		event.Rows = rows
-		event.RowTypes = []common.RowType{common.RowTypeUpdate}
+		// A decoded update occupies two RowTypes entries, matching its before
+		// and after rows in the shared chunk.
+		event.RowTypes = []common.RowType{common.RowTypeUpdate, common.RowTypeUpdate}
 		event.Length = 1
 		event.PreviousTotalOffset = offset
 		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
@@ -263,6 +265,41 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 	require.Equal(t, int64(2), row.PreRow.GetInt64(0))
 	require.Equal(t, int64(3), row.Row.GetInt64(0))
 	_, ok = second.GetNextRow()
+	require.False(t, ok)
+}
+
+func TestEventsGroupRestoresCompactUpdateRows(t *testing.T) {
+	tableInfo := common.WrapTableInfo("test", &model.TableInfo{
+		ID:   1,
+		Name: ast.NewCIStr("t"),
+		Columns: []*model.ColumnInfo{
+			{ID: 1, Name: ast.NewCIStr("id"), FieldType: *types.NewFieldType(mysql.TypeLonglong)},
+		},
+	})
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 2)
+	rows.AppendInt64(0, 1)
+	rows.AppendInt64(0, 2)
+
+	// The Avro decoder represents an update with one RowType even though the
+	// chunk still contains both before and after rows.
+	event := commonEvent.NewDMLEvent(common.NewDispatcherID(), 1, 90, 100, tableInfo)
+	event.Rows = rows
+	event.RowTypes = []common.RowType{common.RowTypeUpdate}
+	event.Length = 1
+
+	group := NewEventsGroup(0, 1)
+	require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
+	messages, err := group.GetAllMessages()
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	restored := messages[0].ToDMLEvent()
+	require.Equal(t, 2, restored.Rows.NumRows())
+	row, ok := restored.GetNextRow()
+	require.True(t, ok)
+	require.Equal(t, int64(1), row.PreRow.GetInt64(0))
+	require.Equal(t, int64(2), row.Row.GetInt64(0))
+	_, ok = restored.GetNextRow()
 	require.False(t, ok)
 }
 

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -225,6 +225,19 @@ func TestEventsGroupRestoresSpilledEventRowsAndTableInfo(t *testing.T) {
 	require.Equal(t, int64(42), restored.Rows.GetRow(0).GetInt64(0))
 }
 
+func TestEventsGroupSpillDoesNotSignalDownstreamCallbacks(t *testing.T) {
+	event := newTestDMLEvent(100, common.RowTypeInsert)
+	var enqueued, flushed int
+	event.AddPostEnqueueFunc(func() { enqueued++ })
+	event.AddPostFlushFunc(func() { flushed++ })
+
+	group := NewEventsGroup(0, 1)
+	defer func() { require.NoError(t, group.Cleanup()) }()
+	require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
+	require.Zero(t, enqueued)
+	require.Zero(t, flushed)
+}
+
 func BenchmarkEventsGroupResolveInto(b *testing.B) {
 	const messageCount = 16 * 1024
 

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -43,6 +44,113 @@ func newTestDMLEvent(commitTs uint64, rowTypes ...common.RowType) *commonEvent.D
 		RowTypes:        rowTypes,
 		Rows:            chunk.NewChunkWithCapacity(nil, 0),
 	}
+}
+
+func newMergeTestTableInfo(tableID int64, updateTS uint64, columnCount int) *common.TableInfo {
+	columns := make([]*model.ColumnInfo, columnCount)
+	for i := range columns {
+		columns[i] = &model.ColumnInfo{
+			ID:        int64(i + 1),
+			Offset:    i,
+			Name:      ast.NewCIStr(fmt.Sprintf("c%d", i)),
+			FieldType: *types.NewFieldType(mysql.TypeLonglong),
+		}
+	}
+	return common.WrapTableInfo("test", &model.TableInfo{
+		ID:       tableID,
+		Name:     ast.NewCIStr("t"),
+		UpdateTS: updateTS,
+		Columns:  columns,
+	})
+}
+
+func newMergeTestDMLEvent(
+	commitTs uint64, tableInfo *common.TableInfo, value int64,
+) *commonEvent.DMLEvent {
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
+	for column := range tableInfo.GetFieldSlice() {
+		rows.AppendInt64(column, value)
+	}
+	return &commonEvent.DMLEvent{
+		DispatcherID:     common.DispatcherID{Low: 1},
+		PhysicalTableID:  tableInfo.TableName.TableID,
+		StartTs:          commitTs - 1,
+		CommitTs:         commitTs,
+		Length:           1,
+		RowTypes:         []common.RowType{common.RowTypeInsert},
+		Rows:             rows,
+		TableInfo:        tableInfo,
+		TableInfoVersion: tableInfo.GetUpdateTS(),
+	}
+}
+
+func TestAppendOrMergeDMLEvent(t *testing.T) {
+	t.Run("merge compatible events", func(t *testing.T) {
+		tableInfo := newMergeTestTableInfo(1, 10, 1)
+		first := newMergeTestDMLEvent(100, tableInfo, 1)
+		second := newMergeTestDMLEvent(100, tableInfo, 2)
+		first.RowKeys = [][]byte{[]byte("first")}
+		second.RowKeys = [][]byte{[]byte("second")}
+		first.Checksum = []*integrity.Checksum{{Current: 1}}
+		second.Checksum = []*integrity.Checksum{{Current: 2}}
+		var flushed []int
+		first.AddPostFlushFunc(func() { flushed = append(flushed, 1) })
+		second.AddPostFlushFunc(func() { flushed = append(flushed, 2) })
+
+		events := AppendOrMergeDMLEvent(nil, first)
+		events = AppendOrMergeDMLEvent(events, second)
+
+		require.Len(t, events, 1)
+		require.Same(t, first, events[0])
+		require.Equal(t, int32(2), first.Length)
+		require.Equal(t, 2, first.Rows.NumRows())
+		require.Equal(t, []byte("second"), first.RowKeys[1])
+		require.Equal(t, uint32(2), first.Checksum[1].Current)
+		first.PostFlush()
+		require.Equal(t, []int{1, 2}, flushed)
+	})
+
+	t.Run("keep different schema layouts separate", func(t *testing.T) {
+		first := newMergeTestDMLEvent(100, newMergeTestTableInfo(1, 10, 1), 1)
+		second := newMergeTestDMLEvent(100, newMergeTestTableInfo(1, 11, 2), 2)
+
+		events := AppendOrMergeDMLEvent(nil, first)
+		events = AppendOrMergeDMLEvent(events, second)
+
+		require.Len(t, events, 2)
+		require.Same(t, first, events[0])
+		require.Same(t, second, events[1])
+	})
+
+	t.Run("keep different dispatchers separate", func(t *testing.T) {
+		tableInfo := newMergeTestTableInfo(1, 10, 1)
+		first := newMergeTestDMLEvent(100, tableInfo, 1)
+		second := newMergeTestDMLEvent(100, tableInfo, 2)
+		second.DispatcherID = common.DispatcherID{Low: 2}
+
+		events := AppendOrMergeDMLEvent(nil, first)
+		events = AppendOrMergeDMLEvent(events, second)
+
+		require.Len(t, events, 2)
+	})
+
+	t.Run("merge compatible events restored from spill", func(t *testing.T) {
+		tableInfo := newMergeTestTableInfo(1, 10, 1)
+		group := NewEventsGroup(0, 1)
+		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(
+			newMergeTestDMLEvent(100, tableInfo, 1))))
+		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(
+			newMergeTestDMLEvent(100, tableInfo, 2))))
+
+		messages, err := group.GetAllMessages()
+		require.NoError(t, err)
+		require.Len(t, messages, 2)
+		events := AppendOrMergeDMLEvent(nil, messages[0].ToDMLEvent())
+		events = AppendOrMergeDMLEvent(events, messages[1].ToDMLEvent())
+
+		require.Len(t, events, 1)
+		require.Equal(t, 2, events[0].Rows.NumRows())
+	})
 }
 
 func TestEventsGroupResolveIntoAppendsAndCleansResolvedSpillRecords(t *testing.T) {

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -234,7 +234,7 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 		},
 	})
 	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 4)
-	for i := int64(0); i < 4; i++ {
+	for i := range int64(4) {
 		rows.AppendInt64(0, i)
 	}
 

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -231,30 +231,19 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 		Name: ast.NewCIStr("t"),
 		Columns: []*model.ColumnInfo{
 			{ID: 1, Name: ast.NewCIStr("id"), FieldType: *types.NewFieldType(mysql.TypeLonglong)},
-			{ID: 2, Name: ast.NewCIStr("v1"), FieldType: *types.NewFieldType(mysql.TypeLong)},
 		},
 	})
 	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 4)
-	for _, value := range []struct {
-		null  bool
-		value int64
-	}{
-		{null: true}, {value: 1}, {null: true}, {value: 2},
-	} {
-		rows.AppendInt64(0, 42)
-		if value.null {
-			rows.AppendNull(1)
-		} else {
-			rows.AppendInt64(1, value.value)
-		}
+	for i := int64(0); i < 4; i++ {
+		rows.AppendInt64(0, i)
 	}
 
 	group := NewEventsGroup(0, 1)
 	for _, offset := range []int{0, 2} {
 		event := commonEvent.NewDMLEvent(common.NewDispatcherID(), 1, 90, 100, tableInfo)
 		event.Rows = rows
-		event.RowTypes = []common.RowType{common.RowTypeInsert, common.RowTypeInsert}
-		event.Length = 2
+		event.RowTypes = []common.RowType{common.RowTypeUpdate}
+		event.Length = 1
 		event.PreviousTotalOffset = offset
 		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
 	}
@@ -265,12 +254,16 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 	for _, message := range messages {
 		restored := message.ToDMLEvent()
 		require.Zero(t, restored.PreviousTotalOffset)
-		require.Len(t, restored.RowTypes, restored.Rows.NumRows())
+		require.Equal(t, 2, restored.Rows.NumRows())
 	}
 
 	second := messages[1].ToDMLEvent()
-	require.True(t, second.Rows.GetRow(0).IsNull(1))
-	require.Equal(t, int64(2), second.Rows.GetRow(1).GetInt64(1))
+	row, ok := second.GetNextRow()
+	require.True(t, ok)
+	require.Equal(t, int64(2), row.PreRow.GetInt64(0))
+	require.Equal(t, int64(3), row.Row.GetInt64(0))
+	_, ok = second.GetNextRow()
+	require.False(t, ok)
 }
 
 func TestEventsGroupSpillDoesNotSignalDownstreamCallbacks(t *testing.T) {

--- a/cmd/util/event_group_test.go
+++ b/cmd/util/event_group_test.go
@@ -36,6 +36,16 @@ func newTestDMLMessage(commitTs uint64) *codeccommon.DMLMessage {
 	return codeccommon.NewDMLMessageFromEvent(newTestDMLEvent(commitTs, common.RowTypeInsert))
 }
 
+func attachTestDMLMessageData(message *codeccommon.DMLMessage) *codeccommon.DMLMessage {
+	messageData := codeccommon.NewDMLMessageData(nil, nil,
+		func([]byte, uint64) (*codeccommon.DMLMessage, error) {
+			return message, nil
+		},
+	)
+	messageData.AttachDMLMessage(message)
+	return message
+}
+
 func newTestDMLEvent(commitTs uint64, rowTypes ...common.RowType) *commonEvent.DMLEvent {
 	return &commonEvent.DMLEvent{
 		PhysicalTableID: 1,
@@ -115,25 +125,10 @@ func TestAppendOrMergeDMLEvent(t *testing.T) {
 		require.Equal(t, []int{1, 2}, flushed)
 	})
 
-	t.Run("keep different schema layouts separate", func(t *testing.T) {
-		first := newMergeTestDMLEvent(100, newMergeTestTableInfo(1, 10, 1), 1)
-		second := newMergeTestDMLEvent(100, newMergeTestTableInfo(1, 11, 2), 2)
-
-		events := DMLMessagesToEvents([]*codeccommon.DMLMessage{
-			newMergeTestDMLMessage(first),
-			newMergeTestDMLMessage(second),
-		})
-
-		require.Len(t, events, 2)
-		require.Same(t, first, events[0])
-		require.Same(t, second, events[1])
-	})
-
-	t.Run("keep different dispatchers separate", func(t *testing.T) {
+	t.Run("keep different commit timestamps separate", func(t *testing.T) {
 		tableInfo := newMergeTestTableInfo(1, 10, 1)
 		first := newMergeTestDMLEvent(100, tableInfo, 1)
-		second := newMergeTestDMLEvent(100, tableInfo, 2)
-		second.DispatcherID = common.DispatcherID{Low: 2}
+		second := newMergeTestDMLEvent(101, tableInfo, 2)
 
 		events := DMLMessagesToEvents([]*codeccommon.DMLMessage{
 			newMergeTestDMLMessage(first),
@@ -148,8 +143,10 @@ func TestAppendOrMergeDMLEvent(t *testing.T) {
 		group := NewEventsGroup(0, 1)
 		first := newMergeTestDMLEvent(100, tableInfo, 1)
 		second := newMergeTestDMLEvent(100, tableInfo, 2)
-		require.NoError(t, group.AppendMessage(newMergeTestDMLMessage(first)))
-		require.NoError(t, group.AppendMessage(newMergeTestDMLMessage(second)))
+		firstMessage := newMergeTestDMLMessage(first)
+		secondMessage := newMergeTestDMLMessage(second)
+		require.NoError(t, group.AppendMessage(attachTestDMLMessageData(firstMessage)))
+		require.NoError(t, group.AppendMessage(attachTestDMLMessageData(secondMessage)))
 
 		messages, err := group.GetAllMessages()
 		require.NoError(t, err)
@@ -159,6 +156,31 @@ func TestAppendOrMergeDMLEvent(t *testing.T) {
 		require.Len(t, events, 1)
 		require.Equal(t, 2, events[0].Rows.NumRows())
 	})
+}
+
+func TestEventsGroupSharesRawMessageData(t *testing.T) {
+	first := newTestDMLMessage(10)
+	second := newTestDMLMessage(10)
+	messageData := codeccommon.NewDMLMessageData(nil, []byte("raw message"),
+		func(_ []byte, dmlIndex uint64) (*codeccommon.DMLMessage, error) {
+			return []*codeccommon.DMLMessage{first, second}[dmlIndex], nil
+		},
+	)
+
+	group := NewEventsGroup(0, 1)
+	messageData.AttachDMLMessage(first)
+	require.NoError(t, group.AppendMessage(first))
+	messageData.AttachDMLMessage(second)
+	require.NoError(t, group.AppendMessage(second))
+	require.Len(t, group.messages, 2)
+	require.Equal(t, group.messages[0].handle, group.messages[1].handle)
+	require.Equal(t, uint64(0), group.messages[0].dmlIndex)
+	require.Equal(t, uint64(1), group.messages[1].dmlIndex)
+
+	messages, err := group.GetAllMessages()
+	require.NoError(t, err)
+	require.Same(t, first, messages[0])
+	require.Same(t, second, messages[1])
 }
 
 func TestEventsGroupResolveIntoAppendsAndCleansResolvedSpillRecords(t *testing.T) {
@@ -175,9 +197,9 @@ func TestEventsGroupResolveIntoAppendsAndCleansResolvedSpillRecords(t *testing.T
 	m1 := newTestDMLMessage(1)
 	m2 := newTestDMLMessage(2)
 	m3 := newTestDMLMessage(3)
-	group.AppendMessage(m1)
-	group.AppendMessage(m2)
-	group.AppendMessage(m3)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m1)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m2)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m3)))
 
 	spillPath := group.spillFile.Path()
 
@@ -206,8 +228,8 @@ func TestEventsGroupResolveIntoNoopWhenNothingResolved(t *testing.T) {
 	group := NewEventsGroup(0, 1)
 	m1 := newTestDMLMessage(10)
 	m2 := newTestDMLMessage(20)
-	group.AppendMessage(m1)
-	group.AppendMessage(m2)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m1)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m2)))
 
 	dst := make([]*codeccommon.DMLMessage, 0, 1)
 	dst, err := group.ResolveInto(5, dst)
@@ -225,8 +247,8 @@ func TestEventsGroupResolveIntoClearsAllWhenFullyResolved(t *testing.T) {
 	group := NewEventsGroup(0, 1)
 	m1 := newTestDMLMessage(1)
 	m2 := newTestDMLMessage(2)
-	group.AppendMessage(m1)
-	group.AppendMessage(m2)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m1)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m2)))
 
 	spillPath := group.spillFile.Path()
 	var dst []*codeccommon.DMLMessage
@@ -248,9 +270,9 @@ func TestEventsGroupResolveIntoSortsOutOfOrderResolvedMessages(t *testing.T) {
 	m1 := newTestDMLMessage(20)
 	m2 := newTestDMLMessage(10)
 	m3 := newTestDMLMessage(30)
-	group.AppendMessage(m1)
-	group.AppendMessage(m2)
-	group.AppendMessage(m3)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m1)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m2)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m3)))
 
 	var dst []*codeccommon.DMLMessage
 	dst, err := group.ResolveInto(25, dst)
@@ -269,9 +291,9 @@ func TestEventsGroupResolveIntoKeepsSameCommitTsStable(t *testing.T) {
 	m1 := newTestDMLMessage(20)
 	m2 := newTestDMLMessage(10)
 	m3 := newTestDMLMessage(20)
-	group.AppendMessage(m1)
-	group.AppendMessage(m2)
-	group.AppendMessage(m3)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m1)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m2)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m3)))
 
 	var dst []*codeccommon.DMLMessage
 	dst, err := group.ResolveInto(20, dst)
@@ -289,9 +311,9 @@ func TestEventsGroupGetAllMessagesSortsOutOfOrderMessages(t *testing.T) {
 	m1 := newTestDMLMessage(20)
 	m2 := newTestDMLMessage(10)
 	m3 := newTestDMLMessage(30)
-	group.AppendMessage(m1)
-	group.AppendMessage(m2)
-	group.AppendMessage(m3)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m1)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m2)))
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(m3)))
 
 	messages, err := group.GetAllMessages()
 	require.NoError(t, err)
@@ -326,7 +348,8 @@ func TestEventsGroupRestoresSpilledEventRowsAndTableInfo(t *testing.T) {
 	event.Checksum = []*integrity.Checksum{{Current: 1, Previous: 2, Corrupted: true, Version: 3}}
 
 	group := NewEventsGroup(0, 1)
-	group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event))
+	message := codeccommon.NewDMLMessageFromEvent(event)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(message)))
 
 	messages, err := group.GetAllMessages()
 	require.NoError(t, err)
@@ -363,7 +386,8 @@ func TestEventsGroupRestoresRowsFromSharedChunk(t *testing.T) {
 		event.RowTypes = []common.RowType{common.RowTypeUpdate, common.RowTypeUpdate}
 		event.Length = 1
 		event.PreviousTotalOffset = offset
-		require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
+		message := codeccommon.NewDMLMessageFromEvent(event)
+		require.NoError(t, group.AppendMessage(attachTestDMLMessageData(message)))
 	}
 
 	messages, err := group.GetAllMessages()
@@ -404,7 +428,8 @@ func TestEventsGroupRestoresCompactUpdateRows(t *testing.T) {
 	event.Length = 1
 
 	group := NewEventsGroup(0, 1)
-	require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
+	message := codeccommon.NewDMLMessageFromEvent(event)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(message)))
 	messages, err := group.GetAllMessages()
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
@@ -427,7 +452,8 @@ func TestEventsGroupSpillDoesNotSignalDownstreamCallbacks(t *testing.T) {
 
 	group := NewEventsGroup(0, 1)
 	defer func() { require.NoError(t, group.Cleanup()) }()
-	require.NoError(t, group.AppendMessage(codeccommon.NewDMLMessageFromEvent(event)))
+	message := codeccommon.NewDMLMessageFromEvent(event)
+	require.NoError(t, group.AppendMessage(attachTestDMLMessageData(message)))
 	require.Zero(t, enqueued)
 	require.Zero(t, flushed)
 }
@@ -471,7 +497,7 @@ func BenchmarkEventsGroupResolveInto(b *testing.B) {
 			for b.Loop() {
 				group := NewEventsGroup(0, 1)
 				for _, message := range source {
-					if err := group.AppendMessage(message); err != nil {
+					if err := group.AppendMessage(attachTestDMLMessageData(message)); err != nil {
 						b.Fatal(err)
 					}
 				}

--- a/pkg/sink/codec/common/decoder.go
+++ b/pkg/sink/codec/common/decoder.go
@@ -14,9 +14,38 @@
 package common
 
 import (
+	"sync/atomic"
+
 	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 )
+
+// DMLMessageData keeps the original encoded input needed to restore a DML
+// message after it has been spilled. One input can be attached to multiple
+// DMLMessages; Attach assigns each message its ordinal in that input.
+type DMLMessageData struct {
+	ID      uint64
+	Key     []byte
+	Value   []byte
+	Restore func([]byte, uint64) (*DMLMessage, error)
+
+	nextDMLIndex uint64
+}
+
+var nextDMLMessageDataID atomic.Uint64
+
+// NewDMLMessageData creates data shared by DMLMessages decoded from one input.
+func NewDMLMessageData(
+	key, value []byte,
+	restore func([]byte, uint64) (*DMLMessage, error),
+) *DMLMessageData {
+	return &DMLMessageData{
+		ID:      nextDMLMessageDataID.Add(1),
+		Key:     key,
+		Value:   value,
+		Restore: restore,
+	}
+}
 
 type DMLMessage struct {
 	TableID int64
@@ -28,6 +57,8 @@ type DMLMessage struct {
 	// toDMLEvent may be called after the decoder has consumed later messages.
 	// It must only use data captured by this DMLMessage and must not depend on decoder cursor state.
 	toDMLEvent func() *commonEvent.DMLEvent
+	spillData  *DMLMessageData
+	dmlIndex   uint64
 }
 
 func NewDMLMessage(
@@ -72,6 +103,21 @@ func (m *DMLMessage) GetCommitTs() uint64 {
 
 func (m *DMLMessage) ToDMLEvent() *commonEvent.DMLEvent {
 	return m.toDMLEvent()
+}
+
+// AttachDMLMessageData attaches the original input required to restore this
+// message after spill. It must be called once for every decoded DML, including
+// DMLs the consumer later discards.
+func (d *DMLMessageData) AttachDMLMessage(message *DMLMessage) {
+	message.spillData = d
+	message.dmlIndex = d.nextDMLIndex
+	d.nextDMLIndex++
+}
+
+// SpillData returns the data and ordinal attached while this message was
+// decoded. They are used by the consumer's in-memory events group only.
+func (m *DMLMessage) SpillData() (*DMLMessageData, uint64) {
+	return m.spillData, m.dmlIndex
 }
 
 // Decoder is an abstraction for events decoder

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -194,10 +194,6 @@ echo "Group Number (parsed): ${group_num}"
 if [[ $group_num =~ ^[0-9]+$ ]] && [[ -n ${groups[10#${group_num}]} ]]; then
 	# force use decimal index
 	test_names="${groups[10#${group_num}]}"
-	if [[ "$sink_type" == "mysql" ]]; then
-		# Temporarily run the regression case in every MySQL shard.
-		test_names="ddl_for_split_tables_with_random_merge_and_split"
-	fi
 	# Run test cases
 	echo "Run cases: ${test_names}"
 	export TICDC_NEWARCH=true


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #2125

### What is changed and how it works?
Consumer EventsGroup now stores buffered DML messages in local spill files instead of retaining them in memory.
  Messages are serialized to a temporary file when appended, then restored only when the resolved-ts flushes them. Spill files are removed after all messages are consumed or when the consumer exits.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test 

Before this PR:
<img width="1475" height="195" alt="截屏2026-09-02 10 50 04" src="https://github.com/user-attachments/assets/20f49b17-67c0-48e3-a14a-5a7a6a5b6460" />
After this PR:
<img width="1475" height="195" alt="截屏2026-09-02 10 50 27" src="https://github.com/user-attachments/assets/4fd82c3a-fb54-4b1e-8d1e-3c99e4003f6e" />

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Event processing now reports failures from writing, flushing, restoration, and temporary-storage operations.
  * Restored data more reliably preserves row details, schema information, and shared event data.
  * Events with identical commit timestamps are preserved individually.
  * Invalid event data is detected more reliably.

* **Bug Fixes**
  * Cleanup continues across all event groups while retaining the first failure.
  * Temporary event data is cleaned up consistently after processing errors.
  * Fallback processing and deferred transformations remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->