### PR TITLE
server: shorten capture removal delay on rolling restart

### DIFF
--- a/docs/design/capture-write-lease-design.md
+++ b/docs/design/capture-write-lease-design.md
@@ -30,8 +30,9 @@ following goal:
   blocking rather than immediate capture termination.
 - A confirmed loss of the etcd session irreversibly fences the capture and
   terminates the process.
-- After capture-key deletion, `captureRemoveTTL` delays scheduler-visible node
-  removal so a replacement cannot take over too early.
+- Scheduler-visible removal uses a durable write-stopped marker, a bounded
+  same-address current-protocol path, or the conservative `captureRemoveTTL`,
+  so a replacement cannot take over before the applicable safety boundary.
 - During a rolling upgrade, P2P is required only after every active capture
   has reported support for the protocol.
 - Normal writes perform only a local atomic state read and do not add a
@@ -85,11 +86,12 @@ The proofs have separate responsibilities:
 
 ## 3. Safety ordering and proof
 
-`captureRemoveTTL` is the scheduling barrier for a replacement. Define:
+The capture-removal policy is the scheduling barrier for a replacement. Define:
 
 ```text
 Le   = maximum etcd proof lifetime = 5s
-R    = captureRemoveTTL = max(captureSessionTTL / 2, 10s)
+Lf   = max(P2P lease, etcd proof lifetime) = 5s
+R    = conservative captureRemoveTTL = max(captureSessionTTL / 2, 10s)
 td   = time the old capture key is deleted in a linearizable etcd view
 tobs = time another CDC node observes that deletion, tobs >= td
 ```
@@ -102,32 +104,40 @@ proof begins at `requestSentAt` and lasts at most `Le`, so:
 oldLastAdmission < td + Le = td + 5s
 ```
 
-Another node does not publish node removal immediately after observing the key
-deletion. It first waits `R`:
+A different capture ID that registers the same address with a non-older start
+time can select the shortened path only when both registrations advertise the
+current write-lease protocol. It waits `Lf` from deletion observation:
 
 ```text
-newFirstAdmission >= tobs + R >= td + 10s
+newFirstAdmission >= tobs + Lf >= td + 5s
 ```
 
-With default values:
+Therefore:
 
 ```text
-oldLastAdmission < td + 5s < td + 10s <= tobs + R <= newFirstAdmission
+oldLastAdmission < td + 5s <= tobs + Lf <= newFirstAdmission
 ```
 
 ![Write admission safety proof](../media/capture-write-lease-safety-proof.svg)
 
-This proves that the new-operation admission windows do not overlap. P2P
-usually stops the old writer sooner, but the proof does not depend on P2P.
-Mixed-version and single-capture modes therefore retain the same time-separation
-lower bound.
+The diagram shows the wider conservative `R` path. Legacy, capability-unknown,
+different-address, and ambiguous cases retain that path. The shortened proof
+does not assume that a recent P2P grant means graceful shutdown; it waits the
+maximum lifetime of both local proofs.
+
+A second path is stronger than either timer. After every local module has
+closed successfully, the server conditionally publishes `write-stopped=true`
+under the capture key's existing session lease and then deletes the key. Since
+all local writers and sinks have closed before marker publication, observers
+can remove the marked capture immediately on deletion. The lease comparison
+prevents a slow shutdown from recreating a key whose session already expired.
 
 The proof depends on four implementation conditions:
 
 1. Every real downstream side effect passes through a transport-owned final
    gate.
 2. Every replacement is produced through the same scheduling path that
-   observes capture removal.
+   observes capture removal and applies the selected removal boundary.
 3. Capture-key deletion and observation follow etcd linearizability.
 4. In-process deadline comparison uses Go's monotonic clock, which advances
    normally for the process.
@@ -213,8 +223,8 @@ O(N) scan and creating O(N^2) control-plane work.
 When no remote capture exists, the coordinator's local capture receives a
 direct grant. This keeps single-node deployments available, but P2P cannot
 prove external connectivity in that topology. The etcd proof remains
-mandatory, and etcd proof plus `captureRemoveTTL` still establishes the
-replacement ordering.
+mandatory, and the etcd proof plus the selected capture-removal boundary still
+establishes replacement ordering.
 
 ### 4.5 Rolling upgrades and capability negotiation
 
@@ -448,11 +458,47 @@ use the same gate.
 Blackhole has no real external side effect, so `SetWriteGate` is a no-op. It
 still satisfies the common interface without waiting.
 
-## 8. Role of `captureRemoveTTL`
+## 8. Capture-removal policy
 
-`captureRemoveTTL` is neither an etcd lease nor the mechanism that terminates
-the old process. It delays scheduler-visible node removal after `NodeManager`
-observes deletion of a capture key:
+The removal policy is neither an etcd lease nor the mechanism that terminates
+the old process. `NodeManager` chooses one of three paths after capture metadata
+changes.
+
+### 8.1 Graceful write-stopped marker
+
+Capture registration includes two additive fields:
+
+- `write-lease-protocol-version` records the write-fencing capability without
+  inferring it from the binary version string.
+- `write-stopped` is false during normal operation. The server sets it only
+  after all submodules, node modules, network modules, pre-services, dispatcher
+  managers, and sinks close successfully.
+
+The marker update uses an etcd transaction comparing the capture key's lease
+with the local session lease. If the key expired, changed ownership, the marker
+write failed, or any module failed or timed out during close, no graceful proof
+is published. When an observer sees deletion of a capture whose latest value
+has `write-stopped=true`, it publishes node removal immediately.
+
+### 8.2 Same-address current-protocol replacement
+
+An unmarked deleted capture uses a five-second boundary when a replacement
+satisfies all of these conditions:
+
+- deletion of the old ID has been observed before removal is published;
+- the new ID differs from the old ID;
+- both values advertise the current write-lease protocol;
+- both have the same non-empty advertised address;
+- the new start timestamp is not older; and
+- the new value is not itself write-stopped.
+
+The replacement may arrive before or after the delete event. Removal is not
+published until five seconds have elapsed since local deletion observation,
+which is no earlier than the expiry of either old write proof.
+
+### 8.3 Conservative fallback
+
+Every case without one of the proofs above retains the existing delay:
 
 ```text
 captureRemoveTTL = max(captureSessionTTL / 2, 10s)
@@ -461,13 +507,13 @@ captureRemoveTTL = max(captureSessionTTL / 2, 10s)
 The default `captureSessionTTL` is ten seconds, so the default
 `captureRemoveTTL` is ten seconds.
 
-The sequence is:
+The delayed sequence is:
 
 ```text
 observe capture key deletion
     -> record pending removal time
     -> keep capture in the node view
-    -> wait captureRemoveTTL
+    -> wait the five-second fenced-replacement bound or captureRemoveTTL
     -> publish node removal
     -> scheduler may create a replacement
 ```
