### PR TITLE
kafka: support private CA for OAuth token endpoint

### DIFF
--- a/api/v2/model.go
+++ b/api/v2/model.go
@@ -490,6 +490,7 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				SASLOAuthClientID:            c.Sink.KafkaConfig.SASLOAuthClientID,
 				SASLOAuthClientSecret:        c.Sink.KafkaConfig.SASLOAuthClientSecret,
 				SASLOAuthTokenURL:            c.Sink.KafkaConfig.SASLOAuthTokenURL,
+				SASLOAuthCA:                  c.Sink.KafkaConfig.SASLOAuthCA,
 				SASLOAuthScopes:              c.Sink.KafkaConfig.SASLOAuthScopes,
 				SASLOAuthGrantType:           c.Sink.KafkaConfig.SASLOAuthGrantType,
 				SASLOAuthAudience:            c.Sink.KafkaConfig.SASLOAuthAudience,
@@ -832,6 +833,7 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				SASLOAuthClientID:            cloned.Sink.KafkaConfig.SASLOAuthClientID,
 				SASLOAuthClientSecret:        cloned.Sink.KafkaConfig.SASLOAuthClientSecret,
 				SASLOAuthTokenURL:            cloned.Sink.KafkaConfig.SASLOAuthTokenURL,
+				SASLOAuthCA:                  cloned.Sink.KafkaConfig.SASLOAuthCA,
 				SASLOAuthScopes:              cloned.Sink.KafkaConfig.SASLOAuthScopes,
 				SASLOAuthGrantType:           cloned.Sink.KafkaConfig.SASLOAuthGrantType,
 				SASLOAuthAudience:            cloned.Sink.KafkaConfig.SASLOAuthAudience,
@@ -1581,6 +1583,7 @@ type KafkaConfig struct {
 	SASLOAuthClientID            *string                   `json:"sasl_oauth_client_id,omitempty" toml:"sasl-oauth-client-id,omitempty"`
 	SASLOAuthClientSecret        *string                   `json:"sasl_oauth_client_secret,omitempty" toml:"sasl-oauth-client-secret,omitempty"`
 	SASLOAuthTokenURL            *string                   `json:"sasl_oauth_token_url,omitempty" toml:"sasl-oauth-token-url,omitempty"`
+	SASLOAuthCA                  *string                   `json:"sasl_oauth_ca,omitempty" toml:"sasl-oauth-ca,omitempty"`
 	SASLOAuthScopes              []string                  `json:"sasl_oauth_scopes,omitempty" toml:"sasl-oauth-scopes,omitempty"`
 	SASLOAuthGrantType           *string                   `json:"sasl_oauth_grant_type,omitempty" toml:"sasl-oauth-grant-type,omitempty"`
 	SASLOAuthAudience            *string                   `json:"sasl_oauth_audience,omitempty" toml:"sasl-oauth-audience,omitempty"`

--- a/api/v2/model_test.go
+++ b/api/v2/model_test.go
@@ -90,6 +90,9 @@ func TestReplicaConfigConversion(t *testing.T) {
 			DebeziumConfig: &DebeziumConfig{
 				IncludeStartTs: util.AddressOf(true),
 			},
+			KafkaConfig: &KafkaConfig{
+				SASLOAuthCA: util.AddressOf("/etc/ssl/oauth-ca.pem"),
+			},
 		},
 		Mounter: &MounterConfig{
 			WorkerNum: util.AddressOf(16),
@@ -124,6 +127,7 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.Equal(t, int64(1024), util.GetOrZero(internalCfg.Sink.CloudStorageConfig.SpoolDiskQuota))
 	require.Equal(t, "/tmp/ticdc-spool", util.GetOrZero(internalCfg.Sink.CloudStorageConfig.SpoolBaseDir))
 	require.True(t, util.GetOrZero(internalCfg.Sink.Debezium.IncludeStartTs))
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(internalCfg.Sink.KafkaConfig.SASLOAuthCA))
 	require.Equal(t, internalCfg.Mounter.WorkerNum, *apiCfg.Mounter.WorkerNum)
 	require.True(t, util.GetOrZero(internalCfg.Scheduler.EnableTableAcrossNodes))
 	require.Equal(t, 1000, util.GetOrZero(internalCfg.Scheduler.RegionThreshold))
@@ -169,6 +173,7 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.Equal(t, "/tmp/ticdc-spool", *apiCfgBack.Sink.CloudStorageConfig.SpoolBaseDir)
 	require.True(t, util.GetOrZero(apiCfgBack.Sink.DebeziumConfig.IncludeStartTs))
 	require.True(t, util.GetOrZero(apiCfgBack.Sink.DebeziumConfig.OutputOldValue))
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(apiCfgBack.Sink.KafkaConfig.SASLOAuthCA))
 	require.Equal(t, 16, *apiCfgBack.Mounter.WorkerNum)
 	require.True(t, *apiCfgBack.Scheduler.EnableTableAcrossNodes)
 	require.Equal(t, "correctness", *apiCfgBack.Integrity.IntegrityCheckLevel)
