### PR TITLE
dispatcher: avoid false DONE on duplicate in-flight block write

### DIFF
--- a/downstreamadapter/dispatcher/basic_dispatcher.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher.go
@@ -182,6 +182,10 @@ type BasicDispatcher struct {
 
 	// blockEventStatus is used to store the current pending ddl/sync point event and its block status.
 	blockEventStatus BlockEventStatus
+	// completedBlockEvent remembers the newest block event that has already
+	// finished local write/pass execution, so a later duplicate action can
+	// re-offer DONE if the original completion status was lost in transit.
+	completedBlockEvent completedBlockEventState
 
 	// tableProgress is used to calculate the checkpointTs of the dispatcher
 	tableProgress *TableProgress
@@ -813,8 +817,9 @@ func (d *BasicDispatcher) HandleDispatcherStatus(dispatcherStatus *heartbeatpb.D
 	// Step3: deal with the dispatcher action
 	action := dispatcherStatus.GetAction()
 	if action != nil {
-		pendingEvent := d.blockEventStatus.getEvent()
-		if pendingEvent == nil && action.CommitTs > d.GetResolvedTs() {
+		pendingEvent, blockStage := d.blockEventStatus.getEventAndStage()
+		if pendingEvent == nil && action.CommitTs > d.GetResolvedTs() &&
+			d.shouldIgnoreUnmatchedBlockAction(action, nil, blockStage) {
 			// we have not received the block event, and the action is for the future event, so just ignore
 			log.Debug("pending event is nil, and the action's commit is larger than dispatchers resolvedTs",
 				zap.Uint64("resolvedTs", d.GetResolvedTs()),
@@ -870,12 +875,18 @@ func (d *BasicDispatcher) HandleDispatcherStatus(dispatcherStatus *heartbeatpb.D
 				return false
 			}
 		} else {
-			ts, ok := d.blockEventStatus.getEventCommitTs()
-			if ok && action.CommitTs > ts {
-				log.Debug("pending event's commitTs is smaller than the action's commitTs, just ignore it",
-					zap.Uint64("pendingEventCommitTs", ts),
-					zap.Uint64("actionCommitTs", action.CommitTs),
-					zap.Stringer("dispatcher", d.id))
+			if d.shouldIgnoreUnmatchedBlockAction(action, pendingEvent, blockStage) {
+				if pendingEvent != nil && action.Action == heartbeatpb.Action_Write &&
+					action.CommitTs == pendingEvent.GetCommitTs() {
+					failpoint.Inject("BlockOrWaitBeforeDuplicateWriteOfferDone", nil)
+				}
+				log.Debug("ignore unmatched block action",
+					zap.Stringer("dispatcher", d.id),
+					zap.Int64("mode", d.mode),
+					zap.Uint64("commitTs", action.CommitTs),
+					zap.Bool("isSyncPoint", action.IsSyncPoint),
+					zap.Int("action", int(action.Action)),
+					zap.Any("blockStage", blockStage))
 				return false
 			}
 		}
@@ -884,6 +895,41 @@ func (d *BasicDispatcher) HandleDispatcherStatus(dispatcherStatus *heartbeatpb.D
 		d.offerDoneBlockStatus(action.CommitTs, action.IsSyncPoint)
 	}
 	return false
+}
+
+func (d *BasicDispatcher) shouldIgnoreUnmatchedBlockAction(
+	action *heartbeatpb.DispatcherAction,
+	pendingEvent commonEvent.BlockEvent,
+	blockStage heartbeatpb.BlockStage,
+) bool {
+	actionIdentifier := BlockEventIdentifier{
+		CommitTs:    action.CommitTs,
+		IsSyncPoint: action.IsSyncPoint,
+	}
+	if pendingEvent != nil {
+		pendingIdentifier := BlockEventIdentifier{
+			CommitTs:    pendingEvent.GetCommitTs(),
+			IsSyncPoint: pendingEvent.GetType() == commonEvent.TypeSyncPointEvent,
+		}
+		switch compareBlockEventIdentifier(actionIdentifier, pendingIdentifier) {
+		case 1:
+			return true
+		case 0:
+			// The current block event is still live. Duplicate actions for the
+			// same event must wait for the real write/pass completion to report DONE.
+			return blockStage != heartbeatpb.BlockStage_NONE
+		default:
+			return false
+		}
+	}
+
+	latestCompleted, ok := d.completedBlockEvent.latest()
+	if !ok {
+		return true
+	}
+	// Once a block event has completed locally, duplicate WRITE/PASS actions for
+	// that event or any older event can safely be answered with DONE again.
+	return compareBlockEventIdentifier(actionIdentifier, latestCompleted) > 0
 }
 
 // ExecuteBlockEventDDL writes the block event to the sink and then reports DONE to the maintainer.
@@ -917,6 +963,10 @@ func (d *BasicDispatcher) reportBlockedEventDone(
 	actionCommitTs uint64,
 	actionIsSyncPoint bool,
 ) {
+	d.completedBlockEvent.markDone(BlockEventIdentifier{
+		CommitTs:    actionCommitTs,
+		IsSyncPoint: actionIsSyncPoint,
+	})
 	d.offerDoneBlockStatus(actionCommitTs, actionIsSyncPoint)
 	GetDispatcherStatusDynamicStream().Wake(d.id)
 }

--- a/downstreamadapter/dispatcher/event_dispatcher_test.go
+++ b/downstreamadapter/dispatcher/event_dispatcher_test.go
@@ -686,6 +686,175 @@ func TestBlockingDDLFlushBeforeWaitingAndWriteDoesNotFlushAgain(t *testing.T) {
 	require.Equal(t, int32(1), flushCalls.Load())
 }
 
+func TestDuplicateWriteDoesNotOfferDoneWhileWriterStillWriting(t *testing.T) {
+	keyspaceID := getTestingKeyspaceID()
+	tableSpan := getUncompleteTableSpan()
+	tableSpan.KeyspaceID = keyspaceID
+	mockSink := newDispatcherTestSink(t, common.MysqlSinkType)
+
+	writeStarted := make(chan struct{}, 1)
+	writeRelease := make(chan struct{})
+	mockSink.SetWriteBlockEventHook(func(event commonEvent.BlockEvent) error {
+		if event.GetCommitTs() != 20 {
+			event.PostFlush()
+			return nil
+		}
+		select {
+		case writeStarted <- struct{}{}:
+		default:
+		}
+		<-writeRelease
+		event.PostFlush()
+		return nil
+	})
+
+	dispatcher := newDispatcherForTest(mockSink.Sink(), tableSpan)
+	nodeID := node.NewID()
+	ddlEvent := &commonEvent.DDLEvent{
+		FinishedTs: 20,
+		StartTs:    20,
+		BlockedTables: &commonEvent.InfluencedTables{
+			InfluenceType: commonEvent.InfluenceTypeNormal,
+			TableIDs:      []int64{1},
+		},
+	}
+
+	block := dispatcher.HandleEvents([]DispatcherEvent{NewDispatcherEvent(&nodeID, ddlEvent)}, func() {})
+	require.True(t, block)
+
+	msg, ok := takeBlockStatusWithTimeout(t, dispatcher, time.Second)
+	require.True(t, ok, "expected blocking DDL to enter WAITING")
+	require.True(t, msg.State.IsBlocked)
+	require.Equal(t, uint64(20), msg.State.BlockTs)
+	require.Equal(t, heartbeatpb.BlockStage_WAITING, msg.State.Stage)
+
+	await := dispatcher.HandleDispatcherStatus(&heartbeatpb.DispatcherStatus{
+		Action: &heartbeatpb.DispatcherAction{
+			Action:      heartbeatpb.Action_Write,
+			CommitTs:    ddlEvent.FinishedTs,
+			IsSyncPoint: false,
+		},
+	})
+	require.True(t, await)
+
+	select {
+	case <-writeStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "expected first write action to start sink write")
+	}
+
+	pendingEvent, blockStage := dispatcher.blockEventStatus.getEventAndStage()
+	require.Same(t, ddlEvent, pendingEvent)
+	require.Equal(t, heartbeatpb.BlockStage_WRITING, blockStage)
+
+	failpointName := "github.com/pingcap/ticdc/downstreamadapter/dispatcher/BlockOrWaitBeforeDuplicateWriteOfferDone"
+	require.NoError(t, failpoint.Enable(failpointName, `pause`))
+	failpointEnabled := true
+	defer func() {
+		if failpointEnabled {
+			require.NoError(t, failpoint.Disable(failpointName))
+		}
+	}()
+
+	duplicateAwaitCh := make(chan bool, 1)
+	go func() {
+		duplicateAwaitCh <- dispatcher.HandleDispatcherStatus(&heartbeatpb.DispatcherStatus{
+			Action: &heartbeatpb.DispatcherAction{
+				Action:      heartbeatpb.Action_Write,
+				CommitTs:    ddlEvent.FinishedTs,
+				IsSyncPoint: false,
+			},
+		})
+	}()
+
+	if msg, ok := takeBlockStatusWithTimeout(t, dispatcher, 200*time.Millisecond); ok {
+		require.FailNow(t, "unexpected DONE before duplicate write fallback resumed", "msg=%v", msg)
+	}
+
+	require.NoError(t, failpoint.Disable(failpointName))
+	failpointEnabled = false
+
+	require.False(t, <-duplicateAwaitCh)
+
+	msg, ok = takeBlockStatusWithTimeout(t, dispatcher, 200*time.Millisecond)
+	require.False(t, ok, "duplicate write must not offer DONE before the real write finishes: %v", msg)
+
+	pendingEvent, blockStage = dispatcher.blockEventStatus.getEventAndStage()
+	require.Same(t, ddlEvent, pendingEvent)
+	require.Equal(t, heartbeatpb.BlockStage_WRITING, blockStage)
+
+	close(writeRelease)
+
+	msg, ok = takeBlockStatusWithTimeout(t, dispatcher, time.Second)
+	require.True(t, ok, "expected DONE only after the real write finishes")
+	require.True(t, msg.State.IsBlocked)
+	require.Equal(t, uint64(20), msg.State.BlockTs)
+	require.Equal(t, heartbeatpb.BlockStage_DONE, msg.State.Stage)
+
+	require.Eventually(t, func() bool {
+		pendingEvent, blockStage = dispatcher.blockEventStatus.getEventAndStage()
+		return pendingEvent == nil && blockStage == heartbeatpb.BlockStage_NONE
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestDuplicateWriteReoffersDoneAfterRealWriteFinished(t *testing.T) {
+	keyspaceID := getTestingKeyspaceID()
+	tableSpan := getUncompleteTableSpan()
+	tableSpan.KeyspaceID = keyspaceID
+	mockSink := newDispatcherTestSink(t, common.MysqlSinkType)
+
+	dispatcher := newDispatcherForTest(mockSink.Sink(), tableSpan)
+	nodeID := node.NewID()
+	ddlEvent := &commonEvent.DDLEvent{
+		FinishedTs: 21,
+		StartTs:    21,
+		BlockedTables: &commonEvent.InfluencedTables{
+			InfluenceType: commonEvent.InfluenceTypeNormal,
+			TableIDs:      []int64{1},
+		},
+	}
+
+	block := dispatcher.HandleEvents([]DispatcherEvent{NewDispatcherEvent(&nodeID, ddlEvent)}, func() {})
+	require.True(t, block)
+
+	msg, ok := takeBlockStatusWithTimeout(t, dispatcher, time.Second)
+	require.True(t, ok, "expected blocking DDL to enter WAITING")
+	require.Equal(t, heartbeatpb.BlockStage_WAITING, msg.State.Stage)
+
+	await := dispatcher.HandleDispatcherStatus(&heartbeatpb.DispatcherStatus{
+		Action: &heartbeatpb.DispatcherAction{
+			Action:      heartbeatpb.Action_Write,
+			CommitTs:    ddlEvent.FinishedTs,
+			IsSyncPoint: false,
+		},
+	})
+	require.True(t, await)
+
+	msg, ok = takeBlockStatusWithTimeout(t, dispatcher, time.Second)
+	require.True(t, ok, "expected DONE after the real write finishes")
+	require.Equal(t, heartbeatpb.BlockStage_DONE, msg.State.Stage)
+
+	require.Eventually(t, func() bool {
+		pendingEvent, blockStage := dispatcher.blockEventStatus.getEventAndStage()
+		return pendingEvent == nil && blockStage == heartbeatpb.BlockStage_NONE
+	}, time.Second, 10*time.Millisecond)
+
+	await = dispatcher.HandleDispatcherStatus(&heartbeatpb.DispatcherStatus{
+		Action: &heartbeatpb.DispatcherAction{
+			Action:      heartbeatpb.Action_Write,
+			CommitTs:    ddlEvent.FinishedTs,
+			IsSyncPoint: false,
+		},
+	})
+	require.False(t, await)
+
+	msg, ok = takeBlockStatusWithTimeout(t, dispatcher, time.Second)
+	require.True(t, ok, "expected duplicate write to re-offer DONE after completion")
+	require.True(t, msg.State.IsBlocked)
+	require.Equal(t, uint64(21), msg.State.BlockTs)
+	require.Equal(t, heartbeatpb.BlockStage_DONE, msg.State.Stage)
+}
+
 // test uncompelete table span can correctly handle the ddl events
 func TestUncompeleteTableSpanDispatcherHandleEvents(t *testing.T) {
 	count.Swap(0)

--- a/downstreamadapter/dispatcher/helper.go
+++ b/downstreamadapter/dispatcher/helper.go
@@ -163,6 +163,41 @@ type BlockEventStatus struct {
 	blockCommitTs     uint64
 }
 
+type completedBlockEventState struct {
+	mutex      sync.Mutex
+	identifier BlockEventIdentifier
+	valid      bool
+}
+
+func (s *completedBlockEventState) markDone(identifier BlockEventIdentifier) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.identifier = identifier
+	s.valid = true
+}
+
+func (s *completedBlockEventState) latest() (BlockEventIdentifier, bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.identifier, s.valid
+}
+
+func compareBlockEventIdentifier(a, b BlockEventIdentifier) int {
+	if a.CommitTs < b.CommitTs {
+		return -1
+	}
+	if a.CommitTs > b.CommitTs {
+		return 1
+	}
+	if a.IsSyncPoint == b.IsSyncPoint {
+		return 0
+	}
+	if !a.IsSyncPoint && b.IsSyncPoint {
+		return -1
+	}
+	return 1
+}
+
 func (b *BlockEventStatus) clear() {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate or out-of-order blocking actions.
  * Prevented premature `DONE` responses while the original operation is still in progress.
  * Re-offered `DONE` after a blocking operation has completed, improving dispatcher reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->