### PR TITLE
tests: reduce split-table move case resource pressure

### DIFF
--- a/tests/integration_tests/_utils/execute_mixed_dml
+++ b/tests/integration_tests/_utils/execute_mixed_dml
@@ -23,8 +23,8 @@
 #    - Arithmetic operation updates
 # 3. DELETE: Randomly deletes records while ensuring at least one record remains
 #
-# Usage: execute_mixed_dml <table_name> <host> <port>
-# Example: execute_mixed_dml "my_table" "127.0.0.1" "4000"
+# Usage: execute_mixed_dml <table_name> <host> <port> [max_operations]
+# Example: execute_mixed_dml "my_table" "127.0.0.1" "4000" 100
 #
 # Note: This function assumes the table exists in the 'test' database
 # and uses the 'run_sql_ignore_error' function for error handling.
@@ -32,9 +32,12 @@ function execute_mixed_dml() {
 	local table_name="$1"
 	local host="$2"
 	local port="$3"
+	# Keep existing callers unbounded unless they opt into a fixed operation count.
+	local max_operations=${4:-0}
 
 	# Initialize DML operation counter
 	local dml_counter=0
+	local operation_count=0
 
 	echo "DML: Executing mixed operations on $table_name..."
 
@@ -42,7 +45,7 @@ function execute_mixed_dml() {
 	run_sql_ignore_error "INSERT INTO test.$table_name (data) VALUES ('initial_data_1_${dml_counter}'), ('initial_data_2_$((dml_counter + 1))'), ('initial_data_3_$((dml_counter + 2))');" $host $port || true
 	dml_counter=$((dml_counter + 3))
 
-	while true; do
+	while [[ $max_operations -eq 0 || $operation_count -lt $max_operations ]]; do
 		# Randomly choose between INSERT, UPDATE, and DELETE operations
 		case $((RANDOM % 3)) in
 		0)
@@ -120,6 +123,7 @@ function execute_mixed_dml() {
 			dml_counter=$((dml_counter + 1))
 			;;
 		esac
+		operation_count=$((operation_count + 1))
 
 		# Add a small delay to prevent overwhelming the database
 		sleep 0.1

--- a/tests/integration_tests/_utils/start_tidb_cluster_impl
+++ b/tests/integration_tests/_utils/start_tidb_cluster_impl
@@ -292,6 +292,11 @@ run_sql "CREATE user 'normal'@'%' identified by '123456';" ${DOWN_TIDB_HOST} ${D
 run_sql "GRANT select,insert,update,delete,index,create,drop,alter,create view,references ON *.* TO 'normal'@'%';" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 run_sql "FLUSH privileges" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
+if [[ "${SKIP_TIFLASH:-0}" == "1" ]]; then
+	echo "Skipping TiFlash startup"
+	exit 0
+fi
+
 cat - >"$OUT_DIR/tiflash-config.toml" <<EOF
 tmp_path = "${OUT_DIR}/tiflash/tmp"
 display_name = "TiFlash"

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/changefeed.toml
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/conf/changefeed.toml
@@ -1,4 +1,4 @@
 [scheduler]
 enable-table-across-nodes=true
 region-threshold=10
-region-count-per-span=10
+region-count-per-span=5

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/data/pre.sql
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/data/pre.sql
@@ -7,8 +7,8 @@ create table table_3 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
 create table table_4 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
 create table table_5 (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255));
 
-split table test.table_1 between (1) and (100000) regions 50;
-split table test.table_2 between (1) and (100000) regions 50;
-split table test.table_3 between (1) and (100000) regions 50;
-split table test.table_4 between (1) and (100000) regions 50;
-split table test.table_5 between (1) and (100000) regions 50;
+split table test.table_1 between (1) and (100000) regions 20;
+split table test.table_2 between (1) and (100000) regions 20;
+split table test.table_3 between (1) and (100000) regions 20;
+split table test.table_4 between (1) and (100000) regions 20;
+split table test.table_5 between (1) and (100000) regions 20;

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
@@ -4,7 +4,7 @@
 # 2. we enable the split table param, and start a changefeed.
 # 2. one thread we execute ddl randomly(including add column, drop column, rename table, add index, drop index)
 # 3. one thread we execute dmls, and insert data to these table.
-# 4. one thread we randomly move the table(all related dispatchers) to other nodes.
+# 4. one thread repeatedly moves every table(all related dispatchers) across nodes.
 # finally, we check the data consistency between the upstream and downstream.
 
 set -eu
@@ -18,12 +18,12 @@ SINK_TYPE=$1
 check_time=60
 ddl_operation_count=40
 dml_operation_count=1000
-move_operation_count=40
+move_operation_count=20
 
 function prepare() {
 	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
-	start_tidb_cluster --workdir $WORK_DIR
+	SKIP_TIFLASH=1 start_tidb_cluster --workdir $WORK_DIR
 
 	# record tso before we create tables to skip the system table DDLs
 	start_ts=$(run_cdc_cli_tso_query ${UP_PD_HOST_1} ${UP_PD_PORT_1})
@@ -90,26 +90,26 @@ function execute_dml() {
 
 function move_split_table() {
 	for ((i = 0; i < move_operation_count; i++)); do
-		table_num=$((RANDOM % 5 + 1))
+		table_num=$((i % 5 + 1))
+		port=$(((i / 5) % 2 + 8300))
 		table_name="table_$table_num"
-		port=$((RANDOM % 2 + 8300))
 
-		# move table to a random node
+		# move all table dispatchers to the target node
 		table_id=$(get_table_id "test" "$table_name")
-		move_split_table_with_retry "127.0.0.1:$port" $table_id "test" 10 || true
+		move_split_table_with_retry "127.0.0.1:$port" $table_id "test" 10
 		sleep 1
 	done
 }
 
 function move_split_table_consistent() {
 	for ((i = 0; i < move_operation_count; i++)); do
-		table_num=$((RANDOM % 5 + 1))
+		table_num=$((i % 5 + 1))
+		port=$(((i / 5) % 2 + 8300))
 		table_name="table_$table_num"
-		port=$((RANDOM % 2 + 8300))
 
-		# move table to a random node
+		# move all table dispatchers to the target node
 		table_id=$(get_table_id "test" "$table_name")
-		move_split_table_with_retry "127.0.0.1:$port" $table_id "test" 10 1 || true
+		move_split_table_with_retry "127.0.0.1:$port" $table_id "test" 10 1
 		sleep 1
 	done
 }

--- a/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_random_move_table/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This test is aimed to test the ddl execution for split tables when the table is scheduled to be moved.
-# 1. we start three TiCDC servers, and create a table with some data and multiple regions.
+# 1. we start two TiCDC servers, and create a table with some data and multiple regions.
 # 2. we enable the split table param, and start a changefeed.
 # 2. one thread we execute ddl randomly(including add column, drop column, rename table, add index, drop index)
 # 3. one thread we execute dmls, and insert data to these table.
@@ -16,6 +16,9 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 check_time=60
+ddl_operation_count=40
+dml_operation_count=1000
+move_operation_count=40
 
 function prepare() {
 	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
@@ -28,7 +31,6 @@ function prepare() {
 	export GO_FAILPOINTS='github.com/pingcap/ticdc/maintainer/scheduler/StopBalanceScheduler=return(true)'
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "0" --addr "127.0.0.1:8300"
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1" --addr "127.0.0.1:8301"
-	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "2" --addr "127.0.0.1:8302"
 
 	run_sql_file $CUR/data/pre.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
@@ -51,7 +53,7 @@ function prepare() {
 }
 
 function execute_ddls() {
-	while true; do
+	for ((i = 0; i < ddl_operation_count; i++)); do
 		table_num=$((RANDOM % 5 + 1))
 		table_name="table_$table_num"
 
@@ -83,14 +85,14 @@ function execute_ddls() {
 
 function execute_dml() {
 	table_name="table_$1"
-	execute_mixed_dml "$table_name" "${UP_TIDB_HOST}" "${UP_TIDB_PORT}"
+	execute_mixed_dml "$table_name" "${UP_TIDB_HOST}" "${UP_TIDB_PORT}" "$dml_operation_count"
 }
 
 function move_split_table() {
-	while true; do
+	for ((i = 0; i < move_operation_count; i++)); do
 		table_num=$((RANDOM % 5 + 1))
 		table_name="table_$table_num"
-		port=$((RANDOM % 3 + 8300))
+		port=$((RANDOM % 2 + 8300))
 
 		# move table to a random node
 		table_id=$(get_table_id "test" "$table_name")
@@ -100,10 +102,10 @@ function move_split_table() {
 }
 
 function move_split_table_consistent() {
-	while true; do
+	for ((i = 0; i < move_operation_count; i++)); do
 		table_num=$((RANDOM % 5 + 1))
 		table_name="table_$table_num"
-		port=$((RANDOM % 3 + 8300))
+		port=$((RANDOM % 2 + 8300))
 
 		# move table to a random node
 		table_id=$(get_table_id "test" "$table_name")
@@ -112,13 +114,28 @@ function move_split_table_consistent() {
 	done
 }
 
+function wait_for_workload() {
+	wait "$NORMAL_TABLE_DDL_PID"
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+	wait "$MOVE_TABLE_PID"
+}
+
+function wait_for_replication() {
+	run_sql "CREATE TABLE test.workload_finished (id INT PRIMARY KEY);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	check_table_exists "test.workload_finished" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 150
+}
+
 main() {
 	prepare changefeed
+	# Each table must still be split into multiple dispatchers after reducing regions.
+	query_dispatcher_count "127.0.0.1:8300" "test" 11 100 ge
 
 	execute_ddls &
 	NORMAL_TABLE_DDL_PID=$!
 
-	# do execute dml for 100 tables, and store the pid for each thread
+	# execute DML for five tables, and store the PID for each thread
 	declare -a pids=()
 
 	for i in {1..5}; do
@@ -129,13 +146,10 @@ main() {
 	move_split_table &
 	MOVE_TABLE_PID=$!
 
-	sleep 500
+	wait_for_workload
+	wait_for_replication
 
-	kill -9 $NORMAL_TABLE_DDL_PID ${pids[@]} $MOVE_TABLE_PID
-
-	sleep 10
-
-	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 30
 
 	cleanup_process $CDC_BINARY
 }
@@ -145,11 +159,12 @@ main_with_consistent() {
 		return
 	fi
 	prepare consistent_changefeed
+	query_dispatcher_count "127.0.0.1:8300" "test" 11 100 ge 1
 
 	execute_ddls &
 	NORMAL_TABLE_DDL_PID=$!
 
-	# do execute dml for 100 tables, and store the pid for each thread
+	# execute DML for five tables, and store the PID for each thread
 	declare -a pids=()
 
 	for i in {1..5}; do
@@ -160,11 +175,8 @@ main_with_consistent() {
 	move_split_table_consistent &
 	MOVE_TABLE_PID=$!
 
-	sleep 500
-
-	kill -9 $NORMAL_TABLE_DDL_PID ${pids[@]} $MOVE_TABLE_PID
-	# to ensure row changed events have been replicated to TiCDC
-	sleep 20
+	wait_for_workload
+	wait_for_replication
 	if ((RANDOM % 2)); then
 		# For rename table, modify column ddl, drop column, drop index and drop table ddl, the struct of table is wrong when appling snapshot.
 		# see https://github.com/pingcap/tidb/issues/63464.
@@ -181,7 +193,7 @@ main_with_consistent() {
 			--sink-uri="mysql://normal:123456@127.0.0.1:3306/" >$WORK_DIR/cdc_redo.log
 		check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 100
 	else
-		check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 300
+		check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 30
 		cleanup_process $CDC_BINARY
 	fi
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6210

The Kafka-heavy `ddl_for_split_tables_with_random_move_table` case combines an
unbounded 500-second workload, 250 regions, three CDC nodes, TiFlash, concurrent
DML and DDL, and repeated whole-table dispatcher moves. This can exhaust or
stall the shared 24 GiB CI container before replication drains.

### What is changed and how it works?

- Add an optional operation limit to `execute_mixed_dml`; existing callers keep
  the unlimited default.
- Reduce the case to 20 regions per table and five regions per span, while
  asserting that multiple dispatchers are still created.
- Let this case opt out of the shared fixture's TiFlash startup; other cases keep
  the existing default topology.
- Use two CDC nodes and bound the workload to 1,000 DML operations per table,
  40 DDL iterations, and 20 split-table moves. Every table is moved to both CDC
  nodes twice, and a failed move now fails the test.
- Wait for all workload workers and a downstream marker DDL before sync-diff,
  instead of killing workers after a fixed sleep.

### Check List

#### Tests

- [x] Integration test
- [x] Manual test

Ran the case twice on the TiCDC development machine with fresh binaries and a
24 GiB/6 CPU container limit:

```text
make integration_test_kafka CASE=ddl_for_split_tables_with_random_move_table
run 1: PASS, 204s, 14.98 GiB sampled peak, OOM=false
run 2: PASS, 201s, 16.55 GiB sampled peak, OOM=false
```

Both runs skipped TiFlash, observed 21 dispatchers, completed 5,000 DML
operations, 40 DDL iterations, and all 20 required cross-node moves. Sync-diff
passed on the first attempt with no data race or CDC/PD fatal error.

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only changes integration-test workload sizing. The shared helper keeps
its existing unlimited behavior unless a caller supplies the new limit.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