@@ -480,11 +526,12 @@ The separation of responsibilities is:
 
 - The local etcd proof establishes the latest time the old writer may admit a
   new operation.
-- `captureRemoveTTL` establishes an earliest time when replacement scheduling
-  may begin.
+- The durable marker proves that all local write paths have closed.
+- Otherwise the selected delay establishes an earliest time when replacement
+  scheduling may begin.
 
-P2P improves stop-write latency during isolation, but it is not the replacement
-scheduling barrier.
+P2P improves stop-write latency during isolation, but a fresh P2P lease alone
+is not proof of graceful shutdown and never permits immediate removal.
 
 ## 9. Failure behavior
 
@@ -494,8 +541,9 @@ scheduling barrier.
 | Coordinator capture is isolated from other nodes | Witness cannot ACK; local P2P expires. | Only if the etcd session is also confirmed lost. | Depends on capture-key deletion. |
 | One witness is unreachable | Rotate after one second; no interruption if another witness succeeds in time. | No. | Not triggered. |
 | PD/etcd TTL query temporarily fails | Do not renew etcd proof; stop writes after proof expiry. | No. | Not triggered while the key remains. |
-| etcd session is confirmed lost | Irreversible local fence. | Yes. | Wait `captureRemoveTTL` after observing key deletion. |
-| Control plane is unreachable but downstream remains reachable | At least one required proof expires and transports stop new writes. | Only after confirmed session loss. | Constrained by `captureRemoveTTL`. |
+| etcd session is confirmed lost | Irreversible local fence. | Yes. | Wait five seconds only after a matching current-protocol restart; otherwise wait `captureRemoveTTL`. |
+| Normal process shutdown completes | Gate and every local writer/sink are closed before metadata changes. | Yes. | Remove immediately after observing the marked key deletion. |
+| Control plane is unreachable but downstream remains reachable | At least one required proof expires and transports stop new writes. | Only after confirmed session loss. | Uses the same-address bounded path only with matching capability evidence; otherwise `captureRemoveTTL`. |
 | A legacy node participates in a rolling upgrade | P2P is not required; etcd proof remains required. | Follows etcd session semantics. | Constrained by `captureRemoveTTL`. |
 
 ### 9.1 Complete example
@@ -510,14 +558,17 @@ coordinator/witness and PD while retaining access to MySQL:
    operation, send, object publication, or redo flush.
 3. Around `t0+10s`, the default session TTL expires and the capture key is
    deleted from etcd.
-4. Other nodes observe the deletion and wait the default ten-second
-   `captureRemoveTTL`.
+4. With no matching same-address registration or graceful marker, other nodes
+   observe the deletion and wait the default ten-second `captureRemoveTTL`.
 5. Only then can the scheduler publish node removal and create a replacement;
-   the replacement's first actual write is later still.
+   the replacement's first actual write is later still. If the same address
+   restarts with the current protocol, the post-observation wait is five
+   seconds instead.
 
 The old writer therefore stops new admission by about `t0+5s`, while a
-replacement normally cannot write until after `t0+20s`. The boundaries create
-an explicit separation interval.
+replacement on the conservative path normally cannot write until after
+`t0+20s`. The shortened same-address path still cannot publish removal before
+the final five-second proof expires.
 
 ### 9.2 Late completion remains possible
 
@@ -554,7 +605,7 @@ The design exposes these primary metrics:
 | `ticdc_coordinator_capture_lease_heartbeat_total{result}` | Coordinator heartbeat-processing results. |
 | `ticdc_server_capture_lease_response_total{result}` | Capture response-processing results. |
 | `ticdc_coordinator_capture_p2p_witness_available` | Whether a remote witness is available for the coordinator capture. |
-| `ticdc_server_capture_safe_to_reschedule_delay_seconds` | Effective `captureRemoveTTL`. |
+| `ticdc_server_capture_safe_to_reschedule_delay_seconds` | Conservative fallback `captureRemoveTTL`; proven graceful and same-address paths may be shorter. |
 
 A writable-to-blocked transition logs its reason, and a blocked-to-writable
 transition logs recovery. Local fencing has a separate explicit log, allowing
@@ -601,6 +652,10 @@ Server and orchestrator tests cover:
 - Gate state and block-transition metrics.
 - `captureRemoveTTL` calculation, delayed removal, and cancellation of pending
   removal when the same capture re-registers.
+- Immediate removal after a write-stopped marker and conditional marker updates
+  bound to the current etcd session lease.
+- Five-second removal for matching same-address current-protocol replacements,
+  with conservative fallback for legacy or different-address registrations.
 
 Messaging tests include in-process and remote serialization round trips for
 the response and witness fields, ensuring that the protocol works through the
@@ -723,7 +778,7 @@ assumption in the proof has direct evidence:
 | The gate opens only when every required proof is fresh. | Gate truth-table, deadline, fence, and mode tests. |
 | A delayed or replayed message cannot extend a lease. | Epoch, sequence, request-age tests and integration failpoints. |
 | Every real side effect checks final admission. | Component tests for five sink types, claim-check, and redo, plus the mandatory sink interface. |
-| Replacement does not start immediately after key deletion. | `captureRemoveTTL` state tests and lifecycle chaos. |
+| Replacement starts only after its selected safety boundary. | Write-stopped, same-address fenced replacement, conservative `captureRemoveTTL`, and lifecycle tests. |
 | A capture stops and recovers when the control plane is isolated but downstream remains reachable. | PD-only and PD+CDC reachability probes and the two-hour rotation. |
 | Recovery leaves no residual data error. | Checkpoint catch-up, 100-table CRC, Sync Diff, and panic scan. |
 
@@ -750,6 +805,7 @@ substitute for a missing safety-proof obligation.
 | etcd TTL safety margin | 1 s | Absorb TTL rounding and transport time. |
 | etcd proof duration | At most 5 s | Bound new writes after PD/etcd loss. |
 | Capture session TTL | 10 s by default | Server-side lifetime of the capture key. |
+| Fenced replacement delay | 5 s | Match the maximum P2P or etcd write-proof lifetime after deletion observation. |
 | `captureRemoveTTL` | `max(sessionTTL / 2, 10s)` | Establish a later replacement-takeover boundary. |
 | Gate monitor interval | 100 ms | Record gate metrics and transition logs. |
 
@@ -762,9 +818,9 @@ substitute for a missing safety-proof obligation.
 | Heartbeat admission and initialized-node snapshot | [`coordinator/controller.go`](../../coordinator/controller.go), [`pkg/bootstrap/bootstrap.go`](../../pkg/bootstrap/bootstrap.go) |
 | Capture heartbeat, response validation, and witness ACK | [`maintainer/maintainer_manager_node.go`](../../maintainer/maintainer_manager_node.go) |
 | Coordinator-generation changes | [`maintainer/maintainer_manager.go`](../../maintainer/maintainer_manager.go) |