@@ -325,22 +330,4 @@ func TestReplicaConfigCodecConfigConversion(t *testing.T) {
 	require.NotNil(t, apiCfgBack.Sink.KafkaConfig)
 	require.NotNil(t, apiCfgBack.Sink.KafkaConfig.CodecConfig)
 	require.True(t, util.GetOrZero(apiCfgBack.Sink.KafkaConfig.CodecConfig.AvroIncludeBeforeValue))
-}
-
-func TestReplicaConfigKafkaOAuthCAConversion(t *testing.T) {
-	t.Parallel()
-
-	apiCfg := &ReplicaConfig{
-		Sink: &SinkConfig{
-			KafkaConfig: &KafkaConfig{
-				SASLOAuthCA: util.AddressOf("/etc/ssl/oauth-ca.pem"),
-			},
-		},
-	}
-
-	internalCfg := apiCfg.ToInternalReplicaConfig()
-	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(internalCfg.Sink.KafkaConfig.SASLOAuthCA))
-
-	apiCfgBack := ToAPIReplicaConfig(internalCfg)
-	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(apiCfgBack.Sink.KafkaConfig.SASLOAuthCA))
 }

--- a/api/v2/model_test.go
+++ b/api/v2/model_test.go
@@ -326,3 +326,21 @@ func TestReplicaConfigCodecConfigConversion(t *testing.T) {
 	require.NotNil(t, apiCfgBack.Sink.KafkaConfig.CodecConfig)
 	require.True(t, util.GetOrZero(apiCfgBack.Sink.KafkaConfig.CodecConfig.AvroIncludeBeforeValue))
 }
+
+func TestReplicaConfigKafkaOAuthCAConversion(t *testing.T) {
+	t.Parallel()
+
+	apiCfg := &ReplicaConfig{
+		Sink: &SinkConfig{
+			KafkaConfig: &KafkaConfig{
+				SASLOAuthCA: util.AddressOf("/etc/ssl/oauth-ca.pem"),
+			},
+		},
+	}
+
+	internalCfg := apiCfg.ToInternalReplicaConfig()
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(internalCfg.Sink.KafkaConfig.SASLOAuthCA))
+
+	apiCfgBack := ToAPIReplicaConfig(internalCfg)
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(apiCfgBack.Sink.KafkaConfig.SASLOAuthCA))
+}

