### PR TITLE
maintainer: prevent stale spans from reentering scheduler state

### DIFF
--- a/maintainer/maintainer_controller.go
+++ b/maintainer/maintainer_controller.go
@@ -282,22 +282,21 @@ func (c *Controller) handleStatus(from node.ID, statusList []*heartbeatpb.TableS
 		// rescheduling, so we mark the span absent to let the scheduler recreate it.
 		//
 		// Safety against message reordering/resend:
-		// - We only reach here when stm != nil and stm.GetNodeID() == from (checked above). If the span was already
-		//   rebound to a different node, we skip it, so late statuses from the old node won't trigger rescheduling.
-		// - MarkSpanAbsent is idempotent and only affects the scheduler state, so even if we get duplicate terminal
-		//   statuses, the worst case is an extra no-op absent mark.
+		// MarkSpanAbsentIfCurrent atomically verifies that stm is still the current desired task and is still bound
+		// to the reporting node. A concurrent split, merge, move, or DDL removal therefore makes this a no-op.
 		if status.ComponentStatus == heartbeatpb.ComponentState_Stopped ||
 			status.ComponentStatus == heartbeatpb.ComponentState_Removed {
 			if op := operatorController.GetOperator(dispatcherID); op == nil {
 				if c.removeTerminalSpanCoveredByMergedSpan(spanController, stm) {
 					continue
 				}
-				log.Warn("dispatcher becomes non-working without operator, mark span absent for rescheduling",
-					zap.String("changefeed", c.changefeedID.Name()),
-					zap.String("from", from.String()),
-					zap.String("dispatcherID", dispatcherID.String()),
-					zap.Any("status", status))
-				spanController.MarkSpanAbsent(stm)
+				if spanController.MarkSpanAbsentIfCurrent(stm, from) {
+					log.Warn("dispatcher becomes non-working without operator, mark span absent for rescheduling",
+						zap.String("changefeed", c.changefeedID.Name()),
+						zap.String("from", from.String()),
+						zap.String("dispatcherID", dispatcherID.String()),
+						zap.Any("status", status))
+				}
 			}
 		}
 	}