-| etcd TTL watchdog and local fence | [`server/server.go`](../../server/server.go) |
+| etcd TTL watchdog, local fence, and graceful write-stopped marker | [`server/server.go`](../../server/server.go), [`server/server_prepare.go`](../../server/server_prepare.go) |
 | Capture-wide gate injection | [`server/server.go`](../../server/server.go), [`pkg/common/context/app_context.go`](../../pkg/common/context/app_context.go) |
-| Replacement delay | [`pkg/orchestrator/reactor_state.go`](../../pkg/orchestrator/reactor_state.go) |
+| Capture metadata and replacement-removal policy | [`pkg/config/capture.go`](../../pkg/config/capture.go), [`pkg/orchestrator/reactor_state.go`](../../pkg/orchestrator/reactor_state.go) |
 | Common outer sink gate | [`downstreamadapter/sink/write_gate.go`](../../downstreamadapter/sink/write_gate.go) |
 | Transport final gates | `downstreamadapter/sink/{mysql,kafka,pulsar,cloudstorage,redo}` |
 | MySQL final SQL check | [`pkg/sink/mysql`](../../pkg/sink/mysql) |
@@ -779,9 +835,11 @@ substitute for a missing safety-proof obligation.
 
 The capture write lease reduces "may this capture still write?" to one local,
 low-overhead, fail-closed gate. The P2P lease proves the current coordinator
-relationship, the etcd proof confirms the capture session identity, and
-`captureRemoveTTL` delays the replacement. Final checks at every real sink
-mutation boundary make asynchronous queues obey the same safety condition.
+relationship, the etcd proof confirms the capture session identity, and the
+capture-removal policy chooses a durable graceful proof, a five-second fenced
+replacement bound, or conservative `captureRemoveTTL`. Final checks at every
+real sink mutation boundary make asynchronous queues obey the same safety
+condition.
 
 The design proves that the new-write admission windows of the old and
 replacement writers do not overlap, and it automatically blocks and recovers

--- a/docs/design/capture-write-lease-overview.md
+++ b/docs/design/capture-write-lease-overview.md
@@ -151,30 +151,47 @@ therefore does not permanently block its local changefeeds, and the cluster
 switches to dual-proof admission automatically after all captures are ready.
 
 The safety implication is explicit: while legacy captures are present, the
-cluster does not have P2P isolation protection. Admission safety relies on the
-etcd proof and `captureRemoveTTL` until all active captures support P2P.
+cluster does not have P2P isolation protection. Admission safety still relies
+on the mandatory etcd proof. Legacy or capability-unknown registrations retain
+the conservative `captureRemoveTTL` replacement path.
 
-## 5. `captureRemoveTTL` and replacement admission
+## 5. Capture removal and replacement admission
 
-`captureRemoveTTL` is not an etcd lease and does not control when the old
-process exits. It is the delay between another CDC node observing deletion of a
-capture key and publishing that capture's removal to schedulers:
+Capture removal is not an etcd lease and does not control when the old process
+exits. After observing deletion of a capture key, another CDC node selects one
+of three removal paths:
+
+1. A capture that successfully closes every local module publishes
+   `write-stopped=true` under its existing session lease before deleting the
+   key. Observers remove this capture immediately on deletion.
+2. If a different capture ID with the same address and a non-older start time
+   registers, and both registrations advertise the current write-lease
+   protocol, observers wait only the five-second write-proof bound from the
+   old key's deletion observation.
+3. Missing, legacy, mismatched, or ambiguous evidence keeps the conservative
+   delay:
 
 ```text
 captureRemoveTTL = max(captureSessionTTL / 2, 10s)
 ```
 
-With the default `captureSessionTTL = 10s`, `captureRemoveTTL = 10s`. During
-this delay:
+The graceful marker is written with an etcd transaction that verifies the key
+is still attached to the capture's own session lease. A slow shutdown therefore
+cannot recreate an expired registration. If any module fails to close, the
+marker write fails, or the registration has changed, shutdown still deletes the
+key but observers use one of the bounded fallback paths.
+
+With the default `captureSessionTTL = 10s`, the conservative delay is ten
+seconds. During any non-zero delay:
 
 - The old capture remains in the node view and is not immediately replaced.
 - A re-registration of the same capture cancels the pending removal.
-- Only after the delay expires is node removal published, after which a
+- Only after the selected delay expires is node removal published, after which a
   replacement may be scheduled.
 
 The local proof creates an upper bound for when the old writer stops admitting
-new work. `captureRemoveTTL` creates a later lower bound for when a replacement
-can begin.
+new work. The selected removal path creates a matching or later lower bound for
+when a replacement can begin.
 
 ## 6. Why new-write admission does not overlap
 
@@ -182,7 +199,8 @@ Define:
 
 ```text
 Le   = maximum local etcd proof lifetime = 5s
-R    = captureRemoveTTL                  >= 10s
+Lf   = maximum write-proof lifetime      = 5s
+R    = conservative captureRemoveTTL     >= 10s
 td   = linearizable deletion time of the old capture key
 tobs = time another CDC node observes the deletion, tobs >= td
 ```
@@ -195,26 +213,32 @@ oldEtcdProofValidUntil < td + 5s
 oldLastAdmission       < td + 5s
 ```
 
-A replacement must wait `R` after observing the deletion:
+A same-address, current-protocol replacement must wait `Lf` after observing the
+deletion:
 
 ```text
-newFirstAdmission >= tobs + R >= td + 10s
+newFirstAdmission >= tobs + Lf >= td + 5s
 ```
 
 Therefore:
 
 ```text
