### PR TITLE
codec: handle table comment DDL in consumer

### DIFF
--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -48,6 +48,10 @@ type partitionProgress struct {
 	decoder     common.Decoder
 }
 
+type tableIDProvider interface {
+	GetTableIDs(schema, table string) []int64
+}
+
 func newPartitionProgress(partition int32, decoder common.Decoder) *partitionProgress {
 	return &partitionProgress{
 		partition:   partition,
@@ -225,6 +229,18 @@ func (w *writer) getBlockTableIDs(ddl *event.DDLEvent) map[int64]struct{} {
 		}
 	default:
 		log.Panic("unsupported influence type", zap.Any("influenceType", ddl.GetBlockedTables().InfluenceType))
+	}
+	if w.partitionTableAccessor != nil &&
+		w.partitionTableAccessor.IsPartitionTable(ddl.GetSchemaName(), ddl.GetTableName()) {
+		for _, progress := range w.progresses {
+			provider, ok := progress.decoder.(tableIDProvider)
+			if !ok {
+				continue
+			}
+			for _, tableID := range provider.GetTableIDs(ddl.GetSchemaName(), ddl.GetTableName()) {
+				tableIDs[tableID] = struct{}{}
+			}
+		}
 	}
 	return tableIDs
 }

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -232,11 +232,8 @@ func (w *writer) getBlockTableIDs(ddl *event.DDLEvent) map[int64]struct{} {
 	}
 	if w.partitionTableAccessor != nil &&
 		w.partitionTableAccessor.IsPartitionTable(ddl.GetSchemaName(), ddl.GetTableName()) {
-		for _, progress := range w.progresses {
-			provider, ok := progress.decoder.(tableIDProvider)
-			if !ok {
-				continue
-			}
+		provider, ok := w.progresses[0].decoder.(tableIDProvider)
+		if ok {
 			for _, tableID := range provider.GetTableIDs(ddl.GetSchemaName(), ddl.GetTableName()) {
 				tableIDs[tableID] = struct{}{}
 			}

--- a/cmd/kafka-consumer/writer_test.go
+++ b/cmd/kafka-consumer/writer_test.go
@@ -303,6 +303,83 @@ func TestWriterWrite_sortsOutOfOrderDMLByWatermark(t *testing.T) {
 	require.Equal(t, []uint64{10, 20}, flushedCommitTs)
 }
 
+func TestPartitionDDLFlushOrder(t *testing.T) {
+	const (
+		logicalTableID   = int64(100)
+		physicalTableID  = int64(101)
+		unrelatedTableID = int64(102)
+	)
+
+	ctrl := gomock.NewController(t)
+	s := sinkmock.NewMockSink(ctrl)
+	order := make([]string, 0, 2)
+	s.EXPECT().AddDMLEvent(gomock.Any()).Do(func(event *commonEvent.DMLEvent) {
+		order = append(order, "dml")
+		event.PostFlush()
+	})
+	s.EXPECT().WriteBlockEvent(gomock.Any()).DoAndReturn(func(commonEvent.BlockEvent) error {
+		order = append(order, "ddl")
+		return nil
+	})
+
+	newMessage := func(tableID int64, table string) *codeccommon.DMLMessage {
+		return codeccommon.NewDMLMessage(tableID, "test", table, 10, common.RowTypeInsert, func() *commonEvent.DMLEvent {
+			return &commonEvent.DMLEvent{
+				PhysicalTableID: tableID,
+				CommitTs:        10,
+				RowTypes:        []common.RowType{common.RowTypeInsert},
+				Rows:            chunk.NewChunkWithCapacity(nil, 0),
+				TableInfo: &common.TableInfo{
+					TableName: common.TableName{Schema: "test", Table: table, TableID: tableID},
+				},
+			}
+		})
+	}
+
+	partitionGroup := util.NewEventsGroup(1, physicalTableID)
+	partitionGroup.AppendMessage(newMessage(physicalTableID, "members"))
+	unrelatedGroup := util.NewEventsGroup(1, unrelatedTableID)
+	unrelatedGroup.AppendMessage(newMessage(unrelatedTableID, "other"))
+
+	w := &writer{
+		progresses: []*partitionProgress{
+			{
+				partition: 0,
+				decoder: &tableIDDecoder{
+					tableIDs: []int64{logicalTableID, physicalTableID},
+				},
+				eventsGroup: make(map[int64]*util.EventsGroup),
+			},
+			{
+				partition: 1,
+				eventsGroup: map[int64]*util.EventsGroup{
+					physicalTableID:  partitionGroup,
+					unrelatedTableID: unrelatedGroup,
+				},
+			},
+		},
+		mysqlSink:              s,
+		partitionTableAccessor: codeccommon.NewPartitionTableAccessor(),
+	}
+	w.partitionTableAccessor.Add("test", "members")
+
+	err := w.flushDDLEvent(context.Background(), &commonEvent.DDLEvent{
+		Query:      "ALTER TABLE members DROP PARTITION p0",
+		SchemaName: "test",
+		TableName:  "members",
+		Type:       byte(timodel.ActionDropTablePartition),
+		FinishedTs: 20,
+		BlockedTables: &commonEvent.InfluencedTables{
+			InfluenceType: commonEvent.InfluenceTypeNormal,
+			TableIDs:      []int64{logicalTableID},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"dml", "ddl"}, order)
+	require.Empty(t, partitionGroup.GetAllMessages())
+	require.Len(t, unrelatedGroup.GetAllMessages(), 1)
+}
+
 func TestWriteMessageIgnoresFallbackDMLBelowGlobalWatermark(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
@@ -476,6 +553,15 @@ func newDMLMessageForWriterTest(commitTs uint64) *codeccommon.DMLMessage {
 type singleDMLDecoder struct {
 	message  *codeccommon.DMLMessage
 	consumed bool
+}
+
+type tableIDDecoder struct {
+	codeccommon.Decoder
+	tableIDs []int64
+}
+
+func (d *tableIDDecoder) GetTableIDs(string, string) []int64 {
+	return d.tableIDs
 }
 
 func (d *singleDMLDecoder) AddKeyValue(_, _ []byte) {

--- a/pkg/sink/codec/common/ddl.go
+++ b/pkg/sink/codec/common/ddl.go
@@ -219,7 +219,7 @@ func GetBlockedTables(
 		timodel.ActionAddIndex, timodel.ActionDropIndex, timodel.ActionRenameIndex,
 		timodel.ActionAddForeignKey, timodel.ActionDropForeignKey,
 		timodel.ActionAddPrimaryKey, timodel.ActionDropPrimaryKey,
-		timodel.ActionModifyTableCharsetAndCollate, timodel.ActionAlterIndexVisibility,
+		timodel.ActionModifyTableCharsetAndCollate, timodel.ActionModifyTableComment, timodel.ActionAlterIndexVisibility,
 		timodel.ActionRebaseAutoID, timodel.ActionMultiSchemaChange, timodel.ActionDropView:
 		return &commonEvent.InfluencedTables{
 			InfluenceType: commonEvent.InfluenceTypeNormal,

--- a/pkg/sink/codec/common/ddl_test.go
+++ b/pkg/sink/codec/common/ddl_test.go
@@ -32,6 +32,21 @@ func init() {
 	}
 }
 
+func TestModifyTableComment(t *testing.T) {
+	allocator := NewTableIDAllocator()
+	allocator.AddBlockTableID("test", "t", 1)
+	ddl := &commonEvent.DDLEvent{
+		Type:       byte(timodel.ActionModifyTableComment),
+		SchemaName: "test",
+		TableName:  "t",
+		Query:      "alter table t comment 'test'",
+	}
+
+	blockedTables := GetBlockedTables(allocator, ddl)
+	require.Equal(t, commonEvent.InfluenceTypeNormal, blockedTables.InfluenceType)
+	require.Equal(t, []int64{1}, blockedTables.TableIDs)
+}
+
 func TestGetDDLActionType(t *testing.T) {
 	helper := commonEvent.NewEventTestHelper(t)
 	defer helper.Close()

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -171,6 +171,7 @@ func (d *Decoder) NextDMLMessage() *common.DMLMessage {
 }
 
 func (d *Decoder) newDMLMessage(msg *message, tableInfo *commonType.TableInfo) *common.DMLMessage {
+	tableIDAllocator.AddBlockTableID(msg.Schema, msg.Table, msg.TableID)
 	return common.NewDMLMessage(msg.TableID, msg.Schema, msg.Table, msg.CommitTs, rowTypeFromMessageType(msg.Type), func() *commonEvent.DMLEvent {
 		return d.assembleDMLEvent(msg, tableInfo)
 	})
@@ -200,8 +201,6 @@ func (d *Decoder) assembleDMLEvent(msg *message, tableInfo *commonType.TableInfo
 	}
 
 	event := buildDMLEvent(msg, tableInfo, d.config.EnableRowChecksum, d.upstreamTiDB)
-
-	tableIDAllocator.AddBlockTableID(event.TableInfo.GetSchemaName(), event.TableInfo.GetTableName(), event.GetTableID())
 
 	log.Debug("row changed event assembled", zap.Any("event", event))
 	return event
@@ -324,6 +323,11 @@ func (d *Decoder) GetCachedMessages() []*common.DMLMessage {
 	result := d.CachedDMLMessages
 	d.CachedDMLMessages = nil
 	return result
+}
+
+// GetTableIDs identifies every table and partition whose events belong to the logical table.
+func (d *Decoder) GetTableIDs(schema, table string) []int64 {
+	return tableIDAllocator.GetBlockedTables(schema, table)
 }
 
 // TableInfoProvider is used to store and read table info

--- a/pkg/sink/codec/simple/decoder_test.go
+++ b/pkg/sink/codec/simple/decoder_test.go
@@ -25,12 +25,15 @@ import (
 
 func TestCachedDMLReturnsMessage(t *testing.T) {
 	const (
-		schema        = "test"
-		table         = "t"
-		tableID       = int64(1)
-		schemaVersion = uint64(100)
-		commitTs      = uint64(90)
+		schema          = "test"
+		table           = "t"
+		logicalTableID  = int64(1)
+		physicalTableID = int64(2)
+		schemaVersion   = uint64(100)
+		commitTs        = uint64(90)
 	)
+	tableIDAllocator.Clean()
+	t.Cleanup(tableIDAllocator.Clean)
 
 	decoder := &Decoder{
 		config:         common.NewConfig(config.ProtocolSimple),
@@ -41,7 +44,7 @@ func TestCachedDMLReturnsMessage(t *testing.T) {
 		Version:       defaultVersion,
 		Schema:        schema,
 		Table:         table,
-		TableID:       tableID,
+		TableID:       physicalTableID,
 		Type:          DMLTypeInsert,
 		CommitTs:      commitTs,
 		SchemaVersion: schemaVersion,
@@ -58,7 +61,7 @@ func TestCachedDMLReturnsMessage(t *testing.T) {
 		TableSchema: &TableSchema{
 			Schema:  schema,
 			Table:   table,
-			TableID: tableID,
+			TableID: logicalTableID,
 			Version: schemaVersion,
 			Columns: []*columnSchema{
 				{
@@ -81,11 +84,12 @@ func TestCachedDMLReturnsMessage(t *testing.T) {
 	require.Zero(t, decoder.cachedMessages.Len())
 
 	dmlMessage := cachedMessages[0]
-	require.Equal(t, tableID, dmlMessage.TableID)
+	require.Equal(t, physicalTableID, dmlMessage.TableID)
 	require.Equal(t, schema, dmlMessage.Schema)
 	require.Equal(t, table, dmlMessage.Table)
 	require.Equal(t, commitTs, dmlMessage.GetCommitTs())
 	require.Equal(t, commonType.RowTypeInsert, dmlMessage.RowType)
+	require.ElementsMatch(t, []int64{logicalTableID, physicalTableID}, decoder.GetTableIDs(schema, table))
 
 	decoder.msg = &message{
 		Version:  defaultVersion,
@@ -94,7 +98,7 @@ func TestCachedDMLReturnsMessage(t *testing.T) {
 	}
 	dmlEvent := dmlMessage.ToDMLEvent()
 	require.NotNil(t, dmlEvent)
-	require.Equal(t, tableID, dmlEvent.GetTableID())
+	require.Equal(t, physicalTableID, dmlEvent.GetTableID())
 	require.Equal(t, commitTs, dmlEvent.GetCommitTs())
 	require.Equal(t, schema, dmlEvent.TableInfo.GetSchemaName())
 	require.Equal(t, table, dmlEvent.TableInfo.GetTableName())

--- a/tests/integration_tests/kafka_simple_basic/data/data.sql
+++ b/tests/integration_tests/kafka_simple_basic/data/data.sql
@@ -7,6 +7,7 @@ create table t (
 
    primary key (a, b)
 );
+alter table t comment = 'test';
 begin;
 insert into t values ("a", 1, "a1");
 insert into t values ("b", 2, "b2");
@@ -17,6 +18,17 @@ update t set b = 0 where c = 'b2';
 
 update t set a = 'a', b = 2 where a = 'b' and b = 0;
 commit;
+
+create table partition_ddl_order (
+    id int,
+    birth_year int,
+    primary key (id, birth_year)
+) partition by range (birth_year) (
+    partition p0 values less than (2000),
+    partition p1 values less than maxvalue
+);
+insert into partition_ddl_order values (1, 1992), (2, 2001);
+alter table partition_ddl_order drop partition p0;
 
 insert into tp_int() values ();
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6165

### What is changed and how it works?

- Classify `ActionModifyTableComment` as a normal single-table DDL in `GetBlockedTables`.
- Record each simple-protocol DML physical table ID when the message becomes ready to queue.
- Resolve a partition DDL's logical table name to its observed physical partition IDs, and flush only those event groups before executing the DDL.
- Add unit tests and a `kafka_simple_basic` integration case for the two regressions.

### Check List

#### Tests

- Unit test
  - `go test ./pkg/sink/codec/common -run TestModifyTableComment -count=1`
  - `go test -race --tags=intest ./pkg/sink/codec/simple -count=1`
  - `go test -race --tags=intest ./cmd/kafka-consumer -count=1`
- Integration test
  - Added coverage to `kafka_simple_basic`.

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Table comment changes are now correctly treated as table-level updates, ensuring related processing is properly coordinated.
  - Improved partitioned-table DDL handling so pending data changes are flushed before partition operations, preserving the correct event order.
  - Enhanced tracking of logical tables and their partitions for more reliable schema-change processing.

- **Tests**
  - Added coverage for table comment updates and partition DDL flush ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->