--- a/maintainer/operator/operator_move_test.go
+++ b/maintainer/operator/operator_move_test.go
@@ -87,6 +87,7 @@ func setupTestEnvironment(t *testing.T) (*span.Controller, common.ChangeFeedID, 
 // 4. Verify that the move is aborted and the span is marked absent after origin is stopped
 func TestMoveOperator_DestNodeRemovedBeforeOriginStopped(t *testing.T) {
 	spanController, _, replicaSet, nodeA, nodeB := setupTestEnvironment(t)
+	spanController.AddReplicatingSpan(replicaSet)
 
 	op := NewMoveDispatcherOperator(spanController, replicaSet, nodeA, nodeB, 7)
 	require.NotNil(t, op)
@@ -131,6 +132,7 @@ func TestMoveOperator_DestNodeRemovedBeforeOriginStopped(t *testing.T) {
 // 5. Verify that the span is marked as absent for rescheduling
 func TestMoveOperator_DestNodeRemovedAfterOriginStopped(t *testing.T) {
 	spanController, _, replicaSet, nodeA, nodeB := setupTestEnvironment(t)
+	spanController.AddReplicatingSpan(replicaSet)
 
 	op := NewMoveDispatcherOperator(spanController, replicaSet, nodeA, nodeB, 7)
 	require.NotNil(t, op)
@@ -270,6 +272,7 @@ func TestMoveOperator_BothNodesRemovedBeforeStartDoesNotLeaveSchedulingWithoutNo
 // 4. Verify that the move is aborted and the span becomes absent for rescheduling
 func TestMoveOperator_DestThenOriginRemovedAbortsToAbsent(t *testing.T) {
 	spanController, _, replicaSet, nodeA, nodeB := setupTestEnvironment(t)
+	spanController.AddReplicatingSpan(replicaSet)
 
 	op := NewMoveDispatcherOperator(spanController, replicaSet, nodeA, nodeB, 7)
 	require.NotNil(t, op)

--- a/maintainer/operator/operator_split_test.go
+++ b/maintainer/operator/operator_split_test.go
@@ -31,6 +31,7 @@ import (
 // 4. Verify that the span is marked as absent, and split is not executed
 func TestSplitOperator_OriginNodeRemovedBeforeStopped(t *testing.T) {
 	spanController, _, replicaSet, nodeA, _ := setupTestEnvironment(t)
+	spanController.AddReplicatingSpan(replicaSet)
 
 	// Define split spans
 	splitSpans := []*heartbeatpb.TableSpan{
@@ -82,6 +83,7 @@ func TestSplitOperator_OriginNodeRemovedBeforeStopped(t *testing.T) {
 // 4. Verify that the span is still marked as absent, and split is not executed
 func TestSplitOperator_OriginNodeRemovedAfterStopped(t *testing.T) {
 	spanController, _, replicaSet, nodeA, _ := setupTestEnvironment(t)
+	spanController.AddReplicatingSpan(replicaSet)
 
 	// Define split spans
 	splitSpans := []*heartbeatpb.TableSpan{

--- a/maintainer/span/span_controller.go
+++ b/maintainer/span/span_controller.go
@@ -394,12 +394,31 @@ func (c *Controller) AddReplicatingSpan(span *replica.SpanReplication) {
 	c.untrackNonReplicatingSpan(span)
 }
 
-// MarkSpanAbsent marks span as absent
-func (c *Controller) MarkSpanAbsent(span *replica.SpanReplication) {
+// MarkSpanAbsent marks span as absent if it is still the current task for its dispatcher ID.
+func (c *Controller) MarkSpanAbsent(span *replica.SpanReplication) bool {
+	if span == nil {
+		return false
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.MarkAbsentWithoutLock(span)
-	c.trackNonReplicatingSpan(span)
+	return c.markSpanAbsentIfCurrentWithoutLock(span)
+}
+
+// MarkSpanAbsentIfCurrent marks span as absent if it is still the current task
+// and is still bound to expectedNode.
+func (c *Controller) MarkSpanAbsentIfCurrent(span *replica.SpanReplication, expectedNode node.ID) bool {
+	if span == nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	current, ok := c.allTasks[span.ID]
+	if !ok || current != span || current.GetNodeID() != expectedNode {
+		return false
+	}
+	return c.markSpanAbsentIfCurrentWithoutLock(span)
 }
 
 // MarkSpanScheduling marks span as scheduling
@@ -605,6 +624,16 @@ func (c *Controller) removeSpanWithoutLock(spans ...*replica.SpanReplication) {
 		}
 		delete(c.allTasks, span.ID)
 	}
+}
+
+func (c *Controller) markSpanAbsentIfCurrentWithoutLock(span *replica.SpanReplication) bool {
+	current, ok := c.allTasks[span.ID]
+	if !ok || current != span {
+		return false
+	}
+	c.MarkAbsentWithoutLock(current)
+	c.trackNonReplicatingSpan(current)
+	return true
 }
 
 func (c *Controller) trackNonReplicatingSpan(span *replica.SpanReplication) {

--- a/maintainer/span/span_controller_test.go
+++ b/maintainer/span/span_controller_test.go
@@ -592,6 +592,32 @@ func TestReplaceReplicaSet(t *testing.T) {
 	require.Equal(t, 2, controller.GetTaskSizeBySchemaID(1))
 }
 
+func TestMarkSpanAbsentIgnoresRemovedSpan(t *testing.T) {
+	controller := newControllerWithCheckerForTest(t)
+	replicaSpanID := common.NewDispatcherID()
+	replicaSpan := replica.NewWorkingSpanReplication(controller.changefeedID, replicaSpanID,
+		1,
+		testutil.GetTableSpanByID(3), &heartbeatpb.TableSpanStatus{
+			ID:              replicaSpanID.ToPB(),
+			ComponentStatus: heartbeatpb.ComponentState_Working,
+			CheckpointTs:    1,
+		}, "node1", false)
+	controller.AddReplicatingSpan(replicaSpan)
+
+	controller.ReplaceReplicaSet(
+		[]*replica.SpanReplication{replicaSpan},
+		[]*heartbeatpb.TableSpan{testutil.GetTableSpanByID(3), testutil.GetTableSpanByID(4)},
+		5,
+		[]node.ID{},
+	)
+	require.False(t, controller.MarkSpanAbsent(replicaSpan))
+
+	require.Nil(t, controller.GetTaskByID(replicaSpan.ID))
+	require.NotContains(t, controller.GetAbsentForTest(3), replicaSpan)
+	require.NotContains(t, controller.nonReplicatingCheckpointTs.checkpointTsBySpanID, replicaSpan.ID)
+	require.Equal(t, 2, controller.GetAbsentSize())
+}
+
 // TestMarkSpanAbsent tests the MarkSpanAbsent functionality
 func TestMarkSpanAbsent(t *testing.T) {
 	controller := newControllerWithCheckerForTest(t)
@@ -605,8 +631,32 @@ func TestMarkSpanAbsent(t *testing.T) {
 			CheckpointTs:    1,
 		}, "node1", false)
 	controller.AddReplicatingSpan(replicaSpan)
-	controller.MarkSpanAbsent(replicaSpan)
+	require.True(t, controller.MarkSpanAbsent(replicaSpan))
 	require.Equal(t, 1, controller.GetAbsentSize())
+	require.Equal(t, "", replicaSpan.GetNodeID().String())
+}
+
+func TestMarkSpanAbsentIfCurrentRejectsOldOwner(t *testing.T) {
+	controller := newControllerWithCheckerForTest(t)
+	replicaSpanID := common.NewDispatcherID()
+	replicaSpan := replica.NewWorkingSpanReplication(controller.changefeedID, replicaSpanID,
+		1,
+		testutil.GetTableSpanByID(3), &heartbeatpb.TableSpanStatus{
+			ID:              replicaSpanID.ToPB(),
+			ComponentStatus: heartbeatpb.ComponentState_Working,
+			CheckpointTs:    1,
+		}, "node1", false)
+	controller.AddReplicatingSpan(replicaSpan)
+	controller.BindSpanToNode("node1", "node2", replicaSpan)
+
+	require.False(t, controller.MarkSpanAbsentIfCurrent(replicaSpan, "node1"))
+	require.Equal(t, 0, controller.GetAbsentSize())
+	require.Equal(t, 1, controller.GetSchedulingSize())
+	require.Equal(t, "node2", replicaSpan.GetNodeID().String())
+
+	require.True(t, controller.MarkSpanAbsentIfCurrent(replicaSpan, "node2"))
+	require.Equal(t, 1, controller.GetAbsentSize())
+	require.Equal(t, 0, controller.GetSchedulingSize())
 	require.Equal(t, "", replicaSpan.GetNodeID().String())
 }
 

--- a/tests/integration_tests/ddl_for_split_tables_with_random_merge_and_split/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_merge_and_split/run.sh
@@ -181,7 +181,7 @@ main_with_consistent() {
 
 	kill -9 $NORMAL_TABLE_DDL_PID ${pids[@]} $MERGE_AND_SPLIT_TABLE_PID
 	# to ensure row changed events have been replicated to TiCDC
-	sleep 20
+	sleep 30
 	if ((RANDOM % 2)); then
 		# For rename table, modify column ddl, drop column, drop index and drop table ddl, the struct of table is wrong when appling snapshot.
 		# see https://github.com/pingcap/tidb/issues/63464.

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -194,6 +194,10 @@ echo "Group Number (parsed): ${group_num}"
 if [[ $group_num =~ ^[0-9]+$ ]] && [[ -n ${groups[10#${group_num}]} ]]; then
 	# force use decimal index
 	test_names="${groups[10#${group_num}]}"
+	if [[ "$sink_type" == "mysql" ]]; then
+		# Temporarily run the regression case in every MySQL shard.
+		test_names="ddl_for_split_tables_with_random_merge_and_split"
+	fi
 	# Run test cases
 	echo "Run cases: ${test_names}"
 	export TICDC_NEWARCH=true


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6072

### What is changed and how it works?
This PR prevents a stale SpanReplication from being reintroduced into the scheduler’s Absent set after it has already been removed, replaced, or rebound to another node.

  Previously, terminal dispatcher status handling performed the following operations separately:

  1. Look up the SpanReplication by dispatcher ID.
  2. Process the dispatcher’s Stopped or Removed status.
  3. Check that no operator exists.
  4. Call MarkSpanAbsent with the previously obtained span pointer.

  A concurrent split could call ReplaceReplicaSet between these operations. The split removed the old span and created its replacement spans, but the terminal-status handler still held a pointer to the old span. Because MarkSpanAbsent did not verify that the span was still part of the controller’s desired state, it inserted the obsolete span into the scheduler’s Absent set.

  This created a ghost Absent span: the scheduler repeatedly tried to create an Add operator for a dispatcher that no longer existed in the span controller, resulting in continuous add operator failed, span not found errors and a stalled checkpoint.

  This PR makes the transition safe in two ways:

  - MarkSpanAbsent now checks, while holding the span controller mutex, that the dispatcher ID is still registered in allTasks and that the registered value is the exact same SpanReplication instance. If the span has already been removed or replaced, the operation returns without changing scheduler or checkpoint-tracker state.

  - The terminal-status fallback uses MarkSpanAbsentIfCurrent, which additionally verifies under the same lock that the span is still bound to the node that reported the terminal status. This prevents a delayed Stopped status from an old owner from marking a span Absent after it has already been moved to another node.

  ReplaceReplicaSet and the new validation use the same span controller mutex. Therefore, removal/replacement and the Absent transition now have a deterministic order:

  ReplaceReplicaSet first
      -> old span is no longer the current task
      -> MarkSpanAbsent is skipped

  MarkSpanAbsent first
      -> the span is still current and owned by the reporting node
      -> the valid Absent transition completes

  The terminal-status warning is now emitted only when the span is actually transitioned to Absent. Stale terminal statuses that lose the atomic validation are ignored without producing a misleading state-change log.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a race condition that could stall the changefeed checkpoint and downstream replication after dispatcher split or move operations.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of terminal dispatcher statuses when no operator is available.
  - Prevented stale, removed, or reassigned spans from being incorrectly marked absent.
  - Ensured rescheduling occurs only when a span remains assigned to the reporting node.
  - Improved reliability during node removal and reassignment scenarios.
  - Increased synchronization wait time in split-and-merge integration checks.
  - Expanded MySQL test coverage across all test shards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->