-oldLastAdmission < td + 5s < td + 10s <= tobs + R <= newFirstAdmission
+oldLastAdmission < td + 5s <= tobs + Lf <= newFirstAdmission
 ```
 
 ![Write admission safety proof](../media/capture-write-lease-safety-proof.svg)
 
+The conservative path waits `R`, so it retains the wider inequality shown in
+the diagram. The graceful path needs no timer: every local writer and sink has
+already closed before the marker is published, and marker publication precedes
+key deletion.
+
 The proof depends on four conditions: every real downstream side effect passes
-through a transport gate; all replacements pass through `captureRemoveTTL`;
-capture-key deletion is observed with etcd linearizability; and the local
-monotonic clock advances normally. MySQL, Kafka, Pulsar, Cloud Storage, and Redo
-all implement the same gate contract, so asynchronous queues are not an
-unbounded gap in the proof.
+through a transport gate; the shortened path is used only for registrations
+that explicitly advertise the current protocol; capture-key deletion is
+observed with etcd linearizability; and the local monotonic clock advances
+normally. MySQL, Kafka, Pulsar, Cloud Storage, and Redo all implement the same
+gate contract, so asynchronous queues are not an unbounded admission gap.
 
 ### Example
 
@@ -228,10 +252,14 @@ access to the downstream system:
    operation, send, file publication, or metadata mutation.
 3. With defaults, the session lease expires around `t0+10s` and the capture key
    is deleted.
-4. Other nodes observe the deletion and wait another ten seconds before
-   publishing node removal and scheduling a replacement.
-5. The replacement's first actual write is normally later than `t0+20s`, about
-   fifteen seconds after the old writer stopped admitting new operations.
+4. If no qualifying same-address registration or graceful marker exists, other
+   nodes wait another ten seconds before publishing node removal and scheduling
+   a replacement.
+5. On that conservative path, the replacement's first actual write is normally
+   later than `t0+20s`, about fifteen seconds after the old writer stopped
+   admitting new operations. A qualifying same-address restart can reduce the
+   post-deletion delay to five seconds without crossing the old admission
+   bound.
 
 Detection and scheduling may add wall-clock delay, but they cannot reverse the
 ordering established by the inequalities above.
@@ -260,10 +288,11 @@ downstream protocol changes and per-write network RTTs.
 ## 8. Implementation entry points
 
 - Gate and proof state: [`pkg/writelease/write_gate.go`](../../pkg/writelease/write_gate.go)
-- etcd TTL watchdog and local fence: [`server/server.go`](../../server/server.go)
+- etcd TTL watchdog, local fence, and graceful marker: [`server/server.go`](../../server/server.go)
 - P2P, mixed-version mode, and witness: [`coordinator/capture_write_lease.go`](../../coordinator/capture_write_lease.go)
 - Capture heartbeat and capability handling: [`maintainer/maintainer_manager_node.go`](../../maintainer/maintainer_manager_node.go)
-- Replacement barrier: [`pkg/orchestrator/reactor_state.go`](../../pkg/orchestrator/reactor_state.go)
+- Capture metadata and replacement policy: [`pkg/config/capture.go`](../../pkg/config/capture.go),
+  [`pkg/orchestrator/reactor_state.go`](../../pkg/orchestrator/reactor_state.go)
 - Common sink gate: [`downstreamadapter/sink/write_gate.go`](../../downstreamadapter/sink/write_gate.go)
 - Transport-owned final checks: `downstreamadapter/sink/{mysql,kafka,pulsar,cloudstorage,redo}`,
   `pkg/sink/mysql`, and `pkg/redo/writer`

--- a/pkg/config/capture.go
+++ b/pkg/config/capture.go
@@ -50,6 +50,13 @@ type CaptureInfo struct {
 	DeployPath     string `json:"deploy-path"`
 	StartTimestamp int64  `json:"start-timestamp"`
 	IsNewArch      bool   `json:"is-new-arch"`
+
+	// WriteLeaseProtocolVersion records the write-fencing protocol supported by
+	// this capture. A missing value means that the capability is unknown.
+	WriteLeaseProtocolVersion uint32 `json:"write-lease-protocol-version,omitempty"`
+	// WriteStopped is published only after every local module has stopped, so
+	// observers can remove this capture without waiting for its write leases.
+	WriteStopped bool `json:"write-stopped,omitempty"`
 }
 
 // Marshal using json.Marshal.

--- a/pkg/metrics/write_lease.go
+++ b/pkg/metrics/write_lease.go
@@ -77,7 +77,7 @@ var (
 			Namespace: "ticdc",
 			Subsystem: "server",
 			Name:      "capture_safe_to_reschedule_delay_seconds",
-			Help:      "Delay after capture lease-key deletion before removal is published.",
+			Help:      "Conservative fallback delay after capture lease-key deletion before removal is published.",
 		})
 	CaptureP2PWitnessAvailable = prometheus.NewGauge(
 		prometheus.GaugeOpts{

--- a/pkg/orchestrator/reactor_state.go
+++ b/pkg/orchestrator/reactor_state.go
@@ -20,15 +20,20 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/orchestrator/util"
+	"github.com/pingcap/ticdc/pkg/writelease"
 	"go.uber.org/zap"
 )
 
-const defaultCaptureRemoveTTL = 10
+const (
+	defaultCaptureRemoveTTL     = 10
+	writeFencedCaptureRemoveTTL = max(writelease.P2PLeaseDuration, writelease.EtcdProofDuration)
+)
 
 // GlobalReactorState represents a global state which stores all key-value pairs in ETCD
 type GlobalReactorState struct {
@@ -47,6 +52,9 @@ type GlobalReactorState struct {
 
 	captureRemoveTTL int
 	toRemoveCaptures map[config.CaptureID]time.Time
+	// writeFencedReplacements contains deleted captures for which a different
+	// current-protocol capture has registered the same address.
+	writeFencedReplacements map[config.CaptureID]struct{}
 }
 
 // NewGlobalState creates a new global state.
@@ -56,13 +64,14 @@ func NewGlobalState(clusterID string, captureSessionTTL int) *GlobalReactorState
 		captureRemoveTTL = defaultCaptureRemoveTTL
 	}
 	return &GlobalReactorState{
-		ClusterID:        clusterID,
-		Owner:            map[string]struct{}{},
-		Captures:         make(map[config.CaptureID]*config.CaptureInfo),
-		Upstreams:        make(map[config.UpstreamID]*config.UpstreamInfo),
-		Changefeeds:      make(map[common.ChangeFeedID]*ChangefeedReactorState),
-		captureRemoveTTL: captureRemoveTTL,
-		toRemoveCaptures: make(map[config.CaptureID]time.Time),
+		ClusterID:               clusterID,
+		Owner:                   map[string]struct{}{},
+		Captures:                make(map[config.CaptureID]*config.CaptureInfo),
+		Upstreams:               make(map[config.UpstreamID]*config.UpstreamInfo),
+		Changefeeds:             make(map[common.ChangeFeedID]*ChangefeedReactorState),
+		captureRemoveTTL:        captureRemoveTTL,
+		toRemoveCaptures:        make(map[config.CaptureID]time.Time),
+		writeFencedReplacements: make(map[config.CaptureID]struct{}),
 	}
 }
 
@@ -80,15 +89,29 @@ func NewGlobalStateForTest(clusterID string) *GlobalReactorState {
 // UpdatePendingChange implements the ReactorState interface
 func (s *GlobalReactorState) UpdatePendingChange() {
 	for c, t := range s.toRemoveCaptures {
-		if time.Since(t) >= time.Duration(s.captureRemoveTTL)*time.Second {
-			log.Info("remote capture offline", zap.Any("info", s.Captures[c]), zap.String("role", s.Role))
-			delete(s.Captures, c)
-			if s.onCaptureRemoved != nil {
-				s.onCaptureRemoved(c)
-			}
-			delete(s.toRemoveCaptures, c)
+		removeTTL := time.Duration(s.captureRemoveTTL) * time.Second
+		reason := "capture remove TTL expired"
+		if _, ok := s.writeFencedReplacements[c]; ok {
+			removeTTL = writeFencedCaptureRemoveTTL
+			reason = "same-address replacement observed after write-lease expiry"
+		}
+		if time.Since(t) >= removeTTL {
+			s.removeCapture(c, reason)
 		}
 	}
+}
+
+func (s *GlobalReactorState) removeCapture(captureID config.CaptureID, reason string) {
+	log.Info("remote capture offline",
+		zap.Any("info", s.Captures[captureID]),
+		zap.String("role", s.Role),
+		zap.String("reason", reason))
+	delete(s.Captures, captureID)
+	if s.onCaptureRemoved != nil {
+		s.onCaptureRemoved(captureID)
+	}
+	delete(s.toRemoveCaptures, captureID)
+	delete(s.writeFencedReplacements, captureID)
 }
 
 // Update implements the ReactorState interface
@@ -109,8 +132,16 @@ func (s *GlobalReactorState) Update(key util.EtcdKey, value []byte, _ bool) erro
 		return nil
 	case etcd.CDCKeyTypeCapture:
 		if value == nil {
-			log.Info("remote capture offline detected", zap.Any("info", s.Captures[k.CaptureID]), zap.String("role", s.Role))
+			captureInfo := s.Captures[k.CaptureID]
+			log.Info("remote capture offline detected", zap.Any("info", captureInfo), zap.String("role", s.Role))
+			if captureInfo != nil && captureInfo.ID == k.CaptureID && captureInfo.WriteStopped {
+				s.removeCapture(k.CaptureID, "capture reported writes stopped")
+				return nil
+			}
 			s.toRemoveCaptures[k.CaptureID] = time.Now()
+			if s.hasWriteFencedReplacement(k.CaptureID, captureInfo) {
+				s.writeFencedReplacements[k.CaptureID] = struct{}{}
+			}
 			return nil
 		}
 
@@ -123,6 +154,8 @@ func (s *GlobalReactorState) Update(key util.EtcdKey, value []byte, _ bool) erro
 		log.Info("remote capture online", zap.Any("info", newCaptureInfo), zap.String("role", s.Role))
 		// A fresh online event supersedes any pending delayed removal for the same capture.
 		delete(s.toRemoveCaptures, k.CaptureID)
+		delete(s.writeFencedReplacements, k.CaptureID)
+		s.markWriteFencedReplacements(k.CaptureID, &newCaptureInfo)
 		if s.onCaptureAdded != nil {
 			s.onCaptureAdded(k.CaptureID, newCaptureInfo.AdvertiseAddr)
 		}
@@ -168,6 +201,47 @@ func (s *GlobalReactorState) Update(key util.EtcdKey, value []byte, _ bool) erro
 			zap.String("role", s.Role))
 	}
 	return nil
+}
+
+func (s *GlobalReactorState) markWriteFencedReplacements(
+	newCaptureID config.CaptureID,
+	newCaptureInfo *config.CaptureInfo,
+) {
+	for oldCaptureID := range s.toRemoveCaptures {
+		if isWriteFencedReplacement(oldCaptureID, s.Captures[oldCaptureID], newCaptureID, newCaptureInfo) {
+			s.writeFencedReplacements[oldCaptureID] = struct{}{}
+		}
+	}
+}
+
+func (s *GlobalReactorState) hasWriteFencedReplacement(
+	oldCaptureID config.CaptureID,
+	oldCaptureInfo *config.CaptureInfo,
+) bool {
+	for newCaptureID, newCaptureInfo := range s.Captures {
+		if isWriteFencedReplacement(oldCaptureID, oldCaptureInfo, newCaptureID, newCaptureInfo) {
+			return true
+		}
+	}
+	return false
+}
+
+func isWriteFencedReplacement(
+	oldCaptureID config.CaptureID,
+	oldCaptureInfo *config.CaptureInfo,
+	newCaptureID config.CaptureID,
+	newCaptureInfo *config.CaptureInfo,
+) bool {
+	return oldCaptureInfo != nil && newCaptureInfo != nil &&
+		oldCaptureID != newCaptureID &&
+		oldCaptureInfo.ID == oldCaptureID &&
+		newCaptureInfo.ID == newCaptureID &&
+		oldCaptureInfo.AdvertiseAddr != "" &&
+		oldCaptureInfo.AdvertiseAddr == newCaptureInfo.AdvertiseAddr &&
+		oldCaptureInfo.WriteLeaseProtocolVersion == heartbeatpb.CurrentWriteLeaseProtocolVersion &&
+		newCaptureInfo.WriteLeaseProtocolVersion == heartbeatpb.CurrentWriteLeaseProtocolVersion &&
+		!newCaptureInfo.WriteStopped &&
+		newCaptureInfo.StartTimestamp >= oldCaptureInfo.StartTimestamp
 }
 
 // GetPatches implements the ReactorState interface

--- a/pkg/orchestrator/reactor_state_capture_test.go
+++ b/pkg/orchestrator/reactor_state_capture_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/orchestrator/util"
@@ -46,6 +47,7 @@ func TestGlobalReactorStateKeepsCaptureAfterReRegister(t *testing.T) {
 	mustUpdateCapture(t, state, captureID, "127.0.0.1:8300")
 	mustDeleteCapture(t, state, captureID)
 	state.toRemoveCaptures[captureID] = time.Now().Add(-11 * time.Second)
+	state.writeFencedReplacements[captureID] = struct{}{}
 	mustUpdateCapture(t, state, captureID, "127.0.0.1:8301")
 
 	state.UpdatePendingChange()
@@ -54,6 +56,7 @@ func TestGlobalReactorStateKeepsCaptureAfterReRegister(t *testing.T) {
 	require.Equal(t, "127.0.0.1:8301", state.Captures[captureID].AdvertiseAddr)
 	require.Empty(t, removed)
 	require.NotContains(t, state.toRemoveCaptures, captureID)
+	require.NotContains(t, state.writeFencedReplacements, captureID)
 }
 
 func TestGlobalReactorStateRemovesCaptureAfterTombstoneExpires(t *testing.T) {
@@ -83,6 +86,181 @@ func TestGlobalReactorStateRemovesCaptureAfterTombstoneExpires(t *testing.T) {
 	require.NotContains(t, state.toRemoveCaptures, captureID)
 }
 
+func TestGlobalReactorStateRemovesWriteStoppedCaptureImmediately(t *testing.T) {
+	t.Parallel()
+
+	state := NewGlobalState(etcd.DefaultCDCClusterID, 0)
+	captureID := config.CaptureID("capture-1")
+	var removed []config.CaptureID
+	state.SetOnCaptureRemoved(func(id config.CaptureID) {
+		removed = append(removed, id)
+	})
+
+	info := &config.CaptureInfo{
+		ID:                        captureID,
+		AdvertiseAddr:             "127.0.0.1:8300",
+		WriteLeaseProtocolVersion: heartbeatpb.CurrentWriteLeaseProtocolVersion,
+	}
+	mustUpdateCaptureInfo(t, state, info)
+	info.WriteStopped = true
+	mustUpdateCaptureInfo(t, state, info)
+	mustDeleteCapture(t, state, captureID)
+
+	require.NotContains(t, state.Captures, captureID)
+	require.Equal(t, []config.CaptureID{captureID}, removed)
+	require.NotContains(t, state.toRemoveCaptures, captureID)
+}
+
+func TestGlobalReactorStateIgnoresMismatchedWriteStoppedMarker(t *testing.T) {
+	t.Parallel()
+
+	state := NewGlobalState(etcd.DefaultCDCClusterID, 0)
+	captureID := config.CaptureID("capture-1")
+	mustUpdateCaptureAtKey(t, state, captureID, &config.CaptureInfo{
+		ID:            "different-capture",
+		AdvertiseAddr: "127.0.0.1:8300",
+		WriteStopped:  true,
+	})
+	mustDeleteCapture(t, state, captureID)
+
+	state.UpdatePendingChange()
+	require.Contains(t, state.Captures, captureID)
+	require.Contains(t, state.toRemoveCaptures, captureID)
+}
+
+func TestGlobalReactorStateShortensDelayForWriteFencedReplacement(t *testing.T) {
+	t.Parallel()
+
+	state := NewGlobalState(etcd.DefaultCDCClusterID, 0)
+	oldCaptureID := config.CaptureID("capture-old")
+	newCaptureID := config.CaptureID("capture-new")
+	oldCaptureInfo := &config.CaptureInfo{
+		ID:                        oldCaptureID,
+		AdvertiseAddr:             "127.0.0.1:8300",
+		StartTimestamp:            1,
+		WriteLeaseProtocolVersion: heartbeatpb.CurrentWriteLeaseProtocolVersion,
+	}
+	newCaptureInfo := &config.CaptureInfo{
+		ID:                        newCaptureID,
+		AdvertiseAddr:             oldCaptureInfo.AdvertiseAddr,
+		StartTimestamp:            2,
+		WriteLeaseProtocolVersion: heartbeatpb.CurrentWriteLeaseProtocolVersion,
+	}
+
+	mustUpdateCaptureInfo(t, state, oldCaptureInfo)
+	mustDeleteCapture(t, state, oldCaptureID)
+	state.toRemoveCaptures[oldCaptureID] = time.Now().Add(-time.Second)
+	mustUpdateCaptureInfo(t, state, newCaptureInfo)
+
+	state.UpdatePendingChange()
+	require.Contains(t, state.Captures, oldCaptureID)
+	require.Contains(t, state.writeFencedReplacements, oldCaptureID)
+
+	state.toRemoveCaptures[oldCaptureID] = time.Now().Add(-6 * time.Second)
+	state.UpdatePendingChange()
+	require.NotContains(t, state.Captures, oldCaptureID)
+	require.Contains(t, state.Captures, newCaptureID)
+	require.NotContains(t, state.writeFencedReplacements, oldCaptureID)
+}
+
+func TestGlobalReactorStateDetectsReplacementRegisteredBeforeDelete(t *testing.T) {
+	t.Parallel()
+
+	state := NewGlobalState(etcd.DefaultCDCClusterID, 0)
+	oldCaptureID := config.CaptureID("capture-old")
+	newCaptureID := config.CaptureID("capture-new")
+	for _, info := range []*config.CaptureInfo{
+		{
+			ID:                        oldCaptureID,
+			AdvertiseAddr:             "127.0.0.1:8300",
+			StartTimestamp:            1,
+			WriteLeaseProtocolVersion: heartbeatpb.CurrentWriteLeaseProtocolVersion,
+		},
+		{
+			ID:                        newCaptureID,
+			AdvertiseAddr:             "127.0.0.1:8300",
+			StartTimestamp:            2,
+			WriteLeaseProtocolVersion: heartbeatpb.CurrentWriteLeaseProtocolVersion,
+		},
+	} {
+		mustUpdateCaptureInfo(t, state, info)
+	}
+
+	mustDeleteCapture(t, state, oldCaptureID)
+	require.Contains(t, state.writeFencedReplacements, oldCaptureID)
+}
+
+func TestGlobalReactorStateKeepsConservativeDelayWithoutMatchingCapability(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		oldProtocol       uint32
+		newProtocol       uint32
+		newAdvertiseAddr  string
+		newStartTimestamp int64
+	}{
+		{
+			name:              "legacy old capture",
+			oldProtocol:       heartbeatpb.LegacyWriteLeaseProtocolVersion,
+			newProtocol:       heartbeatpb.CurrentWriteLeaseProtocolVersion,
+			newAdvertiseAddr:  "127.0.0.1:8300",
+			newStartTimestamp: 2,
+		},
+		{
+			name:              "legacy new capture",
+			oldProtocol:       heartbeatpb.CurrentWriteLeaseProtocolVersion,
+			newProtocol:       heartbeatpb.LegacyWriteLeaseProtocolVersion,
+			newAdvertiseAddr:  "127.0.0.1:8300",
+			newStartTimestamp: 2,
+		},
+		{
+			name:              "different address",
+			oldProtocol:       heartbeatpb.CurrentWriteLeaseProtocolVersion,
+			newProtocol:       heartbeatpb.CurrentWriteLeaseProtocolVersion,
+			newAdvertiseAddr:  "127.0.0.1:8301",
+			newStartTimestamp: 2,
+		},
+		{
+			name:              "older start timestamp",
+			oldProtocol:       heartbeatpb.CurrentWriteLeaseProtocolVersion,
+			newProtocol:       heartbeatpb.CurrentWriteLeaseProtocolVersion,
+			newAdvertiseAddr:  "127.0.0.1:8300",
+			newStartTimestamp: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewGlobalState(etcd.DefaultCDCClusterID, 0)
+			oldCaptureID := config.CaptureID("capture-old")
+			newCaptureID := config.CaptureID("capture-new")
+			mustUpdateCaptureInfo(t, state, &config.CaptureInfo{
+				ID:                        oldCaptureID,
+				AdvertiseAddr:             "127.0.0.1:8300",
+				StartTimestamp:            1,
+				WriteLeaseProtocolVersion: tc.oldProtocol,
+			})
+			mustDeleteCapture(t, state, oldCaptureID)
+			mustUpdateCaptureInfo(t, state, &config.CaptureInfo{
+				ID:                        newCaptureID,
+				AdvertiseAddr:             tc.newAdvertiseAddr,
+				StartTimestamp:            tc.newStartTimestamp,
+				WriteLeaseProtocolVersion: tc.newProtocol,
+			})
+
+			state.toRemoveCaptures[oldCaptureID] = time.Now().Add(-6 * time.Second)
+			state.UpdatePendingChange()
+			require.Contains(t, state.Captures, oldCaptureID)
+			require.NotContains(t, state.writeFencedReplacements, oldCaptureID)
+
+			state.toRemoveCaptures[oldCaptureID] = time.Now().Add(-11 * time.Second)
+			state.UpdatePendingChange()
+			require.NotContains(t, state.Captures, oldCaptureID)
+		})
+	}
+}
+
 func mustUpdateCapture(
 	t *testing.T,
 	state *GlobalReactorState,
@@ -91,10 +269,25 @@ func mustUpdateCapture(
 ) {
 	t.Helper()
 
-	info := &config.CaptureInfo{
+	mustUpdateCaptureInfo(t, state, &config.CaptureInfo{
 		ID:            captureID,
 		AdvertiseAddr: advertiseAddr,
-	}
+	})
+}
+
+func mustUpdateCaptureInfo(t *testing.T, state *GlobalReactorState, info *config.CaptureInfo) {
+	t.Helper()
+	mustUpdateCaptureAtKey(t, state, info.ID, info)
+}
+
+func mustUpdateCaptureAtKey(
+	t *testing.T,
+	state *GlobalReactorState,
+	captureID config.CaptureID,
+	info *config.CaptureInfo,
+) {
+	t.Helper()
+
 	data, err := info.Marshal()
 	require.NoError(t, err)
 

--- a/server/capture_registration_test.go
+++ b/server/capture_registration_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/etcd"
+	"github.com/pingcap/ticdc/pkg/node"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func TestCaptureInfoIncludesWriteLeaseState(t *testing.T) {
+	t.Parallel()
+
+	c := &server{info: &node.Info{
+		ID:             node.ID("capture-1"),
+		AdvertiseAddr:  "127.0.0.1:8300",
+		Version:        "v1.0.0",
+		GitHash:        "git-hash",
+		DeployPath:     "/tmp/cdc",
+		StartTimestamp: 100,
+	}}
+
+	info := c.captureInfo(true)
+
+	require.Equal(t, config.CaptureID(c.info.ID), info.ID)
+	require.Equal(t, c.info.AdvertiseAddr, info.AdvertiseAddr)
+	require.Equal(t, heartbeatpb.CurrentWriteLeaseProtocolVersion, info.WriteLeaseProtocolVersion)
+	require.True(t, info.WriteStopped)
+}
+
+func TestMarkCaptureWriteStoppedUpdatesOnlyCurrentLease(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	cdcEtcdClient := etcd.NewMockCDCEtcdClient(ctrl)
+	rawEtcdClient := etcd.NewMockClient(ctrl)
+	leaseID := clientv3.LeaseID(100)
+	captureID := node.ID("capture-1")
+	key := etcd.GetEtcdKeyCaptureInfo(etcd.DefaultCDCClusterID, string(captureID))
+	c := &server{
+		info: &node.Info{
+			ID:            captureID,
+			AdvertiseAddr: "127.0.0.1:8300",
+		},
+		EtcdClient: cdcEtcdClient,
+	}
+
+	cdcEtcdClient.EXPECT().GetClusterID().Return(etcd.DefaultCDCClusterID)
+	cdcEtcdClient.EXPECT().GetEtcdClient().Return(rawEtcdClient)
+	rawEtcdClient.EXPECT().Txn(
+		gomock.Any(),
+		[]clientv3.Cmp{clientv3.Compare(clientv3.LeaseValue(key), "=", int64(leaseID))},
+		gomock.Any(),
+		etcd.TxnEmptyOpsElse,
+	).DoAndReturn(func(
+		_ context.Context,
+		_ []clientv3.Cmp,
+		opsThen []clientv3.Op,
+		_ []clientv3.Op,
+	) (*clientv3.TxnResponse, error) {
+		require.Equal(t, []clientv3.Op{
+			clientv3.OpPut(key, string(mustMarshalCaptureInfo(t, c.captureInfo(true))), clientv3.WithLease(leaseID)),
+		}, opsThen)
+		return &clientv3.TxnResponse{Succeeded: true}, nil
+	})
+
+	marked, err := c.markCaptureWriteStopped(t.Context(), leaseID)
+
+	require.NoError(t, err)
+	require.True(t, marked)
+}
+
+func mustMarshalCaptureInfo(t *testing.T, info *config.CaptureInfo) []byte {
+	t.Helper()
+
+	data, err := info.Marshal()
+	require.NoError(t, err)
+	return data
+}

--- a/server/server.go
+++ b/server/server.go
@@ -92,6 +92,7 @@ type localFencer interface {
 // 2. subModules     - Business logic modules stop first
 // 3. nodeModules    - Node management stops second
 // 4. networkModules - Network services stop third
+// 5. capture info   - marked write-stopped and removed after all modules close
 //
 // Rationale for this ordering:
 // - preServices provide foundational capabilities (time, messaging) needed by all other modules
@@ -631,21 +632,21 @@ func (c *server) Close() {
 		log.Info("coordinator closed", zap.String("captureID", string(c.info.ID)))
 	}
 
-	var closeGroup sync.WaitGroup
-	closeGroup.Add(1)
+	preServicesClosed := make(chan bool, 1)
 	go func() {
-		defer closeGroup.Done()
-		c.closePreServices()
+		preServicesClosed <- c.closePreServices()
 	}()
 
 	closeCtx, closeCancel := context.WithTimeout(context.Background(), GracefulShutdownTimeout)
 	defer closeCancel()
+	cleanShutdown := true
 
 	// There are also some dependencies inside subModules,
 	// so we close subModules in reverse order of their startup.
 	for i := len(c.subModules) - 1; i >= 0; i-- {
 		m := c.subModules[i]
 		if err := m.Close(closeCtx); err != nil {
+			cleanShutdown = false
 			log.Warn("failed to close sub module",
 				zap.String("module", m.Name()),
 				zap.Error(err))
@@ -655,6 +656,7 @@ func (c *server) Close() {
 
 	for _, m := range c.nodeModules {
 		if err := m.Close(closeCtx); err != nil {
+			cleanShutdown = false
 			log.Warn("failed to close sub common module",
 				zap.String("module", m.Name()),
 				zap.Error(err))
@@ -664,16 +666,36 @@ func (c *server) Close() {
 
 	for _, nm := range c.networkModules {
 		if err := nm.Close(closeCtx); err != nil {
+			cleanShutdown = false
 			log.Warn("failed to close sub base module",
 				zap.String("module", nm.Name()),
 				zap.Error(err))
 		}
 		log.Info("sub base module closed", zap.String("module", nm.Name()))
 	}
+	cleanShutdown = <-preServicesClosed && cleanShutdown
 
-	// delete server info from etcd
+	// Publish a durable proof only after all modules have stopped. The compare on
+	// the lease prevents a slow shutdown from recreating an expired capture key.
 	timeoutCtx, timeoutCancel := context.WithTimeout(closeCtx, cleanMetaDuration)
 	defer timeoutCancel()
+	if cleanShutdown {
+		marked, err := c.markCaptureWriteStopped(timeoutCtx, c.session.Lease())
+		switch {
+		case err != nil:
+			log.Warn("failed to mark capture writes stopped",
+				zap.String("captureID", string(c.info.ID)),
+				zap.Error(err))
+		case !marked:
+			log.Info("skip marking capture writes stopped because registration changed",
+				zap.String("captureID", string(c.info.ID)))
+		default:
+			log.Info("capture writes marked stopped in etcd",
+				zap.String("captureID", string(c.info.ID)))
+		}
+	}
+
+	// Delete server info from etcd after the write-stopped marker is visible.
 	if err := c.EtcdClient.DeleteCaptureInfo(timeoutCtx, string(c.info.ID)); err != nil {
 		log.Warn("failed to delete server info when server exited",
 			zap.String("captureID", string(c.info.ID)),
@@ -682,11 +704,30 @@ func (c *server) Close() {
 		log.Info("server info deleted from etcd", zap.String("captureID", string(c.info.ID)))
 	}
 
-	closeGroup.Wait()
 	log.Info("server closed", zap.Any("ServerInfo", c.info))
 }
 
-func (c *server) closePreServices() {
+func (c *server) markCaptureWriteStopped(ctx context.Context, leaseID clientv3.LeaseID) (bool, error) {
+	info := c.captureInfo(true)
+	data, err := info.Marshal()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	key := etcd.GetEtcdKeyCaptureInfo(c.EtcdClient.GetClusterID(), string(c.info.ID))
+	resp, err := c.EtcdClient.GetEtcdClient().Txn(
+		ctx,
+		[]clientv3.Cmp{clientv3.Compare(clientv3.LeaseValue(key), "=", int64(leaseID))},
+		[]clientv3.Op{clientv3.OpPut(key, string(data), clientv3.WithLease(leaseID))},
+		etcd.TxnEmptyOpsElse,
+	)
+	if err != nil {
+		return false, errors.WrapError(errors.ErrPDEtcdAPIError, err)
+	}
+	return resp.Succeeded, nil
+}
+
+func (c *server) closePreServices() bool {
 	closeCtx, cancel := context.WithTimeout(context.Background(), closeServiceTimeout)
 	defer cancel()
 	done := make(chan struct{})
@@ -699,8 +740,10 @@ func (c *server) closePreServices() {
 	}()
 	select {
 	case <-done:
+		return true
 	case <-closeCtx.Done():
 		log.Warn("service close operation timed out", zap.Error(closeCtx.Err()))
+		return false
 	}
 }
 

--- a/server/server_prepare.go
+++ b/server/server_prepare.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/heartbeatpb"
 	appctx "github.com/pingcap/ticdc/pkg/common/context"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
@@ -200,20 +201,25 @@ func (c *server) setUpDir() {
 
 // registerNodeToEtcd the server by put the server's information in etcd
 func (c *server) registerNodeToEtcd(ctx context.Context) error {
-	cInfo := &config.CaptureInfo{
-		ID:             config.CaptureID(c.info.ID),
-		AdvertiseAddr:  c.info.AdvertiseAddr,
-		Version:        c.info.Version,
-		GitHash:        c.info.GitHash,
-		DeployPath:     c.info.DeployPath,
-		StartTimestamp: c.info.StartTimestamp,
-		IsNewArch:      true,
-	}
-	err := c.EtcdClient.PutCaptureInfo(ctx, cInfo, c.session.Lease())
+	err := c.EtcdClient.PutCaptureInfo(ctx, c.captureInfo(false), c.session.Lease())
 	if err != nil {
 		return errors.WrapError(errors.ErrCaptureRegister, err)
 	}
 	return nil
+}
+
+func (c *server) captureInfo(writeStopped bool) *config.CaptureInfo {
+	return &config.CaptureInfo{
+		ID:                        config.CaptureID(c.info.ID),
+		AdvertiseAddr:             c.info.AdvertiseAddr,
+		Version:                   c.info.Version,
+		GitHash:                   c.info.GitHash,
+		DeployPath:                c.info.DeployPath,
+		StartTimestamp:            c.info.StartTimestamp,
+		IsNewArch:                 true,
+		WriteLeaseProtocolVersion: heartbeatpb.CurrentWriteLeaseProtocolVersion,
+		WriteStopped:              writeStopped,
+	}
 }
 
 func (c *server) newEtcdSession(ctx context.Context) (*concurrency.Session, error) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6203

During a rolling restart, a capture whose etcd key has been deleted remains in the scheduler-visible node view for the full `captureRemoveTTL` (10 seconds by default). This can keep a new coordinator waiting for a bootstrap response from an exited capture after every live capture has responded. Removing the node immediately is unsafe while the old capture may still hold a valid write proof.

### What is changed and how it works?

- Advertise the current write-lease protocol in capture metadata.
- After every local module and sink closes successfully, conditionally publish a lease-bound `write-stopped` marker before deleting the capture key. Observers remove a marked capture immediately.
- For an unmarked replacement with a different ID, the same address, a non-older start time, and current protocol support on both registrations, shorten the delay to the five-second maximum write-proof lifetime.
- Keep the existing conservative `captureRemoveTTL` for legacy, capability-unknown, mismatched, or failed-shutdown cases.
- Add focused server/orchestrator tests and update the write-lease design documentation.

### Check List

#### Tests

- Unit test
  - `go test ./pkg/orchestrator ./server -count=1`
  - `go test ./pkg/config ./pkg/metrics -count=1`
  - Focused `go test -race` for the new paths
  - `make fmt`
  - `make cdc`

#### Questions

##### Will it cause performance regression or break compatibility?

No expected regression. Address matching scans membership only on capture events. The metadata fields are additive; legacy or unknown nodes retain the existing 10-second fallback.

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes. The capture write-lease design and overview, plus the delay metric description, are updated.

### Release note

```release-note
Reduce TiCDC capture removal delay during rolling restarts while preserving conservative write-fencing fallbacks.
```
