### PR TITLE
simple: output start_ts in JSON DML messages

### DIFF
--- a/api/v2/changefeed_toml_test.go
+++ b/api/v2/changefeed_toml_test.go
@@ -124,7 +124,10 @@ func TestChangeFeedInfoTOMLRoundTripToInternal(t *testing.T) {
 	require.Contains(t, out, "start-ts")
 	require.Contains(t, out, "[config.sink.debezium]")
 	require.Contains(t, out, "[config.sink.simple]")
-	require.Contains(t, out, "include-start-ts = true")
+	// Assert include-start-ts under each protocol table so a Debezium-only
+	// serialization cannot satisfy the Simple round-trip.
+	require.Regexp(t, `(?s)\[config\.sink\.debezium\][^\[]*include-start-ts = true`, out)
+	require.Regexp(t, `(?s)\[config\.sink\.simple\][^\[]*include-start-ts = true`, out)
 	require.NotContains(t, out, "gid") // GID is omitted from TOML (toml:"-")
 
 	// The [config] section must decode into the internal ReplicaConfig used by

--- a/api/v2/changefeed_toml_test.go
+++ b/api/v2/changefeed_toml_test.go
@@ -97,6 +97,9 @@ func TestChangeFeedInfoTOMLRoundTripToInternal(t *testing.T) {
 				DebeziumConfig: &DebeziumConfig{
 					IncludeStartTs: util.AddressOf(true),
 				},
+				SimpleConfig: &SimpleConfig{
+					IncludeStartTs: util.AddressOf(true),
+				},
 			},
 			SyncPointInterval: &JSONDuration{duration: 10 * time.Minute},
 			Integrity: &IntegrityConfig{
@@ -120,6 +123,7 @@ func TestChangeFeedInfoTOMLRoundTripToInternal(t *testing.T) {
 	require.Contains(t, out, `sink-uri = "blackhole://"`)
 	require.Contains(t, out, "start-ts")
 	require.Contains(t, out, "[config.sink.debezium]")
+	require.Contains(t, out, "[config.sink.simple]")
 	require.Contains(t, out, "include-start-ts = true")
 	require.NotContains(t, out, "gid") // GID is omitted from TOML (toml:"-")
 
@@ -139,6 +143,7 @@ func TestChangeFeedInfoTOMLRoundTripToInternal(t *testing.T) {
 	require.Equal(t, "correctness", util.GetOrZero(wrapper.Config.Integrity.IntegrityCheckLevel))
 	require.Equal(t, "eventual", util.GetOrZero(wrapper.Config.Consistent.Level))
 	require.True(t, util.GetOrZero(wrapper.Config.Sink.Debezium.IncludeStartTs))
+	require.True(t, util.GetOrZero(wrapper.Config.Sink.Simple.IncludeStartTs))
 }
 
 func TestCodecConfigTOMLRoundTripToInternal(t *testing.T) {

--- a/api/v2/model.go
+++ b/api/v2/model.go
@@ -561,6 +561,12 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				OutputOldValue: c.Sink.OpenProtocolConfig.OutputOldValue,
 			}
 		}
+		var simpleConfig *config.SimpleConfig
+		if c.Sink.SimpleConfig != nil && c.Sink.SimpleConfig.IncludeStartTs != nil {
+			simpleConfig = &config.SimpleConfig{
+				IncludeStartTs: util.AddressOf(*c.Sink.SimpleConfig.IncludeStartTs),
+			}
+		}
 
 		res.Sink = &config.SinkConfig{
 			DispatchRules:                    dispatchRules,
@@ -583,6 +589,7 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 			SafeMode:                         c.Sink.SafeMode,
 			OpenProtocol:                     openProtocolConfig,
 			Debezium:                         debeziumConfig,
+			Simple:                           simpleConfig,
 		}
 
 		if c.Sink.TxnAtomicity != nil {
@@ -930,6 +937,12 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				OutputOldValue: cloned.Sink.OpenProtocol.OutputOldValue,
 			}
 		}
+		var simpleConfig *SimpleConfig
+		if cloned.Sink.Simple != nil && cloned.Sink.Simple.IncludeStartTs != nil {
+			simpleConfig = &SimpleConfig{
+				IncludeStartTs: util.AddressOf(*cloned.Sink.Simple.IncludeStartTs),
+			}
+		}
 		res.Sink = &SinkConfig{
 			Protocol:                         cloned.Sink.Protocol,
 			SchemaRegistry:                   cloned.Sink.SchemaRegistry,
@@ -951,6 +964,7 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 			SafeMode:                         cloned.Sink.SafeMode,
 			DebeziumConfig:                   debeziumConfig,
 			OpenProtocolConfig:               openProtocolConfig,
+			SimpleConfig:                     simpleConfig,
 		}
 
 		if cloned.Sink.TxnAtomicity != nil {
@@ -1220,6 +1234,7 @@ type SinkConfig struct {
 	DebeziumDisableSchema            *bool               `json:"debezium_disable_schema,omitempty" toml:"debezium-disable-schema,omitempty"`
 	DebeziumConfig                   *DebeziumConfig     `json:"debezium,omitempty" toml:"debezium,omitempty"`
 	OpenProtocolConfig               *OpenProtocolConfig `json:"open,omitempty" toml:"open,omitempty"`
+	SimpleConfig                     *SimpleConfig       `json:"simple,omitempty" toml:"simple,omitempty"`
 }
 
 // CSVConfig denotes the csv config
@@ -1660,6 +1675,11 @@ type OpenProtocolConfig struct {
 // DebeziumConfig represents the configurations for debezium protocol encoding
 type DebeziumConfig struct {
 	OutputOldValue *bool `json:"output_old_value,omitempty" toml:"output-old-value,omitempty"`
+	IncludeStartTs *bool `json:"include_start_ts,omitempty" toml:"include-start-ts,omitempty"`
+}
+
+// SimpleConfig represents the configurations for simple protocol encoding
+type SimpleConfig struct {
 	IncludeStartTs *bool `json:"include_start_ts,omitempty" toml:"include-start-ts,omitempty"`
 }
 

--- a/api/v2/model_test.go
+++ b/api/v2/model_test.go
@@ -90,6 +90,9 @@ func TestReplicaConfigConversion(t *testing.T) {
 			DebeziumConfig: &DebeziumConfig{
 				IncludeStartTs: util.AddressOf(true),
 			},
+			SimpleConfig: &SimpleConfig{
+				IncludeStartTs: util.AddressOf(true),
+			},
 		},
 		Mounter: &MounterConfig{
 			WorkerNum: util.AddressOf(16),
@@ -124,6 +127,7 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.Equal(t, int64(1024), util.GetOrZero(internalCfg.Sink.CloudStorageConfig.SpoolDiskQuota))
 	require.Equal(t, "/tmp/ticdc-spool", util.GetOrZero(internalCfg.Sink.CloudStorageConfig.SpoolBaseDir))
 	require.True(t, util.GetOrZero(internalCfg.Sink.Debezium.IncludeStartTs))
+	require.True(t, util.GetOrZero(internalCfg.Sink.Simple.IncludeStartTs))
 	require.Equal(t, internalCfg.Mounter.WorkerNum, *apiCfg.Mounter.WorkerNum)
 	require.True(t, util.GetOrZero(internalCfg.Scheduler.EnableTableAcrossNodes))
 	require.Equal(t, 1000, util.GetOrZero(internalCfg.Scheduler.RegionThreshold))
@@ -168,6 +172,7 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.Equal(t, int64(1024), *apiCfgBack.Sink.CloudStorageConfig.SpoolDiskQuota)
 	require.Equal(t, "/tmp/ticdc-spool", *apiCfgBack.Sink.CloudStorageConfig.SpoolBaseDir)
 	require.True(t, util.GetOrZero(apiCfgBack.Sink.DebeziumConfig.IncludeStartTs))
+	require.True(t, util.GetOrZero(apiCfgBack.Sink.SimpleConfig.IncludeStartTs))
 	require.True(t, util.GetOrZero(apiCfgBack.Sink.DebeziumConfig.OutputOldValue))
 	require.Equal(t, 16, *apiCfgBack.Mounter.WorkerNum)
 	require.True(t, *apiCfgBack.Scheduler.EnableTableAcrossNodes)

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -211,6 +211,8 @@ type SinkConfig struct {
 	OpenProtocol *OpenProtocolConfig `toml:"open" json:"open,omitempty"`
 	// DebeziumConfig related configurations
 	Debezium *DebeziumConfig `toml:"debezium" json:"debezium,omitempty"`
+	// Simple protocol related configurations
+	Simple *SimpleConfig `toml:"simple" json:"simple,omitempty"`
 
 	CaseSensitive *bool `toml:"case-sensitive" json:"case-sensitive,omitempty"`
 	// Integrity is only available when the downstream is MQ.
@@ -1181,6 +1183,13 @@ type DebeziumConfig struct {
 	OutputOldValue bool `toml:"output-old-value" json:"output-old-value"`
 	// IncludeStartTs controls whether the transaction start_ts is included in
 	// the source block of Debezium JSON output.
+	IncludeStartTs *bool `toml:"include-start-ts" json:"include-start-ts,omitempty"`
+}
+
+// SimpleConfig represents the configurations for simple protocol encoding
+type SimpleConfig struct {
+	// IncludeStartTs controls whether the transaction start_ts is included in
+	// Simple JSON DML messages. Encoding-format=avro rejects this option.
 	IncludeStartTs *bool `toml:"include-start-ts" json:"include-start-ts,omitempty"`
 }
 

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -102,6 +102,9 @@ type Config struct {
 	// Debezium only. Whether the transaction start_ts should be included in
 	// the source block of the output. JSON protocol only.
 	DebeziumIncludeStartTs bool
+	// Simple only. Whether the transaction start_ts should be included in
+	// Simple JSON DML messages. Encoding-format=avro rejects this option.
+	SimpleIncludeStartTs bool
 	// CSV only. Whether header should be included in the output.
 	CSVOutputFieldHeader bool
 }
@@ -149,6 +152,7 @@ func NewConfig(protocol config.Protocol) *Config {
 		OpenOutputOldValue:     true,
 		DebeziumDisableSchema:  false,
 		DebeziumIncludeStartTs: false,
+		SimpleIncludeStartTs:   false,
 		CSVOutputFieldHeader:   false,
 	}
 }
@@ -191,6 +195,7 @@ type urlConfig struct {
 
 	DebeziumDisableSchema  *bool `form:"debezium-disable-schema"`
 	DebeziumIncludeStartTs *bool `form:"debezium-include-start-ts"`
+	SimpleIncludeStartTs   *bool `form:"simple-include-start-ts"`
 	// EncodingFormatType is only works for the simple protocol,
 	// can be `json` and `avro`, default to `json`.
 	EncodingFormatType *string `form:"encoding-format"`
@@ -328,6 +333,12 @@ func (c *Config) Apply(sinkURI *url.URL, sinkConfig *config.SinkConfig) error {
 	if rawURLParameter.DebeziumIncludeStartTs != nil {
 		c.DebeziumIncludeStartTs = *rawURLParameter.DebeziumIncludeStartTs
 	}
+	if urlParameter.SimpleIncludeStartTs != nil {
+		c.SimpleIncludeStartTs = *urlParameter.SimpleIncludeStartTs
+	}
+	if rawURLParameter.SimpleIncludeStartTs != nil {
+		c.SimpleIncludeStartTs = *rawURLParameter.SimpleIncludeStartTs
+	}
 
 	return nil
 }
@@ -362,6 +373,9 @@ func mergeConfig(
 		}
 		if sinkConfig.Debezium != nil && sinkConfig.Debezium.IncludeStartTs != nil {
 			dest.DebeziumIncludeStartTs = sinkConfig.Debezium.IncludeStartTs
+		}
+		if sinkConfig.Simple != nil && sinkConfig.Simple.IncludeStartTs != nil {
+			dest.SimpleIncludeStartTs = sinkConfig.Simple.IncludeStartTs
 		}
 	}
 	if err := mergo.Merge(dest, urlParameters, mergo.WithOverride); err != nil {
@@ -410,6 +424,19 @@ func (c *Config) Validate() error {
 		return errors.ErrCodecInvalidConfig.GenWithStack(
 			`debezium-include-start-ts only takes effect with protocol "debezium"`,
 		)
+	}
+
+	if c.SimpleIncludeStartTs {
+		if c.Protocol != config.ProtocolSimple {
+			return errors.ErrCodecInvalidConfig.GenWithStack(
+				`simple-include-start-ts only takes effect with protocol "simple"`,
+			)
+		}
+		if c.EncodingFormat == EncodingFormatAvro {
+			return errors.ErrCodecInvalidConfig.GenWithStack(
+				`simple-include-start-ts is not supported with encoding-format "avro"`,
+			)
+		}
 	}
 
 	if c.Protocol == config.ProtocolAvro || c.Protocol == config.ProtocolDebeziumAvro {

--- a/pkg/sink/codec/common/config_test.go
+++ b/pkg/sink/codec/common/config_test.go
@@ -90,3 +90,42 @@ func TestDebeziumIncludeStartTsConfig(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, errors.ErrCodecInvalidConfig.RFCCode(), errCode)
 }
+
+func TestSimpleIncludeStartTsConfig(t *testing.T) {
+	cfg := NewConfig(config.ProtocolSimple)
+	sinkURI, err := url.Parse("kafka://127.0.0.1:9092/topic?protocol=simple&simple-include-start-ts=true")
+	require.NoError(t, err)
+	require.NoError(t, cfg.Apply(sinkURI, config.GetDefaultReplicaConfig().Sink))
+	require.True(t, cfg.SimpleIncludeStartTs)
+	require.NoError(t, cfg.Validate())
+
+	on := true
+	cfg2 := NewConfig(config.ProtocolSimple)
+	sinkConfig := config.GetDefaultReplicaConfig().Sink
+	sinkConfig.Simple = &config.SimpleConfig{IncludeStartTs: &on}
+	sinkURI2, err := url.Parse("kafka://127.0.0.1:9092/topic?protocol=simple")
+	require.NoError(t, err)
+	require.NoError(t, cfg2.Apply(sinkURI2, sinkConfig))
+	require.True(t, cfg2.SimpleIncludeStartTs)
+
+	cfg3 := NewConfig(config.ProtocolSimple)
+	sinkConfig3 := config.GetDefaultReplicaConfig().Sink
+	sinkConfig3.Simple = &config.SimpleConfig{IncludeStartTs: &on}
+	sinkURI3, err := url.Parse("kafka://127.0.0.1:9092/topic?protocol=simple&simple-include-start-ts=false")
+	require.NoError(t, err)
+	require.NoError(t, cfg3.Apply(sinkURI3, sinkConfig3))
+	require.False(t, cfg3.SimpleIncludeStartTs)
+
+	cfg4 := NewConfig(config.ProtocolSimple)
+	cfg4.SimpleIncludeStartTs = true
+	cfg4.EncodingFormat = EncodingFormatAvro
+	errCode, ok := errors.RFCCode(cfg4.Validate())
+	require.True(t, ok)
+	require.Equal(t, errors.ErrCodecInvalidConfig.RFCCode(), errCode)
+
+	cfg5 := NewConfig(config.ProtocolDebezium)
+	cfg5.SimpleIncludeStartTs = true
+	errCode, ok = errors.RFCCode(cfg5.Validate())
+	require.True(t, ok)
+	require.Equal(t, errors.ErrCodecInvalidConfig.RFCCode(), errCode)
+}

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -595,8 +595,16 @@ func parseValue(
 	return val
 }
 
+func startTsFromMessage(msg *message) uint64 {
+	if msg.StartTs != 0 {
+		return msg.StartTs
+	}
+	return msg.CommitTs
+}
+
 func buildDMLEvent(msg *message, tableInfo *commonType.TableInfo, enableRowChecksum bool, db *sql.DB) *commonEvent.DMLEvent {
 	result := &commonEvent.DMLEvent{
+		StartTs:         startTsFromMessage(msg),
 		CommitTs:        msg.CommitTs,
 		PhysicalTableID: msg.TableID,
 		TableInfo:       tableInfo,

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -255,6 +255,7 @@ func (d *Decoder) assembleHandleKeyOnlyRowChangedEvent(
 		TableID:       m.TableID,
 		Type:          m.Type,
 		CommitTs:      m.CommitTs,
+		StartTs:       m.StartTs,
 		SchemaVersion: m.SchemaVersion,
 	}
 

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -250,7 +250,11 @@ type message struct {
 	// SQL is only for the DDL event.
 	SQL      string `json:"sql,omitempty"`
 	CommitTs uint64 `json:"commitTs"`
-	BuildTs  int64  `json:"buildTs"`
+	// StartTs is the transaction start TSO. Present on DML messages only when
+	// simple-include-start-ts is enabled. omitempty keeps the pre-feature format
+	// when the field is unset (zero).
+	StartTs uint64 `json:"startTs,omitempty"`
+	BuildTs int64  `json:"buildTs"`
 	// SchemaVersion is for the DML event.
 	SchemaVersion uint64 `json:"schemaVersion,omitempty"`
 
@@ -331,6 +335,9 @@ func (a *jsonMarshaller) newDMLMessage(
 		SchemaVersion:      event.TableInfo.GetUpdateTS(),
 		HandleKeyOnly:      onlyHandleKey,
 		ClaimCheckLocation: claimCheckFileName,
+	}
+	if a.config.SimpleIncludeStartTs {
+		m.StartTs = event.StartTs
 	}
 	if event.IsInsert() {
 		m.Type = DMLTypeInsert

--- a/pkg/sink/codec/simple/start_ts_test.go
+++ b/pkg/sink/codec/simple/start_ts_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simple
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeStartTsInSimpleJSON(t *testing.T) {
+	ctx := context.Background()
+	cfg := common.NewConfig(config.ProtocolSimple)
+	cfg.SimpleIncludeStartTs = true
+	enc, err := NewEncoder(cfg, nil)
+	require.NoError(t, err)
+	dec, err := NewDecoder(ctx, cfg, nil)
+	require.NoError(t, err)
+
+	ddlMessage, err := enc.EncodeDDLEvent(common.NewRoutedDDLEvent4Test())
+	require.NoError(t, err)
+	dec.AddKeyValue(ddlMessage.Key, ddlMessage.Value)
+	messageType, hasNext := dec.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeDDL, messageType)
+	require.NotNil(t, dec.NextDDLEvent())
+
+	rowEvent := common.NewRoutedRowEvent4Test()
+	rowEvent.StartTs = 5
+	require.NoError(t, enc.AppendRowChangedEvent(ctx, "", rowEvent))
+	messages := enc.Build()
+	require.Len(t, messages, 1)
+
+	var value map[string]any
+	require.NoError(t, json.Unmarshal(messages[0].Value, &value))
+	require.Equal(t, float64(5), value["startTs"])
+	require.Contains(t, value, "commitTs")
+
+	dec.AddKeyValue(messages[0].Key, messages[0].Value)
+	messageType, hasNext = dec.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeRow, messageType)
+	decoded := dec.NextDMLMessage().ToDMLEvent()
+	require.Equal(t, uint64(5), decoded.GetStartTs())
+}
+
+func TestDecodeStartTsFallbackToCommitTs(t *testing.T) {
+	ctx := context.Background()
+	cfg := common.NewConfig(config.ProtocolSimple)
+	enc, err := NewEncoder(cfg, nil)
+	require.NoError(t, err)
+	dec, err := NewDecoder(ctx, cfg, nil)
+	require.NoError(t, err)
+
+	ddlMessage, err := enc.EncodeDDLEvent(common.NewRoutedDDLEvent4Test())
+	require.NoError(t, err)
+	dec.AddKeyValue(ddlMessage.Key, ddlMessage.Value)
+	_, hasNext := dec.HasNext()
+	require.True(t, hasNext)
+	require.NotNil(t, dec.NextDDLEvent())
+
+	rowEvent := common.NewRoutedRowEvent4Test()
+	rowEvent.StartTs = 5
+	require.NoError(t, enc.AppendRowChangedEvent(ctx, "", rowEvent))
+	messages := enc.Build()
+	require.Len(t, messages, 1)
+
+	var value map[string]any
+	require.NoError(t, json.Unmarshal(messages[0].Value, &value))
+	require.NotContains(t, value, "startTs")
+
+	dec.AddKeyValue(messages[0].Key, messages[0].Value)
+	_, hasNext = dec.HasNext()
+	require.True(t, hasNext)
+	decoded := dec.NextDMLMessage().ToDMLEvent()
+	require.Equal(t, decoded.GetCommitTs(), decoded.GetStartTs())
+	require.NotEqual(t, uint64(5), decoded.GetStartTs())
+}
+
+func TestSimpleStartTsNotInDDLAndWatermark(t *testing.T) {
+	ctx := context.Background()
+	cfg := common.NewConfig(config.ProtocolSimple)
+	cfg.SimpleIncludeStartTs = true
+	enc, err := NewEncoder(cfg, nil)
+	require.NoError(t, err)
+
+	ddlMessage, err := enc.EncodeDDLEvent(common.NewRoutedDDLEvent4Test())
+	require.NoError(t, err)
+	require.NotContains(t, string(ddlMessage.Value), `"startTs"`)
+
+	watermark, err := enc.EncodeCheckpointEvent(446266400629063682)
+	require.NoError(t, err)
+	require.NotContains(t, string(watermark.Value), `"startTs"`)
+
+	dec, err := NewDecoder(ctx, cfg, nil)
+	require.NoError(t, err)
+	dec.AddKeyValue(watermark.Key, watermark.Value)
+	messageType, hasNext := dec.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeResolved, messageType)
+	require.Equal(t, uint64(446266400629063682), dec.NextResolvedEvent())
+}

--- a/pkg/sink/codec/simple/start_ts_test.go
+++ b/pkg/sink/codec/simple/start_ts_test.go
@@ -14,104 +14,235 @@
 package simple
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeStartTsInSimpleJSON(t *testing.T) {
+// 18-digit PD TSO above the float64 mantissa (2^53). json.Unmarshal into
+// map[string]any would round this; UseNumber + ParseUint must keep every digit.
+const (
+	testStartTs  uint64 = 468651996400058379
+	testCommitTs uint64 = 468651996400058400
+)
+
+func decodeSimpleJSON(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value map[string]any
+	require.NoError(t, dec.Decode(&value))
+	return value
+}
+
+func requireStartTs(t *testing.T, raw []byte, expected uint64) {
+	t.Helper()
+	value := decodeSimpleJSON(t, raw)
+	num, ok := value["startTs"].(json.Number)
+	require.True(t, ok, "startTs missing or not a JSON number: %v", value["startTs"])
+	got, err := strconv.ParseUint(num.String(), 10, 64)
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+	require.Equal(t, strconv.FormatUint(expected, 10), num.String())
+	require.Contains(t, string(raw), `"startTs":`+strconv.FormatUint(expected, 10))
+}
+
+func requireNoStartTs(t *testing.T, raw []byte) {
+	t.Helper()
+	value := decodeSimpleJSON(t, raw)
+	_, exists := value["startTs"]
+	require.False(t, exists, "startTs must be omitted, got %v", value["startTs"])
+}
+
+func newEncoderDecoder(t *testing.T, includeStartTs bool) (*Encoder, *Decoder) {
+	t.Helper()
 	ctx := context.Background()
 	cfg := common.NewConfig(config.ProtocolSimple)
-	cfg.SimpleIncludeStartTs = true
+	cfg.SimpleIncludeStartTs = includeStartTs
 	enc, err := NewEncoder(cfg, nil)
 	require.NoError(t, err)
 	dec, err := NewDecoder(ctx, cfg, nil)
 	require.NoError(t, err)
+	return enc.(*Encoder), dec.(*Decoder)
+}
 
+func registerTable(t *testing.T, enc *Encoder, dec *Decoder) {
+	t.Helper()
 	ddlMessage, err := enc.EncodeDDLEvent(common.NewRoutedDDLEvent4Test())
 	require.NoError(t, err)
+	requireNoStartTs(t, ddlMessage.Value)
 	dec.AddKeyValue(ddlMessage.Key, ddlMessage.Value)
 	messageType, hasNext := dec.HasNext()
 	require.True(t, hasNext)
 	require.Equal(t, common.MessageTypeDDL, messageType)
 	require.NotNil(t, dec.NextDDLEvent())
+}
+
+func TestEncodeStartTsInSimpleJSON(t *testing.T) {
+	enc, dec := newEncoderDecoder(t, true)
+	registerTable(t, enc, dec)
 
 	rowEvent := common.NewRoutedRowEvent4Test()
-	rowEvent.StartTs = 5
-	require.NoError(t, enc.AppendRowChangedEvent(ctx, "", rowEvent))
+	rowEvent.StartTs = testStartTs
+	rowEvent.CommitTs = testCommitTs
+	require.NoError(t, enc.AppendRowChangedEvent(context.Background(), "", rowEvent))
 	messages := enc.Build()
 	require.Len(t, messages, 1)
+	requireStartTs(t, messages[0].Value, testStartTs)
 
-	var value map[string]any
-	require.NoError(t, json.Unmarshal(messages[0].Value, &value))
-	require.Equal(t, float64(5), value["startTs"])
-	require.Contains(t, value, "commitTs")
+	value := decodeSimpleJSON(t, messages[0].Value)
+	commit, ok := value["commitTs"].(json.Number)
+	require.True(t, ok)
+	gotCommit, err := strconv.ParseUint(commit.String(), 10, 64)
+	require.NoError(t, err)
+	require.Equal(t, testCommitTs, gotCommit)
 
 	dec.AddKeyValue(messages[0].Key, messages[0].Value)
-	messageType, hasNext = dec.HasNext()
+	messageType, hasNext := dec.HasNext()
 	require.True(t, hasNext)
 	require.Equal(t, common.MessageTypeRow, messageType)
 	decoded := dec.NextDMLMessage().ToDMLEvent()
-	require.Equal(t, uint64(5), decoded.GetStartTs())
+	require.Equal(t, testStartTs, decoded.GetStartTs())
+	require.Equal(t, testCommitTs, decoded.GetCommitTs())
+}
+
+func TestEncodeStartTsOnInsertUpdateDelete(t *testing.T) {
+	enc, _ := newEncoderDecoder(t, true)
+
+	insert := common.NewRoutedRowEvent4Test()
+	insert.StartTs = testStartTs
+	insert.CommitTs = testCommitTs
+
+	update := *insert
+	update.Event.PreRow = insert.Event.Row
+
+	del := *insert
+	del.Event.PreRow = insert.Event.Row
+	del.Event.Row = chunk.Row{}
+
+	require.True(t, insert.IsInsert())
+	require.True(t, update.IsUpdate())
+	require.True(t, del.IsDelete())
+
+	ctx := context.Background()
+	require.NoError(t, enc.AppendRowChangedEvent(ctx, "", insert))
+	require.NoError(t, enc.AppendRowChangedEvent(ctx, "", &update))
+	require.NoError(t, enc.AppendRowChangedEvent(ctx, "", &del))
+	messages := enc.Build()
+	require.Len(t, messages, 3)
+	for _, msg := range messages {
+		requireStartTs(t, msg.Value, testStartTs)
+	}
+
+	types := make([]string, 0, 3)
+	for _, msg := range messages {
+		value := decodeSimpleJSON(t, msg.Value)
+		types = append(types, value["type"].(string))
+	}
+	require.ElementsMatch(t, []string{
+		string(DMLTypeInsert),
+		string(DMLTypeUpdate),
+		string(DMLTypeDelete),
+	}, types)
 }
 
 func TestDecodeStartTsFallbackToCommitTs(t *testing.T) {
-	ctx := context.Background()
-	cfg := common.NewConfig(config.ProtocolSimple)
-	enc, err := NewEncoder(cfg, nil)
-	require.NoError(t, err)
-	dec, err := NewDecoder(ctx, cfg, nil)
-	require.NoError(t, err)
-
-	ddlMessage, err := enc.EncodeDDLEvent(common.NewRoutedDDLEvent4Test())
-	require.NoError(t, err)
-	dec.AddKeyValue(ddlMessage.Key, ddlMessage.Value)
-	_, hasNext := dec.HasNext()
-	require.True(t, hasNext)
-	require.NotNil(t, dec.NextDDLEvent())
+	enc, dec := newEncoderDecoder(t, false)
+	registerTable(t, enc, dec)
 
 	rowEvent := common.NewRoutedRowEvent4Test()
-	rowEvent.StartTs = 5
-	require.NoError(t, enc.AppendRowChangedEvent(ctx, "", rowEvent))
+	rowEvent.StartTs = testStartTs
+	rowEvent.CommitTs = testCommitTs
+	require.NoError(t, enc.AppendRowChangedEvent(context.Background(), "", rowEvent))
 	messages := enc.Build()
 	require.Len(t, messages, 1)
-
-	var value map[string]any
-	require.NoError(t, json.Unmarshal(messages[0].Value, &value))
-	require.NotContains(t, value, "startTs")
+	requireNoStartTs(t, messages[0].Value)
 
 	dec.AddKeyValue(messages[0].Key, messages[0].Value)
-	_, hasNext = dec.HasNext()
+	_, hasNext := dec.HasNext()
 	require.True(t, hasNext)
 	decoded := dec.NextDMLMessage().ToDMLEvent()
 	require.Equal(t, decoded.GetCommitTs(), decoded.GetStartTs())
-	require.NotEqual(t, uint64(5), decoded.GetStartTs())
+	require.Equal(t, testCommitTs, decoded.GetStartTs())
+	require.NotEqual(t, testStartTs, decoded.GetStartTs())
 }
 
-func TestSimpleStartTsNotInDDLAndWatermark(t *testing.T) {
-	ctx := context.Background()
-	cfg := common.NewConfig(config.ProtocolSimple)
-	cfg.SimpleIncludeStartTs = true
-	enc, err := NewEncoder(cfg, nil)
-	require.NoError(t, err)
+func TestDecodeZeroStartTsFallbackToCommitTs(t *testing.T) {
+	enc, dec := newEncoderDecoder(t, true)
+	registerTable(t, enc, dec)
+
+	rowEvent := common.NewRoutedRowEvent4Test()
+	rowEvent.StartTs = 0
+	rowEvent.CommitTs = testCommitTs
+	require.NoError(t, enc.AppendRowChangedEvent(context.Background(), "", rowEvent))
+	messages := enc.Build()
+	require.Len(t, messages, 1)
+	// omitempty drops a zero startTs, so the wire format matches the pre-feature
+	// message and the decoder must fall back to commitTs.
+	requireNoStartTs(t, messages[0].Value)
+
+	dec.AddKeyValue(messages[0].Key, messages[0].Value)
+	_, hasNext := dec.HasNext()
+	require.True(t, hasNext)
+	decoded := dec.NextDMLMessage().ToDMLEvent()
+	require.Equal(t, testCommitTs, decoded.GetStartTs())
+}
+
+func TestDecodeExplicitZeroStartTsFallbackToCommitTs(t *testing.T) {
+	enc, dec := newEncoderDecoder(t, true)
+	registerTable(t, enc, dec)
+
+	rowEvent := common.NewRoutedRowEvent4Test()
+	rowEvent.StartTs = testStartTs
+	rowEvent.CommitTs = testCommitTs
+	require.NoError(t, enc.AppendRowChangedEvent(context.Background(), "", rowEvent))
+	messages := enc.Build()
+	require.Len(t, messages, 1)
+
+	patched := bytes.Replace(
+		messages[0].Value,
+		[]byte(`"startTs":`+strconv.FormatUint(testStartTs, 10)),
+		[]byte(`"startTs":0`),
+		1,
+	)
+	require.NotEqual(t, messages[0].Value, patched)
+
+	dec.AddKeyValue(messages[0].Key, patched)
+	_, hasNext := dec.HasNext()
+	require.True(t, hasNext)
+	decoded := dec.NextDMLMessage().ToDMLEvent()
+	require.Equal(t, testCommitTs, decoded.GetStartTs())
+}
+
+func TestSimpleStartTsNotInDDLWatermarkOrBootstrap(t *testing.T) {
+	enc, dec := newEncoderDecoder(t, true)
 
 	ddlMessage, err := enc.EncodeDDLEvent(common.NewRoutedDDLEvent4Test())
 	require.NoError(t, err)
-	require.NotContains(t, string(ddlMessage.Value), `"startTs"`)
+	requireNoStartTs(t, ddlMessage.Value)
 
-	watermark, err := enc.EncodeCheckpointEvent(446266400629063682)
+	bootstrap := common.NewRoutedDDLEvent4Test()
+	bootstrap.IsBootstrap = true
+	bootstrapMessage, err := enc.EncodeDDLEvent(bootstrap)
 	require.NoError(t, err)
-	require.NotContains(t, string(watermark.Value), `"startTs"`)
+	requireNoStartTs(t, bootstrapMessage.Value)
+	value := decodeSimpleJSON(t, bootstrapMessage.Value)
+	require.Equal(t, string(MessageTypeBootstrap), value["type"].(string))
 
-	dec, err := NewDecoder(ctx, cfg, nil)
+	watermark, err := enc.EncodeCheckpointEvent(testCommitTs)
 	require.NoError(t, err)
+	requireNoStartTs(t, watermark.Value)
+
 	dec.AddKeyValue(watermark.Key, watermark.Value)
 	messageType, hasNext := dec.HasNext()
 	require.True(t, hasNext)
 	require.Equal(t, common.MessageTypeResolved, messageType)
-	require.Equal(t, uint64(446266400629063682), dec.NextResolvedEvent())
+	require.Equal(t, testCommitTs, dec.NextResolvedEvent())
 }

--- a/tests/integration_tests/_utils/kafka_dump
+++ b/tests/integration_tests/_utils/kafka_dump
@@ -5,8 +5,6 @@ set -eu
 CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 UTILITY_DIR="$CUR/../../utils/kafka_dump"
 
-if [ ! -f "$UTILITY_DIR/kafka_dump" ]; then
-	(cd "$UTILITY_DIR" && GO111MODULE=on go build)
-fi
+(cd "$UTILITY_DIR" && GO111MODULE=on go build)
 
 "$UTILITY_DIR/kafka_dump" "$@"

--- a/tests/integration_tests/_utils/kafka_dump
+++ b/tests/integration_tests/_utils/kafka_dump
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+UTILITY_DIR="$CUR/../../utils/kafka_dump"
+
+if [ ! -f "$UTILITY_DIR/kafka_dump" ]; then
+	(cd "$UTILITY_DIR" && GO111MODULE=on go build)
+fi
+
+"$UTILITY_DIR/kafka_dump" "$@"

--- a/tests/integration_tests/kafka_simple_include_start_ts/conf/changefeed.toml
+++ b/tests/integration_tests/kafka_simple_include_start_ts/conf/changefeed.toml
@@ -1,0 +1,2 @@
+[sink.simple]
+include-start-ts = true

--- a/tests/integration_tests/kafka_simple_include_start_ts/run.sh
+++ b/tests/integration_tests/kafka_simple_include_start_ts/run.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+set -e
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+pd_addr="http://${UP_PD_HOST_1}:${UP_PD_PORT_1}"
+
+assert_probe_start_ts() {
+	local dump_file=$1
+	local expected_ts=$2
+	local expect_field=$3
+	python3 - "$dump_file" "$expected_ts" "$expect_field" <<'PY'
+import json, sys
+
+path, expected, expect_field = sys.argv[1], sys.argv[2], sys.argv[3]
+want = expect_field == "true"
+expected_ts = int(expected)
+found = 0
+for line in open(path):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if msg.get("table") != "cdc_start_ts_probe" or msg.get("type") != "INSERT":
+        continue
+    found += 1
+    start_ts = msg.get("startTs")
+    if want:
+        if not isinstance(start_ts, int):
+            raise SystemExit("startTs missing or not an integer: %r" % (start_ts,))
+        if start_ts != expected_ts:
+            raise SystemExit("startTs %s != expected %s" % (start_ts, expected_ts))
+        row_ts = (msg.get("data") or {}).get("expected_start_ts")
+        if str(row_ts) != str(expected_ts):
+            raise SystemExit("row expected_start_ts %s != %s" % (row_ts, expected_ts))
+    elif start_ts is not None:
+        raise SystemExit("startTs must be omitted, got %r" % (start_ts,))
+if found < 2:
+    raise SystemExit("found %d probe INSERT messages, want 2" % found)
+print("probe ok: %d INSERT messages, startTs present=%s ts=%s" % (found, want, expected))
+PY
+}
+
+insert_probe_rows() {
+	mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -N -e "
+		CREATE DATABASE IF NOT EXISTS test;
+		CREATE TABLE IF NOT EXISTS test.cdc_start_ts_probe (
+			id BIGINT PRIMARY KEY,
+			expected_start_ts BIGINT UNSIGNED NOT NULL
+		);
+		TRUNCATE TABLE test.cdc_start_ts_probe;
+		START TRANSACTION;
+		SELECT @@tidb_current_ts INTO @ts;
+		INSERT INTO test.cdc_start_ts_probe VALUES (1, @ts), (2, @ts);
+		COMMIT;
+		SELECT @ts;
+	"
+}
+
+run_mode() {
+	local mode=$1
+	local sink_uri=$2
+	local config_args=$3
+	local expect_field=$4
+	local changefeed_id="simple-start-ts-${mode}"
+	local dump_file="$WORK_DIR/dump-${mode}.jsonl"
+
+	echo "===== $mode ====="
+	cdc_cli_changefeed create --sink-uri="$sink_uri" $config_args -c "$changefeed_id"
+	ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
+	sleep 5
+
+	local ts
+	ts=$(insert_probe_rows | tail -n 1 | tr -d '[:space:]')
+	if [[ ! "$ts" =~ ^[0-9]+$ ]]; then
+		echo "failed to read transaction TSO, got: $ts"
+		exit 1
+	fi
+	echo "probe transaction start ts: $ts"
+
+	kafka_dump --topic "$TOPIC_NAME" --timeout 90s --until-table cdc_start_ts_probe --until-count 2 >"$dump_file"
+	assert_probe_start_ts "$dump_file" "$ts" "$expect_field"
+
+	cdc_cli_changefeed remove -c "$changefeed_id"
+}
+
+function run() {
+	if [ "$SINK_TYPE" != "kafka" ]; then
+		return
+	fi
+
+	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+	start_tidb_cluster --workdir $WORK_DIR
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+
+	TOPIC_NAME="ticdc-simple-include-start-ts-$RANDOM"
+
+	run_mode "uri" \
+		"kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=simple&partition-num=1&simple-include-start-ts=true" \
+		"" \
+		"true"
+
+	TOPIC_NAME="ticdc-simple-include-start-ts-toml-$RANDOM"
+	run_mode "toml" \
+		"kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=simple&partition-num=1" \
+		"--config=$CUR/conf/changefeed.toml" \
+		"true"
+
+	TOPIC_NAME="ticdc-simple-include-start-ts-off-$RANDOM"
+	run_mode "off" \
+		"kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=simple&partition-num=1" \
+		"" \
+		"false"
+
+	cleanup_process $CDC_BINARY
+}
+
+trap 'stop_test $WORK_DIR' EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/kafka_simple_include_start_ts/run.sh
+++ b/tests/integration_tests/kafka_simple_include_start_ts/run.sh
@@ -49,19 +49,19 @@ PY
 }
 
 insert_probe_rows() {
-	mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -N -e "
-		CREATE DATABASE IF NOT EXISTS test;
-		CREATE TABLE IF NOT EXISTS test.cdc_start_ts_probe (
-			id BIGINT PRIMARY KEY,
-			expected_start_ts BIGINT UNSIGNED NOT NULL
-		);
-		TRUNCATE TABLE test.cdc_start_ts_probe;
-		START TRANSACTION;
-		SELECT @@tidb_current_ts INTO @ts;
-		INSERT INTO test.cdc_start_ts_probe VALUES (1, @ts), (2, @ts);
-		COMMIT;
-		SELECT @ts;
-	"
+	mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -N <<EOF
+CREATE DATABASE IF NOT EXISTS test;
+CREATE TABLE IF NOT EXISTS test.cdc_start_ts_probe (
+	id BIGINT PRIMARY KEY,
+	expected_start_ts BIGINT UNSIGNED NOT NULL
+);
+TRUNCATE TABLE test.cdc_start_ts_probe;
+START TRANSACTION;
+SET @ts = @@tidb_current_ts;
+INSERT INTO test.cdc_start_ts_probe VALUES (1, @ts), (2, @ts);
+COMMIT;
+SELECT @ts;
+EOF
 }
 
 run_mode() {

--- a/tests/integration_tests/kafka_simple_include_start_ts/run.sh
+++ b/tests/integration_tests/kafka_simple_include_start_ts/run.sh
@@ -49,7 +49,7 @@ PY
 }
 
 insert_probe_rows() {
-	mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -N <<EOF
+	mysql -uroot -h"${UP_TIDB_HOST}" -P"${UP_TIDB_PORT}" --default-character-set utf8mb4 -N <<EOF
 CREATE DATABASE IF NOT EXISTS test;
 CREATE TABLE IF NOT EXISTS test.cdc_start_ts_probe (
 	id BIGINT PRIMARY KEY,

--- a/tests/integration_tests/kafka_simple_include_start_ts/run.sh
+++ b/tests/integration_tests/kafka_simple_include_start_ts/run.sh
@@ -96,7 +96,8 @@ function run() {
 		return
 	fi
 
-	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+	rm -rf -- "${WORK_DIR:?WORK_DIR is unset}"
+	mkdir -p -- "$WORK_DIR"
 	start_tidb_cluster --workdir $WORK_DIR
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -99,7 +99,7 @@ kafka_groups=(
 	# G13
 	'cli_with_auth fail_over_ddl_N maintainer_failover_when_operator'
 	# G14
-	'kafka_simple_basic avro_basic avro_schema_registry_error fail_over_ddl_O update_changefeed_check_config'
+	'kafka_simple_basic kafka_simple_include_start_ts avro_basic avro_schema_registry_error fail_over_ddl_O update_changefeed_check_config'
 	# G15
 	'kafka_simple_basic_avro split_region autorandom gc_safepoint'
 )

--- a/tests/utils/kafka_dump/main.go
+++ b/tests/utils/kafka_dump/main.go
@@ -1,0 +1,161 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/IBM/sarama"
+)
+
+func main() {
+	brokers := flag.String("brokers", "127.0.0.1:9092", "Comma-separated Kafka broker addresses.")
+	topic := flag.String("topic", "", "Kafka topic name.")
+	timeout := flag.Duration("timeout", 90*time.Second, "How long to wait for matching messages.")
+	untilTable := flag.String("until-table", "", "Stop after seeing this many DML messages for the table.")
+	untilCount := flag.Int("until-count", 1, "Number of matching table messages required to stop.")
+	flag.Parse()
+
+	if *topic == "" {
+		log.Fatal("topic must not be empty")
+	}
+	if *untilTable == "" {
+		log.Fatal("until-table must not be empty")
+	}
+	if *untilCount <= 0 {
+		log.Fatal("until-count must be greater than zero")
+	}
+
+	config := sarama.NewConfig()
+	config.ClientID = "ticdc-integration-test-kafka-dump"
+	config.Consumer.Return.Errors = true
+
+	var consumer sarama.Consumer
+	deadline := time.Now().Add(*timeout)
+	for {
+		var err error
+		consumer, err = sarama.NewConsumer(strings.Split(*brokers, ","), config)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			log.Fatalf("create Kafka consumer: %v", err)
+		}
+		time.Sleep(time.Second)
+	}
+	defer func() {
+		if err := consumer.Close(); err != nil {
+			log.Printf("close Kafka consumer: %v", err)
+		}
+	}()
+
+	var partitions []int32
+	for {
+		var err error
+		partitions, err = consumer.Partitions(*topic)
+		if err == nil && len(partitions) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			log.Fatalf("list partitions for %s: %v", *topic, err)
+		}
+		time.Sleep(time.Second)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	type rec struct {
+		value []byte
+	}
+	ch := make(chan rec, 32)
+	var wg sync.WaitGroup
+	for _, partition := range partitions {
+		pc, err := consumer.ConsumePartition(*topic, partition, sarama.OffsetOldest)
+		if err != nil {
+			log.Fatalf("consume partition %d: %v", partition, err)
+		}
+		wg.Add(1)
+		go func(pc sarama.PartitionConsumer) {
+			defer wg.Done()
+			defer pc.Close()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg, ok := <-pc.Messages():
+					if !ok {
+						return
+					}
+					select {
+					case ch <- rec{value: msg.Value}:
+					case <-ctx.Done():
+						return
+					}
+				case err, ok := <-pc.Errors():
+					if !ok {
+						return
+					}
+					log.Printf("consume error: %v", err)
+				}
+			}
+		}(pc)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	matched := 0
+	for {
+		select {
+		case <-ctx.Done():
+			log.Fatalf("timeout: saw %d DML messages for table %s, want %d", matched, *untilTable, *untilCount)
+		case r, ok := <-ch:
+			if !ok {
+				log.Fatalf("consumers exited: saw %d DML messages for table %s, want %d", matched, *untilTable, *untilCount)
+			}
+			if _, err := os.Stdout.Write(r.value); err != nil {
+				log.Fatalf("write message: %v", err)
+			}
+			if _, err := os.Stdout.Write([]byte("\n")); err != nil {
+				log.Fatalf("write newline: %v", err)
+			}
+			if tableOf(r.value) == *untilTable {
+				matched++
+				if matched >= *untilCount {
+					return
+				}
+			}
+		}
+	}
+}
+
+func tableOf(raw []byte) string {
+	var msg struct {
+		Table string `json:"table"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return ""
+	}
+	return msg.Table
+}

--- a/tests/utils/kafka_dump/main.go
+++ b/tests/utils/kafka_dump/main.go
@@ -96,7 +96,11 @@ func main() {
 		wg.Add(1)
 		go func(pc sarama.PartitionConsumer) {
 			defer wg.Done()
-			defer pc.Close()
+			defer func() {
+				if err := pc.Close(); err != nil {
+					log.Printf("close partition consumer: %v", err)
+				}
+			}()
 			for {
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #6106

Downstream consumers that correlate CDC row changes with application-side records need a stable per-transaction key. `commit_ts` is not unique under 1PC / async-commit. The Simple JSON protocol previously only carried `commitTs`.

### What is changed and how it works?

Mirrors #5903 for the Simple JSON protocol:

- URI: `simple-include-start-ts=true`
- TOML: `[sink.simple] include-start-ts = true`
- Explicit URI values take precedence over TOML, including `false` overriding `true`
- Off by default
- When enabled, Simple JSON DML messages include integer `startTs` next to `commitTs`
- Decoder reads `startTs` and falls back to `commitTs` when the field is absent (old messages)
- Rejected when protocol is not `simple`, and when `encoding-format=avro`
- DDL, BOOTSTRAP and WATERMARK messages are unchanged

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No intended compatibility break: the option is off by default, and omitted `startTs` keeps the previous JSON shape. Enabling it adds one uint64 field on DML messages only.

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes, user docs for Simple protocol / sink URI / changefeed config. Follow-up after this lands.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
TiCDC Simple JSON protocol supports optionally including the source transaction start TSO (`startTs`) in DML messages via `simple-include-start-ts` / `[sink.simple] include-start-ts`. The option is disabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `startTs` support for Simple protocol JSON DML messages.
  - Added configuration through changefeed settings, connection parameters, or API settings.
  - Added Kafka OAuth CA configuration support.
- **Bug Fixes**
  - Simple protocol decoding preserves `startTs` and falls back to `commitTs` when unavailable.
- **Validation**
  - Invalid protocol and Avro configuration combinations are now rejected.
  - Date separator values receive stricter validation.
- **Tests**
  - Added coverage for enabled, disabled, overridden, and integration configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->