### PR TITLE
coordinator: preserve removal progress across concurrent updates

### DIFF
--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/keyspace"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/routing"
+	"github.com/pingcap/ticdc/pkg/server"
 	"github.com/pingcap/ticdc/pkg/txnutil/gc"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/pkg/version"
@@ -641,7 +642,22 @@ func (h *OpenAPIV2) DeleteChangefeed(c *gin.Context) {
 	cfInfo, status, err := co.GetChangefeed(c, changefeedDisplayName)
 	if err != nil {
 		if errors.ErrChangeFeedNotExists.Equal(err) {
-			c.JSON(getStatus(c), nil)
+			// GetChangefeed only checks the coordinator's in-memory state. The
+			// changefeed can already be absent there while its metadata deletion is
+			// still pending or has failed, so only report idempotent success after
+			// checking the metastore as well.
+			cfID := common.NewChangeFeedIDWithDisplayName(changefeedDisplayName)
+			persistedInfo, persistedErr := co.GetPersistedChangefeedInfo(ctx, cfID)
+			switch {
+			case errors.ErrChangeFeedNotExists.Equal(persistedErr):
+				c.JSON(getStatus(c), nil)
+			case persistedErr != nil:
+				_ = c.Error(persistedErr)
+			default:
+				middleware.SetChangefeedOperationTarget(
+					c, persistedInfo.ChangefeedID.Keyspace(), persistedInfo.ChangefeedID.Name())
+				_ = c.Error(errors.ErrChangeFeedDeletionUnfinished.GenWithStackByArgs(changefeedDisplayName.Name))
+			}
 			return
 		}
 		_ = c.Error(err)
@@ -659,7 +675,35 @@ func (h *OpenAPIV2) DeleteChangefeed(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
+	verifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err = waitChangefeedDeleted(verifyCtx, co, cfInfo.ChangefeedID); err != nil {
+		_ = c.Error(err)
+		return
+	}
 	c.JSON(getStatus(c), &EmptyResponse{})
+}
+
+func waitChangefeedDeleted(ctx context.Context, co server.Coordinator, id common.ChangeFeedID) error {
+	const checkInterval = 50 * time.Millisecond
+
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+	for {
+		_, err := co.GetPersistedChangefeedInfo(ctx, id)
+		if errors.ErrChangeFeedNotExists.Equal(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.ErrChangeFeedDeletionUnfinished.GenWithStackByArgs(id.Name())
+		case <-ticker.C:
+		}
+	}
 }
 
 // PauseChangefeed handles pause changefeed request

--- a/api/v2/changefeed_test.go
+++ b/api/v2/changefeed_test.go
@@ -83,6 +83,78 @@ func TestResumeChangefeedRejectsNormalBeforeGC(t *testing.T) {
 	require.False(t, co.resumeCalled)
 }
 
+func TestDeleteChangefeedChecksPersistedMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+	testCases := []struct {
+		name             string
+		coordinator      *deleteCoordinator
+		expectError      bool
+		expectRemoveCall bool
+	}{
+		{
+			name: "idempotent delete after metadata is gone",
+			coordinator: &deleteCoordinator{
+				getChangefeedErr: errors.ErrChangeFeedNotExists.GenWithStackByArgs(cfID.Name()),
+				persistedErr:     errors.ErrChangeFeedNotExists.GenWithStackByArgs(cfID.Name()),
+			},
+		},
+		{
+			name: "memory is gone but metadata remains",
+			coordinator: &deleteCoordinator{
+				getChangefeedErr: errors.ErrChangeFeedNotExists.GenWithStackByArgs(cfID.Name()),
+				persistedInfo: &config.ChangeFeedInfo{
+					ChangefeedID: cfID,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "delete returns only after metadata is gone",
+			coordinator: &deleteCoordinator{
+				changefeedInfo: &config.ChangeFeedInfo{
+					ChangefeedID: cfID,
+					State:        config.StateStopped,
+				},
+				changefeedStatus: &config.ChangeFeedStatus{CheckpointTs: 123},
+				persistedInfo: &config.ChangeFeedInfo{
+					ChangefeedID: cfID,
+				},
+				persistedExistsChecks: 1,
+				persistedErr:          errors.ErrChangeFeedNotExists.GenWithStackByArgs(cfID.Name()),
+			},
+			expectRemoveCall: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &resumeNormalServer{coordinator: tc.coordinator}
+			h := &OpenAPIV2{server: srv}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodDelete, "/api/v2/changefeeds/test?keyspace=default", nil)
+			c.Params = gin.Params{{Key: api.APIOpVarChangefeedID, Value: "test"}}
+
+			h.DeleteChangefeed(c)
+
+			require.Equal(t, tc.expectRemoveCall, tc.coordinator.removeCalled)
+			if tc.expectError {
+				require.Len(t, c.Errors, 1)
+				require.True(t, errors.ErrChangeFeedDeletionUnfinished.Equal(c.Errors.Last().Err))
+				return
+			}
+			require.Empty(t, c.Errors)
+			require.Equal(t, http.StatusOK, w.Code)
+			if tc.expectRemoveCall {
+				require.GreaterOrEqual(t, tc.coordinator.persistedReadCount, 2)
+			}
+		})
+	}
+}
+
 type resumeNormalServer struct {
 	coordinator         server.Coordinator
 	pdClientRequested   bool
@@ -121,6 +193,42 @@ func (s *resumeNormalServer) GetMaintainerManager() *maintainer.Manager { return
 
 type resumeNormalCoordinator struct {
 	resumeCalled bool
+}
+
+type deleteCoordinator struct {
+	resumeNormalCoordinator
+	changefeedInfo        *config.ChangeFeedInfo
+	changefeedStatus      *config.ChangeFeedStatus
+	getChangefeedErr      error
+	persistedInfo         *config.ChangeFeedInfo
+	persistedErr          error
+	persistedExistsChecks int
+	persistedReadCount    int
+	removeCalled          bool
+}
+
+func (c *deleteCoordinator) GetChangefeed(
+	ctx context.Context,
+	changefeedDisplayName common.ChangeFeedDisplayName,
+) (*config.ChangeFeedInfo, *config.ChangeFeedStatus, error) {
+	return c.changefeedInfo, c.changefeedStatus, c.getChangefeedErr
+}
+
+func (c *deleteCoordinator) GetPersistedChangefeedInfo(
+	ctx context.Context,
+	id common.ChangeFeedID,
+) (*config.ChangeFeedInfo, error) {
+	c.persistedReadCount++
+	if c.persistedExistsChecks > 0 {
+		c.persistedExistsChecks--
+		return c.persistedInfo, nil
+	}
+	return c.persistedInfo, c.persistedErr
+}
+
+func (c *deleteCoordinator) RemoveChangefeed(ctx context.Context, id common.ChangeFeedID) (uint64, error) {
+	c.removeCalled = true
+	return 0, nil
 }
 
 func (c *resumeNormalCoordinator) Stop() {}

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -1218,14 +1218,37 @@ func (c *Controller) GetChangefeed(
 
 // GetPersistedChangefeedInfo returns the latest changefeed info persisted in the backend.
 //
-// Use this for resume-time validation because stopped changefeed metadata can
-// be changed outside the coordinator process, for example during metadata
-// migration or by legacy tooling. GetChangefeed intentionally returns the
-// coordinator's in-memory copy.
+// Use this when an operation must validate durable state because changefeed
+// metadata can differ from the coordinator's in-memory view, for example while
+// deletion is finishing or after metadata migration. GetChangefeed
+// intentionally returns the coordinator's in-memory copy.
 func (c *Controller) GetPersistedChangefeedInfo(ctx context.Context, id common.ChangeFeedID) (*config.ChangeFeedInfo, error) {
 	c.apiLock.RLock()
 	defer c.apiLock.RUnlock()
 	return c.backend.GetChangefeedInfo(ctx, id)
+}
+
+// updateChangefeedCheckpointTs serializes checkpoint persistence with API
+// lifecycle changes. Pause and remove persist a non-none progress while holding
+// apiLock, so a checkpoint collected before that operation must not overwrite
+// the newer progress after the operation releases the lock.
+func (c *Controller) updateChangefeedCheckpointTs(
+	ctx context.Context,
+	checkpointTs map[common.ChangeFeedID]uint64,
+) error {
+	c.apiLock.RLock()
+	defer c.apiLock.RUnlock()
+
+	for id := range checkpointTs {
+		cf := c.changefeedDB.GetByID(id)
+		if cf == nil || !shouldRunChangefeed(cf.GetInfo().State) {
+			delete(checkpointTs, id)
+		}
+	}
+	if len(checkpointTs) == 0 {
+		return nil
+	}
+	return c.backend.UpdateChangefeedCheckpointTs(ctx, checkpointTs)
 }
 
 // getChangefeed returns the changefeed by id, return nil if not found

--- a/coordinator/controller_test.go
+++ b/coordinator/controller_test.go
@@ -1013,6 +1013,41 @@ func TestRemoveChangefeed(t *testing.T) {
 	require.Equal(t, uint64(1), cp)
 }
 
+func TestUpdateChangefeedCheckpointTsSkipsStoppedAndRemovedChangefeeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	backend := mock_changefeed.NewMockBackend(ctrl)
+	changefeedDB := changefeed.NewChangefeedDB(1216)
+	controller := &Controller{backend: backend, changefeedDB: changefeedDB}
+
+	runningID := common.NewChangeFeedIDWithName("running", common.DefaultKeyspaceName)
+	stoppedID := common.NewChangeFeedIDWithName("stopped", common.DefaultKeyspaceName)
+	removedID := common.NewChangeFeedIDWithName("removed", common.DefaultKeyspaceName)
+	running := changefeed.NewChangefeed(runningID, &config.ChangeFeedInfo{
+		ChangefeedID: runningID,
+		Config:       config.GetDefaultReplicaConfig(),
+		State:        config.StateNormal,
+	}, 1, true)
+	stopped := changefeed.NewChangefeed(stoppedID, &config.ChangeFeedInfo{
+		ChangefeedID: stoppedID,
+		Config:       config.GetDefaultReplicaConfig(),
+		State:        config.StateStopped,
+	}, 1, true)
+	changefeedDB.AddAbsentChangefeed(running)
+	changefeedDB.AddStoppedChangefeed(stopped)
+
+	checkpointTs := map[common.ChangeFeedID]uint64{
+		runningID: 100,
+		stoppedID: 200,
+		removedID: 300,
+	}
+	backend.EXPECT().UpdateChangefeedCheckpointTs(gomock.Any(), map[common.ChangeFeedID]uint64{
+		runningID: 100,
+	}).Return(nil)
+
+	require.NoError(t, controller.updateChangefeedCheckpointTs(context.Background(), checkpointTs))
+	require.Equal(t, map[common.ChangeFeedID]uint64{runningID: 100}, checkpointTs)
+}
+
 func TestListChangefeed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	backend := mock_changefeed.NewMockBackend(ctrl)

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -359,7 +359,7 @@ func (c *coordinator) saveCheckpointTs(ctx context.Context, changes []*changefee
 	if len(statusMap) == 0 {
 		return nil
 	}
-	err := c.controller.backend.UpdateChangefeedCheckpointTs(ctx, statusMap)
+	err := c.controller.updateChangefeedCheckpointTs(ctx, statusMap)
 	if err != nil {
 		log.Error("failed to update checkpointTs", zap.Error(err))
 		return errors.Trace(err)

--- a/coordinator/operator/operator_controller_test.go
+++ b/coordinator/operator/operator_controller_test.go
@@ -80,8 +80,8 @@ func TestController_StopChangefeed(t *testing.T) {
 
 	oc.StopChangefeed(context.Background(), cfID, false)
 	require.Len(t, oc.operators, 1)
-	// the old  PostFinish will be called
-	backend.EXPECT().SetChangefeedProgress(gomock.Any(), gomock.Any(), config.ProgressNone).Return(nil).Times(1)
+	// Replacing the pause operator must not run its successful PostFinish path,
+	// because the remove path has already persisted ProgressRemoving.
 	oc.StopChangefeed(context.Background(), cfID, true)
 	require.Len(t, oc.operators, 1)
 	oc.StopChangefeed(context.Background(), cfID, true)
@@ -180,7 +180,6 @@ func TestController_StopChangefeedDoesNotReuseStaleOwnerCleanup(t *testing.T) {
 	staleOp := oc.StopRemoteMaintainerWithMaintainerEpoch(cfID, staleOwner.ID, false, 10)
 	require.Equal(t, staleOwner.ID, staleOp.Schedule().To)
 
-	backend.EXPECT().SetChangefeedProgress(gomock.Any(), cfID, config.ProgressNone).Return(nil).Times(1)
 	currentOp := oc.StopChangefeedWithMaintainerEpoch(context.Background(), cfID, false, 20)
 	require.NotSame(t, staleOp, currentOp)
 	currentReqMsg := currentOp.Schedule()

--- a/coordinator/operator/operator_stop.go
+++ b/coordinator/operator/operator_stop.go
@@ -42,6 +42,7 @@ type StopChangefeedOperator struct {
 	nodeID            node.ID
 	changefeedRemoved bool
 	finished          atomic.Bool
+	canceled          atomic.Bool
 	coordinatorNodeID node.ID
 	backend           changefeed.Backend
 	maintainerEpoch   uint64
@@ -115,6 +116,7 @@ func (m *StopChangefeedOperator) IsFinished() bool {
 }
 
 func (m *StopChangefeedOperator) OnTaskRemoved() {
+	m.canceled.Store(true)
 	m.finished.Store(true)
 }
 
@@ -124,6 +126,13 @@ func (m *StopChangefeedOperator) Start() {
 }
 
 func (m *StopChangefeedOperator) PostFinish() {
+	// A stop operator can be replaced by a remove operator. In that case the
+	// replacement has already persisted ProgressRemoving, so the canceled stop
+	// operator must not reset it to ProgressNone.
+	if m.canceled.Load() {
+		return
+	}
+
 	if m.changefeedRemoved {
 		if err := m.backend.DeleteChangefeed(context.Background(), m.cfID); err != nil {
 			log.Warn("failed to delete changefeed",

--- a/coordinator/operator/operator_stop_integration_test.go
+++ b/coordinator/operator/operator_stop_integration_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/ticdc/coordinator/changefeed"
+	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/etcd"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// TestPauseReplacedByRemoveWithEtcd covers the complete metadata lifecycle for
+// the regression where a canceled pause operator reset ProgressRemoving to
+// ProgressNone before the remove operator deleted the changefeed.
+func TestPauseReplacedByRemoveWithEtcd(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientURL, etcdServer, err := etcd.SetupEmbedEtcd(t.TempDir())
+	require.NoError(t, err)
+	defer etcdServer.Close()
+
+	rawClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{clientURL.String()},
+		DialTimeout: 3 * time.Second,
+	})
+	require.NoError(t, err)
+	defer rawClient.Close()
+
+	cdcClient, err := etcd.NewCDCEtcdClient(ctx, rawClient, "operator-integration-test")
+	require.NoError(t, err)
+	backend := changefeed.NewEtcdBackend(cdcClient)
+
+	cfID := common.NewChangeFeedIDWithName("pause-then-remove", common.DefaultKeyspaceName)
+	info := &config.ChangeFeedInfo{
+		ChangefeedID: cfID,
+		Config:       config.GetDefaultReplicaConfig(),
+		SinkURI:      "blackhole://",
+		StartTs:      1,
+		State:        config.StateNormal,
+	}
+	require.NoError(t, backend.CreateChangefeed(ctx, info))
+
+	changefeedDB := changefeed.NewChangefeedDB(1216)
+	cf := changefeed.NewChangefeed(cfID, info, info.StartTs, true)
+	oc, self, _ := newOperatorControllerForTest(t, changefeedDB, backend, nil)
+	changefeedDB.AddReplicatingMaintainer(cf, self.ID)
+
+	// Match the controller's pause path, then replace its in-flight stop
+	// operator with a remove operation before the maintainer has stopped.
+	require.NoError(t, backend.PauseChangefeed(ctx, cfID))
+	pauseOp := oc.StopChangefeed(ctx, cfID, false)
+	require.NoError(t, backend.SetChangefeedProgress(ctx, cfID, config.ProgressRemoving))
+	removeOp := oc.StopChangefeed(ctx, cfID, true)
+	require.NotSame(t, pauseOp, removeOp)
+
+	status, _, err := cdcClient.GetChangeFeedStatus(ctx, cfID)
+	require.NoError(t, err)
+	require.Equal(t, config.ProgressRemoving, status.Progress)
+
+	removeOp.Check(self.ID, &heartbeatpb.MaintainerStatus{
+		State:           heartbeatpb.ComponentState_Stopped,
+		MaintainerEpoch: info.Epoch,
+	})
+	oc.Execute()
+
+	_, err = backend.GetChangefeedInfo(ctx, cfID)
+	require.True(t, errors.ErrChangeFeedNotExists.Equal(err))
+}

--- a/coordinator/operator/operator_stop_test.go
+++ b/coordinator/operator/operator_stop_test.go
@@ -57,6 +57,7 @@ func TestStopChangefeedOperator_OnTaskRemoved(t *testing.T) {
 	op := NewStopChangefeedOperator(common.DefaultKeyspaceID, cfID, "n1", "n2", nil, true, 10, stopChangefeedKindCurrentPlacement)
 	op.OnTaskRemoved()
 	require.True(t, op.finished.Load())
+	require.True(t, op.canceled.Load())
 }
 
 func TestStopChangefeedOperator_PostFinish(t *testing.T) {
@@ -79,4 +80,10 @@ func TestStopChangefeedOperator_PostFinish(t *testing.T) {
 	op2 := NewStopChangefeedOperator(common.DefaultKeyspaceID, cfID, "n1", "n2", backend, false, 10, stopChangefeedKindCurrentPlacement)
 	backend.EXPECT().SetChangefeedProgress(gomock.Any(), cfID, config.ProgressNone).Return(errors.New("err"))
 	op2.PostFinish()
+
+	// A canceled pause operator must not overwrite ProgressRemoving persisted by
+	// the remove operation that replaced it.
+	op3 := NewStopChangefeedOperator(common.DefaultKeyspaceID, cfID, "n1", "n2", backend, false, 10, stopChangefeedKindCurrentPlacement)
+	op3.OnTaskRemoved()
+	op3.PostFinish()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6244 

### What is changed and how it works?

Checkpoint persistence is serialized with lifecycle operations and skips stopped or removed changefeeds. A canceled pause operator no longer resets ProgressRemoving, and the etcd backend preserves removal progress during CAS retries. This ensures concurrent checkpoint or pause completion updates cannot interrupt an in-progress changefeed deletion.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved changefeed removal progress when a pause operation is canceled or replaced by removal.
  * Prevented stale operations from incorrectly resetting changefeed progress.
  * Filtered persisted checkpoints to exclude removed or stopped changefeeds.

* **Tests**
  * Added coverage for checkpoint filtering and progress preservation during removal races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->