--- a/cmd/cdc/cli/cli_changefeed_create_test.go
+++ b/cmd/cdc/cli/cli_changefeed_create_test.go
@@ -77,6 +77,9 @@ func TestTomlFileToApiModel(t *testing.T) {
 
 	[sink.mysql-config]
 	async-ddl-timeout = "45m"
+
+	[sink.kafka-config]
+	sasl-oauth-ca = "/etc/ssl/oauth-ca.pem"
 `
 	err := os.WriteFile(path, []byte(content), 0o644)
 	require.Nil(t, err)
@@ -87,7 +90,10 @@ func TestTomlFileToApiModel(t *testing.T) {
 	err = o.strictDecodeConfig("cdc", cfg)
 	require.Nil(t, err)
 	apiModel := v2.ToAPIReplicaConfig(cfg)
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", *cfg.Sink.KafkaConfig.SASLOAuthCA)
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", *apiModel.Sink.KafkaConfig.SASLOAuthCA)
 	cfg2 := apiModel.ToInternalReplicaConfig()
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", *cfg2.Sink.KafkaConfig.SASLOAuthCA)
 	cfgBuf, err := json.MarshalIndent(cfg, "", "  ")
 	require.NoError(t, err)
 	cfg2Buf, err := json.MarshalIndent(cfg2, "", "  ")

--- a/pkg/config/replica_config_test.go
+++ b/pkg/config/replica_config_test.go
@@ -194,6 +194,25 @@ func TestReplicaConfig_EnableSplittableCheck_DefaultValue(t *testing.T) {
 	require.False(t, util.GetOrZero(config.Scheduler.EnableSplittableCheck))
 }
 
+func TestReplicaConfigClonePreservesKafkaOAuthCA(t *testing.T) {
+	t.Parallel()
+
+	cfg := GetDefaultReplicaConfig()
+	cfg.Sink.KafkaConfig = &KafkaConfig{
+		SASLOAuthCA: util.AddressOf("/etc/ssl/oauth-ca.pem"),
+	}
+
+	cloned := cfg.Clone()
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(cloned.Sink.KafkaConfig.SASLOAuthCA))
+	require.NotSame(t, cfg.Sink.KafkaConfig.SASLOAuthCA, cloned.Sink.KafkaConfig.SASLOAuthCA)
+	encoded, err := cfg.Marshal()
+	require.NoError(t, err)
+	require.Contains(t, encoded, `"sasl-oauth-ca":"/etc/ssl/oauth-ca.pem"`)
+
+	*cloned.Sink.KafkaConfig.SASLOAuthCA = "/etc/ssl/other-ca.pem"
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", util.GetOrZero(cfg.Sink.KafkaConfig.SASLOAuthCA))
+}
+
 func TestReplicaConfigPerformanceMode(t *testing.T) {
 	sinkURI, err := url.Parse("mysql://localhost:3306/test")
 	require.NoError(t, err)

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -489,6 +489,7 @@ type KafkaConfig struct {
 	SASLOAuthClientID            *string                   `toml:"sasl-oauth-client-id" json:"sasl-oauth-client-id,omitempty"`
 	SASLOAuthClientSecret        *string                   `toml:"sasl-oauth-client-secret" json:"sasl-oauth-client-secret,omitempty"`
 	SASLOAuthTokenURL            *string                   `toml:"sasl-oauth-token-url" json:"sasl-oauth-token-url,omitempty"`
+	SASLOAuthCA                  *string                   `toml:"sasl-oauth-ca" json:"sasl-oauth-ca,omitempty"`
 	SASLOAuthScopes              []string                  `toml:"sasl-oauth-scopes" json:"sasl-oauth-scopes,omitempty"`
 	SASLOAuthGrantType           *string                   `toml:"sasl-oauth-grant-type" json:"sasl-oauth-grant-type,omitempty"`
 	SASLOAuthAudience            *string                   `toml:"sasl-oauth-audience" json:"sasl-oauth-audience,omitempty"`

--- a/pkg/sink/kafka/options.go
+++ b/pkg/sink/kafka/options.go
@@ -515,6 +515,15 @@ func (o *options) applySASL(urlParameter *urlConfig, sinkConfig *config.SinkConf
 			o.sasl.oauth2.tokenURL = tokenURL
 		}
 
+		if sinkConfig.KafkaConfig.SASLOAuthCA != nil {
+			caPath := *sinkConfig.KafkaConfig.SASLOAuthCA
+			if caPath == "" {
+				return errors.ErrKafkaInvalidConfig.GenWithStack(
+					"OAuth2 CA path cannot be empty")
+			}
+			o.sasl.oauth2.caPath = caPath
+		}
+
 		if o.sasl.oauth2.clientID != "" ||
 			o.sasl.oauth2.clientSecret != "" ||
 			o.sasl.oauth2.tokenURL != "" {

--- a/pkg/sink/kafka/options_test.go
+++ b/pkg/sink/kafka/options_test.go
@@ -259,6 +259,7 @@ func TestApplySASL(t *testing.T) {
 				SASLOAuthClientID:     aws.String("client_id"),
 				SASLOAuthClientSecret: aws.String("Y2xpZW50X3NlY3JldA=="),
 				SASLOAuthTokenURL:     aws.String("127.0.0.1:9093/token"),
+				SASLOAuthCA:           aws.String("/etc/ssl/oauth-ca.pem"),
 			},
 			expected: saslConfig{
 				mechanism: oauthMechanism,
@@ -266,6 +267,7 @@ func TestApplySASL(t *testing.T) {
 					clientID:     "client_id",
 					clientSecret: "client_secret",
 					tokenURL:     "127.0.0.1:9093/token",
+					caPath:       "/etc/ssl/oauth-ca.pem",
 					grantType:    "client_credentials",
 				},
 			},
@@ -317,6 +319,17 @@ func TestApplySASL(t *testing.T) {
 			},
 			expectErr: "OAuth2 is only supported with SASL mechanism type OAUTHBEARER",
 		},
+		{
+			name: "invalid OAUTHBEARER SASL: empty CA path",
+			uri:  baseURI + "?sasl-mechanism=OAUTHBEARER",
+			kafkaConfig: &config.KafkaConfig{
+				SASLOAuthClientID:     aws.String("client_id"),
+				SASLOAuthClientSecret: aws.String("Y2xpZW50X3NlY3JldA=="),
+				SASLOAuthTokenURL:     aws.String("127.0.0.1:9093/token"),
+				SASLOAuthCA:           aws.String(""),
+			},
+			expectErr: "OAuth2 CA path cannot be empty",
+		},
 	}
 
 	for _, test := range tests {
@@ -343,6 +356,34 @@ func TestApplySASL(t *testing.T) {
 			require.Equal(t, test.expected, *options.sasl)
 		})
 	}
+}
+
+func TestOAuthCAIsIndependentFromBrokerTLS(t *testing.T) {
+	t.Parallel()
+
+	sinkURI, err := url.Parse("kafka://127.0.0.1:9092/abc?sasl-mechanism=OAUTHBEARER")
+	require.NoError(t, err)
+	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.KafkaConfig = &config.KafkaConfig{
+		SASLOAuthClientID:     aws.String("client_id"),
+		SASLOAuthClientSecret: aws.String("Y2xpZW50X3NlY3JldA=="),
+		SASLOAuthTokenURL:     aws.String("https://oauth.example.com/token"),
+		SASLOAuthCA:           aws.String("/etc/ssl/oauth-ca.pem"),
+		CA:                    aws.String("/etc/ssl/broker-ca.pem"),
+		Cert:                  aws.String("/etc/ssl/broker-cert.pem"),
+		Key:                   aws.String("/etc/ssl/broker-key.pem"),
+	}
+
+	options := NewOptions()
+	require.NoError(t, options.Apply(
+		common.NewChangefeedID4Test(common.DefaultKeyspaceName, "test"),
+		sinkURI,
+		replicaConfig.Sink,
+	))
+	require.Equal(t, "/etc/ssl/oauth-ca.pem", options.sasl.oauth2.caPath)
+	require.Equal(t, "/etc/ssl/broker-ca.pem", options.Credential.CAPath)
+	require.Equal(t, "/etc/ssl/broker-cert.pem", options.Credential.CertPath)
+	require.Equal(t, "/etc/ssl/broker-key.pem", options.Credential.KeyPath)
 }
 
 func TestApplyTLS(t *testing.T) {

--- a/pkg/sink/kafka/sarama_oauth2_token_provider.go
+++ b/pkg/sink/kafka/sarama_oauth2_token_provider.go
@@ -15,7 +15,11 @@ package kafka
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/IBM/sarama"
 	"github.com/pingcap/ticdc/pkg/errors"
@@ -71,6 +75,13 @@ func newTokenProvider(ctx context.Context, o *options) (sarama.AccessTokenProvid
 		return nil, errors.WrapError(errors.ErrKafkaInvalidConfig, err)
 	}
 
+	if o.sasl.oauth2.caPath != "" {
+		ctx, err = contextWithOAuthCA(ctx, o.sasl.oauth2.caPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	cfg := clientcredentials.Config{
 		ClientID:       o.sasl.oauth2.clientID,
 		ClientSecret:   o.sasl.oauth2.clientSecret,
@@ -81,4 +92,38 @@ func newTokenProvider(ctx context.Context, o *options) (sarama.AccessTokenProvid
 	return &tokenProvider{
 		tokenSource: cfg.TokenSource(ctx),
 	}, nil
+}
+
+func contextWithOAuthCA(ctx context.Context, caPath string) (context.Context, error) {
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, errors.WrapError(errors.ErrKafkaInvalidConfig, err)
+	}
+
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, errors.WrapError(errors.ErrKafkaInvalidConfig, err)
+	}
+	if !rootCAs.AppendCertsFromPEM(caPEM) {
+		return nil, errors.ErrKafkaInvalidConfig.GenWithStack(
+			"OAuth2 CA file %q does not contain a valid certificate", caPath)
+	}
+
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.ErrKafkaInvalidConfig.GenWithStack(
+			"cannot configure OAuth2 CA file %q with HTTP transport type %T",
+			caPath, http.DefaultTransport)
+	}
+	transport := defaultTransport.Clone()
+	tlsConfig := transport.TLSClientConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+	tlsConfig.RootCAs = rootCAs
+	transport.TLSClientConfig = tlsConfig
+	httpClient := &http.Client{Transport: transport}
+	return context.WithValue(ctx, oauth2.HTTPClient, httpClient), nil
 }

--- a/pkg/sink/kafka/sarama_oauth2_token_provider.go
+++ b/pkg/sink/kafka/sarama_oauth2_token_provider.go
@@ -116,14 +116,9 @@ func contextWithOAuthCA(ctx context.Context, caPath string) (context.Context, er
 			caPath, http.DefaultTransport)
 	}
 	transport := defaultTransport.Clone()
-	tlsConfig := transport.TLSClientConfig
-	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
-	} else {
-		tlsConfig = tlsConfig.Clone()
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
 	}
-	tlsConfig.RootCAs = rootCAs
-	transport.TLSClientConfig = tlsConfig
-	httpClient := &http.Client{Transport: transport}
-	return context.WithValue(ctx, oauth2.HTTPClient, httpClient), nil
+	transport.TLSClientConfig.RootCAs = rootCAs
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: transport}), nil
 }

--- a/pkg/sink/kafka/sarama_oauth2_token_provider_test.go
+++ b/pkg/sink/kafka/sarama_oauth2_token_provider_test.go
@@ -15,21 +15,17 @@ package kafka
 
 import (
 	"context"
-	"crypto/ed25519"
-	"crypto/rand"
-	"crypto/x509"
 	"encoding/pem"
 	"io"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/security"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
@@ -185,35 +181,16 @@ func TestTokenProviderRejectsMismatchedOAuthCA(t *testing.T) {
 	t.Parallel()
 
 	tokenServer := newTLSTokenServer(t)
-	options := newOAuthOptions(tokenServer.URL, writeUnrelatedCA(t))
+	unrelatedCA, err := security.NewCA()
+	require.NoError(t, err)
+	caPath := filepath.Join(t.TempDir(), "unrelated-ca.pem")
+	require.NoError(t, os.WriteFile(caPath, unrelatedCA.CAPEM, 0o600))
+	options := newOAuthOptions(tokenServer.URL, caPath)
 
 	provider, err := newTokenProvider(t.Context(), options)
 	require.NoError(t, err)
 	_, err = provider.Token()
 	require.ErrorContains(t, err, "certificate signed by unknown authority")
-}
-
-func writeUnrelatedCA(t *testing.T) string {
-	t.Helper()
-
-	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	template := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	certificate, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
-	require.NoError(t, err)
-
-	caPath := filepath.Join(t.TempDir(), "unrelated-ca.pem")
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate})
-	require.NotNil(t, caPEM)
-	require.NoError(t, os.WriteFile(caPath, caPEM, 0o600))
-	return caPath
 }
 
 func TestTokenProviderWithoutOAuthCAKeepsContextHTTPClient(t *testing.T) {

--- a/pkg/sink/kafka/sarama_oauth2_token_provider_test.go
+++ b/pkg/sink/kafka/sarama_oauth2_token_provider_test.go
@@ -14,11 +14,20 @@
 package kafka
 
 import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -131,4 +140,126 @@ func TestTokenProviderPropagatesEndpointError(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, retrieveErr.Response.StatusCode)
 	require.Equal(t, "invalid_client", retrieveErr.ErrorCode)
 	require.Equal(t, "bad credentials", retrieveErr.ErrorDescription)
+}
+
+func TestTokenProviderUsesOAuthCA(t *testing.T) {
+	t.Parallel()
+
+	server := newTLSTokenServer(t)
+	caPath := writeServerCA(t, server)
+	options := newOAuthOptions(server.URL, caPath)
+
+	provider, err := newTokenProvider(t.Context(), options)
+	require.NoError(t, err)
+	token, err := provider.Token()
+	require.NoError(t, err)
+	require.Equal(t, "access-token", token.Token)
+}
+
+func TestTokenProviderRejectsInvalidOAuthCA(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+
+		caPath := filepath.Join(t.TempDir(), "missing-ca.pem")
+		_, err := newTokenProvider(t.Context(), newOAuthOptions("https://example.com/token", caPath))
+		require.ErrorIs(t, err, errors.ErrKafkaInvalidConfig)
+		require.ErrorContains(t, err, caPath)
+		require.ErrorContains(t, err, "no such file")
+	})
+
+	t.Run("invalid PEM", func(t *testing.T) {
+		t.Parallel()
+
+		caPath := filepath.Join(t.TempDir(), "invalid-ca.pem")
+		require.NoError(t, os.WriteFile(caPath, []byte("not a certificate"), 0o600))
+		_, err := newTokenProvider(t.Context(), newOAuthOptions("https://example.com/token", caPath))
+		require.ErrorIs(t, err, errors.ErrKafkaInvalidConfig)
+		require.ErrorContains(t, err, caPath)
+		require.ErrorContains(t, err, "does not contain a valid certificate")
+	})
+}
+
+func TestTokenProviderRejectsMismatchedOAuthCA(t *testing.T) {
+	t.Parallel()
+
+	tokenServer := newTLSTokenServer(t)
+	options := newOAuthOptions(tokenServer.URL, writeUnrelatedCA(t))
+
+	provider, err := newTokenProvider(t.Context(), options)
+	require.NoError(t, err)
+	_, err = provider.Token()
+	require.ErrorContains(t, err, "certificate signed by unknown authority")
+}
+
+func writeUnrelatedCA(t *testing.T) string {
+	t.Helper()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	require.NoError(t, err)
+
+	caPath := filepath.Join(t.TempDir(), "unrelated-ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate})
+	require.NotNil(t, caPEM)
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0o600))
+	return caPath
+}
+
+func TestTokenProviderWithoutOAuthCAKeepsContextHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	server := newTLSTokenServer(t)
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, server.Client())
+	provider, err := newTokenProvider(ctx, newOAuthOptions(server.URL, ""))
+	require.NoError(t, err)
+	token, err := provider.Token()
+	require.NoError(t, err)
+	require.Equal(t, "access-token", token.Token)
+}
+
+func newTLSTokenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, `{"access_token":"access-token","token_type":"bearer"}`); err != nil {
+			t.Errorf("write token response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeServerCA(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	require.NotNil(t, caPEM)
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0o600))
+	return caPath
+}
+
+func newOAuthOptions(tokenURL, caPath string) *options {
+	return &options{
+		sasl: &saslConfig{
+			oauth2: oauth2Config{
+				clientID:     "client-id",
+				clientSecret: "client-secret",
+				tokenURL:     tokenURL,
+				caPath:       caPath,
+			},
+		},
+	}
 }

--- a/pkg/sink/kafka/sasl_config.go
+++ b/pkg/sink/kafka/sasl_config.go
@@ -68,6 +68,7 @@ type oauth2Config struct {
 	clientID     string
 	clientSecret string
 	tokenURL     string
+	caPath       string
 	scopes       []string
 	grantType    string
 	audience     string


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6141

Kafka OAuth token requests use the default HTTP trust store. An HTTPS token endpoint signed by a private CA cannot be used, and changefeed configuration rejects `sink.kafka-config.sasl-oauth-ca` as unknown.

### What is changed and how it works?

- Add `sasl-oauth-ca` to the Kafka sink configuration model with TOML and internal JSON names, clone support, API model conversion, and strict configuration parsing coverage.
- Propagate the CA path through Kafka OAuth options independently from the broker `ca`, `cert`, and `key` settings.
- When the setting is present, read the CA PEM while constructing the OAuth token provider, append its certificates to the system certificate pool, and install the pool on a cloned `http.DefaultTransport`.
- Create a dedicated HTTP client from that transport and attach it to a derived context with the library-defined `oauth2.HTTPClient` key. `clientcredentials.Config.TokenSource` uses this client for token acquisition; the parent context and broker transport remain unchanged.
- Preserve the existing default HTTP client behavior when the setting is absent.
- Return `ErrKafkaInvalidConfig` with the configured path and cause for missing files and PEM files that contain no valid certificate.

### Check List

#### Tests

- [x] Unit test

The tests cover strict TOML parsing, configuration clone and API conversion, Kafka option propagation, broker TLS isolation, private CA success, missing and invalid CA files, CA mismatch, OAuth HTTP client scoping, and the behavior without a custom CA.

#### Questions

##### Will it cause performance regression or break compatibility?

No. The new setting is optional. Existing changefeeds retain their current token client and broker TLS behavior. The certificate pool and HTTP transport are created once while constructing a Kafka client when the setting is present.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No design or monitoring changes are required. The new configuration behavior is described in this PR and covered by configuration and provider tests.

### Release note

```release-note
Support private CA certificates for Kafka OAuth token endpoints through the `sasl-oauth-ca` changefeed setting.
```
