### PR TITLE
tests: restore MySQL heavy test group selection

### DIFF
--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -194,10 +194,6 @@ echo "Group Number (parsed): ${group_num}"
 if [[ $group_num =~ ^[0-9]+$ ]] && [[ -n ${groups[10#${group_num}]} ]]; then
 	# force use decimal index
 	test_names="${groups[10#${group_num}]}"
-	if [[ "$sink_type" == "mysql" ]]; then
-		# Temporarily run the regression case in every MySQL shard.
-		test_names="ddl_for_split_tables_with_random_merge_and_split"
-	fi
 	# Run test cases
 	echo "Run cases: ${test_names}"
 	export TICDC_NEWARCH=true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6072

MySQL-heavy CI currently overwrites every shard's configured test list with `ddl_for_split_tables_with_random_merge_and_split`. As a result, all 16 shards run the G06 case and skip their intended per-shard coverage.

### What is changed and how it works?

Remove the temporary MySQL-only override from `run_heavy_it_in_ci.sh`. The existing G06 entry still runs the regression case, while every other shard again uses its configured `mysql_groups` entry.

### Check List

#### Tests

- Manual test (add detailed scripts or steps below)

Ran `bash -n`, `git diff --check`, and a read-only selection validation for MySQL G00-G15. All 16 groups selected their configured cases; G06 retained `ddl_for_split_tables_with_random_merge_and_split`.

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only restores the intended CI shard distribution and removes duplicate expensive work.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restored the standard test selection for MySQL CI groups.
  * Removed the temporary forced execution of a specific regression test across every MySQL shard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->